### PR TITLE
Cache headers for static files

### DIFF
--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -167,6 +167,7 @@ USE_TZ = True
 
 STATIC_URL = "/static/"
 STATICFILES_DIRS = [os.path.join(BASE_DIR, "benefits", "static")]
+STATICFILES_STORAGE = "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
 STATIC_ROOT = os.path.join(BASE_DIR, "static")
 
 # Logging configuration

--- a/nginx.conf
+++ b/nginx.conf
@@ -38,6 +38,8 @@ http {
     # path for static files
     location /static/ {
       alias /home/calitp/app/static/;
+      expires 1y;
+      add_header Cache-Control public;
     }
 
     location / {

--- a/nginx.conf
+++ b/nginx.conf
@@ -33,6 +33,8 @@ http {
     location /favicon.ico {
       access_log off;
       log_not_found off;
+      expires 1y;
+      add_header Cache-Control public;
     }
 
     # path for static files


### PR DESCRIPTION
Introduce caching at the `nginx` layer for static file requests (images, CSS, JS, etc.)

Use a static file storage mechanism in Django that silently rewrites file names with a hash of their contents, allowing long cache times and easy cache busting when the contents changes.

See the new headers for `/static`/ files:

![image](https://user-images.githubusercontent.com/1783439/144688560-17ffa11b-d6b1-4181-9974-9da12aa0622c.png)

**NOTE:** when running locally, to get `nginx` to run, you have to have to `docker compose up client` _outside_ the devcontainer. `F5` inside the devcontainer uses the Django debug server.
