### PR TITLE
Refactor PEM data in models

### DIFF
--- a/benefits/core/admin.py
+++ b/benefits/core/admin.py
@@ -11,6 +11,12 @@ if ADMIN:
 
     logger = logging.getLogger(__name__)
 
-    for model in [models.EligibilityType, models.EligibilityVerifier, models.TransitAgency, models.PaymentProcessor]:
+    for model in [
+        models.EligibilityType,
+        models.EligibilityVerifier,
+        models.PaymentProcessor,
+        models.PemData,
+        models.TransitAgency,
+    ]:
         logger.debug(f"Register {model.__name__}")
         admin.site.register(model)

--- a/benefits/core/migrations/0001_initial.py
+++ b/benefits/core/migrations/0001_initial.py
@@ -34,7 +34,7 @@ class Migration(migrations.Migration):
                 ("api_auth_header", models.TextField()),
                 ("api_auth_key", models.TextField()),
                 # fmt: off
-                ("public_key_pem", models.TextField(help_text="The Verifier's public key in PEM format, used to encrypt requests targeted at this Verifier and to verify signed responses from this verifier.")),  # noqa: E501
+                ("public_key", models.ForeignKey(help_text="The Verifier's public key, used to encrypt requests targeted at this Verifier and to verify signed responses from this verifier.", on_delete=models.deletion.PROTECT, related_name="+", to="core.PemData")),  # noqa: E501
                 ("jwe_cek_enc", models.TextField(help_text="The JWE-compatible Content Encryption Key (CEK) key-length and mode")),  # noqa: E501
                 ("jwe_encryption_alg", models.TextField(help_text="The JWE-compatible encryption algorithm")),
                 # fmt: on
@@ -55,9 +55,9 @@ class Migration(migrations.Migration):
                 ("card_tokenize_func", models.TextField()),
                 ("card_tokenize_env", models.TextField()),
                 # fmt: off
-                ("client_cert_pem", models.TextField(help_text="A certificate in PEM format, used for client certificate authentication to the API.")),  # noqa: E501
-                ("client_cert_private_key_pem", models.TextField(help_text="The private key in PEM format used to sign the certificate.")),  # noqa: E501
-                ("client_cert_root_ca_pem", models.TextField(help_text="The root CA bundle in PEM format used to verify the server.")),  # noqa: E501
+                ("client_cert", models.ForeignKey(help_text="The certificate used for client certificate authentication to the API.", on_delete=models.deletion.PROTECT, related_name="+", to="core.PemData")),  # noqa: E501
+                ("client_cert_private_key", models.ForeignKey(help_text="The private key used to sign the certificate.", on_delete=models.deletion.PROTECT, related_name="+", to="core.PemData")),  # noqa: E501
+                ("client_cert_root_ca", models.ForeignKey(help_text="The root CA bundle used to verify the server.", on_delete=models.deletion.PROTECT, related_name="+", to="core.PemData")),  # noqa: E501
                 ("customer_endpoint", models.TextField()),
                 # fmt: on
                 ("customers_endpoint", models.TextField()),
@@ -77,7 +77,7 @@ class Migration(migrations.Migration):
                 ("phone", models.TextField()),
                 ("active", models.BooleanField(default=False)),
                 # fmt: off
-                ("private_key_pem", models.TextField(help_text="The Agency's private key in PEM format, used to sign tokens created on behalf of this Agency.")),  # noqa: E501
+                ("private_key", models.ForeignKey(help_text="The Agency's private key, used to sign tokens created on behalf of this Agency.", on_delete=models.deletion.PROTECT, related_name="+", to="core.PemData")),  # noqa: E501
                 ("jws_signing_alg", models.TextField(help_text="The JWS-compatible signing algorithm.")),
                 ("payment_processor", models.ForeignKey(on_delete=models.deletion.PROTECT, to="core.paymentprocessor")),
                 ("eligibility_types", models.ManyToManyField(to="core.EligibilityType")),

