### PR TITLE
Fix Linux devcontainer issue from file permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN useradd --create-home --shell /bin/bash $USER && \
 # enter app directory
 WORKDIR /home/$USER/app
 
+USER $USER
 # install python dependencies
 COPY requirements.txt requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
@@ -40,6 +41,7 @@ COPY bin/ bin/
 # overwrite default nginx.conf
 COPY nginx.conf /etc/nginx/nginx.conf
 
+USER root
 # ensure $USER can compile messages in the locale directories
 RUN chown -R $USER /home/$USER/app/benefits/locale
 

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -20,7 +20,7 @@ fi
 
 # generate language *.mo files for use by Django
 
-django-admin compilemessages
+python manage.py compilemessages
 
 # collect static files
 

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -11,4 +11,4 @@ nginx
 
 # start the application server
 
-gunicorn benefits.wsgi
+python -m gunicorn benefits.wsgi

--- a/localhost/Dockerfile.dev
+++ b/localhost/Dockerfile.dev
@@ -2,18 +2,18 @@ FROM benefits_client:latest
 
 USER root
 
-RUN apt-get install -qq --no-install-recommends curl git jq ssh && \
-    python -m pip install --upgrade pip && \
-    pip install --no-cache-dir black flake8 pre-commit
-
 # install node.js
 # see https://github.com/nodesource/distributions#installation-instructions
 
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash
-RUN apt-get install -qq nodejs libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev \
-                        libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+
+RUN apt-get install -qq nodejs npm libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev \
+    libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb curl git jq ssh
 
 USER $USER
-ENV PATH "$PATH:/home/${USER}/.local/bin"
+
+RUN python -m pip install --upgrade pip && \
+    pip install black flake8 pre-commit
+
 COPY docs/requirements.txt docs/requirements.txt
-RUN pip install --no-cache-dir -r docs/requirements.txt
+RUN pip install -r docs/requirements.txt

--- a/localhost/Dockerfile.dev
+++ b/localhost/Dockerfile.dev
@@ -13,8 +13,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash
 RUN apt-get install -qq nodejs libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev \
                         libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
 
-# todo: need to extract this
-USER calitp
-ENV PATH "$PATH:/home/calitp/.local/bin"
+USER $USER
+ENV PATH "$PATH:/home/${USER}/.local/bin"
 COPY docs/requirements.txt docs/requirements.txt
 RUN pip install --no-cache-dir -r docs/requirements.txt

--- a/localhost/Dockerfile.dev
+++ b/localhost/Dockerfile.dev
@@ -13,5 +13,8 @@ RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash
 RUN apt-get install -qq nodejs libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev \
                         libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
 
+# todo: need to extract this
+USER calitp
+ENV PATH "$PATH:/home/calitp/.local/bin"
 COPY docs/requirements.txt docs/requirements.txt
 RUN pip install --no-cache-dir -r docs/requirements.txt


### PR DESCRIPTION
Closes #171 

- Added lines to `Dockerfile.dev` to use the `calitp` user so that the npm dependencies are installed using that user rather than root
- Added lines in `Dockerfile` to make the Python packages be installed using `calitp` as well