### PR TITLE
Fix: AWS copy files matching CONFIG_FILE pattern

### DIFF
--- a/.aws/ecs-task.json
+++ b/.aws/ecs-task.json
@@ -53,7 +53,10 @@
       },
       "essential": false,
       "entryPoint": ["/bin/sh"],
-      "command": ["-c", "aws s3 cp s3://${AWS_BUCKET}/${CONFIG_FILE} /aws"],
+      "command": [
+        "-c",
+        "aws s3 cp s3://${AWS_BUCKET}/ /aws/ --recursive --exclude '*' --include '${CONFIG_FILE}'"
+      ],
       "environmentFiles": [
         {
           "value": "arn:aws:s3:::<aws_bucket>/.env",


### PR DESCRIPTION
`aws s3 cp` doesn't recognize glob/unix file patterns in the path, they can be used with `--exclude`/`--include` flags though.

https://docs.aws.amazon.com/cli/latest/reference/s3/index.html#use-of-exclude-and-include-filters

Pattern support is needed to copy all of the new separated [fixture files](https://github.com/cal-itp/benefits/tree/dev/fixtures).

`CONFIG_FILE` is set in the [.env](https://github.com/cal-itp/benefits/blob/dev/.devcontainer/.env.sample) file inside the same `AWS_BUCKET`.