### PR TITLE
Instrument with Amplitude

### DIFF
--- a/.aws/ecs-task-definition.json
+++ b/.aws/ecs-task-definition.json
@@ -43,6 +43,10 @@
             },
             "secrets": [
                 {
+                    "valueFrom": "arn:aws:ssm:us-west-2:373436483103:parameter/ANALYTICS_KEY",
+                    "name": "ANALYTICS_KEY"
+                },
+                {
                     "valueFrom": "arn:aws:ssm:us-west-2:373436483103:parameter/DJANGO_ALLOWED_HOSTS",
                     "name": "DJANGO_ALLOWED_HOSTS"
                 },

--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,5 @@
 # Amplitude config
-AMP_API_KEY=amp-api-key
+ANALYTICS_KEY=amplitude-api-key
 
 # AWS config
 AWS_DEFAULT_REGION=us-west-2

--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,7 @@
-#AWS config
+# Amplitude config
+AMP_API_KEY=amp-api-key
+
+# AWS config
 AWS_DEFAULT_REGION=us-west-2
 AWS_ACCESS_KEY_ID=access-key-id
 AWS_SECRET_ACCESS_KEY=secret-access-key

--- a/benefits/__init__.py
+++ b/benefits/__init__.py
@@ -1,0 +1,3 @@
+__version__ = "0.0.1"
+
+VERSION = __version__

--- a/benefits/core/analytics.py
+++ b/benefits/core/analytics.py
@@ -25,6 +25,7 @@ class Event:
     def __init__(self, request, event_type, **kwargs):
         """Analytics event of the given type, including attributes from request's session."""
         self.app_version = VERSION
+        self.device_id = session.did(request)
         self.event_properties = {}
         self.event_type = str(event_type).lower()
         self.insert_id = str(uuid.uuid4())

--- a/benefits/core/analytics.py
+++ b/benefits/core/analytics.py
@@ -1,0 +1,64 @@
+"""
+The core application: analytics implementation.
+"""
+import logging
+import time
+import uuid
+
+import requests
+
+from benefits.settings import ANALYTICS_KEY
+from . import session
+
+
+logger = logging.getLogger(__name__)
+
+
+class ApiError(Exception):
+    """Error calling the Analytics API."""
+
+    pass
+
+
+class Event:
+    """Represents a single analytics event."""
+
+    def __init__(self, request, event_type):
+        self.event_type = event_type
+        self.insert_id = str(uuid.uuid4())
+        self.session_id = session.start(request)
+        self.time = int(time.time() * 1000)
+        self.user_id = session.uid(request)
+
+
+class Client:
+    """Analytics API client"""
+
+    def __init__(self):
+        logger.debug("Initialize Analytics API Client")
+        self.headers = {"Accept": "*/*", "Content-type": "application/json"}
+        self.url = "https://api2.amplitude.com/2/httpapi"
+
+    def _payload(self, events):
+        return {"api_key": ANALYTICS_KEY, "events": events}
+
+    def send(self, event):
+        """Send a single event."""
+        logger.debug("Sending a single event.")
+        self.batch([event])
+
+    def batch(self, events):
+        """Send a batch of events."""
+        logger.debug(f"Sending a batch of {len(events)} events.")
+        r = requests.post(self.url, headers=self.headers, data=self._payload(events))
+
+        if r.status_code == 200:
+            logger.debug("Batch sent successfully")
+        elif r.status_code == 400:
+            logger.error("Batch request was invalid", exc_info=r.json())
+        elif r.status_code == 413:
+            logger.error("Batch payload was too large", exc_info=r.json())
+        elif r.status_code == 429:
+            logger.error("Batch contained too many requests for some users", exc_info=r.json())
+        else:
+            logger.error("Batch failed to send", exc_info=r.json())

--- a/benefits/core/analytics.py
+++ b/benefits/core/analytics.py
@@ -4,6 +4,7 @@ The core application: analytics implementation.
 import itertools
 import json
 import logging
+import re
 import time
 import uuid
 
@@ -17,40 +18,58 @@ from . import session
 logger = logging.getLogger(__name__)
 
 
-class ApiError(Exception):
-    """Error calling the Analytics API."""
-
-    pass
-
-
 class Event:
-    """Represents a single analytics event."""
-
     _counter = itertools.count()
 
     def __init__(self, request, event_type, **kwargs):
+        """A single analytics event of the given type, including attributes from request's session."""
         self.app_version = VERSION
+        self.event_properties = {}
         self.event_type = event_type
         self.insert_id = str(uuid.uuid4())
         self.language = session.language(request)
         self.session_id = session.start(request)
         self.time = int(time.time() * 1000)
         self.user_id = session.uid(request)
-        self.event_properties = kwargs
+        self.user_properties = {}
+        self.update(**kwargs)
         # event is initialized, consume next counter
         self.event_id = next(Event._counter)
 
     def __str__(self):
         return json.dumps(self.__dict__)
 
+    def update(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+class PageviewEvent(Event):
+    _domain_re = re.compile(r"^(?:https?:\/\/)?(?:[^@\n]+@)?(?:www\.)?([^:\/\n?]+)", re.IGNORECASE)
+
+    def __init__(self, request, page_name, **kwargs):
+        """Analytics event representing a single pageview, with common properties."""
+        super().__init__(request, f"land on {page_name} page", **kwargs)
+
+        uagent = request.headers.get("user-agent")
+
+        ref = request.headers.get("referer")
+        match = PageviewEvent._domain_re.match(ref) if ref else None
+        refdom = match.group(1) if match else None
+
+        agency = session.agency(request)
+
+        self.update(
+            event_properties=dict(path=request.path, provider_name=agency.long_name if agency else None),
+            user_properties=dict(referrer=ref, referring_domain=refdom, user_agent=uagent),
+        )
+
 
 class Client:
-    """Analytics API client"""
-
     def __init__(self):
-        logger.debug("Initialize Analytics API Client")
+        """Analytics API client"""
         self.headers = {"Accept": "*/*", "Content-type": "application/json"}
         self.url = "https://api2.amplitude.com/2/httpapi"
+        logger.debug(f"Initialize Client for {self.url}")
 
     def _payload(self, events):
         if not isinstance(events, list):
@@ -59,34 +78,40 @@ class Client:
 
     def send(self, event):
         """Send an analytics event."""
+        if not isinstance(event, Event):
+            raise ValueError("event must be an Event instance")
+
         if not ANALYTICS_KEY:
             logger.warning(f"ANALYTICS_KEY is not configured, cannot send: {event}")
             return
 
-        payload = self._payload(event)
-        logger.debug(f"Sending event payload: {payload}")
-        r = requests.post(self.url, headers=self.headers, json=payload)
+        try:
+            payload = self._payload(event)
+            logger.debug(f"Sending event payload: {payload}")
 
-        if r.status_code == 200:
-            logger.debug(f"Event sent successfully: {r.json()}")
-        elif r.status_code == 400:
-            logger.error(f"Event request was invalid: {r.json()}")
-        elif r.status_code == 413:
-            logger.error(f"Event payload was too large: {r.json()}")
-        elif r.status_code == 429:
-            logger.error(f"Event contained too many requests for some users: {r.json()}")
-        else:
-            logger.error(f"Event failed to send: {r.json()}")
+            r = requests.post(self.url, headers=self.headers, json=payload)
+            if r.status_code == 200:
+                logger.info(f"Event sent successfully: {r.json()}")
+            elif r.status_code == 400:
+                logger.error(f"Event request was invalid: {r.json()}")
+            elif r.status_code == 413:
+                logger.error(f"Event payload was too large: {r.json()}")
+            elif r.status_code == 429:
+                logger.error(f"Event contained too many requests for some users: {r.json()}")
+            else:
+                logger.error(f"Failed to send event: {r.json()}")
+        except Exception:
+            logger.error(f"Failed to send event: {event}")
 
 
 def send_event(event=None, request=None, event_type=None, **kwargs):
     """
-    Send an analytics event. If :event: is an Event instance, send that.
+    Send an analytics event. If :event: is an Event instance, use that.
     Otherwise :request: and :event_type: are required to construct a new Event instance.
-    Extra kwargs are added as event_properties (must be JSON-serializable).
+    Extra kwargs are merged as event attributes (must be JSON-serializable).
     """
     if isinstance(event, Event):
-        event.event_properties.update(kwargs)
+        event.update(**kwargs)
         Client().send(event)
     elif all((request, event_type)):
         event = Event(request, event_type, **kwargs)

--- a/benefits/core/analytics.py
+++ b/benefits/core/analytics.py
@@ -25,7 +25,7 @@ class Event:
         """A single analytics event of the given type, including attributes from request's session."""
         self.app_version = VERSION
         self.event_properties = {}
-        self.event_type = event_type
+        self.event_type = str(event_type).lower()
         self.insert_id = str(uuid.uuid4())
         self.language = session.language(request)
         self.session_id = session.start(request)
@@ -43,17 +43,17 @@ class Event:
         self.__dict__.update(kwargs)
 
 
-class PageviewEvent(Event):
+class ViewPageEvent(Event):
     _domain_re = re.compile(r"^(?:https?:\/\/)?(?:[^@\n]+@)?(?:www\.)?([^:\/\n?]+)", re.IGNORECASE)
 
     def __init__(self, request, page_name, **kwargs):
         """Analytics event representing a single pageview, with common properties."""
-        super().__init__(request, f"land on {page_name} page", **kwargs)
+        super().__init__(request, f"view page {page_name}", **kwargs)
 
         uagent = request.headers.get("user-agent")
 
         ref = request.headers.get("referer")
-        match = PageviewEvent._domain_re.match(ref) if ref else None
+        match = ViewPageEvent._domain_re.match(ref) if ref else None
         refdom = match.group(1) if match else None
 
         agency = session.agency(request)
@@ -64,7 +64,7 @@ class PageviewEvent(Event):
         )
 
 
-class LanguageChangeEvent(Event):
+class ChangeLanguageEvent(Event):
     def __init__(self, request, new_lang, **kwargs):
         """Analytics event representing a change in the app's language."""
         super().__init__(request, "change language", **kwargs)

--- a/benefits/core/analytics.py
+++ b/benefits/core/analytics.py
@@ -64,6 +64,13 @@ class PageviewEvent(Event):
         )
 
 
