### PR TITLE
Fix the documentation labeler

### DIFF
--- a/.github/workflows/labeler-docs.yml
+++ b/.github/workflows/labeler-docs.yml
@@ -16,4 +16,4 @@ jobs:
       - name: add-label
         uses: andymckay/labeler@master
         with:
-          add-labels: "docs"
+          add-labels: "documentation"


### PR DESCRIPTION
Apply the `documentation` label, not `docs`