### PR TITLE
Refactor JS

### DIFF
--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -69,7 +69,6 @@
             </div>
         </footer>
 
-        <script src="https://california.azureedge.net/cdt/statetemplate/6.0.2/js/cagov.core.min.js"></script>
         <script>
             $(function() {
                 document.cookie = "testcookie"

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -213,7 +213,6 @@ CSP_FRAME_SRC = ["'none'"]
 
 CSP_SCRIPT_SRC = [
     "'unsafe-inline'",
-    "https://california.azureedge.net/cdt/statetemplate/",
     "https://cdn.amplitude.com/libs/",
     "https://code.jquery.com/",
     "*.littlepay.com",

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -206,7 +206,7 @@ CSP_DEFAULT_SRC = ["'self'"]
 
 CSP_CONNECT_SRC = ["'self'", "https://api.amplitude.com/"]
 
-CSP_FONT_SRC = ["https://california.azureedge.net/cdt/statetemplate/", "https://fonts.gstatic.com/"]
+CSP_FONT_SRC = ["https://fonts.gstatic.com/"]
 
 CSP_FRAME_ANCESTORS = ["'none'"]
 CSP_FRAME_SRC = ["'none'"]

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -206,7 +206,7 @@ CSP_DEFAULT_SRC = ["'self'"]
 
 CSP_CONNECT_SRC = ["'self'", "https://api.amplitude.com/"]
 
-CSP_FONT_SRC = ["https://fonts.gstatic.com/"]
+CSP_FONT_SRC = ["https://california.azureedge.net/cdt/statetemplate/", "https://fonts.gstatic.com/"]
 
 CSP_FRAME_ANCESTORS = ["'none'"]
 CSP_FRAME_SRC = ["'none'"]


### PR DESCRIPTION
closes part of #183

## What this PR does
- Remove the California state JS template entirely.
- I _believe_ this was only used to render the up arrow that appears once you scroll. The Benefits app does not need this.

## How to test this PR
- Go through the app in desktop and mobile and look for any regressions

## Performance testing

Shows marked improvement in speed index and first contentful paint from previous PR https://github.com/cal-itp/benefits/pull/234
- Help page
![image](https://user-images.githubusercontent.com/3673236/144365267-556707f8-ecc0-43c3-9a06-83fc4a88d292.png)

- Home page - The image slows it down
![image](https://user-images.githubusercontent.com/3673236/144365298-507a4302-ae71-4409-afe6-0dcd870f99ea.png)
