### PR TITLE
Fix ALLOWED_HOSTS setting

### DIFF
--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -19,7 +19,7 @@ ALLOWED_HOSTS = []
 if DEBUG:
     ALLOWED_HOSTS.extend(["*"])
 else:
-    hosts = os.environ["DJANGO_ALLOWED_HOSTS"].split()
+    hosts = os.environ["DJANGO_ALLOWED_HOSTS"].split(",")
     ALLOWED_HOSTS.extend(hosts)
 
 # Application definition

--- a/localhost/.env.sample
+++ b/localhost/.env.sample
@@ -13,7 +13,7 @@ CONFIG_FILE=file.json
 
 # Django config
 DJANGO_ADMIN=false
-DJANGO_ALLOWED_HOSTS="localhost 127.0.0.1 [::1]"
+DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1,[::1]
 DJANGO_DB=django
 DJANGO_DEBUG=true
 DJANGO_INIT_PATH=localhost/data/client.json


### PR DESCRIPTION
The problem was only seen when `DEBUG=False`, as settings tried to load the allowed hosts from the environment.

Since the value in the `.env` file was quoted, the quotes were taken as part of the value when read into settings.

`"host.com"` is not the same as `host.com`, and so the app failed to load!