### PR TITLE
Refactor ECS task and workflow for environments

### DIFF
--- a/.aws/ecs-task.json
+++ b/.aws/ecs-task.json
@@ -1,6 +1,6 @@
 {
-    "executionRoleArn": "arn:aws:iam::373436483103:role/cal-itp-benefits-client-task-execution-role",
-    "taskRoleArn": "arn:aws:iam::373436483103:role/cal-itp-benefits-client-task-role",
+    "executionRoleArn": "arn:aws:iam::<aws_account>:role/cal-itp-benefits-client-task-execution-role",
+    "taskRoleArn": "arn:aws:iam::<aws_account>:role/cal-itp-benefits-client-task-role",
     "containerDefinitions": [
         {
             "name": "cal-itp-benefits-client",
@@ -8,7 +8,7 @@
                 "logDriver": "awslogs",
                 "options": {
                     "awslogs-group": "/ecs/cal-itp-benefits-client",
-                    "awslogs-region": "us-west-2",
+                    "awslogs-region": "<aws_region>",
                     "awslogs-stream-prefix": "ecs"
                 }
             },
@@ -26,10 +26,6 @@
                 }
             ],
             "environment": [
-                {
-                    "name": "DJANGO_LOG_LEVEL",
-                    "value": "DEBUG"
-                }
             ],
             "healthCheck": {
                 "retries": 2,
@@ -43,23 +39,27 @@
             },
             "secrets": [
                 {
-                    "valueFrom": "arn:aws:ssm:us-west-2:373436483103:parameter/ANALYTICS_KEY",
+                    "valueFrom": "arn:aws:ssm:<aws_region>:<aws_account>:parameter/ANALYTICS_KEY",
                     "name": "ANALYTICS_KEY"
                 },
                 {
-                    "valueFrom": "arn:aws:ssm:us-west-2:373436483103:parameter/DJANGO_ALLOWED_HOSTS",
+                    "valueFrom": "arn:aws:ssm:<aws_region>:<aws_account>:parameter/DJANGO_ALLOWED_HOSTS",
                     "name": "DJANGO_ALLOWED_HOSTS"
                 },
                 {
-                    "valueFrom": "arn:aws:ssm:us-west-2:373436483103:parameter/DJANGO_DEBUG",
+                    "valueFrom": "arn:aws:ssm:<aws_region>:<aws_account>:parameter/DJANGO_DEBUG",
                     "name": "DJANGO_DEBUG"
                 },
                 {
-                    "valueFrom": "arn:aws:ssm:us-west-2:373436483103:parameter/DJANGO_INIT_PATH",
+                    "valueFrom": "arn:aws:ssm:<aws_region>:<aws_account>:parameter/DJANGO_INIT_PATH",
                     "name": "DJANGO_INIT_PATH"
                 },
                 {
-                    "valueFrom": "arn:aws:ssm:us-west-2:373436483103:parameter/DJANGO_SECRET_KEY",
+                    "valueFrom": "arn:aws:ssm:<aws_region>:<aws_account>:parameter/DJANGO_LOG_LEVEL",
+                    "name": "DJANGO_LOG_LEVEL"
+                },
+                {
+                    "valueFrom": "arn:aws:ssm:<aws_region>:<aws_account>:parameter/DJANGO_SECRET_KEY",
                     "name": "DJANGO_SECRET_KEY"
                 }
             ],
@@ -77,26 +77,26 @@
                 "logDriver": "awslogs",
                 "options": {
                     "awslogs-group": "/ecs/cal-itp-benefits-client",
-                    "awslogs-region": "us-west-2",
+                    "awslogs-region": "<aws_region>",
                     "awslogs-stream-prefix": "ecs"
                 }
             },
             "essential": false,
             "image": "amazon/aws-cli",
             "repositoryCredentials": {
-                "credentialsParameter": "arn:aws:secretsmanager:us-west-2:373436483103:secret:DockerHubSecret-pf4cDS"
+                "credentialsParameter": "arn:aws:secretsmanager:<aws_region>:<aws_account>:secret:<docker_hub_secret>"
             },
             "entryPoint": ["/bin/sh"],
             "command": ["-c", "aws s3 cp s3://${CONFIG_BUCKET_PATH} /aws"],
             "environment": [
                 {
                     "name": "AWS_DEFAULT_REGION",
-                    "value": "us-west-2"
+                    "value": "<aws_region>"
                 }
             ],
             "secrets": [
                 {
-                    "valueFrom": "arn:aws:ssm:us-west-2:373436483103:parameter/CONFIG_BUCKET_PATH",
+                    "valueFrom": "arn:aws:ssm:<aws_region>:<aws_account>:parameter/CONFIG_BUCKET_PATH",
                     "name": "CONFIG_BUCKET_PATH"
                 }
             ],

--- a/.env.sample
+++ b/.env.sample
@@ -8,7 +8,7 @@ AWS_SECRET_ACCESS_KEY=secret-access-key
 CONFIG_BUCKET_PATH=bucket-name/file.json
 
 # Django config
-DJANGO_ADMIN=true
+DJANGO_ADMIN=false
 DJANGO_ALLOWED_HOSTS="localhost 127.0.0.1 [::1]"
 DJANGO_DB=django
 DJANGO_DEBUG=true

--- a/.github/workflows/ecs-deploy.yml
+++ b/.github/workflows/ecs-deploy.yml
@@ -52,9 +52,11 @@ jobs:
         env:
           AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
+          DOCKER_HUB_SECRET: ${{ secrets.DOCKER_HUB_SECRET }}
         run: |
           sed -i "s/<aws_account>/$AWS_ACCOUNT/g" .aws/ecs-task.json
           sed -i "s/<aws_region>/$AWS_REGION/g" .aws/ecs-task.json
+          sed -i "s/<docker_hub_secret>/$DOCKER_HUB_SECRET/g" .aws/ecs-task.json
 
       - name: Fill in the new image ID in the Amazon ECS task definition
         id: task-def

--- a/.github/workflows/ecs-deploy.yml
+++ b/.github/workflows/ecs-deploy.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches:
+      - dev
+      - test
       - main
 
 defaults:
@@ -11,8 +13,10 @@ defaults:
     shell: bash
 
 jobs:
-  deploy:
+  deploy-dev:
     runs-on: ubuntu-latest
+    environment: dev
+    concurrency: dev
 
     steps:
       - name: Checkout
@@ -23,7 +27,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Login to Amazon ECR
         id: login-ecr
@@ -43,11 +47,20 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 
+      - name: Add environment-specific config in the Amazon ECS task definition
+        id: task-env
+        env:
+          AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+        run: |
+          sed -i "s/<aws_account>/$AWS_ACCOUNT/g" .aws/ecs-task.json
+          sed -i "s/<aws_region>/$AWS_REGION/g" .aws/ecs-task.json
+
       - name: Fill in the new image ID in the Amazon ECS task definition
         id: task-def
         uses: aws-actions/amazon-ecs-render-task-definition@v1
         with:
-          task-definition: .aws/ecs-task-definition.json
+          task-definition: .aws/ecs-task.json
           container-name: cal-itp-benefits-client
           image: ${{ steps.build-image.outputs.image }}
 


### PR DESCRIPTION
Getting ready for a dev, test, and prod deployment. 

Remove environment-specific info from ECS task template, add a step that uses `sed` to fill in with environment secrets.