### PR TITLE
Add JavaScript/JSON/CSS linting

### DIFF
--- a/.aws/ecs-task.json
+++ b/.aws/ecs-task.json
@@ -1,90 +1,84 @@
 {
-    "executionRoleArn": "arn:aws:iam::<aws_account>:role/cal-itp-benefits-client-task-execution-role",
-    "taskRoleArn": "arn:aws:iam::<aws_account>:role/cal-itp-benefits-client-task-role",
-    "containerDefinitions": [
-        {
-            "name": "cal-itp-benefits-client",
-            "logConfiguration": {
-                "logDriver": "awslogs",
-                "options": {
-                    "awslogs-group": "/ecs/cal-itp-benefits-client",
-                    "awslogs-region": "<aws_region>",
-                    "awslogs-stream-prefix": "ecs"
-                }
-            },
-            "portMappings": [
-                {
-                    "hostPort": 8000,
-                    "protocol": "tcp",
-                    "containerPort": 8000
-                }
-            ],
-            "mountPoints": [
-                {
-                    "containerPath": "/home/calitp/app/config",
-                    "sourceVolume": "cal-itp-config-volume"
-                }
-            ],
-            "environment": [
-            ],
-            "environmentFiles": [
-                {
-                    "value": "arn:aws:s3:::<aws_bucket>/.env",
-                    "type": "s3"
-                }
-            ],
-            "secrets": [
-            ],
-            "essential": true,
-            "dependsOn": [
-                {
-                    "containerName": "cal-itp-benefits-client-config",
-                    "condition": "SUCCESS"
-                }
-            ]
-        },
-        {
-            "name": "cal-itp-benefits-client-config",
-            "logConfiguration": {
-                "logDriver": "awslogs",
-                "options": {
-                    "awslogs-group": "/ecs/cal-itp-benefits-client",
-                    "awslogs-region": "<aws_region>",
-                    "awslogs-stream-prefix": "ecs"
-                }
-            },
-            "essential": false,
-            "entryPoint": ["/bin/sh"],
-            "command": ["-c", "aws s3 cp s3://${AWS_BUCKET}/${CONFIG_FILE} /aws"],
-            "environmentFiles": [
-                {
-                    "value": "arn:aws:s3:::<aws_bucket>/.env",
-                    "type": "s3"
-                }
-            ],
-            "secrets": [
-            ],
-            "mountPoints": [
-                {
-                    "containerPath": "/aws",
-                    "sourceVolume": "cal-itp-config-volume"
-                }
-            ]
+  "executionRoleArn": "arn:aws:iam::<aws_account>:role/cal-itp-benefits-client-task-execution-role",
+  "taskRoleArn": "arn:aws:iam::<aws_account>:role/cal-itp-benefits-client-task-role",
+  "containerDefinitions": [
+    {
+      "name": "cal-itp-benefits-client",
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/cal-itp-benefits-client",
+          "awslogs-region": "<aws_region>",
+          "awslogs-stream-prefix": "ecs"
         }
-    ],
-    "placementConstraints": [
-    ],
-    "memory": "1024",
-    "family": "cal-itp-benefits-client",
-    "requiresCompatibilities": [
-        "FARGATE"
-    ],
-    "networkMode": "awsvpc",
-    "cpu": "512",
-    "volumes": [
+      },
+      "portMappings": [
         {
-            "name": "cal-itp-config-volume",
-            "host": {}
+          "hostPort": 8000,
+          "protocol": "tcp",
+          "containerPort": 8000
         }
-    ]
+      ],
+      "mountPoints": [
+        {
+          "containerPath": "/home/calitp/app/config",
+          "sourceVolume": "cal-itp-config-volume"
+        }
+      ],
+      "environment": [],
+      "environmentFiles": [
+        {
+          "value": "arn:aws:s3:::<aws_bucket>/.env",
+          "type": "s3"
+        }
+      ],
+      "secrets": [],
+      "essential": true,
+      "dependsOn": [
+        {
+          "containerName": "cal-itp-benefits-client-config",
+          "condition": "SUCCESS"
+        }
+      ]
+    },
+    {
+      "name": "cal-itp-benefits-client-config",
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/cal-itp-benefits-client",
+          "awslogs-region": "<aws_region>",
+          "awslogs-stream-prefix": "ecs"
+        }
+      },
+      "essential": false,
+      "entryPoint": ["/bin/sh"],
+      "command": ["-c", "aws s3 cp s3://${AWS_BUCKET}/${CONFIG_FILE} /aws"],
+      "environmentFiles": [
+        {
+          "value": "arn:aws:s3:::<aws_bucket>/.env",
+          "type": "s3"
+        }
+      ],
+      "secrets": [],
+      "mountPoints": [
+        {
+          "containerPath": "/aws",
+          "sourceVolume": "cal-itp-config-volume"
+        }
+      ]
+    }
+  ],
+  "placementConstraints": [],
+  "memory": "1024",
+  "family": "cal-itp-benefits-client",
+  "requiresCompatibilities": ["FARGATE"],
+  "networkMode": "awsvpc",
+  "cpu": "512",
+  "volumes": [
+    {
+      "name": "cal-itp-config-volume",
+      "host": {}
+    }
+  ]
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,4 +41,4 @@ repos:
     rev: v2.4.1
     hooks:
       - id: prettier
