### PR TITLE
Use`noopener noreferrer` for external links

### DIFF
--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -62,7 +62,7 @@
                         <ul class="footer-links">
                             <li><a href="{% url "core:payment_options" %}">{% translate "core.payment-options" %}</a></li>
                             <li><a href="{% url "core:help" %}">{% translate "core.help" %}</a></li>
-                            <li><a href="https://www.dmv.ca.gov/portal/privacy-and-security/" target="_blank">{% translate "core.privacy" %}</a></li>
+                            <li><a href="https://www.dmv.ca.gov/portal/privacy-and-security/" target="_blank" rel="noopener noreferrer">{% translate "core.privacy" %}</a></li>
                         </ul>
                     </div>
                 </div>

--- a/benefits/core/templates/core/help.html
+++ b/benefits/core/templates/core/help.html
@@ -4,8 +4,6 @@
 {{ block.super }}
 <p class="mt-4">
     {% translate "core.help.foss.text" %}
-    <a href="https://www.github.com/cal-itp/benefits" target="_blank">
-        {% translate "core.help.foss.link" %}
-    </a>.
+    <a href="https://www.github.com/cal-itp/benefits" target="_blank" rel="noopener noreferrer">{% translate "core.help.foss.link" %}</a>.
 </p>
 {% endblock %}

--- a/benefits/core/templates/core/includes/button.html
+++ b/benefits/core/templates/core/includes/button.html
@@ -4,6 +4,7 @@
 {% endif %}
 <a {%if button.id %}id="{{ button.id }}"{% endif %}
     {%if button.target %}target="{{ button.target }}"{% endif %}
+    {%if button.rel %}rel="{{ button.rel }}"{% endif %}
     class="{{ button.classes | join:" " }}"
     href="{{ button.url }}"
     role="button">

--- a/benefits/core/viewmodels.py
+++ b/benefits/core/viewmodels.py
@@ -16,6 +16,8 @@ class Button:
     * classes: str, str[]
     * text: str
     * url: str
+    * target: str
+    * rel: str
     """
 
     def __init__(self, **kwargs):
@@ -30,13 +32,14 @@ class Button:
         self.text = kwargs.get("text", "Button")
         self.url = kwargs.get("url")
         self.target = kwargs.get("target")
+        self.rel = kwargs.get("rel")
 
     @staticmethod
     def agency_contact_links(agency):
         """Create link buttons for agency contact information."""
         return [
             # fmt: off
-            Button.link(classes="agency-url", label=agency.long_name, text=agency.info_url, url=agency.info_url, target="_blank"),  # noqa: E501
+            Button.link(classes="agency-url", label=agency.long_name, text=agency.info_url, url=agency.info_url, target="_blank", rel="noopener noreferrer"),  # noqa: E501
             Button.link(classes="agency-phone", text=agency.phone, url=f"tel:{agency.phone}"),
             # fmt: on
         ]


### PR DESCRIPTION
closes #221 


## What this PR does
- Add `rel="noopener noreferrer"` to external links in 3 places: GitHub link, Privacy Policy link and transit agency link
- Adds `rel` as a parameter to the `Button` class, hardcodes `rel` value into `agency_contact_links` method, and adds `rel` to button template
- Removed extra space between `GitHub` and `.`
![image](https://user-images.githubusercontent.com/3673236/142955736-7e5d9842-eea4-4af5-8669-c4550f8ca72c.png)
vs.
![image](https://user-images.githubusercontent.com/3673236/142955748-accb19b4-7f82-4b1c-adec-b1673d0130c0.png)

## What do `noopener` and `noreferrer` do?
From 
https://web.dev/external-anchors-use-rel-noopener/
![image](https://user-images.githubusercontent.com/3673236/142956477-dfc55196-245d-465b-a732-f8a4b6598632.png)

## How to test this PR
- Run the app and click all the links
- Links should open in a new tab, as usual
- Check the Lighthouse test result for `Best Practices` for the Help page and the Home Page. The Best Practices score improves to 100%. Currently, it's at 93% (https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/1637367932497-10685.report.html).

New results:
https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/1637628492649-92901.report.html
https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/1637628493148-52106.report.html#best-practices
![image](https://user-images.githubusercontent.com/3673236/142956279-d7eb8d6d-b539-4753-b96a-c3ab043e1e7b.png)
