### PR TITLE
Require confirmed eligibility for enrollment

### DIFF
--- a/benefits/core/middleware.py
+++ b/benefits/core/middleware.py
@@ -26,6 +26,17 @@ class AgencySessionRequired(MiddlewareMixin):
             raise AttributeError("Session not configured with agency")
 
 
+class EligibleSessionRequired(MiddlewareMixin):
+    """Middleware raises an exception for sessions lacking confirmed eligibility."""
+
+    def process_request(self, request):
+        if session.eligible(request):
+            logger.debug("Session has confirmed eligibility")
+            return None
+        else:
+            raise AttributeError("Session has no confirmed eligibility")
+
+
 class DebugSession(MiddlewareMixin):
     """Middleware to configure debug context in the request session."""
 

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -78,7 +78,7 @@ def _index(request):
     return TemplateResponse(request, "enrollment/index.html", context)
 
 
-@decorator_from_middleware(middleware.AgencySessionRequired)
+@decorator_from_middleware(middleware.EligibleSessionRequired)
 def index(request):
     """View handler for the enrollment landing page."""
     if request.method == "POST":
@@ -113,7 +113,7 @@ def _enroll(request):
         raise Exception("Updated customer_id does not match enrolled customer_id")
 
 
-@decorator_from_middleware(middleware.AgencySessionRequired)
+@decorator_from_middleware(middleware.EligibleSessionRequired)
 def retry(request):
     """View handler for a recoverable failure condition."""
     if request.method == "POST":

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -78,17 +78,6 @@ def _index(request):
     return TemplateResponse(request, "enrollment/index.html", context)
 
 
-@decorator_from_middleware(middleware.EligibleSessionRequired)
-def index(request):
-    """View handler for the enrollment landing page."""
-    if request.method == "POST":
-        response = _enroll(request)
-    else:
-        response = _index(request)
-
-    return response
-
-
 def _enroll(request):
     """Helper calls the enrollment APIs."""
     logger.debug("Read tokenized card")
@@ -111,6 +100,17 @@ def _enroll(request):
         return success(request)
     else:
         raise Exception("Updated customer_id does not match enrolled customer_id")
+
+
+@decorator_from_middleware(middleware.EligibleSessionRequired)
+def index(request):
+    """View handler for the enrollment landing page."""
+    if request.method == "POST":
+        response = _enroll(request)
+    else:
+        response = _index(request)
+
+    return response
 
 
 @decorator_from_middleware(middleware.EligibleSessionRequired)


### PR DESCRIPTION
## Overview

This fixes #186.

Add a new middleware definition similar to `AgencySessionRequired` that raises an exception when the `session` does not contain a verified eligibility.

Apply this middleware to the enrollment views instead of `AgencySessionRequired` (the new middleware effectively requires an agency in the session as well).

## Notes

We already had the [`session.eligible()`](https://github.com/cal-itp/benefits/blob/dev/benefits/core/session.py#L92) helper for doing this check. This is being used in routing the [`/eligibility/confirm` form response](https://github.com/cal-itp/benefits/blob/dev/benefits/eligibility/views.py#L66). This PR builds on that helper to guard the `/enrollment` phase as well.

Additionally, UI test(s) would normally accompany this fix to ensure we don't introduce a regression later. However given the notes in #178 also apply to this situation, we don't currently have a way to load the `/enrollment` page in a fully stubbed/mocked environment.
