### PR TITLE
Fix dev container pre-commit installation

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -6,6 +6,7 @@
     "runServices": ["dev", "server"],
     "workspaceFolder": "/home/calitp/app",
     "postStartCommand": ["/bin/bash", "bin/init.sh"],
+    "postAttachCommand": "pre-commit install",
 
     // Set *default* container specific settings.json values on container create.
     "settings": {

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -3,5 +3,4 @@ FROM benefits_client:latest
 USER root
 
 RUN apt-get install -qq --no-install-recommends curl git jq ssh && \
-    pip install --no-cache-dir flake8 debugpy pre-commit && \
-    pre-commit install
+    pip install --no-cache-dir flake8 debugpy pre-commit


### PR DESCRIPTION
Wait to `pre-commit install` until dev container attaches to local source.

At Docker build time, the git repository is not available!