### PR TITLE
Use minified JS and CSS files

### DIFF
--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -9,8 +9,8 @@
         <title>{% block page_title %}{% endblock  %}Cal-ITP</title>
 
         <link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet" type="text/css">
-        <link href="https://california.azureedge.net/cdt/statetemplate/6.0.2/css/cagov.core.css" rel="stylesheet">
-        <link href="https://california.azureedge.net/cdt/statetemplate/6.0.2/css/colorscheme-oceanside.css" rel="stylesheet">
+        <link href="https://california.azureedge.net/cdt/statetemplate/6.0.2/css/cagov.core.min.css" rel="stylesheet">
+        <link href="https://california.azureedge.net/cdt/statetemplate/6.0.2/css/colorscheme-oceanside.min.css" rel="stylesheet">
         <link href="{% static "css/styles.css" %}" rel="stylesheet">
         <link href="{% static "img/favicon.ico" %}" rel="icon" type="image/x-icon" />
 
@@ -69,7 +69,7 @@
             </div>
         </footer>
 
-        <script src="https://california.azureedge.net/cdt/statetemplate/6.0.2/js/cagov.core.js"></script>
+        <script src="https://california.azureedge.net/cdt/statetemplate/6.0.2/js/cagov.core.min.js"></script>
         <script>
             $(function() {
                 document.cookie = "testcookie"


### PR DESCRIPTION
#220 

This is a small fix that came from a Lighthouse test.

## What this PR does
- Replace https://california.azureedge.net/cdt/statetemplate/6.0.2/css/cagov.core.css with https://california.azureedge.net/cdt/statetemplate/6.0.2/css/cagov.core.min.css
- Replace https://california.azureedge.net/cdt/statetemplate/6.0.2/css/colorscheme-oceanside.css with https://california.azureedge.net/cdt/statetemplate/6.0.2/css/colorscheme-oceanside.min.css
- Replace https://california.azureedge.net/cdt/statetemplate/6.0.2/js/cagov.core.js with https://california.azureedge.net/cdt/statetemplate/6.0.2/js/cagov.core.min.js

I found the links here:

![image](https://user-images.githubusercontent.com/3673236/142946960-9f5672ae-a298-4a94-b16f-389b26208b4a.png)

https://template.webstandards.ca.gov/cdn.html