### PR TITLE
Refactor handling of eligibility types

### DIFF
--- a/benefits/core/models.py
+++ b/benefits/core/models.py
@@ -56,10 +56,10 @@ class EligibilityType(models.Model):
         return self.label
 
     @staticmethod
-    def by_name(name):
-        """Get an EligibilityType instance by its name."""
-        logger.debug(f"Get {EligibilityType.__name__} by name: {name}")
-        return EligibilityType.objects.get(name=name)
+    def get(id):
+        """Get an EligibilityType instance by its id."""
+        logger.debug(f"Get {EligibilityType.__name__} by id: {id}")
+        return EligibilityType.objects.get(pk=id)
 
     @staticmethod
     def get_many(ids):
@@ -115,6 +115,14 @@ class TransitAgency(models.Model):
 
     def __str__(self):
         return self.long_name
+
+    def get_type_id(self, name):
+        """Get the id of the EligibilityType identified by the given name for this agency."""
+        eligibility = self.eligibility_types.all().filter(name=name)
+        if eligibility.count() == 1:
+            return eligibility[0].id
+        else:
+            raise Exception("name does not correspond to a single eligibility type for agency")
 
     def supports_type(self, eligibility_type):
         """True if the eligibility_type is one of this agency's types. False otherwise."""

--- a/benefits/core/session.py
+++ b/benefits/core/session.py
@@ -88,9 +88,7 @@ def eligibility(request):
 def eligible(request):
     """True if the request's session is configured with an active agency and has confirmed eligibility. False otherwise."""
     logger.debug("Get session eligible flag")
-    a = agency(request)
-    e = eligibility(request)
-    return active_agency(request) and len(e) > 0 and set(e).issubset(a.eligibility_set)
+    return active_agency(request) and agency(request).supports_type(eligibility(request))
 
 
 def language(request):

--- a/benefits/eligibility/api.py
+++ b/benefits/eligibility/api.py
@@ -33,8 +33,8 @@ class RequestToken:
     def __init__(self, agency, verifier, sub, name):
         logger.info("Initialize new request token")
 
-        # compute the eligibility set for this token from agency and verifier
-        eligibility = list(verifier.eligibility_set & agency.eligibility_set)
+        # send the eligibility type names
+        types = list(map(lambda t: t.name, agency.types_to_verify()))
 
         # craft the main token payload
         payload = dict(
@@ -42,7 +42,7 @@ class RequestToken:
             iss=ALLOWED_HOSTS[0],
             iat=int(datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).timestamp()),
             agency=agency.agency_id,
-            eligibility=eligibility,
+            eligibility=types,
             sub=sub,
             name=name,
         )

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -64,7 +64,8 @@ def confirm(request):
             page.forms = [form]
             response = PageTemplateResponse(request, page)
     elif session.eligible(request):
-        response = verified(request, session.eligibility(request))
+        eligibility = session.eligibility(request)
+        response = verified(request, [eligibility.name])
     else:
         response = PageTemplateResponse(request, page)
 

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -98,16 +98,11 @@ def _enroll(request):
     card_token = form.cleaned_data.get("card_token")
 
     eligibility = session.eligibility(request)
-    if len(eligibility) > 0:
-        eligibility = eligibility[0]
-        if len(eligibility) == 1:
-            logger.debug(f"Session contains 1 {models.EligibilityType.__name__}")
-        else:
-            logger.debug(f"Session contains ({len(eligibility)}) {models.EligibilityType.__name__}s")
+    if eligibility:
+        logger.debug(f"Session contains an {models.EligibilityType.__name__}")
     else:
         raise Exception("Session contains no eligibility information")
 
-    eligibility = models.EligibilityType.by_name(eligibility)
     agency = session.agency(request)
 
     response = api.Client(agency).enroll(card_token, eligibility.group_id)


### PR DESCRIPTION
The central change in this PR is to adapt get/set of eligibility information from/to session to use the `EligibilityType.id` property rather than `name`. Since this object carries the value sent in the eligibility phase and also the group identifier for the enrollment phase, we may have multiple types with the same name pointing to different enrollment groups.

The current logic relying on `name` causes errors when there are duplicates because we cannot determine which `EligibilityType` was meant. 

A future todo could be to refactor the models to separate eligibility name and benefit group identifier.