### PR TITLE
Fix: list init path before loading

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -7,7 +7,7 @@ python manage.py migrate
 
 # load config data
 
-python manage.py loaddata $DJANGO_INIT_PATH
+ls ${DJANGO_INIT_PATH} | xargs python manage.py loaddata
 
 # create a superuser account for backend admin access
 # check DJANGO_ADMIN = true, default to false if empty or unset


### PR DESCRIPTION
List the `DJANGO_INIT_PATH` variable then use `xargs` to call Django's `loaddata` with each result. 

