### PR TITLE
Run tests-ui on all paths on deploy branches

### DIFF
--- a/.github/workflows/tests-ui.yml
+++ b/.github/workflows/tests-ui.yml
@@ -3,13 +3,7 @@ name: UI & a11y tests
 on:
   workflow_dispatch:
   pull_request:
-    branches: ["*"]
-    paths:
-      - .github/workflows/tests-ui.yml
-      - "benefits/**"
-      - "fixtures/**"
-      - "tests/e2e/**"
-      - requirements.txt
+    branches: [dev, test, prod]
 
 defaults:
   run:


### PR DESCRIPTION
Since the `tests-ui` job is used as a PR merge check, we need a PR-related event to trigger the check --> `workflow_dispatch` doesn't trigger the check. 

See https://github.community/t/workflow-dispatch-does-not-update-commit-status/125981/2 for more.

This PR changes the workflow so the the job runs on all PRs to the deploy branches (`dev`, `test`, `prod`)