### PR TITLE
Pre-commit hook runs bandit

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,4 +1,4 @@
-name: Lint and formatting
+name: Pre-commit checks
 
 on:
   push:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,5 +24,6 @@ repos:
     rev: 1.7.0
     hooks:
       - id: bandit
-        args: ["-ll", "-x", "./server"]
+        args: ["-ll"]
+        exclude: ^server/
         files: .py$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,9 @@ repos:
       - id: flake8
         types:
           - python
+  - repo: https://github.com/pycqa/bandit
+    rev: 1.7.0
+    hooks:
+      - id: bandit
+        args: ["-ll", "-x ./server"]
+        files: .py$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,5 +24,5 @@ repos:
     rev: 1.7.0
     hooks:
       - id: bandit
-        args: ["-ll", "-x ./server"]
+        args: ["-ll", "-x", "./server"]
         files: .py$

--- a/benefits/core/session.py
+++ b/benefits/core/session.py
@@ -21,9 +21,12 @@ _ELIGIBILITY = "eligibility"
 _LANG = "lang"
 _ORIGIN = "origin"
 _START = "start"
-_TOKEN = "token"
-_TOKEN_EXP = "token_exp"
 _UID = "uid"
+
+# ignore bandit B105:hardcoded_password_string
+# as these are not passwords, but keys for the session dict
+_TOKEN = "token"  # nosec
+_TOKEN_EXP = "token_exp"  # nosec
 
 
 def agency(request):


### PR DESCRIPTION
[Bandit](https://bandit.readthedocs.io/en/latest/) looks for common security issues by analyzing python code.

Exclude the test server directory since this is not part of any production deployment, and is meant for local testing only. The exclusion is done via pre-commit's `exclude` key, since the action runs pre-commit with `--all-files` and Bandit's exclude doesn't take effect when given an explicit list of files to check. See https://github.com/PyCQA/bandit/issues/499 and https://stackoverflow.com/a/61046953