### PR TITLE
Implement Content Security Policy

### DIFF
--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -197,5 +197,8 @@ ANALYTICS_KEY = os.environ.get("ANALYTICS_KEY")
 # https://django-csp.readthedocs.io/en/latest/configuration.html#policy-settings
 
 CSP_DEFAULT_SRC = ["'self'"]
+
+CSP_FONT_SRC = ["https://california.azureedge.net/cdt/statetemplate/", "https://fonts.gstatic.com/"]
+
 CSP_FRAME_ANCESTORS = ["'none'"]
 CSP_FRAME_SRC = ["'none'"]

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -203,6 +203,14 @@ CSP_FONT_SRC = ["https://california.azureedge.net/cdt/statetemplate/", "https://
 CSP_FRAME_ANCESTORS = ["'none'"]
 CSP_FRAME_SRC = ["'none'"]
 
+CSP_SCRIPT_SRC_ELEM = [
+    "'unsafe-inline'",
+    "https://california.azureedge.net/cdt/statetemplate/",
+    "https://cdn.amplitude.com/libs/",
+    "https://code.jquery.com/",
+    "*.littlepay.com",
+]
+
 CSP_STYLE_SRC = ["'unsafe-inline'"]
 
 CSP_STYLE_SRC_ELEM = [

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -50,6 +50,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "csp.middleware.CSPMiddleware",
     "benefits.core.middleware.DebugSession",
     "benefits.core.middleware.ChangedLanguageEvent",
 ]

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -189,3 +189,13 @@ LOGGING = {
 # Analytics configuration
 
 ANALYTICS_KEY = os.environ.get("ANALYTICS_KEY")
+
+# Content Security Policy
+# Configuration docs at https://django-csp.readthedocs.io/en/latest/configuration.html
+
+# In particular, note that the inner single-quotes are required!
+# https://django-csp.readthedocs.io/en/latest/configuration.html#policy-settings
+
+CSP_DEFAULT_SRC = ["'self'"]
+CSP_FRAME_ANCESTORS = ["'none'"]
+CSP_FRAME_SRC = ["'none'"]

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -202,3 +202,12 @@ CSP_FONT_SRC = ["https://california.azureedge.net/cdt/statetemplate/", "https://
 
 CSP_FRAME_ANCESTORS = ["'none'"]
 CSP_FRAME_SRC = ["'none'"]
+
+CSP_STYLE_SRC = ["'unsafe-inline'"]
+
+CSP_STYLE_SRC_ELEM = [
+    "'self'",
+    "'unsafe-inline'",
+    "https://california.azureedge.net/cdt/statetemplate/",
+    "https://fonts.googleapis.com/css",
+]

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -198,6 +198,8 @@ ANALYTICS_KEY = os.environ.get("ANALYTICS_KEY")
 
 CSP_DEFAULT_SRC = ["'self'"]
 
+CSP_CONNECT_SRC = ["'self'", "https://api.amplitude.com/"]
+
 CSP_FONT_SRC = ["https://california.azureedge.net/cdt/statetemplate/", "https://fonts.gstatic.com/"]
 
 CSP_FRAME_ANCESTORS = ["'none'"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 cryptography==35.0.0
 Django==3.2.9
+django-csp==3.7
 gunicorn==20.1.0
 jwcrypto==1.0
 requests==2.26.0


### PR DESCRIPTION
Closes #203.

## Testing this PR

The Content Security Policy blocks assets from loading unless configured correctly. After `git checkout` the branch, load the app in your browser and run through the flow - you should see no errors in loading scripts, styles, fonts, etc. and all images, styles, etc. should be applied and visible.

To break the Policy and see what happens, comment out everything after the [`CSP_DEFAULT_SRC` directive in `settings.py`](https://github.com/cal-itp/benefits/blob/feat/content-security-policy/benefits/settings.py#L199). Then load the app locally and check the browser console:

![image](https://user-images.githubusercontent.com/1783439/142672160-96a24861-c2e8-4e44-8ff4-bd5dd042dd58.png)