+class LanguageChangeEvent(Event):
+    def __init__(self, request, new_lang, **kwargs):
+        """Analytics event representing a change in the app's language."""
+        super().__init__(request, "change language", **kwargs)
+        self.update(event_properties=dict(language=new_lang))
+
+
 class Client:
     def __init__(self):
         """Analytics API client"""

--- a/benefits/core/analytics.py
+++ b/benefits/core/analytics.py
@@ -42,7 +42,7 @@ class Event:
         uagent = request.headers.get("user-agent")
 
         ref = request.headers.get("referer")
-        match = ViewedPageEvent._domain_re.match(ref) if ref else None
+        match = Event._domain_re.match(ref) if ref else None
         refdom = match.group(1) if match else None
 
         self.update_user_properties(referrer=ref, referring_domain=refdom, user_agent=uagent)

--- a/benefits/core/analytics.py
+++ b/benefits/core/analytics.py
@@ -72,8 +72,9 @@ class ChangeLanguageEvent(Event):
 
 
 class Client:
-    def __init__(self):
+    def __init__(self, api_key):
         """Analytics API client"""
+        self.api_key = api_key
         self.headers = {"Accept": "*/*", "Content-type": "application/json"}
         self.url = "https://api2.amplitude.com/2/httpapi"
         logger.debug(f"Initialize Client for {self.url}")