-        types_or: [javascript]
+        types_or: [javascript, css]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,3 +36,9 @@ repos:
       - id: bandit
         args: ["-ll"]
         files: .py$
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.4.1
+    hooks:
+      - id: prettier
+        types_or: [javascript]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,20 +1,16 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Django: Benefits Client",
-            "type": "python",
-            "request": "launch",
-            "program": "${workspaceFolder}/manage.py",
-            "args": [
-                "runserver",
-                "--insecure",
-                "0.0.0.0:8000"
-            ],
-            "django": true
-        }
-    ]
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Django: Benefits Client",
+      "type": "python",
+      "request": "launch",
+      "program": "${workspaceFolder}/manage.py",
+      "args": ["runserver", "--insecure", "0.0.0.0:8000"],
+      "django": true
+    }
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,12 @@
 {
-    "editor.formatOnSave": true,
-    "files.encoding": "utf8",
-    "files.eol": "\n",
-    "files.insertFinalNewline": true,
-    "files.trimFinalNewlines": true,
-    "files.trimTrailingWhitespace": true,
-    "python.formatting.provider": "black",
-    "python.linting.flake8Enabled": true,
-    "python.linting.enabled": true,
-    "python.languageServer": "Pylance",
+  "editor.formatOnSave": true,
+  "files.encoding": "utf8",
+  "files.eol": "\n",
+  "files.insertFinalNewline": true,
+  "files.trimFinalNewlines": true,
+  "files.trimTrailingWhitespace": true,
+  "python.formatting.provider": "black",
+  "python.linting.flake8Enabled": true,
+  "python.linting.enabled": true,
+  "python.languageServer": "Pylance"
 }

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -1,253 +1,269 @@
 /* HTML element overrides */
 
 body {
-    font-weight: 400;
-    font-size: 16px;
-    line-height: 22px;
-    color: #000000;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 22px;
+  color: #000000;
 }
 
