### PR TITLE
Add meta description

### DIFF
--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -6,6 +6,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <meta name="description" content="{% translate "core.help.p1" %}">
         <title>{% block page_title %}{% endblock  %}Cal-ITP</title>
 
         <link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet" type="text/css">


### PR DESCRIPTION
close #224 

## What this PR does
- Adds a meta description, for SEO
![image](https://user-images.githubusercontent.com/3673236/143135524-9920d9c5-50da-49c7-81ef-10c13ee344b8.png)
- It's important b/c https://web.dev/meta-description/

## Copy
Currently using copy from the Help page. If and when specific copy for this description is written, we can update the copy.