### PR TITLE
Move healthcheck to middleware

### DIFF
--- a/benefits/core/middleware.py
+++ b/benefits/core/middleware.py
@@ -3,6 +3,7 @@ The core application: middleware definitions for request/response cycle.
 """
 import logging
 
+from django.http import HttpResponse
 from django.utils.decorators import decorator_from_middleware
 from django.utils.deprecation import MiddlewareMixin
 from django.views import i18n
@@ -31,6 +32,18 @@ class DebugSession(MiddlewareMixin):
     def process_request(self, request):
         session.update(request, debug=DEBUG)
         return None
+
+
+class Healthcheck:
+    """Middleware intercepts and accepts /healthcheck requests."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if request.path == "/healthcheck":
+            return HttpResponse("Healthy", content_type="text/plain")
+        return self.get_response(request)
 
 
 class ViewedPageEvent(MiddlewareMixin):

--- a/benefits/core/urls.py
+++ b/benefits/core/urls.py
@@ -46,7 +46,6 @@ app_name = "core"
 urlpatterns = [
     path("", views.index, name="index"),
     path("<agency:agency>", views.agency_index, name="agency_index"),
-    path("healthcheck", views.healthcheck, name="healthcheck"),
     path("help", views.help, name="help"),
     path("payment-options", views.payment_options, name="payment_options"),
 ]

--- a/benefits/core/views.py
+++ b/benefits/core/views.py
@@ -1,7 +1,7 @@
 """
 The core application: view definition for the root of the webapp.
 """
-from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseNotFound, HttpResponseServerError
+from django.http import HttpResponseBadRequest, HttpResponseNotFound, HttpResponseServerError
 from django.template import loader
 from django.template.response import TemplateResponse
 from django.urls import reverse
@@ -72,11 +72,6 @@ def agency_index(request, agency):
     )
 
     return PageTemplateResponse(request, page)
-
-
-def healthcheck(request):
-    """Simple healthcheck to see if app is responding."""
-    return HttpResponse("Healthy", content_type="text/plain")
 
 
 @middleware.pageview_decorator

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -46,6 +46,7 @@ MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.locale.LocaleMiddleware",
+    "benefits.core.middleware.Healthcheck",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",


### PR DESCRIPTION
Prior to this change, ELB healthcheck requests were failing with 400 as the HOST_HEADER was the ELB node's (internal) IP address.

This change moves the healthcheck to a middleware placed before the HOST_HEADER verification (in `django.middleware.common.CommonMiddleware`), so healthcheck requests always pass.

Based on https://stackoverflow.com/a/64623669.

Closes #105.