### PR TITLE
Deploy fixes

### DIFF
--- a/.aws/ecs-task-definition.json
+++ b/.aws/ecs-task-definition.json
@@ -84,7 +84,7 @@
             "essential": false,
             "image": "amazon/aws-cli",
             "repositoryCredentials": {
-                "credentialsParameter": "arn:aws:ssm:us-west-2:373436483103:parameter/DockerHubSecret"
+                "credentialsParameter": "arn:aws:secretsmanager:us-west-2:373436483103:secret:DockerHubSecret-pf4cDS"
             },
             "entryPoint": ["/bin/sh"],
             "command": ["-c", "aws s3 cp s3://${CONFIG_BUCKET_PATH} /aws"],

--- a/.aws/ecs-task-definition.json
+++ b/.aws/ecs-task-definition.json
@@ -83,6 +83,9 @@
             },
             "essential": false,
             "image": "amazon/aws-cli",
+            "repositoryCredentials": {
+                "credentialsParameter": "arn:aws:ssm:us-west-2:373436483103:parameter/DockerHubSecret"
+            },
             "entryPoint": ["/bin/sh"],
             "command": ["-c", "aws s3 cp s3://${CONFIG_BUCKET_PATH} /aws"],
             "environment": [

--- a/benefits/core/templates/core/includes/button.html
+++ b/benefits/core/templates/core/includes/button.html
@@ -2,7 +2,11 @@
 {% if button.label %}
 <label>{{ button.label }}</label>
 {% endif %}
-<a {%if button.id %}id="{{ button.id }}"{% endif %} class="{{ button.classes | join:" " }}" href="{{ button.url }}" role="button">
+<a {%if button.id %}id="{{ button.id }}"{% endif %}
+    {%if button.target %}target="{{ button.target }}"{% endif %}
+    class="{{ button.classes | join:" " }}"
+    href="{{ button.url }}"
+    role="button">
     {{ button.text }}
 </a>
 {% endif %}

--- a/benefits/core/viewmodels.py
+++ b/benefits/core/viewmodels.py
@@ -29,13 +29,16 @@ class Button:
         self.label = kwargs.get("label")
         self.text = kwargs.get("text", "Button")
         self.url = kwargs.get("url")
+        self.target = kwargs.get("target")
 
     @staticmethod
     def agency_contact_links(agency):
-        """"""
+        """Create link buttons for agency contact information."""
         return [
-            Button.link(classes="agency-url", label=agency.long_name, text=agency.info_url, url=agency.info_url),
+            # fmt: off
+            Button.link(classes="agency-url", label=agency.long_name, text=agency.info_url, url=agency.info_url, target="_blank"),  # noqa: E501
             Button.link(classes="agency-phone", text=agency.phone, url=f"tel:{agency.phone}"),
+            # fmt: on
         ]
 
     @staticmethod


### PR DESCRIPTION
Need to sign in to Docker Hub with credentials because we're being rate limited pulling `aws/aws-cli` from a public AWS IP address.  

Quick fix on the `agency.info_url` to allow `target=_blank`.