### PR TITLE
Pin conventional-pre-commit to v1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v1.0.0
+    rev: v1
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]


### PR DESCRIPTION
Closes #165 

As noted by @machikoyasuda in cal-itp/eligibility-server#47, you will see a warning due to this `rev`, but 
> we decided it's okay, because the Dev Container always will install only once.