@@ -81,15 +82,15 @@ class Client:
     def _payload(self, events):
         if not isinstance(events, list):
             events = [events]
-        return {"api_key": ANALYTICS_KEY, "events": [e.__dict__ for e in events]}
+        return {"api_key": self.api_key, "events": [e.__dict__ for e in events]}
 
     def send(self, event):
         """Send an analytics event."""
         if not isinstance(event, Event):
             raise ValueError("event must be an Event instance")
 
-        if not ANALYTICS_KEY:
-            logger.warning(f"ANALYTICS_KEY is not configured, cannot send: {event}")
+        if not self.api_key:
+            logger.warning(f"api_key is not configured, cannot send event: {event}")
             return
 
         try:
@@ -119,9 +120,9 @@ def send_event(event=None, request=None, event_type=None, **kwargs):
     """
     if isinstance(event, Event):
         event.update(**kwargs)
-        Client().send(event)
+        Client(ANALYTICS_KEY).send(event)
     elif all((request, event_type)):
         event = Event(request, event_type, **kwargs)
-        Client().send(event)
+        Client(ANALYTICS_KEY).send(event)
     else:
         raise ValueError("Either pass an Event instance, or Django request object and event type string")

--- a/benefits/core/context_processors.py
+++ b/benefits/core/context_processors.py
@@ -1,16 +1,16 @@
 """
 The core application: context processors for enriching request context data.
 """
-from benefits.settings import DEBUG
+from benefits.settings import ANALYTICS_KEY
 
 from . import session
 
 
+def analytics(request):
+    """Context processor adds some analytics information to request context."""
+    return {"analytics": {"api_key": ANALYTICS_KEY, "uid": session.uid(request), "did": session.did(request)}}
+
+
 def debug(request):
     """Context processor adds debug information to request context."""
-    context = {}
-
-    if DEBUG:
-        context.update(dict(debug=session.context_dict(request)))
-
-    return context
+    return {"debug": session.context_dict(request)}

--- a/benefits/core/middleware.py
+++ b/benefits/core/middleware.py
@@ -6,7 +6,7 @@ import logging
 from django.utils.deprecation import MiddlewareMixin
 
 from benefits.settings import DEBUG
-from . import session
+from . import analytics, session
 
 
 logger = logging.getLogger(__name__)
@@ -17,7 +17,7 @@ class AgencySessionRequired(MiddlewareMixin):
 
     # Django 1.9 and older method signature needed for decorators
     # https://docs.djangoproject.com/en/3.1/ref/utils/#django.utils.decorators.decorator_from_middleware
-    def process_view(self, request, view_func, view_args, view_kwargs):
+    def process_request(self, request):
         if session.active_agency(request):
             logger.debug("Session configured with agency")
             return None
@@ -34,3 +34,14 @@ class DebugSession:
     def __call__(self, request):
         session.update(request, debug=DEBUG)
         return self.get_response(request)
+
+
+class PageviewEvent(MiddlewareMixin):
+    """Middleware sends an analytics event for pageviews."""
+
+    # Django 1.9 and older method signature needed for decorators
+    # https://docs.djangoproject.com/en/3.1/ref/utils/#django.utils.decorators.decorator_from_middleware
+    def process_request(self, request):
+        kwargs = dict(path=request.path, referer=request.headers.get("referer"))
+        analytics.send_event(request=request, event_type="pageview", **kwargs)
+        return None

--- a/benefits/core/middleware.py
+++ b/benefits/core/middleware.py
@@ -3,7 +3,7 @@ The core application: middleware definitions for request/response cycle.
 """
 import logging
 
