### PR TITLE
CI: run CodeQL on PRs to deploy branches

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,10 +2,8 @@
 name: CodeQL
 
 on:
-  push:
-    branches: [ dev, test, prod ]
   pull_request:
-    branches: [ dev ]
+    branches: [ dev, test, prod ]
   schedule:
     - cron: "24 9 * * 6"
 


### PR DESCRIPTION
Push directly to deploy branches blocked with protection rules, check runs on PRs only.