### PR TITLE
Auto-label deploy PRs

### DIFF
--- a/.github/workflows/deploy-labeler.yml
+++ b/.github/workflows/deploy-labeler.yml
@@ -1,0 +1,16 @@
+name: Label deploys
+
+on:
+  pull_request:
+    branches: [prod, test]
+    types: [closed]
+
+jobs:
+  label-deploy:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: add-label
+        uses: andymckay/labeler@master
+        with:
+          add-labels: "deployment"


### PR DESCRIPTION
After a successful merge to `test` or `prod`, apply the `deployment` label to the closed PR.