-from django.utils.decorators import decorator_from_middleware_with_args
+from django.utils.decorators import decorator_from_middleware
 from django.utils.deprecation import MiddlewareMixin
 from django.views import i18n
 
@@ -25,50 +25,36 @@ class AgencySessionRequired(MiddlewareMixin):
             raise AttributeError("Session not configured with agency")
 
 
-class DebugSession:
+class DebugSession(MiddlewareMixin):
     """Middleware to configure debug context in the request session."""
 
-    def __init__(self, get_response):
-        self.get_response = get_response
-
-    def __call__(self, request):
-        session.update(request, debug=DEBUG)
-        return self.get_response(request)
-
-
-class ViewPageEvent(MiddlewareMixin):
-    """Middleware sends an analytics event for pageviews."""
-
-    def __init__(self, get_response, page_name):
-        super().__init__(get_response)
-        # the value sent via Analyics API
-        self.page_name = page_name
-
     def process_request(self, request):
-        event = analytics.ViewPageEvent(request, self.page_name)
+        session.update(request, debug=DEBUG)
+        return None
+
+
+class ViewedPageEvent(MiddlewareMixin):
+    """Middleware sends an analytics event for page views."""
+
+    def process_response(self, request, response):
+        event = analytics.ViewedPageEvent(request)
         try:
             analytics.send_event(event)
         except Exception:
             logger.warning(f"Failed to send event: {event}")
         finally:
-            return None
+            return response
 
 
-pageview_decorator = decorator_from_middleware_with_args(ViewPageEvent)
+pageview_decorator = decorator_from_middleware(ViewedPageEvent)
 
 
-class ChangeLanguageEvent:
+class ChangedLanguageEvent(MiddlewareMixin):
     """Middleware hooks into django.views.i18n.set_language to send an analytics event."""
-
-    def __init__(self, get_response):
-        self.get_response = get_response
-
-    def __call__(self, request):
-        return self.get_response(request)
 
     def process_view(self, request, view_func, view_args, view_kwargs):
         if view_func == i18n.set_language:
             new_lang = request.POST["language"]
-            event = analytics.ChangeLanguageEvent(request, new_lang)
+            event = analytics.ChangedLanguageEvent(request, new_lang)
             analytics.send_event(event)
         return None

--- a/benefits/core/session.py
+++ b/benefits/core/session.py
@@ -1,6 +1,7 @@
 """
 The core application: helpers to work with request sessions.
 """
+import hashlib
 import logging
 import time
 import uuid
@@ -61,6 +62,12 @@ def debug(request):
     """Get the DEBUG flag from the request's session."""
     logger.debug("Get session debug flag")
     return bool(request.session.get(_DEBUG, False))
+
+
+def did(request):
+    """Get the session's device ID, a hashed version of the unique ID."""
+    hash = hashlib.sha512(bytes(uid(request), "utf8"))
+    return hash.hexdigest()[:26]
 
 
 def eligibility(request):
@@ -127,7 +134,7 @@ def token_expiry(request):
 
 
 def uid(request):
-    """Get the session's unique ID, or None."""
+    """Get the session's unique ID, generating a new one if necessary."""
     logger.debug("Get session uid")
     u = request.session.get(_UID)
     if not u:

--- a/benefits/core/session.py
+++ b/benefits/core/session.py
@@ -98,7 +98,7 @@ def reset(request):
     request.session[_TOKEN] = None
     request.session[_TOKEN_EXP] = None
 
-    if not uid(request):
+    if _UID not in request.session or not request.session[_UID]:
         logger.info("Reset session time and uid")
         request.session[_START] = int(time.time() * 1000)
         request.session[_UID] = str(uuid.uuid4())
@@ -107,7 +107,11 @@ def reset(request):
 def start(request):
     """Get the start time from the request's session, as integer milliseconds since Epoch."""
     logger.info("Get session time")
-    return request.session.get(_START)
+    s = request.session.get(_START)
+    if not s:
+        reset(request)
+        s = request.session.get(_START)
+    return s
 
 
 def token(request):
@@ -124,8 +128,12 @@ def token_expiry(request):
 
 def uid(request):
     """Get the session's unique ID, or None."""
-    logger.debug("Get session key")
-    return request.session.get(_UID)
+    logger.debug("Get session uid")
+    u = request.session.get(_UID)
+    if not u:
+        reset(request)
+        u = request.session.get(_UID)
+    return u
 
 
 def update(request, agency=None, debug=None, eligibility_types=None, origin=None, token=None, token_exp=None):

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -16,6 +16,8 @@
 
         <script src="https://code.jquery.com/jquery-3.4.1.min.js" type="text/javascript"></script>
         <script src="https://code.jquery.com/jquery-migrate-3.0.1.min.js"></script>
