### PR TITLE
Use launch type debugger

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -15,8 +15,7 @@
             "bash": {
                 "path": "/bin/bash"
             }
-        },
-        "python.pythonPath": "/usr/local/bin/python",
+        }
     },
 
     // Add the IDs of extensions you want installed when the container is created.

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,11 +7,12 @@
         {
             "name": "Django: Benefits Client",
             "type": "python",
-            "request": "attach",
-            "connect": {
-                "host": "localhost",
-                "port": 5678
-            },
+            "request": "launch",
+            "program": "${workspaceFolder}/manage.py",
+            "args": [
+                "runserver",
+                "0.0.0.0:8000"
+            ],
             "django": true
         },
         {

--- a/localhost/Dockerfile.dev
+++ b/localhost/Dockerfile.dev
@@ -4,7 +4,7 @@ USER root
 
 RUN apt-get install -qq --no-install-recommends curl git jq ssh && \
     python -m pip install --upgrade pip && \
-    pip install --no-cache-dir flake8 debugpy pre-commit
+    pip install --no-cache-dir flake8 pre-commit
 
 # install node.js
 # see https://github.com/nodesource/distributions#installation-instructions

--- a/localhost/docker-compose.yml
+++ b/localhost/docker-compose.yml
@@ -34,13 +34,12 @@ services:
       - DJANGO_INIT_PATH
       - DJANGO_LOG_LEVEL
       - DJANGO_SECRET_KEY
-    entrypoint: python
-    command: -m debugpy --wait-for-client --listen 0.0.0.0:5678 manage.py runserver 0.0.0.0:8000
+    entrypoint: []
+    command: sleep infinity
     depends_on:
       - server
     ports:
       - "8000"
-      - "5678"
     volumes:
       - ./data:/home/calitp/app/data:cached
       - ../:/home/calitp/app:cached


### PR DESCRIPTION
Maintain the `F5`-to-start sequence, but allow for stop/restart unlike the attach type. We no longer need to expose a debugger port.

The compose service definition was simplified to decouple the app and devcontainer startup, using the `sleep infinity` command ensures the devcontainer stays active if the app/debugger crash.

Since VS Code handles the debugger interaction, we don't need to explicitly install `debugpy`.

## To run this PR

1. Rebuild and Reopen the devcontainer
2. Add a breakpoint to `/healthcheck`, Hit `F5` to launch the debugger, navigate to `/healthcheck`, hit breakpoint
3. Observe you can **stop** the debugger, then **restart** with `F5`