### PR TITLE
Payment processor API fix

### DIFF
--- a/benefits/enrollment/api.py
+++ b/benefits/enrollment/api.py
@@ -70,10 +70,11 @@ class GroupResponse:
         else:
             try:
                 # Group API uses an error response (500) to indicate that the customer already exists in the group (!!!)
-                # The error message should contain the customer ID we sent via payload
+                # The error message should contain the customer ID we sent via payload and start with "Duplicate"
                 error = response.json()["errors"][0]
                 customer_id = payload[0]
-                if not error["detail"].startswith("Duplicate") and customer_id in error["detail"]:
+                detail = error["detail"]
+                if all((customer_id, detail)) and customer_id in detail and not detail.startswith("Duplicate"):
                     raise ApiError("Invalid response format")
             except (KeyError, ValueError):
                 raise ApiError("Invalid response format")

--- a/benefits/enrollment/api.py
+++ b/benefits/enrollment/api.py
@@ -53,7 +53,6 @@ class CustomerResponse:
             raise ApiError("Invalid response format")
 
         self.id = payload.get("id", customer_id)
-        self.customer_ref = payload.get("customer_ref")
         self.is_registered = str(payload.get("is_registered", "false")).lower() == "true"
 
         logger.info("Customer details successfully read from response")
@@ -162,7 +161,7 @@ class Client:
                     return customer
                 else:
                     logger.debug("Customer is not registered, update")
-                    return self._update_customer(customer.id, customer.customer_ref)
+                    return self._update_customer(customer.id)
             else:
                 r.raise_for_status()
         except requests.ConnectionError:
@@ -174,17 +173,15 @@ class Client:
         except requests.HTTPError as e:
             raise ApiError(e)
 
-    def _update_customer(self, customer_id, customer_ref):
+    def _update_customer(self, customer_id):
         """Update a customer using their unique info."""
         logger.info("Update existing customer record")
 
         if customer_id is None:
             raise ValueError("customer_id")
-        if customer_ref is None:
-            raise ValueError("customer_ref")
 
         url = self._make_url(self.payment_processor.customer_endpoint, customer_id)
-        payload = {"customer_ref": customer_ref, "is_registered": True}
+        payload = {"is_registered": True}
 
         r = self._patch(url, payload)
         r.raise_for_status()


### PR DESCRIPTION
The Payment Processor API is returning `{"customer_ref": None}` for some customers. Contrary to their API documentation, `customer_ref` is not a required value when we send a payload back in the customer update `PATCH` request.

Since we don't actually use/need this value, and there is no reason for the Benefits app to generate one for a customer, this PR removes handling of the value entirely.

This fixes a bug when the value was `None` but the customer was already marked as registered in the Payment processor system.