### PR TITLE
Naming env with explicit .env extension

### DIFF
--- a/.aws/ecs-task.json
+++ b/.aws/ecs-task.json
@@ -72,7 +72,7 @@
             "command": ["-c", "aws s3 cp s3://${AWS_BUCKET}/${CONFIG_FILE} /aws"],
             "environmentFiles": [
                 {
-                    "value": "arn:aws:s3:::<aws_bucket>/.env",
+                    "value": "arn:aws:s3:::<aws_bucket>/env.env",
                     "type": "s3"
                 }
             ],


### PR DESCRIPTION
AWS is complaining about the file, maybe because it didn't have a full name