### PR TITLE
Add workflow to monitor API

### DIFF
--- a/.github/workflows/check-api.yml
+++ b/.github/workflows/check-api.yml
@@ -28,12 +28,14 @@ jobs:
             key: API_CHECK_PROD_KEY
             ca-cert: API_CHECK_PROD_CA_CERT
             url: API_CHECK_PROD_URL
+            data: API_CHECK_PROD_DATA
 
           - name: qa
             cert: API_CHECK_QA_CERT
             key: API_CHECK_QA_KEY
             ca-cert: API_CHECK_QA_CA_CERT
             url: API_CHECK_QA_URL
+            data: API_CHECK_QA_DATA
 
     name: Check API endpoint (${{ matrix.name }})
     steps:
@@ -58,7 +60,7 @@ jobs:
           curl -i --url ${{ secrets[matrix.url] }} \
           --header 'Accept: application/json' \
           --header 'Content-type: application/json' \
-          --data '{"request_access":"CARD_TOKENISATION"}' \
+          --data '${{ matrix.data }}' \
           --cert $temp_dir/cert.pem \
           --key $temp_dir/key.pem \
           --cacert $temp_dir/cacert.ca > $temp_dir/payload.txt

--- a/.github/workflows/check-api.yml
+++ b/.github/workflows/check-api.yml
@@ -1,0 +1,66 @@
+name: Check access to API
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        type: choice
+        description: Select the API environment
+        options: [all, prod, qa]
+  schedule:
+    - cron: "0 12 * * *"
+
+jobs:
+  check-api:
+    runs-on: ubuntu-latest
+    env:
+      SHOULD_RUN: |
+        ${{ github.event.name == 'schedule'
+        || github.event.inputs.environment == 'all'
+        || github.event.inputs.environment == matrix.name
+        }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: prod
+            cert: API_CHECK_PROD_CERT
+            key: API_CHECK_PROD_KEY
+            ca-cert: API_CHECK_PROD_CA_CERT
+            url: API_CHECK_PROD_URL
+
+          - name: qa
+            cert: API_CHECK_QA_CERT
+            key: API_CHECK_QA_KEY
+            ca-cert: API_CHECK_QA_CA_CERT
+            url: API_CHECK_QA_URL
+
+    name: Check API endpoint (${{ matrix.name }})
+    steps:
+      - name: Echo workflow run information
+        run: |
+          echo "Triggering event name: \"${{ github.event.name }}\", \
+          APIs to check: \"${{ github.event.inputs.environment }}\""
+
+      - name: Decode cert files
+        if: contains(env.SHOULD_RUN, 'true')
+        run: |
+          mkdir $RUNNER_TEMP/${{ matrix.name }}
+          temp_dir=$RUNNER_TEMP/${{ matrix.name }}
+          echo ${{ secrets[matrix.cert] }} | base64 -d > $temp_dir/cert.pem
+          echo ${{ secrets[matrix.key] }} | base64 -d > $temp_dir/key.pem
+          echo ${{ secrets[matrix.ca-cert] }} | base64 -d > $temp_dir/cacert.ca
+
+      - name: Call API endpoint
+        if: contains(env.SHOULD_RUN, 'true')
+        run: |
+          temp_dir=$RUNNER_TEMP/${{ matrix.name }}
+          curl -i --url ${{ secrets[matrix.url] }} \
+          --header 'Accept: application/json' \
+          --header 'Content-type: application/json' \
+          --data '{"request_access":"CARD_TOKENISATION"}' \
+          --cert $temp_dir/cert.pem \
+          --key $temp_dir/key.pem \
+          --cacert $temp_dir/cacert.ca > $temp_dir/payload.txt
+
+          test $(head -n 1 $temp_dir/payload.txt | grep -o 201) == "201"


### PR DESCRIPTION
Fixes #252 

## How it works
This workflow will alert us if our access to the payment processor is broken. There are two ways it can be triggered:
 - via the configured schedule (set to run at 12:00 UTC)
 - manually through the Actions tab

Secrets need to be configured for this to work. For the cert-file secrets, the expectation is that they are base64-encoded strings.

The general idea is:
 - decode the strings back into files
 - build up the `curl` command to call the API endpoint, with the `-i` flag to include the HTTP header in the output
 - check that the response code is what we expect

Note that we are **not** printing the payload or anything about the certs/endpoint to the console.

## Workflow workarounds
I got very familiar with the GitHub Actions documentation while working on this workflow. 😂 Here are some notes about workarounds I had to do:
 - `jobs.<job_id>.if` does [not support](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability) using the `matrix` context, so I had to unfortunately duplicate the `if` condition on the steps. I used a job-level `env` variable though to reduce the duplication.
 - I looked into using the `jobs.<job_id>.environment` parameter as a way of reusing names for Secrets (i.e. create a GitHub Environment for each API we would want to check, and use generic secret names like `CERT`, `KEY`, `URL`, etc.). There were a few undesirable things about it though, so I went with using [custom variables in the matrix](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#using-environment-variables-in-a-matrix). This does mean though that there will be `(# of APIs) * (# of secrets per API)` secrets names.
    - Undesirable things about using Environments:
       - "Environments" are tied to "Deployment" objects, which will show up in the sidebar of the repo and keep a record. (see [docs](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#how-environments-relate-to-deployments)) I don't think we'd want this API check to be mixed in with our actual deployments: https://github.com/cal-itp/benefits/deployments
       - I also could not find a way to read the job's `environment` value, which I wanted to get for the `if` condition - for example, if the user triggering a manual run selects `qa`, the job/step should check if it is running with `environment: qa` and run or skip accordingly.
 - It seems that `matrix` does not support using expressions, so I used this trick with array notation: https://github.community/t/secrets-in-matrix/17307