### PR TITLE
Delay acquisition of Enrollment access token

### DIFF
--- a/benefits/core/viewmodels.py
+++ b/benefits/core/viewmodels.py
@@ -208,16 +208,16 @@ class PaymentProcessor:
     """
     Represents a core.models.PaymentProcessor:
     * model: core.models.PaymentProcessor
-    * access_token: str
+    * access_token_url: str
     * element_id: str
     * color: str
     * [name: str]
     * [loading_text: str]
     """
 
-    def __init__(self, model, access_token, element_id, color, name=None, loading_text=_("core.buttons.wait")):
+    def __init__(self, model, access_token_url, element_id, color, name=None, loading_text=_("core.buttons.wait")):
         if isinstance(model, models.PaymentProcessor):
-            self.access_token = access_token
+            self.access_token_url = access_token_url
             self.element_id = element_id
             self.color = color
             self.name = name or model.name

--- a/benefits/enrollment/templates/enrollment/index.html
+++ b/benefits/enrollment/templates/enrollment/index.html
@@ -11,61 +11,63 @@
 
         $.getScript("{{ payment_processor.card_tokenize_url }}")
             .done(function() {
-                $(".loading").remove();
-                $(".invisible").removeClass("invisible");
+                $.get("{{ payment_processor.access_token_url }}", function(data) {
+                    $(".loading").remove();
+                    $(".invisible").removeClass("invisible");
 
-                $("{{ payment_processor.element_id }}").on("click", function() {
-                    amplitude.getInstance().logEvent(startedEvent, {
-                        card_tokenize_url: "{{ payment_processor.card_tokenize_url }}",
-                        card_tokenize_func: "{{ payment_processor.card_tokenize_func }}"
+                    $("{{ payment_processor.element_id }}").on("click", function() {
+                        amplitude.getInstance().logEvent(startedEvent, {
+                            card_tokenize_url: "{{ payment_processor.card_tokenize_url }}",
+                            card_tokenize_func: "{{ payment_processor.card_tokenize_func }}"
+                        });
+                        $(this).addClass("disabled").attr("aria-disabled", "true").text("{{ payment_processor.loading_text }}");
                     });
-                    $(this).addClass("disabled").attr("aria-disabled", "true").text("{{ payment_processor.loading_text }}");
-                });
 
-                {{ payment_processor.card_tokenize_func }}({
-                    authorization: '{{ payment_processor.access_token }}',
-                    element: '{{ payment_processor.element_id }}',
-                    envUrl: '{{ payment_processor.card_tokenize_env }}',
-                    options: {
-                        name: '{{ payment_processor.name }}',
-                        color: '{{ payment_processor.color }}'
-                    },
-                    onTokenize: function (response) {
-                        /* This function executes when the
-                        /* card/address verification returns
-                        /* successfully with a token from enrollment server */
-                        amplitude.getInstance().logEvent(closedEvent, {status: "success"});
+                    {{ payment_processor.card_tokenize_func }}({
+                        authorization: data.token,
+                        element: '{{ payment_processor.element_id }}',
+                        envUrl: '{{ payment_processor.card_tokenize_env }}',
+                        options: {
+                            name: '{{ payment_processor.name }}',
+                            color: '{{ payment_processor.color }}'
+                        },
+                        onTokenize: function (response) {
+                            /* This function executes when the
+                            /* card/address verification returns
+                            /* successfully with a token from enrollment server */
+                            amplitude.getInstance().logEvent(closedEvent, {status: "success"});
 
-                        var form = $("form[action='{{ forms.tokenize_success }}']");
-                        $("#card_token", form).val(response.token);
-                        form.submit();
-                    },
-                    onVerificationFailure: function (response) {
-                        /* This function executes when the
-                        /* card/address verification fails and server
-                        /* return verification failure message */
-                        amplitude.getInstance().logEvent(closedEvent, {status: "fail"});
+                            var form = $("form[action='{{ forms.tokenize_success }}']");
+                            $("#card_token", form).val(response.token);
+                            form.submit();
+                        },
+                        onVerificationFailure: function (response) {
+                            /* This function executes when the
+                            /* card/address verification fails and server
+                            /* return verification failure message */
+                            amplitude.getInstance().logEvent(closedEvent, {status: "fail"});
 
-                        var form = $("form[action='{{ forms.tokenize_retry }}']");
-                        form.submit();
-                    },
-                    onError: function (response) {
-                        /* This function executes when the
-                        /* server returns error or token is invalid.
-                        /* 400 or 500 will return. */
-                        amplitude.getInstance().logEvent(closedEvent, {status: "error", error: response});
+                            var form = $("form[action='{{ forms.tokenize_retry }}']");
+                            form.submit();
+                        },
+                        onError: function (response) {
+                            /* This function executes when the
+                            /* server returns error or token is invalid.
+                            /* 400 or 500 will return. */
+                            amplitude.getInstance().logEvent(closedEvent, {status: "error", error: response});
 
-                        var form = $("form[action='{{ forms.tokenize_retry }}']");
-                        form.submit();
-                    },
-                    onCancel: function () {
-                        /* This function executes when the
-                        /* user cancels and closes the window
-                        /* and returns to home page. */
-                        amplitude.getInstance().logEvent(closedEvent, {status: "cancel"});
+                            var form = $("form[action='{{ forms.tokenize_retry }}']");
+                            form.submit();
+                        },
+                        onCancel: function () {
+                            /* This function executes when the
+                            /* user cancels and closes the window
+                            /* and returns to home page. */
+                            amplitude.getInstance().logEvent(closedEvent, {status: "cancel"});
 
-                        return location.reload();
-                    }
+                            return location.reload();
+                        }
+                    });
                 });
             })
             .fail(function(jqxhr, settings, exception) {

--- a/benefits/enrollment/urls.py
+++ b/benefits/enrollment/urls.py
@@ -10,6 +10,7 @@ app_name = "enrollment"
 urlpatterns = [
     # /enrollment
     path("", views.index, name="index"),
+    path("token", views.token, name="token"),
     path("retry", views.retry, name="retry"),
     path("success", views.success, name="success"),
 ]

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -61,7 +61,7 @@ def _index(request):
     # and payment processor details
     processor_vm = viewmodels.PaymentProcessor(
         model=agency.payment_processor,
-        access_token=session.token(request),
+        access_token_url=reverse("enrollment:token"),
         element_id=f"#{tokenize_button}",
         color="#046b99",
         name=f"{agency.long_name} {_('partnered with')} {agency.payment_processor.name}",
@@ -100,6 +100,12 @@ def _enroll(request):
         return success(request)
     else:
         raise Exception("Updated customer_id does not match enrolled customer_id")
+
+
+@decorator_from_middleware(middleware.EligibleSessionRequired)
+def token(request):
+    """View handler for the enrollment auth token."""
+    pass
 
 
 @decorator_from_middleware(middleware.EligibleSessionRequired)


### PR DESCRIPTION
## Background

When a user successfully verifies their eligibility, we redirect the user into the `enrollment` flow. The first step of that flow (on the server) is to acquire an API access token for the Payment Processor's API.

This presents a number of problems, such as that documented in #178 - but also e.g. we lose the ability to give the user a more nuanced error message if their eligibility _was verified_ but the initial connection to the Payment Processor / API token failed.

## What this PR does

This PR delays the request for the API access token until the page has loaded in the user's browser. By introducing a simple `JsonResponse` endpoint and moving the existing code around, it was a minor change to `$.get()` the token async via JavaScript rather than in the Django request.