### PR TITLE
CI: CodeQL scanning workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,10 +1,10 @@
+# https://codeql.github.com/
 name: CodeQL
 
 on:
   push:
     branches: [ dev, test, prod ]
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [ dev ]
   schedule:
     - cron: "24 9 * * 6"
@@ -22,7 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         language: [ "javascript", "python" ]
-        # Learn more about CodeQL language support at https://git.io/codeql-language-support
 
     steps:
     - name: Checkout repository
@@ -37,10 +36,5 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
-    
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ dev, test, prod ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ dev ]
+  schedule:
+    - cron: "24 9 * * 6"
+
+jobs:
+  codeql:
+    name: CodeQL Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ "javascript", "python" ]
+        # Learn more about CodeQL language support at https://git.io/codeql-language-support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+    
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
New version of #239

> https://codeql.github.com/docs/codeql-overview/about-codeql/
>
>> CodeQL is the analysis engine used by developers to automate security checks, and by security researchers to perform variant analysis.
>
> Runs on:
>
> * PR to `dev`
> * Push to `dev`, `test`, `prod`
> * Weekly on Saturdays
>
> See the scan results under the *Security* tab of this repo: https://github.com/cal-itp/benefits/security/code-scanning

Also see the *Checks* tab of a PR, under *Code scanning results* > *CodeQL* to see the results for a given PR.

For example, for this PR: https://github.com/cal-itp/benefits/pull/242/checks?check_run_id=4413708654