-body, h1, h2, h3, h4, h5, h6, p, a, span, li {
-    font-family: "Roboto", sans-serif;
+body,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+a,
+span,
+li {
+  font-family: "Roboto", sans-serif;
 }
 
-h1, h2, h3, h4, h5, h6 {
-    font-weight: 500;
-    font-size: 24px;
-    line-height: 30px;
-    margin-top: 30px;
-    margin-bottom: 20px;
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-weight: 500;
+  font-size: 24px;
+  line-height: 30px;
+  margin-top: 30px;
+  margin-bottom: 20px;
 }
 
 h1 {
-    font-weight: 700;
+  font-weight: 700;
 }
 
 p {
-    margin-bottom: 1rem;
+  margin-bottom: 1rem;
 }
 
 /* making the sticky footer */
 
-html, body {
-    height: 100%;
-    overflow-y: unset;
+html,
+body {
+  height: 100%;
+  overflow-y: unset;
 }
 body {
-    display: flex;
-    flex-direction: column;
+  display: flex;
+  flex-direction: column;
 }
 main {
-    flex-shrink: 0 !important;
+  flex-shrink: 0 !important;
 }
 footer {
-    margin-top: auto;
-    padding-top: 1rem;
-    padding-bottom: 1rem;
+  margin-top: auto;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
 }
 
 /* class styles */
 
 .btn-lg {
-    border-width: 2px;
+  border-width: 2px;
 }
 
 .btn-link {
-    color: #046b99;
+  color: #046b99;
 }
 
 .form-control {
-    border-radius: 0.25rem;
-    border-color: #212121;
-    border-width: 2px;
-    color: #212121;
+  border-radius: 0.25rem;
+  border-color: #212121;
+  border-width: 2px;
+  color: #212121;
 }
 
 .form-control:focus-within {
-    color: #212121;
+  color: #212121;
 }
 
 .form-control-lg {
-    border-radius: 0.3rem;
+  border-radius: 0.3rem;
 }
 
 .required-label {
-    color: #000;
+  color: #000;
 }
 
 .form-group:not(.with-errors) {
-    margin-bottom: 2.375rem;
+  margin-bottom: 2.375rem;
 }
 
 .form-group:not(.with-errors):nth-last-of-type(2) {
-    margin-bottom: 3.375rem;
+  margin-bottom: 3.375rem;
 }
 
 .form-group.with-errors label,
 .form-group.with-errors .required-label {
-    color: #DE0C0C;
+  color: #de0c0c;
 }
 
 .form-group.with-errors .form-control {
-    border-color: #DE0C0C;
+  border-color: #de0c0c;
 }
 
 .form-group.with-errors .error-message {
-    font-size: 14px;
-    padding-left: 1rem;
+  font-size: 14px;
+  padding-left: 1rem;
 }
 
 .media-list {
-    margin-top: 2rem;
-    margin-bottom: 2rem;
+  margin-top: 2rem;
+  margin-bottom: 2rem;
 }
 
 .media-list .media {
-    margin-bottom: 2rem;
-    display: flex;
-    align-items: center;
+  margin-bottom: 2rem;
+  display: flex;
+  align-items: center;
 }
 
 .media-list .media .media-left {
-    margin-right: 18px;
+  margin-right: 18px;
 }
 
 .media-list .media .media-left img {
-    height: 75px;
+  height: 75px;
 }
 
 /* context-specific overrides */
 
 .navbar-brand img.sm {
-    width: 120px;
+  width: 120px;
 }
 
 .navbar-brand img.lg {
-    width: 274px;
+  width: 274px;
 }
 
 .image[class*="col-"] {
-    min-height: 230px;
+  min-height: 230px;
 }
 
 .container.content {
-    margin-top: 2rem;
-    margin-bottom: 2rem;
+  margin-top: 2rem;
+  margin-bottom: 2rem;
 }
 
 .container.content h1.icon-title span.icon {
-    text-align: center;
-    display: block;
-    margin-bottom: 1rem;
+  text-align: center;
+  display: block;
+  margin-bottom: 1rem;
 }
 
 .container.content h1 ~ p:nth-last-of-type(1) {
-    margin-bottom: 2rem;
+  margin-bottom: 2rem;
 }
 
 .container.content .btn-lg {
-    font-weight: 500;
-    margin-bottom: 1rem;
-    padding: 1rem;
-    width: 100%;
+  font-weight: 500;
+  margin-bottom: 1rem;
+  padding: 1rem;
+  width: 100%;
 }
 
 .container.content .btn-lg.agency-url {
-    margin-bottom: 0;
-    padding-bottom: 0;
+  margin-bottom: 0;
+  padding-bottom: 0;
 }
 .container.content .btn-lg.agency-url,
 .container.content .btn-lg.agency-phone {
-    padding-top: 0;
+  padding-top: 0;
 }
 
 .container.content .btn-link {
-    text-decoration: underline;
+  text-decoration: underline;
 }
 
 .text-lg-center form {
-    text-align: left !important;
+  text-align: left !important;
 }
 .text-lg-center .buttons label {
-    width: 100%;
-    text-align: center !important;
+  width: 100%;
+  text-align: center !important;
 }
 
 /* media queries */
 
 @media (max-width: 767px) {
-    /* xs and sm */
-    .media-list .media .media-body {
-        max-width: 160px;
-    }
+  /* xs and sm */
+  .media-list .media .media-body {
+    max-width: 160px;
+  }
 
-    .global-footer ul li {
-        width: 40%;
-    }
+  .global-footer ul li {
+    width: 40%;
+  }
 }
 
 @media (min-width: 992px) {
-    /* lg+ */
+  /* lg+ */
 
-    /* undoing the sticky footer for pages with header image
+  /* undoing the sticky footer for pages with header image
        the backup plan is to color the body the same as the footer
        to avoid the floating footer look
     */
-    .with-image main {
-        flex-shrink: unset;
-    }
-    .with-image .container.content {
-        min-height: 800px;
-    }
-    .with-image footer {
-        margin-top: unset;
-        padding-top: 1rem;
-        padding-bottom: 1rem;
-    }
+  .with-image main {
+    flex-shrink: unset;
+  }
+  .with-image .container.content {
+    min-height: 800px;
+  }
+  .with-image footer {
+    margin-top: unset;
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+  }
 
-    h1 {
-        font-size: 36px;
-        line-height: 45px;
-    }
+  h1 {
+    font-size: 36px;
+    line-height: 45px;
+  }
 
-    h1.icon-title {
-        text-align: center;
-    }
+  h1.icon-title {
+    text-align: center;
+  }
 
-    h2 {
-        font-size: 30px;
-        line-height: 36px;
-    }
+  h2 {
+    font-size: 30px;
+    line-height: 36px;
+  }
 
-    .home p,
-    .home label {
-        font-size: 24px;
-        line-height: 30px;
-    }
+  .home p,
+  .home label {
+    font-size: 24px;
+    line-height: 30px;
+  }
 
-    .image[class*="col-"] {
-        min-height: 725px;
-    }
+  .image[class*="col-"] {
+    min-height: 725px;
+  }
 
-    .container.content {
-        padding-left: 3.5rem;
-        padding-right: 3.5rem;
-        margin-top: 8rem;
-        margin-bottom: 7rem;
-    }
+  .container.content {
+    padding-left: 3.5rem;
+    padding-right: 3.5rem;
+    margin-top: 8rem;
+    margin-bottom: 7rem;
+  }
 
-    .container.content input[type=submit],
-    .container.content .btn {
-        width: 70%;
-        margin-left: 15%;
-        margin-right: 15%;
-    }
+  .container.content input[type="submit"],
+  .container.content .btn {
+    width: 70%;
+    margin-left: 15%;
+    margin-right: 15%;
+  }
 }
 
 @media (min-width: 1200px) {
-    /* xl+ */
-    .container.content {
-        padding-left: 5rem;
-        padding-right: 5rem;
-    }
+  /* xl+ */
+  .container.content {
+    padding-left: 5rem;
+    padding-right: 5rem;
+  }
 }

--- a/localhost/data/client.json
+++ b/localhost/data/client.json
@@ -1,124 +1,117 @@
 [
-    {
-        "model": "core.pemdata",
-        "pk": 1,
-        "fields": {
-            "text": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyYo6Pe9OSfPGX0oQXyLA\nblOwrMgc/j1JlF07b1ahq1lc3FH0XEk3Dzqbt9NuQs8hz6493vBNtNWTpVmvbGe4\nVX3UjhpEARhN3m4jf/Z2OEuDt2A9q19NLSjgeyhieLkYLwN1ezYXrkn7cfOngcJM\nnGDXp45CaA+g3DzasrjETnKUdqecCzJ3FJ/RRwfibrju7eS/8s6H03nvydzeAJzT\nkEv7Fic2JJEUhh2rJhyLxt+qKkIYeBG+5fBri4miaS8FPnD/yjZzEAFsQc7n0dGq\nDAhSJS8tYNmXFmGlaCfRUBNV3mvOx0vFPuH21WQ5KKZxZP0e64/uQdotbPIImiyR\nJwIDAQAB\n-----END PUBLIC KEY-----\n",
-            "label": "Eligibility server public key"
-        }
-    },
-    {
-        "model": "core.pemdata",
-        "pk": 2,
-        "fields": {
-            "text": "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA1pt0ZoOuPEVPJJS+5r884zcjZLkZZ2GcPwr79XOLDbOi46on\nCa79kjRnhS0VUK96SwUPS0z9J5mDA5LSNL2RoxFb5QGaevnJY828NupzTNdUd0sY\nJK3kRjKUggHWuB55hwJcH/Dx7I3DNH4NL68UAlK+VjwJkfYPrhq/bl5z8ZiurvBa\n5C1mDxhFpcTZlCfxQoas7D1d+uPACF6mEMbQNd3RaIaSREO50NvNywXIIt/OmCiR\nqI7JtOcn4eyh1I4j9WtlbMhRJLfwPMAgY5epTsWcURmhVofF2wVoFbib3JGCfA7t\nz/gmP5YoEKnf/cumKmF3e9LrZb8zwm7bTHUViwIDAQABAoIBAQCIv0XMjNvZS9DC\nXoXGQtVpcxj6dXfaiDgnc7hZDubsNCr3JtT5NqgdIYdVNQUABNDIPNEiCkzFjuwM\nuuF2+dRzM/x6UCs/cSsCjXYBCCOwMwV/fjpEJQnwMQqwTLulVsXZYYeSUtXVBf/8\n0tVULRty34apLFhsyX30UtboXQdESfpmm5ZsqsZJlYljw+M7JxRMneQclI19y/ya\nhPWlfhLB9OffVEJXGaWx1NSYnKoCMKqE/+4krROr6V62xXaNyX6WtU6XiT7C6R5A\nPBxfhmoeFdVCF6a+Qq0v2fKThYoZnV4sn2q2An9YPfynFYnlgzdfnAFSejsqxQd0\nfxYLOtMBAoGBAP1jxjHDJngZ1N+ymw9MIpRgr3HeuMP5phiSTbY2tu9lPzQd+TMX\nfhr1bQh2Fd/vU0u7X0yPnTWtUrLlCdGnWPpXivx95GNGgUUIk2HStFdrRx+f2Qvk\nG8vtLgmSbjQ26UiHzxi9Wa0a41PWIA3TixkcFrS2X29Qc4yd6pVHmicfAoGBANjR\nZ8aaDkSKLkq5Nk1T7I0E1+mtPoH1tPV/FJClXjJrvfDuYHBeOyUpipZddnZuPGWA\nIW2tFIsMgJQtgpvgs52NFI7pQGJRUPK/fTG+Ycocxo78TkLr/RIj8Kj5brXsbZ9P\n3/WBX5GAISTSp1ab8xVgK/Tm07hGupKVqnY2lCAVAoGAIql0YjhE2ecGtLcU+Qm8\nLTnwpg4GjmBnNTNGSCfB7IuYEsQK489R49Qw3xhwM5rkdRajmbCHm+Eiz+/+4NwY\nkt5I1/NMu7vYUR40MwyEuPSm3Q+bvEGu/71pL8wFIUVlshNJ5CN60fA8qqo+5kVK\n4Ntzy7Kq6WpC9Dhh75vE3ZcCgYEAty99uXtxsJD6+aEwcvcENkUwUztPQ6ggAwci\nje9Z/cmwCj6s9mN3HzfQ4qgGrZsHpk4ycCK655xhilBFOIQJ3YRUKUaDYk4H0YDe\nOsf6gTP8wtQDH2GZSNlavLk5w7UFDYQD2b47y4fw+NaOEYvjPl0p5lmb6ebAPZb8\nFbKZRd0CgYBC1HTbA+zMEqDdY4MWJJLC6jZsjdxOGhzjrCtWcIWEGMDF7oDDEoix\nW3j2hwm4C6vaNkH9XX1dr5+q6gq8vJQdbYoExl22BGMiNbfI3+sLRk0zBYL//W6c\ntSREgR4EjosqQfbkceLJ2JT1wuNjInI0eR9H3cRugvlDTeWtbdJ5qA==\n-----END RSA PRIVATE KEY-----\n",
-            "label": "Benefits client private key"
-        }
-    },
-    {
-        "model": "core.pemdata",
-        "pk": 3,
-        "fields": {
-            "text": "-----BEGIN CERTIFICATE-----\nPEM DATA\n-----END CERTIFICATE-----\n",
-            "label": "Dummy certificate"
-        }
-    },
-    {
-        "model": "core.paymentprocessor",
-        "pk": 1,
-        "fields": {
-            "name": "Test Payment Processor",
-            "api_base_url": "http://server:5000",
-            "api_access_token_endpoint": "access-token",
-            "api_access_token_request_key": "request_access",
-            "api_access_token_request_val": "REQUEST_ACCESS",
-            "card_tokenize_url": "http://localhost:5000/static/tokenize.js",
-            "card_tokenize_func": "tokenize",
-            "card_tokenize_env": "test",
-            "client_cert": 3,
-            "client_cert_private_key": 2,
-            "client_cert_root_ca": 3,
-            "customer_endpoint": "customer",
-            "customers_endpoint": "customers",
-            "group_endpoint": "group"
-        }
-    },
-    {
-        "model": "core.eligibilitytype",
-        "pk": 1,
-        "fields": {
-            "name": "type1",
-            "label": "Eligibility Type 1",
-            "group_id": "group1"
-        }
-    },
-    {
-        "model": "core.eligibilitytype",
-        "pk": 2,
-        "fields": {
-            "name": "type2",
-            "label": "Eligibility Type 2",
-            "group_id": "group2"
-        }
-    },
-    {
-        "model": "core.eligibilityverifier",
-        "pk": 1,
-        "fields": {
-            "name": "Test Eligibility Verifier",
-            "api_url": "http://server:5000/verify",
-            "api_auth_header": "X-Server-API-Key",
-            "api_auth_key": "server-auth-token",
-            "eligibility_types": [
-                1,
-                2
-            ],
-            "public_key": 1,
-            "jwe_cek_enc": "A256CBC-HS512",
-            "jwe_encryption_alg": "RSA-OAEP",
-            "jws_signing_alg": "RS256"
-        }
-    },
-    {
-        "model": "core.transitagency",
-        "pk": 1,
-        "fields": {
-            "slug": "abc",
-            "short_name": "ABC",
-            "long_name": "ABC Transit Company",
-            "agency_id": "abc123",
-            "merchant_id": "abc",
-            "info_url": "https://www.example.com/help",
-            "phone": "800-555-5555",
-            "active": true,
-            "eligibility_types": [
-                1
-            ],
-            "eligibility_verifier": 1,
-            "private_key": 2,
-            "jws_signing_alg": "RS256",
-            "payment_processor": 1
-        }
-    },
-    {
-        "model": "core.transitagency",
-        "pk": 2,
-        "fields": {
-            "slug": "deftl",
-            "short_name": "DefTL",
-            "long_name": "DEF Transit Lines",
-            "agency_id": "def456",
-            "merchant_id": "deftl",
-            "info_url": "https://www.example.com/help",
-            "phone": "321-555-5555",
-            "active": true,
-            "eligibility_types": [
-                2
-            ],
-            "eligibility_verifier": 1,
-            "private_key": 2,
-            "jws_signing_alg": "RS256",
-            "payment_processor": 1
-        }
+  {
+    "model": "core.pemdata",
+    "pk": 1,
+    "fields": {
+      "text": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyYo6Pe9OSfPGX0oQXyLA\nblOwrMgc/j1JlF07b1ahq1lc3FH0XEk3Dzqbt9NuQs8hz6493vBNtNWTpVmvbGe4\nVX3UjhpEARhN3m4jf/Z2OEuDt2A9q19NLSjgeyhieLkYLwN1ezYXrkn7cfOngcJM\nnGDXp45CaA+g3DzasrjETnKUdqecCzJ3FJ/RRwfibrju7eS/8s6H03nvydzeAJzT\nkEv7Fic2JJEUhh2rJhyLxt+qKkIYeBG+5fBri4miaS8FPnD/yjZzEAFsQc7n0dGq\nDAhSJS8tYNmXFmGlaCfRUBNV3mvOx0vFPuH21WQ5KKZxZP0e64/uQdotbPIImiyR\nJwIDAQAB\n-----END PUBLIC KEY-----\n",
+      "label": "Eligibility server public key"
     }
+  },
+  {
+    "model": "core.pemdata",
+    "pk": 2,
+    "fields": {
+      "text": "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA1pt0ZoOuPEVPJJS+5r884zcjZLkZZ2GcPwr79XOLDbOi46on\nCa79kjRnhS0VUK96SwUPS0z9J5mDA5LSNL2RoxFb5QGaevnJY828NupzTNdUd0sY\nJK3kRjKUggHWuB55hwJcH/Dx7I3DNH4NL68UAlK+VjwJkfYPrhq/bl5z8ZiurvBa\n5C1mDxhFpcTZlCfxQoas7D1d+uPACF6mEMbQNd3RaIaSREO50NvNywXIIt/OmCiR\nqI7JtOcn4eyh1I4j9WtlbMhRJLfwPMAgY5epTsWcURmhVofF2wVoFbib3JGCfA7t\nz/gmP5YoEKnf/cumKmF3e9LrZb8zwm7bTHUViwIDAQABAoIBAQCIv0XMjNvZS9DC\nXoXGQtVpcxj6dXfaiDgnc7hZDubsNCr3JtT5NqgdIYdVNQUABNDIPNEiCkzFjuwM\nuuF2+dRzM/x6UCs/cSsCjXYBCCOwMwV/fjpEJQnwMQqwTLulVsXZYYeSUtXVBf/8\n0tVULRty34apLFhsyX30UtboXQdESfpmm5ZsqsZJlYljw+M7JxRMneQclI19y/ya\nhPWlfhLB9OffVEJXGaWx1NSYnKoCMKqE/+4krROr6V62xXaNyX6WtU6XiT7C6R5A\nPBxfhmoeFdVCF6a+Qq0v2fKThYoZnV4sn2q2An9YPfynFYnlgzdfnAFSejsqxQd0\nfxYLOtMBAoGBAP1jxjHDJngZ1N+ymw9MIpRgr3HeuMP5phiSTbY2tu9lPzQd+TMX\nfhr1bQh2Fd/vU0u7X0yPnTWtUrLlCdGnWPpXivx95GNGgUUIk2HStFdrRx+f2Qvk\nG8vtLgmSbjQ26UiHzxi9Wa0a41PWIA3TixkcFrS2X29Qc4yd6pVHmicfAoGBANjR\nZ8aaDkSKLkq5Nk1T7I0E1+mtPoH1tPV/FJClXjJrvfDuYHBeOyUpipZddnZuPGWA\nIW2tFIsMgJQtgpvgs52NFI7pQGJRUPK/fTG+Ycocxo78TkLr/RIj8Kj5brXsbZ9P\n3/WBX5GAISTSp1ab8xVgK/Tm07hGupKVqnY2lCAVAoGAIql0YjhE2ecGtLcU+Qm8\nLTnwpg4GjmBnNTNGSCfB7IuYEsQK489R49Qw3xhwM5rkdRajmbCHm+Eiz+/+4NwY\nkt5I1/NMu7vYUR40MwyEuPSm3Q+bvEGu/71pL8wFIUVlshNJ5CN60fA8qqo+5kVK\n4Ntzy7Kq6WpC9Dhh75vE3ZcCgYEAty99uXtxsJD6+aEwcvcENkUwUztPQ6ggAwci\nje9Z/cmwCj6s9mN3HzfQ4qgGrZsHpk4ycCK655xhilBFOIQJ3YRUKUaDYk4H0YDe\nOsf6gTP8wtQDH2GZSNlavLk5w7UFDYQD2b47y4fw+NaOEYvjPl0p5lmb6ebAPZb8\nFbKZRd0CgYBC1HTbA+zMEqDdY4MWJJLC6jZsjdxOGhzjrCtWcIWEGMDF7oDDEoix\nW3j2hwm4C6vaNkH9XX1dr5+q6gq8vJQdbYoExl22BGMiNbfI3+sLRk0zBYL//W6c\ntSREgR4EjosqQfbkceLJ2JT1wuNjInI0eR9H3cRugvlDTeWtbdJ5qA==\n-----END RSA PRIVATE KEY-----\n",
+      "label": "Benefits client private key"
+    }
+  },
+  {
+    "model": "core.pemdata",
+    "pk": 3,
+    "fields": {
+      "text": "-----BEGIN CERTIFICATE-----\nPEM DATA\n-----END CERTIFICATE-----\n",
+      "label": "Dummy certificate"
+    }
+  },
+  {
+    "model": "core.paymentprocessor",
+    "pk": 1,
+    "fields": {
+      "name": "Test Payment Processor",
+      "api_base_url": "http://server:5000",
+      "api_access_token_endpoint": "access-token",
+      "api_access_token_request_key": "request_access",
+      "api_access_token_request_val": "REQUEST_ACCESS",
+      "card_tokenize_url": "http://localhost:5000/static/tokenize.js",
+      "card_tokenize_func": "tokenize",
+      "card_tokenize_env": "test",
+      "client_cert": 3,
+      "client_cert_private_key": 2,
+      "client_cert_root_ca": 3,
+      "customer_endpoint": "customer",
+      "customers_endpoint": "customers",
+      "group_endpoint": "group"
+    }
+  },
+  {
+    "model": "core.eligibilitytype",
+    "pk": 1,
+    "fields": {
+      "name": "type1",
+      "label": "Eligibility Type 1",
+      "group_id": "group1"
+    }
+  },
+  {
+    "model": "core.eligibilitytype",
+    "pk": 2,
+    "fields": {
+      "name": "type2",
+      "label": "Eligibility Type 2",
+      "group_id": "group2"
+    }
+  },
+  {
+    "model": "core.eligibilityverifier",
+    "pk": 1,
+    "fields": {
+      "name": "Test Eligibility Verifier",
+      "api_url": "http://server:5000/verify",
+      "api_auth_header": "X-Server-API-Key",
+      "api_auth_key": "server-auth-token",
+      "eligibility_types": [1, 2],
+      "public_key": 1,
+      "jwe_cek_enc": "A256CBC-HS512",
+      "jwe_encryption_alg": "RSA-OAEP",
+      "jws_signing_alg": "RS256"
+    }
+  },
+  {
+    "model": "core.transitagency",
+    "pk": 1,
+    "fields": {
+      "slug": "abc",
+      "short_name": "ABC",
+      "long_name": "ABC Transit Company",
+      "agency_id": "abc123",
+      "merchant_id": "abc",
+      "info_url": "https://www.example.com/help",
+      "phone": "800-555-5555",
+      "active": true,
+      "eligibility_types": [1],
+      "eligibility_verifier": 1,
+      "private_key": 2,
+      "jws_signing_alg": "RS256",
+      "payment_processor": 1
+    }
+  },
+  {
+    "model": "core.transitagency",
+    "pk": 2,
+    "fields": {
+      "slug": "deftl",
+      "short_name": "DefTL",
+      "long_name": "DEF Transit Lines",
+      "agency_id": "def456",
+      "merchant_id": "deftl",
+      "info_url": "https://www.example.com/help",
+      "phone": "321-555-5555",
+      "active": true,
+      "eligibility_types": [2],
+      "eligibility_verifier": 1,
+      "private_key": 2,
+      "jws_signing_alg": "RS256",
+      "payment_processor": 1
+    }
+  }
 ]

--- a/tests/e2e/cypress.json
+++ b/tests/e2e/cypress.json
@@ -1,4 +1,4 @@
 {
-    "pluginsFile": false,
-    "supportFile": false
+  "pluginsFile": false,
+  "supportFile": false
 }

--- a/tests/e2e/cypress/integration/eligibility.spec.js
+++ b/tests/e2e/cypress/integration/eligibility.spec.js
@@ -1,76 +1,67 @@
-const users = require("../fixtures/users.json")
-const agencies = require('../fixtures/transit-agencies.json')
+const users = require("../fixtures/users.json");
+const agencies = require("../fixtures/transit-agencies.json");
 
 describe("Confirms a user’s eligibility status", () => {
   beforeEach(() => {
-    cy.visit("/")
-    cy.contains(agencies[0].short_name)
-      .click()
-    cy.contains("Let’s do it!")
-      .click()
-    cy.contains("Ready to continue")
-      .click()
-  })
+    cy.visit("/");
+    cy.contains(agencies[0].short_name).click();
+    cy.contains("Let’s do it!").click();
+    cy.contains("Ready to continue").click();
+  });
 
   it("Takes user to eligibility confirmation page", () => {
-    cy.contains("Let’s see if we can confirm your age")
-    cy.contains("CA driver’s license or ID number *")
-  })
+    cy.contains("Let’s see if we can confirm your age");
+    cy.contains("CA driver’s license or ID number *");
+  });
 
   it("Confirmation page has a form with a driver’s license or ID number form label and corresponding form field", () => {
-    cy.get('input:focus').should('have.length', 0)
-    cy.contains("CA driver’s license or ID number *")
-      .click()
+    cy.get("input:focus").should("have.length", 0);
+    cy.contains("CA driver’s license or ID number *").click();
 
-    cy.get('input:focus').should('have.length', 1)
-  })
+    cy.get("input:focus").should("have.length", 1);
+  });
 
   it("Confirmation page has a form with a lastname form label and corresponding form field", () => {
-    cy.get('input:focus').should('have.length', 0)
-    cy.contains("Last name (as it appears on ID) *")
-      .click()
+    cy.get("input:focus").should("have.length", 0);
+    cy.contains("Last name (as it appears on ID) *").click();
 
-    cy.get('input:focus').should('have.length', 1)
-  })
+    cy.get("input:focus").should("have.length", 1);
+  });
 
   it.skip("From the confirmation page, confirms an eligible user", () => {
-    cy.get("#sub").type(users.eligible.sub)
-    cy.get("#name").type(users.eligible.name)
-    cy.get("input[type='submit']")
-      .click()
+    cy.get("#sub").type(users.eligible.sub);
+    cy.get("#name").type(users.eligible.name);
+    cy.get("input[type='submit']").click();
 
-    cy.contains("Great! You’re eligible for a discount!")
-  })
+    cy.contains("Great! You’re eligible for a discount!");
+  });
 
   it("From the confirmation page, confirms an ineligible user", () => {
-    cy.get("#sub").type(users.ineligible.sub)
-    cy.get("#name").type(users.ineligible.name)
-    cy.get("input[type='submit']")
-      .click()
+    cy.get("#sub").type(users.ineligible.sub);
+    cy.get("#name").type(users.ineligible.name);
+    cy.get("input[type='submit']").click();
 
-    cy.contains("We can’t confirm your age")
-    cy.contains("You may still be eligible for a discount, but we can’t verify your age")
-  })
+    cy.contains("We can’t confirm your age");
+    cy.contains(
+      "You may still be eligible for a discount, but we can’t verify your age"
+    );
+  });
 
   it("From the confirmation page, validates an invalid number/id field", () => {
-    cy.get("#sub").type(users.invalidSub.sub)
-    cy.get("#name").type(users.invalidSub.name)
-    cy.get("input[type='submit']")
-      .click()
+    cy.get("#sub").type(users.invalidSub.sub);
+    cy.get("#name").type(users.invalidSub.name);
+    cy.get("input[type='submit']").click();
 
-    cy.contains("Check your input. The format looks wrong.")
-    cy.get("#id_sub")
-      .then(($e) => {
-        expect($e).to.have.css("border-color", "rgb(222, 12, 12)")
-      })
-  })
+    cy.contains("Check your input. The format looks wrong.");
+    cy.get("#id_sub").then(($e) => {
+      expect($e).to.have.css("border-color", "rgb(222, 12, 12)");
+    });
+  });
 
   it("From the confirmation page, validates an empty name field", () => {
-    cy.get("#sub").type(users.invalidSub.sub)
-    cy.get("input[type='submit']")
-      .click()
+    cy.get("#sub").type(users.invalidSub.sub);
+    cy.get("input[type='submit']").click();
 
-    cy.get("input:invalid")
-      .should("have.length", 1)
-  })
-})
+    cy.get("input:invalid").should("have.length", 1);
+  });
+});