+
+        {% include "core/includes/analytics.html" with api_key=analytics.api_key uid=analytics.uid did=analytics.did %}
     </head>
     <body>
         <header role="banner" id="header" class="global-header">

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -75,6 +75,9 @@
                         localStorage.setItem("scroll", doc.scrollTop);
                     });
                 }
+                $("a[href^='https'], a[href^='tel']").on("click", function(e) {
+                    amplitude.getInstance().logEvent('clicked link', {'href': e.target.href, 'path': window.location.pathname});
+                });
             });
         </script>
     </body>

--- a/benefits/core/templates/core/includes/analytics.html
+++ b/benefits/core/templates/core/includes/analytics.html
@@ -1,0 +1,36 @@
+<script type="text/javascript">
+    (function(e,t){var n=e.amplitude||{_q:[],_iq:{}};var r=t.createElement("script")
+    ;r.type="text/javascript"
+    ;r.integrity="sha384-u0hlTAJ1tNefeBKwiBNwB4CkHZ1ck4ajx/pKmwWtc+IufKJiCQZ+WjJIi+7C6Ntm"
+    ;r.crossOrigin="anonymous";r.async=true
+    ;r.src="https://cdn.amplitude.com/libs/amplitude-8.1.0-min.gz.js"
+    ;r.onload=function(){if(!e.amplitude.runQueuedFunctions){
+    console.log("[Amplitude] Error: could not load SDK")}}
+    ;var i=t.getElementsByTagName("script")[0];i.parentNode.insertBefore(r,i)
+    ;function s(e,t){e.prototype[t]=function(){
+    this._q.push([t].concat(Array.prototype.slice.call(arguments,0)));return this}}
+    var o=function(){this._q=[];return this}
+    ;var a=["add","append","clearAll","prepend","set","setOnce","unset","preInsert","postInsert","remove"]
+    ;for(var c=0;c<a.length;c++){s(o,a[c])}n.Identify=o;var u=function(){this._q=[]
+    ;return this}
+    ;var l=["setProductId","setQuantity","setPrice","setRevenueType","setEventProperties"]
+    ;for(var p=0;p<l.length;p++){s(u,l[p])}n.Revenue=u
+    ;var d=["init","logEvent","logRevenue","setUserId","setUserProperties","setOptOut","setVersionName","setDomain","setDeviceId","enableTracking","setGlobalUserProperties","identify","clearUserProperties","setGroup","logRevenueV2","regenerateDeviceId","groupIdentify","onInit","logEventWithTimestamp","logEventWithGroups","setSessionId","resetSessionId"]
+    ;function v(e){function t(t){e[t]=function(){
+    e._q.push([t].concat(Array.prototype.slice.call(arguments,0)))}}
+    for(var n=0;n<d.length;n++){t(d[n])}}v(n);n.getInstance=function(e){
+    e=(!e||e.length===0?"$default_instance":e).toLowerCase()
+    ;if(!Object.prototype.hasOwnProperty.call(n._iq,e)){n._iq[e]={_q:[]};v(n._iq[e])
+    }return n._iq[e]};e.amplitude=n})(window,document);
+    amplitude.getInstance().init("{{api_key}}", "{{uid}}", {
+        sameSiteCookie: "strict",
+        includeReferrer: true,
+        secureCookie: true,
+        trackingOptions: {
+            dma: false,
+            ip_address: false
+        }
+    }, function(instance) {
+        instance.setDeviceId("{{did}}")
+    });
+</script>

--- a/benefits/core/views.py
+++ b/benefits/core/views.py
@@ -35,7 +35,7 @@ def _index_url():
     return reverse("core:index")
 
 
-@middleware.pageview_decorator("index")
+@middleware.pageview_decorator
 def index(request):
     """View handler for the main entry page."""
     session.reset(request)
@@ -57,7 +57,7 @@ def index(request):
     return PageTemplateResponse(request, page)
 
 
-@middleware.pageview_decorator("agency_index")
+@middleware.pageview_decorator
 def agency_index(request, agency):
     """View handler for an agency entry page."""
     session.reset(request)
@@ -74,7 +74,7 @@ def agency_index(request, agency):
     return PageTemplateResponse(request, page)
 
 
-@middleware.pageview_decorator("help")
+@middleware.pageview_decorator
 def help(request):
     """View handler for the help page."""
     if session.active_agency(request):
@@ -96,7 +96,7 @@ def help(request):
     return TemplateResponse(request, "core/help.html", page.context_dict())
 
 
