### PR TITLE
Fix browser support in Content Security Policy

### DIFF
--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -209,7 +209,7 @@ CSP_FONT_SRC = ["https://california.azureedge.net/cdt/statetemplate/", "https://
 CSP_FRAME_ANCESTORS = ["'none'"]
 CSP_FRAME_SRC = ["'none'"]
 
-CSP_SCRIPT_SRC_ELEM = [
+CSP_SCRIPT_SRC = [
     "'unsafe-inline'",
     "https://california.azureedge.net/cdt/statetemplate/",
     "https://cdn.amplitude.com/libs/",
@@ -217,9 +217,7 @@ CSP_SCRIPT_SRC_ELEM = [
     "*.littlepay.com",
 ]
 
-CSP_STYLE_SRC = ["'unsafe-inline'"]
-
-CSP_STYLE_SRC_ELEM = [
+CSP_STYLE_SRC = [
     "'self'",
     "'unsafe-inline'",
     "https://california.azureedge.net/cdt/statetemplate/",


### PR DESCRIPTION
Following up to #211.

Chrome understands the `script-src-elem` directive for JavaScript and `style-src-elem` for CSS. Firefox and Safari don't support either of these.

This PR falls back to the `script-src` and `style-src` directives for wider browser support.

More info: 

* https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src-elem
* https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src
* https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src-elem
* https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src