### PR TITLE
Agency info URLs

### DIFF
--- a/benefits/core/migrations/0001_initial.py
+++ b/benefits/core/migrations/0001_initial.py
@@ -65,7 +65,7 @@ class Migration(migrations.Migration):
                 ("long_name", models.TextField()),
                 ("agency_id", models.TextField()),
                 ("merchant_id", models.TextField()),
-                ("logo_url", models.URLField()),
+                ("info_url", models.URLField()),
                 ("phone", models.TextField()),
                 ("active", models.BooleanField(default=False)),
                 # fmt: off

--- a/benefits/core/migrations/0001_initial.py
+++ b/benefits/core/migrations/0001_initial.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name="BenefitsProvider",
             fields=[
-                ("id", models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("id", models.AutoField(primary_key=True, serialize=False, verbose_name="ID")),
                 ("name", models.TextField()),
                 ("api_base_url", models.TextField()),
                 ("api_access_token_endpoint", models.TextField()),
@@ -33,7 +33,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name="EligibilityType",
             fields=[
-                ("id", models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("id", models.AutoField(primary_key=True, serialize=False, verbose_name="ID")),
                 ("name", models.TextField()),
                 ("label", models.TextField()),
                 ("group_id", models.TextField()),
@@ -42,7 +42,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name="EligibilityVerifier",
             fields=[
-                ("id", models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("id", models.AutoField(primary_key=True, serialize=False, verbose_name="ID")),
                 ("name", models.TextField()),
                 ("api_url", models.TextField()),
                 ("api_auth_header", models.TextField()),
@@ -59,7 +59,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name="TransitAgency",
             fields=[
-                ("id", models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("id", models.AutoField(primary_key=True, serialize=False, verbose_name="ID")),
                 ("slug", models.TextField()),
                 ("short_name", models.TextField()),
                 ("long_name", models.TextField()),

--- a/benefits/core/models.py
+++ b/benefits/core/models.py
@@ -102,7 +102,7 @@ class TransitAgency(models.Model):
     long_name = models.TextField()
     agency_id = models.TextField()
     merchant_id = models.TextField()
-    logo_url = models.URLField()
+    info_url = models.URLField()
     phone = models.TextField()
     active = models.BooleanField(default=False)
     eligibility_types = models.ManyToManyField(EligibilityType)

--- a/benefits/core/models.py
+++ b/benefits/core/models.py
@@ -23,6 +23,7 @@ class BenefitsProvider(models.Model):
     """An entity that provides transit benefits."""
 
     # fmt: off
+    id = models.AutoField(primary_key=True)
     name = models.TextField()
     api_base_url = models.TextField()
     api_access_token_endpoint = models.TextField()
@@ -46,6 +47,7 @@ class BenefitsProvider(models.Model):
 class EligibilityType(models.Model):
     """A single conditional eligibility type."""
 
+    id = models.AutoField(primary_key=True)
     name = models.TextField()
     label = models.TextField()
     group_id = models.TextField()
@@ -64,6 +66,7 @@ class EligibilityVerifier(models.Model):
     """An entity that verifies eligibility."""
 
     # fmt: off
+    id = models.AutoField(primary_key=True)
     name = models.TextField()
     api_url = models.TextField()
     api_auth_header = models.TextField()
@@ -93,6 +96,7 @@ class TransitAgency(models.Model):
     """An agency offering transit service."""
 
     # fmt: off
+    id = models.AutoField(primary_key=True)
     slug = models.TextField()
     short_name = models.TextField()
     long_name = models.TextField()

--- a/benefits/core/viewmodels.py
+++ b/benefits/core/viewmodels.py
@@ -31,9 +31,12 @@ class Button:
         self.url = kwargs.get("url")
 
     @staticmethod
-    def agency_phone_link(agency):
-        """Create a tel: link button with the agency's phone number."""
-        return Button.link(classes="pt-0", label=agency.long_name, text=agency.phone, url=f"tel:{agency.phone}")
+    def agency_contact_links(agency):
+        """"""
+        return [
+            Button.link(classes="agency-url", label=agency.long_name, text=_("core.agency.url.text"), url=agency.info_url),
+            Button.link(classes="agency-phone", text=agency.phone, url=f"tel:{agency.phone}"),
+        ]
 
     @staticmethod
     def home(request, text=_("core.buttons.home")):
@@ -235,7 +238,7 @@ class TransitAgency:
             self.long_name = model.long_name
             self.agency_id = model.agency_id
             self.merchant_id = model.merchant_id
-            self.logo_url = model.logo_url
+            self.info_url = model.info_url
             self.phone = model.phone
 
     def context_dict(self):

--- a/benefits/core/viewmodels.py
+++ b/benefits/core/viewmodels.py
@@ -34,7 +34,7 @@ class Button:
     def agency_contact_links(agency):
         """"""
         return [
-            Button.link(classes="agency-url", label=agency.long_name, text=_("core.agency.url.text"), url=agency.info_url),
+            Button.link(classes="agency-url", label=agency.long_name, text=agency.info_url, url=agency.info_url),
             Button.link(classes="agency-phone", text=agency.phone, url=f"tel:{agency.phone}"),
         ]
 

--- a/benefits/core/views.py
+++ b/benefits/core/views.py
@@ -79,9 +79,9 @@ def help(request):
     """View handler for the help page."""
     if session.active_agency(request):
         agency = session.agency(request)
-        buttons = [viewmodels.Button.agency_phone_link(agency)]
+        buttons = viewmodels.Button.agency_contact_links(agency)
     else:
-        buttons = [viewmodels.Button.agency_phone_link(a) for a in models.TransitAgency.all_active()]
+        buttons = [btn for a in models.TransitAgency.all_active() for btn in viewmodels.Button.agency_contact_links(a)]
 
     buttons.append(viewmodels.Button.home(request, _("core.buttons.back")))
 

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -113,7 +113,7 @@ def unverified(request):
 
     # tel: link to agency phone number
     agency = session.agency(request)
-    buttons = [viewmodels.Button.agency_phone_link(agency)]
+    buttons = viewmodels.Button.agency_contact_links(agency)
 
     page = viewmodels.Page(
         title=_("eligibility.unverified.title"),

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -130,11 +130,9 @@ def retry(request):
                 icon=viewmodels.Icon("bankcardquestion", pgettext("image alt text", "core.icons.bankcardquestion")),
                 content_title=_("enrollment.retry.title"),
                 paragraphs=[_("enrollment.retry.p1")],
-                buttons=[
-                    viewmodels.Button.agency_phone_link(agency),
-                    viewmodels.Button.primary(text=_("enrollment.retry.button"), url=session.origin(request)),
-                ],
+                buttons=viewmodels.Button.agency_contact_links(agency),
             )
+            page.buttons.append(viewmodels.Button.primary(text=_("enrollment.retry.button"), url=session.origin(request)))
             return PageTemplateResponse(request, page)
         else:
             raise Exception("Invalid retry submission.")

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -118,10 +118,6 @@ msgstr ""
 "You can still get your discount by going through your local transit "
 "provider’s application process."
 
-#: benefits/core/viewmodels.py:37
-msgid "core.agency.url.text"
-msgstr "More information online"
-
 #: benefits/core/viewmodels.py:122
 msgid "core.page.title"
 msgstr "Transit Benefits"

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues\n"
-"POT-Creation-Date: 2021-04-20 20:00+0000\n"
+"POT-Creation-Date: 2021-05-20 19:20+0000\n"
 "Language: English\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -63,7 +63,7 @@ msgstr ""
 
 #: benefits/core/templates/core/includes/nocookies.html:8
 #: benefits/core/templates/core/includes/noscript.html:8
-#: benefits/core/viewmodels.py:39
+#: benefits/core/viewmodels.py:42
 msgid "core.buttons.home"
 msgstr "Return home"
 
@@ -118,49 +118,53 @@ msgstr ""
 "You can still get your discount by going through your local transit "
 "provider’s application process."
 
-#: benefits/core/viewmodels.py:119
+#: benefits/core/viewmodels.py:37
+msgid "core.agency.url.text"
+msgstr "More information online"
+
+#: benefits/core/viewmodels.py:122
 msgid "core.page.title"
 msgstr "Transit Benefits"
 
-#: benefits/core/viewmodels.py:165 benefits/core/viewmodels.py:167
+#: benefits/core/viewmodels.py:168 benefits/core/viewmodels.py:170
 #: benefits/eligibility/forms.py:34
 msgid "core.error"
 msgstr "Error"
 
-#: benefits/core/viewmodels.py:166
+#: benefits/core/viewmodels.py:169
 msgctxt "image alt text"
 msgid "core.icons.sadbus"
 msgstr "Bus icon with flat tire"
 
-#: benefits/core/viewmodels.py:168
+#: benefits/core/viewmodels.py:171
 msgid "core.error.server.content_title"
 msgstr "Unfortunately, our system is having a problem right now."
 
-#: benefits/core/viewmodels.py:174 benefits/core/viewmodels.py:175
+#: benefits/core/viewmodels.py:177 benefits/core/viewmodels.py:178
 msgid "core.error.server.title"
 msgstr "Service is down"
 
-#: benefits/core/viewmodels.py:176
+#: benefits/core/viewmodels.py:179
 msgid "core.error.server.p1"
 msgstr "We should be back in operation soon!"
 
-#: benefits/core/viewmodels.py:176
+#: benefits/core/viewmodels.py:179
 msgid "core.error.server.p2"
 msgstr "Please check back later."
 
-#: benefits/core/viewmodels.py:184
+#: benefits/core/viewmodels.py:187
 msgid "core.error.notfound.title"
 msgstr "Page not found"
 
-#: benefits/core/viewmodels.py:185
+#: benefits/core/viewmodels.py:188
 msgid "core.error.notfound.content_title"
 msgstr "We can’t find that page"
 
-#: benefits/core/viewmodels.py:186
+#: benefits/core/viewmodels.py:189
 msgid "core.error.notfound.p1"
 msgstr "It looks like that page doesn’t exist or it was moved."
 
-#: benefits/core/viewmodels.py:209
+#: benefits/core/viewmodels.py:212
 msgid "core.buttons.wait"
 msgstr "Please wait..."
 
@@ -267,7 +271,7 @@ msgstr "Your California ID"
 msgid "eligibility.index.item1.text"
 msgstr "Driver’s license or ID card"
 
-#: benefits/eligibility/views.py:30 benefits/enrollment/views.py:152
+#: benefits/eligibility/views.py:30 benefits/enrollment/views.py:150
 msgctxt "image alt text"
 msgid "core.icons.bankcardcheck"
 msgstr "Bank card icon with contactless symbol and checkmark"
@@ -378,17 +382,17 @@ msgstr ""
 msgid "enrollment.retry.button"
 msgstr "Try again"
 
-#: benefits/enrollment/views.py:151 benefits/enrollment/views.py:153
+#: benefits/enrollment/views.py:149 benefits/enrollment/views.py:151
 msgid "enrollment.success.title"
 msgstr "Success!"
 
-#: benefits/enrollment/views.py:154
+#: benefits/enrollment/views.py:152
 msgid "enrollment.success.p1"
 msgstr ""
 "Your discount is now linked to your bank card. You were not charged anything "
 "today."
 
-#: benefits/enrollment/views.py:154
+#: benefits/enrollment/views.py:152
 msgid "enrollment.success.p2"
 msgstr ""
 "When boarding transit, pay with this same card, and your discount will "

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -121,10 +121,6 @@ msgstr ""
 "Aún puede obtener su descuento mediante el proceso de solicitud de su "
 "proveedor de transporte público."
 
-#: benefits/core/viewmodels.py:37
-msgid "core.agency.url.text"
-msgstr "Más información en línea"
-
 #: benefits/core/viewmodels.py:122
 msgid "core.page.title"
 msgstr "Beneficios del Tránsito"

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues\n"
-"POT-Creation-Date: 2021-04-20 20:00+0000\n"
+"POT-Creation-Date: 2021-05-20 19:20+0000\n"
 "Language: Español\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -65,7 +65,7 @@ msgstr ""
 
 #: benefits/core/templates/core/includes/nocookies.html:8
 #: benefits/core/templates/core/includes/noscript.html:8
-#: benefits/core/viewmodels.py:39
+#: benefits/core/viewmodels.py:42
 msgid "core.buttons.home"
 msgstr "Regresar a la pantalla de inicio"
 
@@ -121,49 +121,53 @@ msgstr ""
 "Aún puede obtener su descuento mediante el proceso de solicitud de su "
 "proveedor de transporte público."
 
-#: benefits/core/viewmodels.py:119
+#: benefits/core/viewmodels.py:37
+msgid "core.agency.url.text"
+msgstr "Más información en línea"
+
+#: benefits/core/viewmodels.py:122
 msgid "core.page.title"
 msgstr "Beneficios del Tránsito"
 
-#: benefits/core/viewmodels.py:165 benefits/core/viewmodels.py:167
+#: benefits/core/viewmodels.py:168 benefits/core/viewmodels.py:170
 #: benefits/eligibility/forms.py:34
 msgid "core.error"
 msgstr "Error"
 
-#: benefits/core/viewmodels.py:166
+#: benefits/core/viewmodels.py:169
 msgctxt "image alt text"
 msgid "core.icons.sadbus"
 msgstr "Icono de autobus con llanta ponchada"
 
-#: benefits/core/viewmodels.py:168
+#: benefits/core/viewmodels.py:171
 msgid "core.error.server.content_title"
 msgstr "El servicio no está funcionando"
 
-#: benefits/core/viewmodels.py:174 benefits/core/viewmodels.py:175
+#: benefits/core/viewmodels.py:177 benefits/core/viewmodels.py:178
 msgid "core.error.server.title"
 msgstr "El servicio no está funcionando"
 
-#: benefits/core/viewmodels.py:176
+#: benefits/core/viewmodels.py:179
 msgid "core.error.server.p1"
 msgstr "¡Pronto volveremos a estar en funcionamiento!"
 
-#: benefits/core/viewmodels.py:176
+#: benefits/core/viewmodels.py:179
 msgid "core.error.server.p2"
 msgstr "Por favor, vuelva más tarde."
 
-#: benefits/core/viewmodels.py:184
+#: benefits/core/viewmodels.py:187
 msgid "core.error.notfound.title"
 msgstr "No podemos encontrar esa página"
 
-#: benefits/core/viewmodels.py:185
+#: benefits/core/viewmodels.py:188
 msgid "core.error.notfound.content_title"
 msgstr "No podemos encontrar esa página"
 
-#: benefits/core/viewmodels.py:186
+#: benefits/core/viewmodels.py:189
 msgid "core.error.notfound.p1"
 msgstr "Parece que esa página no existe o se ha movido."
 
-#: benefits/core/viewmodels.py:209
+#: benefits/core/viewmodels.py:212
 msgid "core.buttons.wait"
 msgstr "Espere por favor..."
 
@@ -270,7 +274,7 @@ msgstr "Tu identificación de California"
 msgid "eligibility.index.item1.text"
 msgstr "Licencia de conducir o tarjeta de identificación"
 
-#: benefits/eligibility/views.py:30 benefits/enrollment/views.py:152
+#: benefits/eligibility/views.py:30 benefits/enrollment/views.py:150
 msgctxt "image alt text"
 msgid "core.icons.bankcardcheck"
 msgstr ""
@@ -386,17 +390,17 @@ msgstr ""
 msgid "enrollment.retry.button"
 msgstr "Inténtalo de nuevo"
 
-#: benefits/enrollment/views.py:151 benefits/enrollment/views.py:153
+#: benefits/enrollment/views.py:149 benefits/enrollment/views.py:151
 msgid "enrollment.success.title"
 msgstr "¡Éxito!"
 
-#: benefits/enrollment/views.py:154
+#: benefits/enrollment/views.py:152
 msgid "enrollment.success.p1"
 msgstr ""
 "Su descuento ahora está vinculado a su tarjeta bancaria. Hoy no se le cobró "
 "nada."
 
-#: benefits/enrollment/views.py:154
+#: benefits/enrollment/views.py:152
 msgid "enrollment.success.p2"
 msgstr ""
 "Pague con esta misma tarjeta al abordar el transporte público y su descuento "

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -152,6 +152,15 @@ footer {
     width: 100%;
 }
 
+.container.content .btn-lg.agency-url {
+    margin-bottom: 0;
+    padding-bottom: 0;
+}
+.container.content .btn-lg.agency-url,
+.container.content .btn-lg.agency-phone {
+    padding-top: 0;
+}
+
 .container.content .btn-link {
     text-decoration: underline;
 }

--- a/data/client.json
+++ b/data/client.json
@@ -64,7 +64,7 @@
             "long_name": "ABC Transit Company",
             "agency_id": "abc123",
             "merchant_id": "abc",
-            "logo_url": "https://www.example.com/logo.png",
+            "info_url": "https://www.example.com/help",
             "phone": "800-555-5555",
             "active": true,
             "eligibility_types": [
@@ -85,7 +85,7 @@
             "long_name": "DEF Transit Lines",
             "agency_id": "def456",
             "merchant_id": "deftl",
-            "logo_url": "https://www.example.com/logo.png",
+            "info_url": "https://www.example.com/help",
             "phone": "321-555-5555",
             "active": true,
             "eligibility_types": [


### PR DESCRIPTION
Rename the unused `logo_url` field to `help_url`, meant to point to the agency's online resources for their benefits program.

Display the a link to the agency's help URL along with phone link wherever a phone link was displayed before.

Closes #58.

Also introduces explicit primary key `id` fields on each model, to suppress newer Django warnings related to a changed default. The explicit fields implement what was implicit and default in versions of Django prior to the new warning.