### PR TITLE
[WIP] Refactor for multiple flows - define pageviews per agency

### DIFF
--- a/benefits/core/pageviews.py
+++ b/benefits/core/pageviews.py
@@ -1,0 +1,122 @@
+from django.urls import reverse
+from django.utils.decorators import method_decorator
+from django.utils.translation import pgettext, ugettext as _
+
+from . import middleware, models, session, viewmodels
+
+
+def _index_content_title():
+    """Helper returns the content title for the common index page."""
+    return _("core.index.content_title")
+
+
+def _index_image():
+    """Helper returns a viewmodels.Image for the common index page."""
+    return viewmodels.Image("ridertappingbankcard.png", pgettext("image alt text", "core.index.image"))
+
+
+def _index_paragraphs():
+    """Helper returns the content paragraphs for the common index page."""
+    return [_("core.index.p1"), _("core.index.p2"), _("core.index.p3")]
+
+
+"""
+Common PageViews for reuse
+"""
+
+
+class PageView:
+    def accept(self, request, **kwargs):
+        pass
+
+    def render_page(self, **kwargs):
+        return self.page
+
+
+class IndexView(PageView):
+    def __init__(self):
+        # generate a button to the landing page for each active agency
+        agencies = models.TransitAgency.all_active()
+        buttons = [viewmodels.Button.outline_primary(text=a.short_name, url=a.index_url) for a in agencies]
+        buttons[0].classes.append("mt-3")
+        buttons[0].label = _("core.index.chooseprovider")
+
+        self.page = viewmodels.Page(
+            content_title=_index_content_title(),
+            paragraphs=_index_paragraphs(),
+            image=_index_image(),
+            buttons=buttons,
+            classes="home",
+        )
+
+    def accept(self, request, **kwargs):
+        session.reset(request)
+
+
+class AgencyIndexView(PageView):
+    def __init__(self):
+        self.page = viewmodels.Page(
+            content_title=_index_content_title(),
+            paragraphs=_index_paragraphs(),
+            image=_index_image(),
+            button=viewmodels.Button.primary(text=_("core.index.continue"), url=reverse("eligibility:index")),
+            classes="home",
+        )
+
+    @method_decorator(middleware.pageview_decorator)
+    def accept(self, request, **kwargs):
+        session.reset(request)
+        session.update(request, agency=kwargs["agency"], origin=kwargs["agency"].index_url)
+
+    def render_page(self, **kwargs):
+        return self.page
+
+
+"""
+Classes that define PageViews for specific agencies
+"""
+
+
+class AgencyPageViews:
+    def get_initial_pageview(self):
+        pass
+
+    def get_pageview_from_slug(self, slug):
+        pass
+
+
+class Mst(AgencyPageViews):
+    def get_initial_pageview(self):
+        return AgencyIndexView()
+
+    def get_pageview_from_slug(self, slug):
+        pass
+
+
+class Sacrt(AgencyPageViews):
+    def get_initial_pageview(self):
+        pageview = AgencyIndexView()
+        pageview.page = viewmodels.Page(
+            content_title=_index_content_title(),
+            paragraphs=_index_paragraphs(),
+            image=_index_image(),
+            # text would come from i18n file of course. Just putting inline for now.
+            button=viewmodels.Button.primary(text="Different text", url="types"),
+            classes="home",
+        )
+
+        return pageview
+
+    def get_pageview_from_slug(self, slug):
+        # imagine a mapping of slugs to pages (here we're just always returning this one)
+        pageview = PageView()
+        pageview.page = viewmodels.Page(
+            # text would come from i18n file of course. Just putting inline for now.
+            content_title="This is a new page just for Sacrt",
+            paragraphs=["This is a paragraph just for Sacrt", "This is another paragraph"],
+            image=_index_image(),
+            button=viewmodels.Button.primary(text=_("core.index.continue"), url=reverse("eligibility:index")),
+            classes="home",
+        )
+
+        return pageview

--- a/benefits/core/urls.py
+++ b/benefits/core/urls.py
@@ -47,5 +47,7 @@ urlpatterns = [
     path("", views.index, name="index"),
     path("help", views.help, name="help"),
     path("payment-options", views.payment_options, name="payment_options"),
+    # need to figure out what to do for reverse("core:agency_index")
     path("<agency:agency>", views.agency_index, name="agency_index"),
+    path("<slug>", views.agency_page),
 ]

--- a/fixtures/04_transitagency.json
+++ b/fixtures/04_transitagency.json
@@ -3,7 +3,7 @@
     "model": "core.transitagency",
     "pk": 1,
     "fields": {
-      "slug": "abc",
+      "slug": "mst",
       "short_name": "ABC",
       "long_name": "ABC Transit Company",
       "agency_id": "abc123",
@@ -24,7 +24,7 @@
     "model": "core.transitagency",
     "pk": 2,
     "fields": {
-      "slug": "deftl",
+      "slug": "sacrt",
       "short_name": "DefTL",
       "long_name": "DEF Transit Lines",
       "agency_id": "def456",


### PR DESCRIPTION
⚠️ This is a WIP ⚠️ 

## Overview
This PR shows a potential alternative approach for accomplishing the goal recorded in #253.  In this potential refactor, we change our `views.py` to work against `PageView` classes. 

All the class/method names are fair game for changing, but the main idea is that this class knows how to accept the request (and do whatever it needs to - like update the session or handle a form) and then render a page. The current `PageView` name was inspired from Django's class-based views, but I see we have a `pageview_decorator` which is referring to something else entirely, so it could be confusing.

I think we can still have the explicit `index` and `agency_index` view functions, but the big change that gives us the flexibility for multiple workflows is that the `agency_index` PageView will be looked up from a class. We'll have a class per transit-agency that knows which PageViews should be returned. The `agency_index` will have buttons that can navigate further into those PageViews, eventually reaching one that has a button to go to the `/eligibility` app. The current name for this class is `AgencyPageViews`.

Here are the base class definitions for convenience:
```
class PageView:
    def accept(self, request, **kwargs):
        pass

    def render_page(self, **kwargs):
        return self.page
```

```
class AgencyPageViews:
    def get_initial_pageview(self): # maybe get_index instead?
        pass

    def get_pageview_from_slug(self, slug):
        pass
```

### Trying it out
In this proof-of-concept code, I've defined two `AgencyPageViews`s. The first, with name `Mst`, goes through the basic workflow. The second, with name `Sacrt`, defines an additional page with slug `types` to come after the agency index page. You could have as many additional pages as you want as long as the slug maps to a page. Notice that the page layouts/text/images can be custom to the transit agency and is abstracted from the code in `views.py`.

### Some notes
 - We are no better or worse than #230 at coupling the pages to transit agencies. (If you add a new transit agency or are trying to use our `abc` and `deftl` ones, you have to add a corresponding `AgencyPageViews` class.)
 - (Need to think this through more) There is (maybe?) the open question of how we expect to use `django.urls.reverse` under this approach.