### PR TITLE
Configure X-XSS-Protection

### DIFF
--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -75,6 +75,8 @@ if not DEBUG:
     CSRF_FAILURE_VIEW = "benefits.core.views.csrf_failure"
     SESSION_COOKIE_SECURE = True
 
+SECURE_BROWSER_XSS_FILTER = True
+
 ROOT_URLCONF = "benefits.urls"
 
 template_ctx_processors = [


### PR DESCRIPTION
Fixes #204 

[`SECURE_BROWSER_XSS_FILTER`](https://docs.djangoproject.com/en/3.2/ref/settings/#secure-browser-xss-filter) set to `True` will achieve the desired response header. That setting comes from [`SecurityMiddleware`](https://docs.djangoproject.com/en/3.2/ref/middleware/#x-xss-protection) which we are using in [`settings.py`](https://github.com/cal-itp/benefits/blob/dev/benefits/settings.py#L46), so all we need to do is set it.

## Testing this PR
 - Launch the benefits app
 - Open dev console (F12) and use the Network tab to ensure the response header is as expected (`X-XSS-Protection: 1; mode=block`)
 
![image](https://user-images.githubusercontent.com/25497886/142680868-1f48e708-d288-4b9b-8b6a-13777f4fe7ec.png)
