### PR TITLE
Fix API response parsing

### DIFF
--- a/benefits/eligibility/api.py
+++ b/benefits/eligibility/api.py
@@ -75,7 +75,11 @@ class ResponseToken:
         logger.info("Read encrypted token from response")
 
         try:
-            encrypted_signed_token = response.json()
+            encrypted_signed_token = response.text
+            if not encrypted_signed_token:
+                raise ValueError()
+            # strip extra spaces and wrapping quote chars
+            encrypted_signed_token = encrypted_signed_token.strip("'\n\"")
         except ValueError:
             raise TokenError("Invalid response format")
 

--- a/benefits/eligibility/api.py
+++ b/benefits/eligibility/api.py
@@ -139,6 +139,7 @@ class Client:
             raise TokenError("Failed to tokenize form values")
 
         try:
+            logger.debug(f"GET request to {self.verifier.api_url}")
             r = requests.get(self.verifier.api_url, headers=self._auth_headers(token))
         except requests.ConnectionError:
             raise ApiError("Connection to verification server failed")


### PR DESCRIPTION
Interpreting the HTTP response as JSON is incorrect; the response body comes back as the text of the encrypted, encoded JWT. 