--- a/tests/e2e/cypress/integration/help.spec.js
+++ b/tests/e2e/cypress/integration/help.spec.js
@@ -1,58 +1,50 @@
-const agencies = require('../fixtures/transit-agencies.json')
+const agencies = require("../fixtures/transit-agencies.json");
 
 describe("Help page spec", () => {
   beforeEach(() => {
-    cy.visit("/")
-  })
+    cy.visit("/");
+  });
 
   it("Clicking on Help takes user to Help", () => {
-    cy.contains("Help")
-      .click()
+    cy.contains("Help").click();
 
-    cy.location("pathname").should("eq", "/help")
-  })
+    cy.location("pathname").should("eq", "/help");
+  });
 
   it("Contains a back link", () => {
-    cy.contains("Help")
-      .click()
+    cy.contains("Help").click();
 
-    cy.contains("Go back")
-      .then(($e) => {
-        expect($e).attr("href").eql("/")
-      })
-  })
+    cy.contains("Go back").then(($e) => {
+      expect($e).attr("href").eql("/");
+    });
+  });
 
   it("Allows user to go back", () => {
-    cy.contains("Help")
-      .click()
+    cy.contains("Help").click();
 
-    cy.contains("Go back")
-      .click()
+    cy.contains("Go back").click();
 
-    cy.location("pathname").should("eq", "/")
-  })
+    cy.location("pathname").should("eq", "/");
+  });
 
   it("Has help information for all transit agencies", () => {
-    cy.contains("Help")
-      .click()
+    cy.contains("Help").click();
 
     agencies.forEach(function (agency) {
-      cy.contains(agency.long_name)
-      cy.contains(agency.phone)
-    })
-  })
+      cy.contains(agency.long_name);
+      cy.contains(agency.phone);
+    });
+  });
 
   it("Has help information for correct transit agency if clicking Help from a transit page", () => {
-    let chosenAgency = agencies[0]
-    let otherAgency = agencies[1]
-    cy.contains(chosenAgency.short_name)
-      .click()
-    cy.contains("Help")
-      .click()
+    let chosenAgency = agencies[0];
+    let otherAgency = agencies[1];
+    cy.contains(chosenAgency.short_name).click();
+    cy.contains("Help").click();
 
-    cy.contains(chosenAgency.long_name)
-    cy.contains(chosenAgency.phone)
-    cy.should("not.contain", otherAgency.long_name)
-    cy.should("not.contain", otherAgency.phone)
-  })
-})
+    cy.contains(chosenAgency.long_name);
+    cy.contains(chosenAgency.phone);
+    cy.should("not.contain", otherAgency.long_name);
+    cy.should("not.contain", otherAgency.phone);
+  });
+});