-@middleware.pageview_decorator("payment_options")
+@middleware.pageview_decorator
 def payment_options(request):
     """View handler for the Payment Options page."""
     page = viewmodels.Page(
@@ -109,7 +109,7 @@ def payment_options(request):
     return TemplateResponse(request, "core/payment-options.html", page.context_dict())
 
 
-@middleware.pageview_decorator("bad_request")
+@middleware.pageview_decorator
 def bad_request(request, exception, template_name="400.html"):
     """View handler for HTTP 400 Bad Request responses."""
     if session.active_agency(request):
@@ -124,7 +124,7 @@ def bad_request(request, exception, template_name="400.html"):
     return HttpResponseBadRequest(t.render(page.context_dict()))
 
 
-@middleware.pageview_decorator("page_not_found")
+@middleware.pageview_decorator
 def page_not_found(request, exception, template_name="404.html"):
     """View handler for HTTP 404 Not Found responses."""
     if session.active_agency(request):
@@ -139,7 +139,7 @@ def page_not_found(request, exception, template_name="404.html"):
     return HttpResponseNotFound(t.render(page.context_dict()))
 
 
-@middleware.pageview_decorator("server_error")
+@middleware.pageview_decorator
 def server_error(request, template_name="500.html"):
     """View handler for HTTP 500 Server Error responses."""
     if session.active_agency(request):

--- a/benefits/core/views.py
+++ b/benefits/core/views.py
@@ -5,7 +5,6 @@ from django.http import HttpResponseBadRequest, HttpResponseNotFound, HttpRespon
 from django.template import loader
 from django.template.response import TemplateResponse
 from django.urls import reverse
-from django.utils.decorators import decorator_from_middleware
 from django.utils.translation import pgettext, ugettext as _
 
 from . import middleware, models, session, viewmodels
@@ -36,7 +35,7 @@ def _index_url():
     return reverse("core:index")
 
 
-@decorator_from_middleware(middleware.PageviewEvent)
+@middleware.pageview_decorator("index")
 def index(request):
     """View handler for the main entry page."""
     session.reset(request)
@@ -58,7 +57,7 @@ def index(request):
     return PageTemplateResponse(request, page)
 
 
-@decorator_from_middleware(middleware.PageviewEvent)
+@middleware.pageview_decorator("agency_index")
 def agency_index(request, agency):
     """View handler for an agency entry page."""
     session.reset(request)
@@ -75,7 +74,7 @@ def agency_index(request, agency):
     return PageTemplateResponse(request, page)
 
 
-@decorator_from_middleware(middleware.PageviewEvent)
+@middleware.pageview_decorator("help")
 def help(request):
     """View handler for the help page."""
     if session.active_agency(request):
@@ -97,7 +96,7 @@ def help(request):
     return TemplateResponse(request, "core/help.html", page.context_dict())
 
 
-@decorator_from_middleware(middleware.PageviewEvent)
+@middleware.pageview_decorator("payment_options")
 def payment_options(request):
     """View handler for the Payment Options page."""
     page = viewmodels.Page(
@@ -110,7 +109,7 @@ def payment_options(request):
     return TemplateResponse(request, "core/payment-options.html", page.context_dict())
 
 
-@decorator_from_middleware(middleware.PageviewEvent)
+@middleware.pageview_decorator("bad_request")
 def bad_request(request, exception, template_name="400.html"):
     """View handler for HTTP 400 Bad Request responses."""
     if session.active_agency(request):
@@ -125,7 +124,7 @@ def bad_request(request, exception, template_name="400.html"):
     return HttpResponseBadRequest(t.render(page.context_dict()))
 
 
-@decorator_from_middleware(middleware.PageviewEvent)
+@middleware.pageview_decorator("page_not_found")
 def page_not_found(request, exception, template_name="404.html"):
     """View handler for HTTP 404 Not Found responses."""
     if session.active_agency(request):
@@ -140,7 +139,7 @@ def page_not_found(request, exception, template_name="404.html"):
     return HttpResponseNotFound(t.render(page.context_dict()))
 
 
-@decorator_from_middleware(middleware.PageviewEvent)
+@middleware.pageview_decorator("server_error")
 def server_error(request, template_name="500.html"):
     """View handler for HTTP 500 Server Error responses."""
     if session.active_agency(request):

--- a/benefits/core/views.py
+++ b/benefits/core/views.py
@@ -5,9 +5,10 @@ from django.http import HttpResponseBadRequest, HttpResponseNotFound, HttpRespon
 from django.template import loader
 from django.template.response import TemplateResponse
 from django.urls import reverse
+from django.utils.decorators import decorator_from_middleware
 from django.utils.translation import pgettext, ugettext as _
 
-from . import models, session, viewmodels
+from . import middleware, models, session, viewmodels
 
 
 def PageTemplateResponse(request, page_vm):
@@ -35,6 +36,7 @@ def _index_url():
     return reverse("core:index")
 
 
+@decorator_from_middleware(middleware.PageviewEvent)
 def index(request):
     """View handler for the main entry page."""
     session.reset(request)
@@ -56,6 +58,7 @@ def index(request):
     return PageTemplateResponse(request, page)
 
 
+@decorator_from_middleware(middleware.PageviewEvent)
 def agency_index(request, agency):
     """View handler for an agency entry page."""
     session.reset(request)
@@ -72,6 +75,7 @@ def agency_index(request, agency):
     return PageTemplateResponse(request, page)
 
 
+@decorator_from_middleware(middleware.PageviewEvent)
 def help(request):
     """View handler for the help page."""
     if session.active_agency(request):
@@ -93,6 +97,7 @@ def help(request):
     return TemplateResponse(request, "core/help.html", page.context_dict())
 
 
+@decorator_from_middleware(middleware.PageviewEvent)
 def payment_options(request):
     """View handler for the Payment Options page."""
     page = viewmodels.Page(
@@ -105,6 +110,7 @@ def payment_options(request):
     return TemplateResponse(request, "core/payment-options.html", page.context_dict())
 
 
+@decorator_from_middleware(middleware.PageviewEvent)
 def bad_request(request, exception, template_name="400.html"):
     """View handler for HTTP 400 Bad Request responses."""
     if session.active_agency(request):
@@ -119,6 +125,7 @@ def bad_request(request, exception, template_name="400.html"):
     return HttpResponseBadRequest(t.render(page.context_dict()))
 
 
+@decorator_from_middleware(middleware.PageviewEvent)
 def page_not_found(request, exception, template_name="404.html"):
     """View handler for HTTP 404 Not Found responses."""
     if session.active_agency(request):
@@ -133,6 +140,7 @@ def page_not_found(request, exception, template_name="404.html"):
     return HttpResponseNotFound(t.render(page.context_dict()))
 
 
+@decorator_from_middleware(middleware.PageviewEvent)
 def server_error(request, template_name="500.html"):
     """View handler for HTTP 500 Server Error responses."""
     if session.active_agency(request):

--- a/benefits/discounts/templates/discounts/index.html
+++ b/benefits/discounts/templates/discounts/index.html
@@ -7,12 +7,18 @@
         {{ provider.loading_text }}
     </button>
     <script>
+        var startedEvent = "started payment connection", closedEvent = "closed payment connection";
+
         $.getScript("{{ provider.card_tokenize_url }}")
             .done(function() {
                 $(".loading").remove();
                 $(".invisible").removeClass("invisible");
 
                 $("{{ provider.element_id }}").on("click", function() {
+                    amplitude.getInstance().logEvent(startedEvent, {
+                        card_tokenize_url: "{{ provider.card_tokenize_url }}",
+                        card_tokenize_func: "{{ provider.card_tokenize_func }}"
+                    });
                     $(this).addClass("disabled").attr("aria-disabled", "true").text("{{ provider.loading_text }}");
                 });
 
@@ -28,6 +34,8 @@
                         /* This function executes when the
                         /* card/address verification returns
                         /* successfully with a token from discount server */
+                        amplitude.getInstance().logEvent(closedEvent, {status: "success"});
+
                         var form = $("form[action='{{ forms.tokenize_success }}']");
                         $("#card_token", form).val(response.token);
                         form.submit();
@@ -36,6 +44,8 @@
                         /* This function executes when the
                         /* card/address verification fails and server
                         /* return verification failure message */
+                        amplitude.getInstance().logEvent(closedEvent, {status: "fail"});
+
                         var form = $("form[action='{{ forms.tokenize_retry }}']");
                         form.submit();
                     },
@@ -43,6 +53,8 @@
                         /* This function executes when the
                         /* server returns error or token is invalid.
                         /* 400 or 500 will return. */
+                        amplitude.getInstance().logEvent(closedEvent, {status: "error", error: response});
+
                         var form = $("form[action='{{ forms.tokenize_retry }}']");
                         form.submit();
                     },
@@ -50,7 +62,8 @@
                         /* This function executes when the
                         /* user cancels and closes the window
                         /* and returns to home page. */
-                        console.log('canceled');
+                        amplitude.getInstance().logEvent(closedEvent, {status: "cancel"});
+
                         return location.reload();
                     }
                 });

