### PR TITLE
Manage ECS container environment with environmentFiles

### DIFF
--- a/.aws/ecs-task.json
+++ b/.aws/ecs-task.json
@@ -27,6 +27,12 @@
             ],
             "environment": [
             ],
+            "environmentFiles": [
+                {
+                    "value": "arn:aws:s3:::<aws_bucket>/.env",
+                    "type": "s3"
+                }
+            ],
             "healthCheck": {
                 "retries": 2,
                 "command": [
@@ -38,30 +44,6 @@
                 "startPeriod": 30
             },
             "secrets": [
-                {
-                    "valueFrom": "arn:aws:ssm:<aws_region>:<aws_account>:parameter/ANALYTICS_KEY",
-                    "name": "ANALYTICS_KEY"
-                },
-                {
-                    "valueFrom": "arn:aws:ssm:<aws_region>:<aws_account>:parameter/DJANGO_ALLOWED_HOSTS",
-                    "name": "DJANGO_ALLOWED_HOSTS"
-                },
-                {
-                    "valueFrom": "arn:aws:ssm:<aws_region>:<aws_account>:parameter/DJANGO_DEBUG",
-                    "name": "DJANGO_DEBUG"
-                },
-                {
-                    "valueFrom": "arn:aws:ssm:<aws_region>:<aws_account>:parameter/DJANGO_INIT_PATH",
-                    "name": "DJANGO_INIT_PATH"
-                },
-                {
-                    "valueFrom": "arn:aws:ssm:<aws_region>:<aws_account>:parameter/DJANGO_LOG_LEVEL",
-                    "name": "DJANGO_LOG_LEVEL"
-                },
-                {
-                    "valueFrom": "arn:aws:ssm:<aws_region>:<aws_account>:parameter/DJANGO_SECRET_KEY",
-                    "name": "DJANGO_SECRET_KEY"
-                }
             ],
             "essential": true,
             "dependsOn": [
@@ -87,18 +69,14 @@
                 "credentialsParameter": "arn:aws:secretsmanager:<aws_region>:<aws_account>:secret:<docker_hub_secret>"
             },
             "entryPoint": ["/bin/sh"],
-            "command": ["-c", "aws s3 cp s3://${CONFIG_BUCKET_PATH} /aws"],
-            "environment": [
+            "command": ["-c", "aws s3 cp s3://${AWS_BUCKET}/${CONFIG_FILE} /aws"],
+            "environmentFiles": [
                 {
-                    "name": "AWS_DEFAULT_REGION",
-                    "value": "<aws_region>"
+                    "value": "arn:aws:s3:::<aws_bucket>/.env",
+                    "type": "s3"
                 }
             ],
             "secrets": [
-                {
-                    "valueFrom": "arn:aws:ssm:<aws_region>:<aws_account>:parameter/CONFIG_BUCKET_PATH",
-                    "name": "CONFIG_BUCKET_PATH"
-                }
             ],
             "mountPoints": [
                 {

--- a/.env.sample
+++ b/.env.sample
@@ -5,7 +5,8 @@ ANALYTICS_KEY=amplitude-api-key
 AWS_DEFAULT_REGION=us-west-2
 AWS_ACCESS_KEY_ID=access-key-id
 AWS_SECRET_ACCESS_KEY=secret-access-key
-CONFIG_BUCKET_PATH=bucket-name/file.json
+AWS_BUCKET=bucket-name
+CONFIG_FILE=file.json
 
 # Django config
 DJANGO_ADMIN=false

--- a/.github/workflows/ecs-deploy-dev.yml
+++ b/.github/workflows/ecs-deploy-dev.yml
@@ -1,19 +1,17 @@
-name: Deploy to Amazon ECS
+name: Deploy to Amazon ECS (dev)
 
 on:
   workflow_dispatch:
   push:
     branches:
       - dev
-      - test
-      - main
 
 defaults:
   run:
     shell: bash
 
 jobs:
-  deploy-dev:
+  deploy:
     runs-on: ubuntu-latest
     environment: dev
     concurrency: dev
@@ -52,9 +50,11 @@ jobs:
         env:
           AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_BUCKET: ${{ secrets.AWS_BUCKET }}
           DOCKER_HUB_SECRET: ${{ secrets.DOCKER_HUB_SECRET }}
         run: |
           sed -i "s/<aws_account>/$AWS_ACCOUNT/g" .aws/ecs-task.json
+          sed -i "s/<aws_bucket>/$AWS_BUCKET/g" .aws/ecs-task.json
           sed -i "s/<aws_region>/$AWS_REGION/g" .aws/ecs-task.json
           sed -i "s/<docker_hub_secret>/$DOCKER_HUB_SECRET/g" .aws/ecs-task.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.db
-.env
+*.env
 *.mo
 static/
 !benefits/static

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
   s3config:
     image: amazon/aws-cli
     entrypoint: ["/bin/sh"]
-    command: ["-c", "aws s3 cp s3://${CONFIG_BUCKET_PATH} ."]
+    command: ["-c", "aws s3 cp s3://${AWS_BUCKET}/${CONFIG_FILE} ."]
     environment:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
Major simplification over secrets, store an .env file in S3 and reference it in the ECS task with the `environmentFiles` property. 

GitHub Action secret points to bucket per deploy environment, with replacement in the ECS task template.