### PR TITLE
Make sure locale directory is writable by calitp user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,11 +26,25 @@ RUN useradd --create-home --shell /bin/bash $USER && \
     apt-get update && \
     apt-get install -qq --no-install-recommends gettext nginx
 
-# switch to non-root $USER
-USER $USER
-
 # enter app directory
 WORKDIR /home/$USER/app
+
+# copy config files
+COPY gunicorn.conf.py gunicorn.conf.py
+COPY manage.py manage.py
+
+# overwrite default nginx.conf
+COPY nginx.conf /etc/nginx/nginx.conf
+
+# copy source files
+COPY benefits/ benefits/
+COPY bin/ bin/
+
+# ensure $USER can compile messages in the locale directories
+RUN chmod -R 777 benefits/locale
+
+# switch to non-root $USER
+USER $USER
 
 # update PATH for local pip installs
 ENV PATH "$PATH:/home/$USER/.local/bin"
@@ -38,22 +52,6 @@ ENV PATH "$PATH:/home/$USER/.local/bin"
 # install python dependencies
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt
-
-# copy source files (as root)
-COPY gunicorn.conf.py gunicorn.conf.py
-COPY manage.py manage.py
-COPY benefits/ benefits/
-COPY bin/ bin/
-
-# ensure $USER can compile messages in the locale directories
-USER root
-RUN chmod -R 777 /home/$USER/app/benefits/locale
-
-# switch back to non-root $USER
-USER $USER
-
-# overwrite default nginx.conf
-COPY nginx.conf /etc/nginx/nginx.conf
 
 # configure container executable
 ENTRYPOINT ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,11 +39,18 @@ ENV PATH "$PATH:/home/$USER/.local/bin"
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 
-# copy source files
+# copy source files (as root)
 COPY gunicorn.conf.py gunicorn.conf.py
 COPY manage.py manage.py
 COPY benefits/ benefits/
 COPY bin/ bin/
+
+# ensure $USER can compile messages in the locale directories
+USER root
+RUN chmod -R 777 /home/$USER/app/benefits/locale
+
+# switch back to non-root $USER
+USER $USER
 
 # overwrite default nginx.conf
 COPY nginx.conf /etc/nginx/nginx.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,8 @@ COPY manage.py manage.py
 COPY nginx.conf /etc/nginx/nginx.conf
 
 # copy source files
-COPY benefits/ benefits/
 COPY bin/ bin/
+COPY benefits/ benefits/
 
 # ensure $USER can compile messages in the locale directories
 RUN chmod -R 777 benefits/locale


### PR DESCRIPTION
Related to #171 

The [deploy to dev](https://github.com/cal-itp/benefits/actions/runs/1419184744) failed because the `benefits/locale/**` directories are not writable by the `calitp` user.

[Changes](https://github.com/cal-itp/benefits/pull/172/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L44) from #172 removed the explicit ownership-change on `benefits/locale` and moved the `USER $USER` switch to occur before we `COPY` the source files. We thought this would make `calitp` the owner of the app files/directories, but it turns out [COPY commands are run as root](https://stackoverflow.com/a/44766666/453168).

We actually decided it is better to have `root` be the owner, so in this pull request we just change the permissions for `benefits/locale/**`.