### PR TITLE
Fix the mkdocs action

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@master
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REQUIREMENTS: docs/requirements.txt
           CUSTOM_DOMAIN: docs.calitp.org
           CONFIG_FILE: docs/mkdocs.yml
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,7 +2,8 @@ FROM benefits_client:latest
 
 USER root
 
+COPY docs/requirements.txt docs/requirements.txt
+
 RUN apt-get install -qq --no-install-recommends curl git jq ssh && \
-    pip install --no-cache-dir flake8 debugpy pre-commit \
-        mkdocs mkdocs-material mkdocs-awesome-pages-plugin \
-        fontawesome_markdown mdx_truly_sane_lists mkdocs-macros-plugin
+    pip install --no-cache-dir flake8 debugpy pre-commit && \
+    pip install --no-cache-dir -r docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,6 @@
+fontawesome_markdown
+mdx_truly_sane_lists
+mkdocs
+mkdocs-awesome-pages-plugin
+mkdocs-macros-plugin
+mkdocs-material


### PR DESCRIPTION
`mhausenblas/mkdocs-deploy-gh-pages` pip installs the requirements.txt from the root of the repo unless overridden with another path.

There is currently no way to opt-out; this was under discussion in Dec 2020: https://github.com/mhausenblas/mkdocs-deploy-gh-pages/pull/55

This is problem, we don't want to install requirements from benefits for mkdocs, so provide the REQUIREMENTS env with our mkdocs dependencies.