--- a/tests/e2e/cypress/integration/index.spec.js
+++ b/tests/e2e/cypress/integration/index.spec.js
@@ -1,38 +1,37 @@
-const agencies = require('../fixtures/transit-agencies.json')
+const agencies = require("../fixtures/transit-agencies.json");
 
 describe("Index page spec", () => {
   beforeEach(() => {
-    cy.visit("/")
-  })
+    cy.visit("/");
+  });
 
   it("Gives user transit provider options to click", () => {
-    cy.contains("Choose your transit provider")
-    cy.contains(agencies[0].short_name)
-      .then(($e) => {
-        expect($e).attr("href").to.include("/" + agencies[0].slug)
-      })
-    cy.contains(agencies[1].short_name)
-      .then(($e) => {
-        expect($e).attr("href").to.include("/" + agencies[1].slug)
-      })
-  })
+    cy.contains("Choose your transit provider");
+    cy.contains(agencies[0].short_name).then(($e) => {
+      expect($e)
+        .attr("href")
+        .to.include("/" + agencies[0].slug);
+    });
+    cy.contains(agencies[1].short_name).then(($e) => {
+      expect($e)
+        .attr("href")
+        .to.include("/" + agencies[1].slug);
+    });
+  });
 
   it("Clicking transit option link takes user to a transit provider page", () => {
-    cy.contains(agencies[0].short_name)
-      .click()
+    cy.contains(agencies[0].short_name).click();
 
-    cy.contains("Let’s do it!")
-      .then(($e) => {
-        expect($e).attr("href").to.include("/eligibility")
-      })
-  })
+    cy.contains("Let’s do it!").then(($e) => {
+      expect($e).attr("href").to.include("/eligibility");
+    });
+  });
 
   it("Has a payment options page link", () => {
-    cy.contains("Payment Options")
-  })
+    cy.contains("Payment Options");
+  });
 
   it("Has a help page link", () => {
-    cy.contains("Help")
-  })
-
-})
+    cy.contains("Help");
+  });
+});

