### PR TITLE
Workflow: Only deploy Docs site when docs files change

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -6,6 +6,8 @@ on:
       - dev
     paths:
       - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/mkdocs.yml'
 
 jobs:
   docs:

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - dev
+    paths:
+      - 'docs/**'
 
 jobs:
   docs:


### PR DESCRIPTION
closes #109 

## How to test this GitHub Action (or, How I tested this GitHub Action)

1. Fork this repository
2. As an extra precaution, delete all unrelated GitHub Action workflows. To make sure unnecessary deploys to Production were absolutely impossible, I deleted the `.github/workflows/ecs-deploy.dev.yml` and `.github/workflows/ecs-deploy-test.yml' files.
3. Merge the PR I am testing into `dev`. I merged `109-docs-action-config`.
4. Click **Actions** tab. Click the button to turn on Actions for this repository. (Sidenote: It's great that GitHub turns Actions off by default on repositories that are forked.)
5. Create new PRs to test the workflow filter: I first created a PR that changes a `/localhost/` file. Then, I created a PR that changes a `/docs/` file. 
6. Merge one PR at a time and look at the **Actions** tab to confirm the desired result.

## Desired results

### When merging a PR to `dev` that changes `/docs/` files

![image](https://user-images.githubusercontent.com/3673236/134218920-91b8c340-0d45-4cd1-a4f7-97ab4fc6d814.png)

After the PR is created, `machikoyasuda-patch-1`, the pre-commit workflow runs. Then, after this PR is merged to `dev`, the `Publish docs` action runs.

### When merging a PR to `dev` that changes `non-/docs/` files

![image](https://user-images.githubusercontent.com/3673236/134218771-204e9a81-4b24-4885-80ab-0439cf001b8a.png)

After this PR - that only changed a `/localhost/` file - is created and merged to `dev`, the `Publish docs` action is **not** triggered.