### PR TITLE
Refactor CSS: Reduce number of css file calls

### DIFF
--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -11,7 +11,6 @@
 
         <link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet" type="text/css">
         <link href="https://california.azureedge.net/cdt/statetemplate/6.0.2/css/cagov.core.min.css" rel="stylesheet">
-        <link href="https://california.azureedge.net/cdt/statetemplate/6.0.2/css/colorscheme-oceanside.min.css" rel="stylesheet">
         <link href="{% static "css/styles.css" %}" rel="stylesheet">
         <link href="{% static "img/favicon.ico" %}" rel="icon" type="image/x-icon" />
 

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -49,17 +49,29 @@ body {
   height: 100%;
   overflow-y: unset;
 }
+
 body {
   display: flex;
   flex-direction: column;
 }
+
 main {
   flex-shrink: 0 !important;
 }
+
 footer {
   margin-top: auto;
   padding-top: 1rem;
   padding-bottom: 1rem;
+}
+
+.bg-p2,
+.bg-primary {
+  background-color: #046b99 !important;
+}
+
+.global-footer {
+  background: #222;
 }
 
 /* class styles */

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -65,16 +65,12 @@ footer {
   padding-bottom: 1rem;
 }
 
+/* class styles */
+
 .bg-p2,
 .bg-primary {
   background-color: #046b99 !important;
 }
-
-.global-footer {
-  background: #222;
-}
-
-/* class styles */
 
 .btn-lg {
   border-width: 2px;
@@ -123,6 +119,10 @@ footer {
 .form-group.with-errors .error-message {
   font-size: 14px;
   padding-left: 1rem;
+}
+
+.global-footer {
+  background: #222;
 }
 
 .media-list {


### PR DESCRIPTION
closes part of #183

## What this PR does
- Add 2 css classes from [oceanside](https://github.com/Office-of-Digital-Innovation/California-State-Template/blob/master/css/colorscheme-oceanside.css) into benefits/static/css/styles.css
- Remove oceanside.css call from base template

## Why?
- Fewer CSS files to load ==> Lighter page weight and faster web performance

## How I tested this PR
- I manually visually compared all the pages on the site, in both Desktop and Mobile, side by side with this branch and production:
![image](https://user-images.githubusercontent.com/3673236/144358456-aad162c1-bc35-4daf-96b3-591f5abb98ba.png)
![image](https://user-images.githubusercontent.com/3673236/144358498-c4817182-ed22-4806-9cb4-8a0b33938b60.png)
- Check focus, hover states, check `Skip to Main Content` button visually

## Performance testing

This PR:
![image](https://user-images.githubusercontent.com/3673236/144364965-4c6a12b4-e838-4a1d-87c1-2bbb7fe80854.png)
![image](https://user-images.githubusercontent.com/3673236/144364977-035c641b-8134-4675-89c0-2954fd1eb853.png)
