### PR TITLE
Fixing mkdocs build/serve

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,4 +47,5 @@ RUN chown -R $USER /home/$USER/app/benefits/locale
 USER $USER
 
 # configure container executable
-ENTRYPOINT ["/bin/bash", "bin/start.sh"]
+ENTRYPOINT ["/bin/bash"]
+CMD ["bin/start.sh"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,8 +2,9 @@ FROM benefits_client:latest
 
 USER root
 
+RUN apt-get install -qq --no-install-recommends curl git jq ssh && \
+    pip install --no-cache-dir flake8 debugpy pre-commit
+
 COPY docs/requirements.txt docs/requirements.txt
 
-RUN apt-get install -qq --no-install-recommends curl git jq ssh && \
-    pip install --no-cache-dir flake8 debugpy pre-commit && \
-    pip install --no-cache-dir -r docs/requirements.txt
+RUN pip install --no-cache-dir -r docs/requirements.txt

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,35 @@
 # Home
 
-This is the documentation website for [`benefits`](https://github.com/cal-itp/benefits)
-from Cal-ITP, the [California Integrated Travel Project](https://calitp.org).
+This website provides technical documentation for [`benefits`](https://github.com/cal-itp/benefits)
+from the [California Integrated Travel Project (Cal-ITP)](https://www.calitp.org).
+
+Documentation for the `main` branch is available online at: <https://cal-itp.github.io/benefits>.
+
+## Editing documentation
+
+Docs content all lives under `docs/`, with some top-level configuration for how the website is built under `mkdocs.yml`.
+To add new sections/articles, simply create new directories/files under `docs/` in Markdown format.
+
+## Documentation features
+
+- [Material for MkDocs: Reference](https://squidfunk.github.io/mkdocs-material/reference/admonitions/)
+
+    See `mkdocs.yml` for enabled plugins/features
+
+- [Mermaid](https://mermaid-js.github.io/mermaid/)
+
+    Use code fences with `mermaid` type to render Mermaid diagrams within docs. For example, this markdown:
+
+    ~~~markdown
+    ```mermaid
+    graph LR
+        Start --> Stop
+    ```
+    ~~~
+
+    Yields this diagram:
+
+    ~~~mermaid
+    graph LR
+        Start --> Stop
+    ~~~

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 fontawesome_markdown
 mdx_truly_sane_lists
-mkdocs
+mkdocs==1.1.2
 mkdocs-awesome-pages-plugin
 mkdocs-macros-plugin
 mkdocs-material


### PR DESCRIPTION
Fix an issue with the `docs` Compose service by splitting `ENTRYPOINT` and `CMD` in the upstream Docker image.

Also pin to `mkdocs==v1.1.2` to address an issue with newly released v1.2.0.