### PR TITLE
Simplify API check's usage of cert files

### DIFF
--- a/.github/workflows/check-api.yml
+++ b/.github/workflows/check-api.yml
@@ -49,9 +49,18 @@ jobs:
         run: |
           mkdir $RUNNER_TEMP/${{ matrix.name }}
           temp_dir=$RUNNER_TEMP/${{ matrix.name }}
-          echo ${{ secrets[matrix.cert] }} | base64 -d > $temp_dir/cert.pem
-          echo ${{ secrets[matrix.key] }} | base64 -d > $temp_dir/key.pem
-          echo ${{ secrets[matrix.ca-cert] }} | base64 -d > $temp_dir/cacert.ca
+
+          cat > $temp_dir/cert.pem <<- EOM
+          ${{ secrets[matrix.cert] }}
+          EOM
+
+          cat > $temp_dir/key.pem <<- EOM
+          ${{ secrets[matrix.key] }}
+          EOM
+
+          cat > $temp_dir/cacert.ca
+          ${{ secrets[matrix.ca-cert] }}
+          EOM
 
       - name: Call API endpoint
         if: contains(env.SHOULD_RUN, 'true')

--- a/.github/workflows/check-api.yml
+++ b/.github/workflows/check-api.yml
@@ -41,8 +41,8 @@ jobs:
     steps:
       - name: Echo workflow run information
         run: |
-          echo "Triggering event name: \"${{ github.event_name }}\", \
-          APIs to check: \"${{ github.event.inputs.environment }}\""
+          echo "Triggering event name: ${{ github.event_name }}, \
+          APIs to check: ${{ github.event.inputs.environment }}"
 
       - name: Decode cert files
         if: contains(env.SHOULD_RUN, 'true')

--- a/.github/workflows/check-api.yml
+++ b/.github/workflows/check-api.yml
@@ -69,9 +69,9 @@ jobs:
           curl -i --url ${{ secrets[matrix.url] }} \
           --header 'Accept: application/json' \
           --header 'Content-type: application/json' \
-          --data '${{ matrix.data }}' \
+          --data '${{ secrets[matrix.data] }}' \
           --cert $temp_dir/cert.pem \
           --key $temp_dir/key.pem \
           --cacert $temp_dir/cacert.ca > $temp_dir/payload.txt
 
-          test $(head -n 1 $temp_dir/payload.txt | grep -o 201) == "201"
+          test $(head -n 1 $temp_dir/payload.txt | grep -o 201)

--- a/.github/workflows/check-api.yml
+++ b/.github/workflows/check-api.yml
@@ -58,7 +58,7 @@ jobs:
           ${{ secrets[matrix.key] }}
           EOM
 
-          cat > $temp_dir/cacert.ca
+          cat > $temp_dir/cacert.ca <<- EOM
           ${{ secrets[matrix.ca-cert] }}
           EOM
 

--- a/.github/workflows/check-api.yml
+++ b/.github/workflows/check-api.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SHOULD_RUN: |
-        ${{ github.event.name == 'schedule'
+        ${{ github.event_name == 'schedule'
         || github.event.inputs.environment == 'all'
         || github.event.inputs.environment == matrix.name
         }}
@@ -41,7 +41,7 @@ jobs:
     steps:
       - name: Echo workflow run information
         run: |
-          echo "Triggering event name: \"${{ github.event.name }}\", \
+          echo "Triggering event name: \"${{ github.event_name }}\", \
           APIs to check: \"${{ github.event.inputs.environment }}\""
 
       - name: Decode cert files


### PR DESCRIPTION
It is not necessary to base64-encode the cert files as a single string.
The workflow will now read the secret, which is expected to be simply the file contents, newlines and all).