### PR TITLE
Upgrade jQuery from 3.4.1 to 3.6.0

### DIFF
--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -15,7 +15,6 @@
         <link href="{% static "img/favicon.ico" %}" rel="icon" type="image/x-icon" />
 
         <script src="https://code.jquery.com/jquery-3.6.0.min.js" type="text/javascript"></script>
-        <script src="https://code.jquery.com/jquery-migrate-3.3.2.min.js"></script>
 
         {% include "core/includes/analytics.html" with api_key=analytics.api_key uid=analytics.uid did=analytics.did %}
     </head>

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -14,8 +14,8 @@
         <link href="{% static "css/styles.css" %}" rel="stylesheet">
         <link href="{% static "img/favicon.ico" %}" rel="icon" type="image/x-icon" />
 
-        <script src="https://code.jquery.com/jquery-3.4.1.min.js" type="text/javascript"></script>
-        <script src="https://code.jquery.com/jquery-migrate-3.0.1.min.js"></script>
+        <script src="https://code.jquery.com/jquery-3.6.0.min.js" type="text/javascript"></script>
+        <script src="https://code.jquery.com/jquery-migrate-3.3.2.min.js"></script>
 
         {% include "core/includes/analytics.html" with api_key=analytics.api_key uid=analytics.uid did=analytics.did %}
     </head>


### PR DESCRIPTION
close #182 

## What this PR does
- Upgrade jQuery from 3.4.1 to 3.6.0
- Remove jQuery Migrate plugin

## What was tested

## Changelog
- 3.4: https://blog.jquery.com/2019/04/10/jquery-3-4-0-released/
- 3.5: https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/
- 3.6: https://blog.jquery.com/2021/03/02/jquery-3-6-0-released/