### PR TITLE
Fix: enrollment flow for existing customers

### DIFF
--- a/benefits/enrollment/api.py
+++ b/benefits/enrollment/api.py
@@ -193,7 +193,7 @@ class Client:
             raise ValueError("customer_id")
 
         url = self._make_url(self.payment_processor.customer_endpoint, customer_id)
-        payload = {"is_registered": True}
+        payload = {"is_registered": True, "id": customer_id}
 
         r = self._patch(url, payload)
         r.raise_for_status()

--- a/benefits/enrollment/api.py
+++ b/benefits/enrollment/api.py
@@ -44,15 +44,18 @@ class AccessTokenResponse:
 class CustomerResponse:
     """Benefits Enrollment Customer API response."""
 
-    def __init__(self, response, customer_id=None):
+    def __init__(self, response):
         logger.info("Read customer details from response")
 
         try:
             payload = response.json()
-        except ValueError:
+            self.id = payload["id"]
+        except (KeyError, ValueError):
             raise ApiError("Invalid response format")
 
-        self.id = payload.get("id", customer_id)
+        if self.id is None:
+            raise ApiError("Invalid response format")
+
         self.is_registered = str(payload.get("is_registered", "false")).lower() == "true"
 
         logger.info("Customer details successfully read from response")


### PR DESCRIPTION
When a customer's card has already been seen by the payment processor (e.g. they have tapped on a device), before registering through `benefits`, the payment processor considers the customer account as _unregistered_ (e.g. unregistered for any discounts) - although the account does exists.

Our current implementation handled this case, by registering any unregistered customers.

However, there is a mismatch in some of the API docs and what happens during real API calls. It turns out that when updating a customer, we need to include the customer's ID in the request payload (in addition to the URL fragment) in order to get it back in the response payload.

Instead of sending `{"is_registered: "true"}` we need to send `{"is_registered: "true", "id": "UUID"}`.

This PR adds the `id` field to customer update calls, and adds some additional checks on the response to raise errors earlier when responses don't look like we expect.