--- a/tests/e2e/cypress/integration/payment-options.spec.js
+++ b/tests/e2e/cypress/integration/payment-options.spec.js
@@ -1,25 +1,22 @@
 describe("Payment Options page spec", () => {
   beforeEach(() => {
-    cy.visit("/")
-    cy.contains("Payment Options")
-      .click()
-  })
+    cy.visit("/");
+    cy.contains("Payment Options").click();
+  });
 
   it("Clicking on Payment Options takes user to Payment Options", () => {
-    cy.location("pathname").should("eq", "/payment-options")
-  })
+    cy.location("pathname").should("eq", "/payment-options");
+  });
 
   it("Contains a back link", () => {
-    cy.contains("Go back")
-      .then(($e) => {
-        expect($e).attr("href").eql("/")
-      })
-  })
+    cy.contains("Go back").then(($e) => {
+      expect($e).attr("href").eql("/");
+    });
+  });
 
   it("Allows user to go back", () => {
-    cy.contains("Go back")
-      .click()
+    cy.contains("Go back").click();
 
-    cy.location("pathname").should("eq", "/")
-  })
-})
+    cy.location("pathname").should("eq", "/");
+  });
+});

--- a/tests/e2e/cypress/integration/spanish.spec.js
+++ b/tests/e2e/cypress/integration/spanish.spec.js
@@ -1,50 +1,47 @@
-const agencies = require('../fixtures/transit-agencies.json')
+const agencies = require("../fixtures/transit-agencies.json");
 
 describe("Spanish language", () => {
   beforeEach(() => {
-    cy.visit("/")
-  })
+    cy.visit("/");
+  });
 
   it("Gives user Spanish language option", () => {
-    cy.get("#header").should("contain", "Español")
-    cy.get("#header").should("not.contain", "English")
-  })
+    cy.get("#header").should("contain", "Español");
+    cy.get("#header").should("not.contain", "English");
+  });
 
   it("Changes the language to Spanish and does not change URL", () => {
-    cy.location("pathname").should("eq", "/")
+    cy.location("pathname").should("eq", "/");
 
-    cy.contains("Español")
-      .click()
+    cy.contains("Español").click();
 
-    cy.get("#header").should("not.contain", "Español")
-    cy.get("#header").should("contain", "English")
-    cy.location("pathname").should("eq", "/")
-  })
+    cy.get("#header").should("not.contain", "Español");
+    cy.get("#header").should("contain", "English");
+    cy.location("pathname").should("eq", "/");
+  });
 
   it("Changes the language from Spanish back to English", () => {
-    cy.contains("Español")
-      .click()
+    cy.contains("Español").click();
 
-    cy.get("#header").should("not.contain", "Español")
-    cy.get("#header").should("contain", "English")
-    cy.contains("English")
-      .click()
+    cy.get("#header").should("not.contain", "Español");
+    cy.get("#header").should("contain", "English");
+    cy.contains("English").click();
 
-    cy.get("#header").should("contain", "Español")
-    cy.get("#header").should("not.contain", "English")
-  })
+    cy.get("#header").should("contain", "Español");
+    cy.get("#header").should("not.contain", "English");
+  });
 
   it("Changes the language to Spanish from any page", () => {
-    let agencySlug = agencies[0].slug
+    let agencySlug = agencies[0].slug;
     cy.contains(agencies[0].short_name)
       .click()
-      .location("pathname").should("eq", "/" + agencySlug)
+      .location("pathname")
+      .should("eq", "/" + agencySlug);
 
-    cy.contains("Español")
-      .click()
+    cy.contains("Español").click();
 
-    cy.get("#header").should("not.contain", "Español")
-    cy.get("#header").should("contain", "English")
-    cy.location("pathname").should("eq", "/" + agencySlug)
-  })
-})
+    cy.get("#header").should("not.contain", "Español");
+    cy.get("#header").should("contain", "English");
+    cy.location("pathname").should("eq", "/" + agencySlug);
+  });
+});


### PR DESCRIPTION
closes #184 

## What this PR does
- Add prettier to the pre-commit list of linters
- Configures prettier to lint .js, .json, .css files only
- Lints all .css, .js and .json files
- Add Prettier VSCode extension

## Decisions
- We decided to lint CSS, JS, JSON for now. HTML will require more careful testing, so we're not adding HTML yet. Created a ticket in backlog.