--- a/benefits/discounts/views.py
+++ b/benefits/discounts/views.py
@@ -51,7 +51,8 @@ def _index(request):
             ),
         ],
     )
-    context = page.context_dict()
+    context = {}
+    context.update(page.context_dict())
 
     # add agency details
     agency_vm = viewmodels.TransitAgency(agency)
@@ -69,14 +70,10 @@ def _index(request):
     logger.info(f"card_tokenize_url: {context['provider'].card_tokenize_url}")
 
     # the tokenize form URLs are injected to page-generated Javascript
-    context.update(
-        {
-            "forms": {
-                "tokenize_retry": reverse(tokenize_retry_form.action_url),
-                "tokenize_success": reverse(tokenize_success_form.action_url),
-            }
-        }
-    )
+    context["forms"] = {
+        "tokenize_retry": reverse(tokenize_retry_form.action_url),
+        "tokenize_success": reverse(tokenize_success_form.action_url),
+    }
 
     return TemplateResponse(request, "discounts/index.html", context)
 
@@ -149,8 +146,12 @@ def retry(request):
         raise Exception("This view method only supports POST.")
 
 
+@middleware.pageview_decorator
 def success(request):
     """View handler for the final success page."""
+
+    request.path = "/discounts/success"
+
     page = viewmodels.Page(
         title=_("discounts.success.title"),
         icon=viewmodels.Icon("bankcardcheck", pgettext("image alt text", "core.icons.bankcardcheck")),

--- a/benefits/eligibility/analytics.py
+++ b/benefits/eligibility/analytics.py
@@ -1,0 +1,38 @@
+"""
+The eligibility application: analytics implementation.
+"""
+from benefits.core import analytics as core
+
+
+class StartedEligibilityEvent(core.Event):
+    def __init__(self, request):
+        """Analytics event representing the beginning of an eligibility verification check."""
+        super().__init__(request, "started eligibility")
+
+
+class ReturnedEligibilityEvent(core.Event):
+    def __init__(self, request, status, error=None):
+        """Analytics event representing the end of an eligibility verification check."""
+        super().__init__(request, "returned eligibility")
+        if str(status).lower() in ("error", "fail", "success"):
+            self.update_event_properties(status=status, error=error)
+
+
+def started_eligibility(request):
+    """Send the "started eligibility" analytics event."""
+    core.send_event(StartedEligibilityEvent(request))
+
+
+def returned_error(request, error):
+    """Send the "returned eligibility" analytics event with an error status."""
+    core.send_event(ReturnedEligibilityEvent(request, status="error", error=error))
+
+
+def returned_fail(request):
+    """Send the "returned eligibility" analytics event with a fail status."""
+    core.send_event(ReturnedEligibilityEvent(request, status="fail"))
+
+
+def returned_success(request):
+    """Send the "returned eligibility" analytics event with a success status."""
+    core.send_event(ReturnedEligibilityEvent(request, status="success"))

--- a/benefits/eligibility/api.py
+++ b/benefits/eligibility/api.py
@@ -140,8 +140,6 @@ class Client:
 
         try:
             r = requests.get(self.verifier.api_url, headers=self._auth_headers(token))
-            del token
-            r.raise_for_status()
         except requests.ConnectionError:
             raise ApiError("Connection to verification server failed")
         except requests.Timeout:

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -50,7 +50,7 @@ MIDDLEWARE = [
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "benefits.core.middleware.DebugSession",
-    "benefits.core.middleware.ChangeLanguageEvent",
+    "benefits.core.middleware.ChangedLanguageEvent",
 ]
 
 if ADMIN:

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -50,7 +50,7 @@ MIDDLEWARE = [
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "benefits.core.middleware.DebugSession",
-    "benefits.core.middleware.LanguageChangeEvent",
+    "benefits.core.middleware.ChangeLanguageEvent",
 ]
 
 if ADMIN:

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -75,6 +75,7 @@ ROOT_URLCONF = "benefits.urls"
 
 template_ctx_processors = [
     "django.template.context_processors.request",
+    "benefits.core.context_processors.analytics",
 ]
 
 if DEBUG:

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -181,4 +181,4 @@ LOGGING = {
 
 # Analytics configuration
 
-ANALYTICS_KEY = os.environ.get("AMP_API_KEY")
+ANALYTICS_KEY = os.environ.get("ANALYTICS_KEY")

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -50,6 +50,7 @@ MIDDLEWARE = [
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "benefits.core.middleware.DebugSession",
+    "benefits.core.middleware.LanguageChangeEvent",
 ]
 
 if ADMIN:

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -176,3 +176,7 @@ LOGGING = {
     },
     "loggers": {"django": {"handlers": ["default"], "propagate": False}},
 }
+
+# Analytics configuration
+
+ANALYTICS_KEY = os.environ.get("AMP_API_KEY")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build: .
     image: benefits_client:latest
     environment:
-      - AMP_API_KEY
+      - ANALYTICS_KEY
       - DJANGO_ADMIN
       - DJANGO_ALLOWED_HOSTS
       - DJANGO_DB
@@ -25,7 +25,7 @@ services:
       dockerfile: Dockerfile.dev
     image: benefits_client:dev
     environment:
-      - AMP_API_KEY
+      - ANALYTICS_KEY
       - DJANGO_ADMIN
       - DJANGO_ALLOWED_HOSTS
       - DJANGO_DB

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     build: .
     image: benefits_client:latest
     environment:
+      - AMP_API_KEY
       - DJANGO_ADMIN
       - DJANGO_ALLOWED_HOSTS
       - DJANGO_DB
@@ -24,6 +25,7 @@ services:
       dockerfile: Dockerfile.dev
     image: benefits_client:dev
     environment:
+      - AMP_API_KEY
       - DJANGO_ADMIN
       - DJANGO_ALLOWED_HOSTS
       - DJANGO_DB


### PR DESCRIPTION
Use Amplitude to track key events through the app flow while maintaining user anonymity. The [javascript SDK](https://developers.amplitude.com/docs/javascript) is used for a handful of client-side events, but the bulk of the logging is done server-side via the [HTTP API V2](https://developers.amplitude.com/docs/http-api-v2).

* `user_id` and `device_id` are random UUIDs generated on the server per-session
* event for important lifecycle pages
* events for begin/end of eligibility process
* events for begin/end of enrollment process
* event for language change
* events for external link clicks

Following guidance from Amplitude's [Data Taxonomy Playbook](https://help.amplitude.com/hc/en-us/articles/115000465251-Data-Taxonomy-Playbook)