### PR TITLE
Add Lighthouse a11y testing to Test UI workflow

### DIFF
--- a/.github/lighthouserc.json
+++ b/.github/lighthouserc.json
@@ -2,7 +2,8 @@
   "ci": {
     "assert": {
       "assertions": {
-        "categories:accessibility": ["error", {"minScore": 1}]
+        "categories:accessibility": ["error", {"minScore": 1}],
+        "categories:best-practices": ["warn", {"minScore": 1}]
       }
     }
   }

--- a/.github/lighthouserc.json
+++ b/.github/lighthouserc.json
@@ -1,0 +1,9 @@
+{
+  "ci": {
+    "assert": {
+      "assertions": {
+        "categories:accessibility": ["error", {"minScore": 1}]
+      }
+    }
+  }
+}

--- a/.github/lighthouserc.json
+++ b/.github/lighthouserc.json
@@ -1,15 +1,14 @@
 {
   "ci": {
-    "numberOfRuns": 2,
+    "numberOfRuns": 3,
     "settings": {
       "preset": "mobile"
     },
     "assert": {
       "assertions": {
         "categories:accessibility": ["error", {"minScore": 1}],
-        "categories:best-practices": ["warn", {"minScore": 1}]
-      },
-      "includePassedAssertions": true
+        "categories:best-practices": ["warn", {"minScore": 0.9}]
+      }
     }
   }
 }

--- a/.github/lighthouserc.json
+++ b/.github/lighthouserc.json
@@ -1,10 +1,15 @@
 {
   "ci": {
+    "numberOfRuns": 2,
+    "settings": {
+      "preset": "mobile"
+    },
     "assert": {
       "assertions": {
         "categories:accessibility": ["error", {"minScore": 1}],
         "categories:best-practices": ["warn", {"minScore": 1}]
-      }
+      },
+      "includePassedAssertions": true
     }
   }
 }

--- a/.github/workflows/tests-ui.yml
+++ b/.github/workflows/tests-ui.yml
@@ -1,4 +1,4 @@
-name: UI automation tests
+name: UI automation and a11y Lighthouse tests
 
 on:
   pull_request:
@@ -46,7 +46,7 @@ jobs:
             -v ${{ github.workspace }}/fixtures:/home/calitp/app/fixtures \
             benefits_client:${{ github.sha }}
 
-      - name: Run tests
+      - name: Run UI automation tests
         uses: cypress-io/github-action@v2
         env:
           CYPRESS_baseUrl: http://localhost:8000
@@ -55,3 +55,9 @@ jobs:
           wait-on: http://localhost:8000/healthcheck
           spec: |
             cypress/specs/ui/*.spec.js
+
+      - name: Run Lighthouse tests for a11y
+        uses: treosh/lighthouse-ci-action@v8
+        with:
+          urls: http://localhost:8000
+          configPath: ".github/lighthouserc.json"

--- a/.github/workflows/tests-ui.yml
+++ b/.github/workflows/tests-ui.yml
@@ -59,5 +59,7 @@ jobs:
       - name: Run Lighthouse tests for a11y
         uses: treosh/lighthouse-ci-action@v8
         with:
-          urls: http://localhost:8000
+          urls: |
+            http://localhost:8000
+            http://localhost:8000/help
           configPath: ".github/lighthouserc.json"

--- a/.github/workflows/tests-ui.yml
+++ b/.github/workflows/tests-ui.yml
@@ -1,4 +1,4 @@
-name: UI automation and a11y Lighthouse tests
+name: UI & a11y tests
 
 on:
   pull_request:
@@ -63,3 +63,5 @@ jobs:
             http://localhost:8000
             http://localhost:8000/help
           configPath: ".github/lighthouserc.json"
+          temporaryPublicStorage: true
+          uploadArtifacts: true


### PR DESCRIPTION
closes #167

## What this PR does 
- Add a step to the existing UI Test GitHub Action that runs `Lighthouse` testing on the homepage and the help page
- Run A11y and Best Practices, on Mobile
- The test will show a "Warn" when the overall Best Practices score is under 90%
- The test will show a blocking "Error" when the overall A11y score is under 100%
- The test results will be uploaded so they can be viewed easily, like this: https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/1637284608781-6224.report.html and the link can be found in the Action logs https://github.com/cal-itp/benefits/runs/4259113826?check_suite_focus=true#step:7:47 (The report only lasts for 60 days)
- The tests take about 30 seconds
<img width="1006" alt="image" src="https://user-images.githubusercontent.com/3673236/142677181-167c21f7-26fb-4b05-9875-b9cc841f1183.png">

## Important notes on Accessibility
- What Lighthouse's a11y test checks:
https://github.com/GoogleChrome/lighthouse/blob/v5.5.0/lighthouse-core/config/default-config.js#L427:L474
![image](https://user-images.githubusercontent.com/3673236/142513723-6d0f1a32-f961-44da-bdff-4ee2ca52beb1.png)

- What the test doesn't check, and needs to be manually tested:
![image](https://user-images.githubusercontent.com/3673236/142513749-d75009ee-ac97-47c7-8a06-6d2fa88f8d2a.png)
https://developers.google.com/web/fundamentals/accessibility/how-to-review?utm_source=lighthouse&utm_medium=devtools

## Future improvements
- It would be nice to be able to be able to easily test a more complex page, like the form page. In the meantime, developers should be careful to run the Lighthouse a11y audits and do their own manual audits for forms and buttons.