### PR TITLE
Feat: Add provider_name to analytics user props

### DIFF
--- a/benefits/core/analytics.py
+++ b/benefits/core/analytics.py
@@ -37,7 +37,9 @@ class Event:
         self.__dict__.update(kwargs)
 
         agency = session.agency(request)
-        self.update_event_properties(path=request.path, provider_name=agency.long_name if agency else None)
+        name = agency.long_name if agency else None
+
+        self.update_event_properties(path=request.path, provider_name=name)
 
         uagent = request.headers.get("user-agent")
 
@@ -45,7 +47,7 @@ class Event:
         match = Event._domain_re.match(ref) if ref else None
         refdom = match.group(1) if match else None
 
-        self.update_user_properties(referrer=ref, referring_domain=refdom, user_agent=uagent)
+        self.update_user_properties(referrer=ref, referring_domain=refdom, user_agent=uagent, provider_name=name)
 
         # event is initialized, consume next counter
         self.event_id = next(Event._counter)


### PR DESCRIPTION
This will allow for more kinds of event segmentation by transit agency when the app is eventually configured for multiple agencies.

`provider_name` as an event prop doesn't make as much sense as it is largely independent from the type of event and more down to the (type of) user - however segmentation of events by `provider_name` may prove useful so this PR leaves the prop there.

More info: https://help.amplitude.com/hc/en-us/articles/115002380567-User-properties-and-event-properties