--- a/benefits/core/migrations/0001_initial.py
+++ b/benefits/core/migrations/0001_initial.py
@@ -18,6 +18,14 @@ class Migration(migrations.Migration):
             ],
         ),
         migrations.CreateModel(
+            name="PemData",
+            fields=[
+                ("id", models.AutoField(primary_key=True, serialize=False)),
+                ("text", models.TextField(help_text="The data in utf-8 encoded PEM text format.")),
+                ("label", models.TextField(help_text="Human description of the PEM data.")),
+            ],
+        ),
+        migrations.CreateModel(
             name="EligibilityVerifier",
             fields=[
                 ("id", models.AutoField(primary_key=True, serialize=False, verbose_name="ID")),

--- a/benefits/core/models.py
+++ b/benefits/core/models.py
@@ -19,29 +19,21 @@ def pem_to_jwk(pem):
     return jwk.JWK.from_pem(pem)
 
 
-class PaymentProcessor(models.Model):
-    """An entity that processes payments for transit agencies."""
+class PemData(models.Model):
+    """API Certificate or Key in PEM format."""
 
-    # fmt: off
     id = models.AutoField(primary_key=True)
-    name = models.TextField()
-    api_base_url = models.TextField()
-    api_access_token_endpoint = models.TextField()
-    api_access_token_request_key = models.TextField()
-    api_access_token_request_val = models.TextField()
-    card_tokenize_url = models.TextField()
-    card_tokenize_func = models.TextField()
-    card_tokenize_env = models.TextField()
-    client_cert_pem = models.TextField(help_text="A certificate in PEM format, used for client certificate authentication to the API.")  # noqa: 503
-    client_cert_private_key_pem = models.TextField(help_text="The private key in PEM format used to sign the certificate.")
-    client_cert_root_ca_pem = models.TextField(help_text="The root CA bundle in PEM format used to verify the server.")  # noqa: 503
-    customer_endpoint = models.TextField()
-    customers_endpoint = models.TextField()
-    group_endpoint = models.TextField()
-    # fmt: on
+    text = models.TextField(help_text="The data in utf-8 encoded PEM text format.")
+    label = models.TextField(help_text="Human description of the PEM data.")
 
     def __str__(self):
-        return self.name
+        return self.label
+
+    @property
+    def jwk(self):
+        """jwcrypto.jwk.JWK instance from this PemData."""
+        pem_bytes = bytes(self.text, "utf-8")
+        return jwk.JWK.from_pem(pem_bytes)
 
 
 class EligibilityType(models.Model):
@@ -91,6 +83,31 @@ class EligibilityVerifier(models.Model):
     def public_jwk(self):
         """jwcrypto.jwk.JWK instance of this Verifier's public key"""
         return pem_to_jwk(self.public_key_pem)
+
+
+class PaymentProcessor(models.Model):
+    """An entity that processes payments for transit agencies."""
+
+    # fmt: off
+    id = models.AutoField(primary_key=True)
+    name = models.TextField()
+    api_base_url = models.TextField()
+    api_access_token_endpoint = models.TextField()
+    api_access_token_request_key = models.TextField()
+    api_access_token_request_val = models.TextField()
+    card_tokenize_url = models.TextField()
+    card_tokenize_func = models.TextField()
+    card_tokenize_env = models.TextField()
+    client_cert_pem = models.TextField(help_text="A certificate in PEM format, used for client certificate authentication to the API.")  # noqa: 503
+    client_cert_private_key_pem = models.TextField(help_text="The private key in PEM format used to sign the certificate.")
+    client_cert_root_ca_pem = models.TextField(help_text="The root CA bundle in PEM format used to verify the server.")  # noqa: 503
+    customer_endpoint = models.TextField()
+    customers_endpoint = models.TextField()
+    group_endpoint = models.TextField()
+    # fmt: on
+
+    def __str__(self):
+        return self.name
 
 
 class TransitAgency(models.Model):

--- a/benefits/core/models.py
+++ b/benefits/core/models.py
@@ -12,13 +12,6 @@ from jwcrypto import jwk
 logger = logging.getLogger(__name__)
 
 
-def pem_to_jwk(pem):
-    """jwcrypto.jwk.JWK instance of a key in PEM format"""
-    if not isinstance(pem, bytes):
-        pem = bytes(str(pem), "utf-8")
-    return jwk.JWK.from_pem(pem)
-
-
 class PemData(models.Model):
     """API Certificate or Key in PEM format."""
 
@@ -70,7 +63,7 @@ class EligibilityVerifier(models.Model):
     api_auth_header = models.TextField()
     api_auth_key = models.TextField()
     eligibility_types = models.ManyToManyField(EligibilityType)
-    public_key_pem = models.TextField(help_text="The Verifier's public key in PEM format, used to encrypt requests targeted at this Verifier and to verify signed responses from this verifier.")  # noqa: 503
+    public_key = models.ForeignKey(PemData, help_text="The Verifier's public key, used to encrypt requests targeted at this Verifier and to verify signed responses from this verifier.", related_name="+", on_delete=models.PROTECT)  # noqa: 503
     jwe_cek_enc = models.TextField(help_text="The JWE-compatible Content Encryption Key (CEK) key-length and mode")
     jwe_encryption_alg = models.TextField(help_text="The JWE-compatible encryption algorithm")
     jws_signing_alg = models.TextField(help_text="The JWS-compatible signing algorithm")
@@ -82,7 +75,7 @@ class EligibilityVerifier(models.Model):
     @property
     def public_jwk(self):
         """jwcrypto.jwk.JWK instance of this Verifier's public key"""
-        return pem_to_jwk(self.public_key_pem)
+        return self.public_key.jwk
 
 
 class PaymentProcessor(models.Model):
@@ -98,9 +91,9 @@ class PaymentProcessor(models.Model):
     card_tokenize_url = models.TextField()
     card_tokenize_func = models.TextField()
     card_tokenize_env = models.TextField()
-    client_cert_pem = models.TextField(help_text="A certificate in PEM format, used for client certificate authentication to the API.")  # noqa: 503
-    client_cert_private_key_pem = models.TextField(help_text="The private key in PEM format used to sign the certificate.")
-    client_cert_root_ca_pem = models.TextField(help_text="The root CA bundle in PEM format used to verify the server.")  # noqa: 503
+    client_cert = models.ForeignKey(PemData, help_text="The certificate used for client certificate authentication to the API.", related_name="+", on_delete=models.PROTECT)  # noqa: 503
+    client_cert_private_key = models.ForeignKey(PemData, help_text="The private key, used to sign the certificate.", related_name="+", on_delete=models.PROTECT)  # noqa: 503
+    client_cert_root_ca = models.ForeignKey(PemData, help_text="The root CA bundle, used to verify the server.", related_name="+", on_delete=models.PROTECT)  # noqa: 503
     customer_endpoint = models.TextField()
     customers_endpoint = models.TextField()
     group_endpoint = models.TextField()
@@ -126,7 +119,7 @@ class TransitAgency(models.Model):
     eligibility_types = models.ManyToManyField(EligibilityType)
     eligibility_verifier = models.ForeignKey(EligibilityVerifier, on_delete=models.PROTECT)
     payment_processor = models.ForeignKey(PaymentProcessor, on_delete=models.PROTECT)
-    private_key_pem = models.TextField(help_text="The Agency's private key in PEM format, used to sign tokens created on behalf of this Agency.")  # noqa: 503
+    private_key = models.ForeignKey(PemData, help_text="The Agency's private key, used to sign tokens created on behalf of this Agency.", related_name="+", on_delete=models.PROTECT)  # noqa: 503
     jws_signing_alg = models.TextField(help_text="The JWS-compatible signing algorithm.")
     # fmt: on
 
@@ -161,7 +154,7 @@ class TransitAgency(models.Model):
     @property
     def private_jwk(self):
         """jwcrypto.jwk.JWK instance of this Agency's private key"""
-        return pem_to_jwk(self.private_key_pem)
+        return self.private_key.jwk
 
     @staticmethod
     def by_id(id):

--- a/localhost/data/client.json
+++ b/localhost/data/client.json
@@ -1,5 +1,29 @@
 [
     {
+        "model": "core.pemdata",
+        "pk": 1,
+        "fields": {
+            "text": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyYo6Pe9OSfPGX0oQXyLA\nblOwrMgc/j1JlF07b1ahq1lc3FH0XEk3Dzqbt9NuQs8hz6493vBNtNWTpVmvbGe4\nVX3UjhpEARhN3m4jf/Z2OEuDt2A9q19NLSjgeyhieLkYLwN1ezYXrkn7cfOngcJM\nnGDXp45CaA+g3DzasrjETnKUdqecCzJ3FJ/RRwfibrju7eS/8s6H03nvydzeAJzT\nkEv7Fic2JJEUhh2rJhyLxt+qKkIYeBG+5fBri4miaS8FPnD/yjZzEAFsQc7n0dGq\nDAhSJS8tYNmXFmGlaCfRUBNV3mvOx0vFPuH21WQ5KKZxZP0e64/uQdotbPIImiyR\nJwIDAQAB\n-----END PUBLIC KEY-----\n",
+            "label": "Eligibility server public key"
+        }
+    },
+    {
+        "model": "core.pemdata",
+        "pk": 2,
+        "fields": {
+            "text": "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA1pt0ZoOuPEVPJJS+5r884zcjZLkZZ2GcPwr79XOLDbOi46on\nCa79kjRnhS0VUK96SwUPS0z9J5mDA5LSNL2RoxFb5QGaevnJY828NupzTNdUd0sY\nJK3kRjKUggHWuB55hwJcH/Dx7I3DNH4NL68UAlK+VjwJkfYPrhq/bl5z8ZiurvBa\n5C1mDxhFpcTZlCfxQoas7D1d+uPACF6mEMbQNd3RaIaSREO50NvNywXIIt/OmCiR\nqI7JtOcn4eyh1I4j9WtlbMhRJLfwPMAgY5epTsWcURmhVofF2wVoFbib3JGCfA7t\nz/gmP5YoEKnf/cumKmF3e9LrZb8zwm7bTHUViwIDAQABAoIBAQCIv0XMjNvZS9DC\nXoXGQtVpcxj6dXfaiDgnc7hZDubsNCr3JtT5NqgdIYdVNQUABNDIPNEiCkzFjuwM\nuuF2+dRzM/x6UCs/cSsCjXYBCCOwMwV/fjpEJQnwMQqwTLulVsXZYYeSUtXVBf/8\n0tVULRty34apLFhsyX30UtboXQdESfpmm5ZsqsZJlYljw+M7JxRMneQclI19y/ya\nhPWlfhLB9OffVEJXGaWx1NSYnKoCMKqE/+4krROr6V62xXaNyX6WtU6XiT7C6R5A\nPBxfhmoeFdVCF6a+Qq0v2fKThYoZnV4sn2q2An9YPfynFYnlgzdfnAFSejsqxQd0\nfxYLOtMBAoGBAP1jxjHDJngZ1N+ymw9MIpRgr3HeuMP5phiSTbY2tu9lPzQd+TMX\nfhr1bQh2Fd/vU0u7X0yPnTWtUrLlCdGnWPpXivx95GNGgUUIk2HStFdrRx+f2Qvk\nG8vtLgmSbjQ26UiHzxi9Wa0a41PWIA3TixkcFrS2X29Qc4yd6pVHmicfAoGBANjR\nZ8aaDkSKLkq5Nk1T7I0E1+mtPoH1tPV/FJClXjJrvfDuYHBeOyUpipZddnZuPGWA\nIW2tFIsMgJQtgpvgs52NFI7pQGJRUPK/fTG+Ycocxo78TkLr/RIj8Kj5brXsbZ9P\n3/WBX5GAISTSp1ab8xVgK/Tm07hGupKVqnY2lCAVAoGAIql0YjhE2ecGtLcU+Qm8\nLTnwpg4GjmBnNTNGSCfB7IuYEsQK489R49Qw3xhwM5rkdRajmbCHm+Eiz+/+4NwY\nkt5I1/NMu7vYUR40MwyEuPSm3Q+bvEGu/71pL8wFIUVlshNJ5CN60fA8qqo+5kVK\n4Ntzy7Kq6WpC9Dhh75vE3ZcCgYEAty99uXtxsJD6+aEwcvcENkUwUztPQ6ggAwci\nje9Z/cmwCj6s9mN3HzfQ4qgGrZsHpk4ycCK655xhilBFOIQJ3YRUKUaDYk4H0YDe\nOsf6gTP8wtQDH2GZSNlavLk5w7UFDYQD2b47y4fw+NaOEYvjPl0p5lmb6ebAPZb8\nFbKZRd0CgYBC1HTbA+zMEqDdY4MWJJLC6jZsjdxOGhzjrCtWcIWEGMDF7oDDEoix\nW3j2hwm4C6vaNkH9XX1dr5+q6gq8vJQdbYoExl22BGMiNbfI3+sLRk0zBYL//W6c\ntSREgR4EjosqQfbkceLJ2JT1wuNjInI0eR9H3cRugvlDTeWtbdJ5qA==\n-----END RSA PRIVATE KEY-----\n",
+            "label": "Benefits client private key"
+        }
+    },
+    {
+        "model": "core.pemdata",
+        "pk": 3,
+        "fields": {
+            "text": "-----BEGIN CERTIFICATE-----\nPEM DATA\n-----END CERTIFICATE-----\n",
+            "label": "Dummy certificate"
+        }
+    },
+    {
         "model": "core.paymentprocessor",
         "pk": 1,
         "fields": {
@@ -11,9 +35,9 @@
             "card_tokenize_url": "http://localhost:5000/static/tokenize.js",
             "card_tokenize_func": "tokenize",
             "card_tokenize_env": "test",
-            "client_cert_pem": "client_cert_pem",
-            "client_cert_private_key_pem": "client_cert_private_key_pem",
-            "client_cert_root_ca_pem": "client_cert_root_ca_pem",
+            "client_cert": 3,
+            "client_cert_private_key": 2,
+            "client_cert_root_ca": 3,
             "customer_endpoint": "customer",
             "customers_endpoint": "customers",
             "group_endpoint": "group"
@@ -49,7 +73,7 @@
                 1,
                 2
             ],
-            "public_key_pem": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyYo6Pe9OSfPGX0oQXyLA\nblOwrMgc/j1JlF07b1ahq1lc3FH0XEk3Dzqbt9NuQs8hz6493vBNtNWTpVmvbGe4\nVX3UjhpEARhN3m4jf/Z2OEuDt2A9q19NLSjgeyhieLkYLwN1ezYXrkn7cfOngcJM\nnGDXp45CaA+g3DzasrjETnKUdqecCzJ3FJ/RRwfibrju7eS/8s6H03nvydzeAJzT\nkEv7Fic2JJEUhh2rJhyLxt+qKkIYeBG+5fBri4miaS8FPnD/yjZzEAFsQc7n0dGq\nDAhSJS8tYNmXFmGlaCfRUBNV3mvOx0vFPuH21WQ5KKZxZP0e64/uQdotbPIImiyR\nJwIDAQAB\n-----END PUBLIC KEY-----\n",
+            "public_key": 1,
             "jwe_cek_enc": "A256CBC-HS512",
             "jwe_encryption_alg": "RSA-OAEP",
             "jws_signing_alg": "RS256"
@@ -71,7 +95,7 @@
                 1
             ],
             "eligibility_verifier": 1,
-            "private_key_pem": "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA1pt0ZoOuPEVPJJS+5r884zcjZLkZZ2GcPwr79XOLDbOi46on\nCa79kjRnhS0VUK96SwUPS0z9J5mDA5LSNL2RoxFb5QGaevnJY828NupzTNdUd0sY\nJK3kRjKUggHWuB55hwJcH/Dx7I3DNH4NL68UAlK+VjwJkfYPrhq/bl5z8ZiurvBa\n5C1mDxhFpcTZlCfxQoas7D1d+uPACF6mEMbQNd3RaIaSREO50NvNywXIIt/OmCiR\nqI7JtOcn4eyh1I4j9WtlbMhRJLfwPMAgY5epTsWcURmhVofF2wVoFbib3JGCfA7t\nz/gmP5YoEKnf/cumKmF3e9LrZb8zwm7bTHUViwIDAQABAoIBAQCIv0XMjNvZS9DC\nXoXGQtVpcxj6dXfaiDgnc7hZDubsNCr3JtT5NqgdIYdVNQUABNDIPNEiCkzFjuwM\nuuF2+dRzM/x6UCs/cSsCjXYBCCOwMwV/fjpEJQnwMQqwTLulVsXZYYeSUtXVBf/8\n0tVULRty34apLFhsyX30UtboXQdESfpmm5ZsqsZJlYljw+M7JxRMneQclI19y/ya\nhPWlfhLB9OffVEJXGaWx1NSYnKoCMKqE/+4krROr6V62xXaNyX6WtU6XiT7C6R5A\nPBxfhmoeFdVCF6a+Qq0v2fKThYoZnV4sn2q2An9YPfynFYnlgzdfnAFSejsqxQd0\nfxYLOtMBAoGBAP1jxjHDJngZ1N+ymw9MIpRgr3HeuMP5phiSTbY2tu9lPzQd+TMX\nfhr1bQh2Fd/vU0u7X0yPnTWtUrLlCdGnWPpXivx95GNGgUUIk2HStFdrRx+f2Qvk\nG8vtLgmSbjQ26UiHzxi9Wa0a41PWIA3TixkcFrS2X29Qc4yd6pVHmicfAoGBANjR\nZ8aaDkSKLkq5Nk1T7I0E1+mtPoH1tPV/FJClXjJrvfDuYHBeOyUpipZddnZuPGWA\nIW2tFIsMgJQtgpvgs52NFI7pQGJRUPK/fTG+Ycocxo78TkLr/RIj8Kj5brXsbZ9P\n3/WBX5GAISTSp1ab8xVgK/Tm07hGupKVqnY2lCAVAoGAIql0YjhE2ecGtLcU+Qm8\nLTnwpg4GjmBnNTNGSCfB7IuYEsQK489R49Qw3xhwM5rkdRajmbCHm+Eiz+/+4NwY\nkt5I1/NMu7vYUR40MwyEuPSm3Q+bvEGu/71pL8wFIUVlshNJ5CN60fA8qqo+5kVK\n4Ntzy7Kq6WpC9Dhh75vE3ZcCgYEAty99uXtxsJD6+aEwcvcENkUwUztPQ6ggAwci\nje9Z/cmwCj6s9mN3HzfQ4qgGrZsHpk4ycCK655xhilBFOIQJ3YRUKUaDYk4H0YDe\nOsf6gTP8wtQDH2GZSNlavLk5w7UFDYQD2b47y4fw+NaOEYvjPl0p5lmb6ebAPZb8\nFbKZRd0CgYBC1HTbA+zMEqDdY4MWJJLC6jZsjdxOGhzjrCtWcIWEGMDF7oDDEoix\nW3j2hwm4C6vaNkH9XX1dr5+q6gq8vJQdbYoExl22BGMiNbfI3+sLRk0zBYL//W6c\ntSREgR4EjosqQfbkceLJ2JT1wuNjInI0eR9H3cRugvlDTeWtbdJ5qA==\n-----END RSA PRIVATE KEY-----\n",
+            "private_key": 2,
             "jws_signing_alg": "RS256",
             "payment_processor": 1
         }
@@ -92,7 +116,7 @@
                 2
             ],
             "eligibility_verifier": 1,
-            "private_key_pem": "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA1pt0ZoOuPEVPJJS+5r884zcjZLkZZ2GcPwr79XOLDbOi46on\nCa79kjRnhS0VUK96SwUPS0z9J5mDA5LSNL2RoxFb5QGaevnJY828NupzTNdUd0sY\nJK3kRjKUggHWuB55hwJcH/Dx7I3DNH4NL68UAlK+VjwJkfYPrhq/bl5z8ZiurvBa\n5C1mDxhFpcTZlCfxQoas7D1d+uPACF6mEMbQNd3RaIaSREO50NvNywXIIt/OmCiR\nqI7JtOcn4eyh1I4j9WtlbMhRJLfwPMAgY5epTsWcURmhVofF2wVoFbib3JGCfA7t\nz/gmP5YoEKnf/cumKmF3e9LrZb8zwm7bTHUViwIDAQABAoIBAQCIv0XMjNvZS9DC\nXoXGQtVpcxj6dXfaiDgnc7hZDubsNCr3JtT5NqgdIYdVNQUABNDIPNEiCkzFjuwM\nuuF2+dRzM/x6UCs/cSsCjXYBCCOwMwV/fjpEJQnwMQqwTLulVsXZYYeSUtXVBf/8\n0tVULRty34apLFhsyX30UtboXQdESfpmm5ZsqsZJlYljw+M7JxRMneQclI19y/ya\nhPWlfhLB9OffVEJXGaWx1NSYnKoCMKqE/+4krROr6V62xXaNyX6WtU6XiT7C6R5A\nPBxfhmoeFdVCF6a+Qq0v2fKThYoZnV4sn2q2An9YPfynFYnlgzdfnAFSejsqxQd0\nfxYLOtMBAoGBAP1jxjHDJngZ1N+ymw9MIpRgr3HeuMP5phiSTbY2tu9lPzQd+TMX\nfhr1bQh2Fd/vU0u7X0yPnTWtUrLlCdGnWPpXivx95GNGgUUIk2HStFdrRx+f2Qvk\nG8vtLgmSbjQ26UiHzxi9Wa0a41PWIA3TixkcFrS2X29Qc4yd6pVHmicfAoGBANjR\nZ8aaDkSKLkq5Nk1T7I0E1+mtPoH1tPV/FJClXjJrvfDuYHBeOyUpipZddnZuPGWA\nIW2tFIsMgJQtgpvgs52NFI7pQGJRUPK/fTG+Ycocxo78TkLr/RIj8Kj5brXsbZ9P\n3/WBX5GAISTSp1ab8xVgK/Tm07hGupKVqnY2lCAVAoGAIql0YjhE2ecGtLcU+Qm8\nLTnwpg4GjmBnNTNGSCfB7IuYEsQK489R49Qw3xhwM5rkdRajmbCHm+Eiz+/+4NwY\nkt5I1/NMu7vYUR40MwyEuPSm3Q+bvEGu/71pL8wFIUVlshNJ5CN60fA8qqo+5kVK\n4Ntzy7Kq6WpC9Dhh75vE3ZcCgYEAty99uXtxsJD6+aEwcvcENkUwUztPQ6ggAwci\nje9Z/cmwCj6s9mN3HzfQ4qgGrZsHpk4ycCK655xhilBFOIQJ3YRUKUaDYk4H0YDe\nOsf6gTP8wtQDH2GZSNlavLk5w7UFDYQD2b47y4fw+NaOEYvjPl0p5lmb6ebAPZb8\nFbKZRd0CgYBC1HTbA+zMEqDdY4MWJJLC6jZsjdxOGhzjrCtWcIWEGMDF7oDDEoix\nW3j2hwm4C6vaNkH9XX1dr5+q6gq8vJQdbYoExl22BGMiNbfI3+sLRk0zBYL//W6c\ntSREgR4EjosqQfbkceLJ2JT1wuNjInI0eR9H3cRugvlDTeWtbdJ5qA==\n-----END RSA PRIVATE KEY-----\n",
+            "private_key": 2,
             "jws_signing_alg": "RS256",
             "payment_processor": 1
         }


### PR DESCRIPTION
## What this PR does

1. Creates a new model class `core.PemData`
2. Refactors existing models `core.EligibilityVerifier`, `core.PaymentProcessor`, `core.TransitAgency` to use references to `core.PemData` instead of storing their certificates/keys directly

Closes #125

## Testing this PR

1. Checkout the branch, Rebuild and Reopen the devcontainer
2. Launch with `F5`
3. Go through the eligibility flow