### PR TITLE
Tokenize response only for expected statuses

### DIFF
--- a/benefits/eligibility/api.py
+++ b/benefits/eligibility/api.py
@@ -154,8 +154,13 @@ class Client:
         except requests.HTTPError as e:
             raise ApiError(e)
 
-        logger.debug("Process eligiblity verification response")
-        return self._tokenize_response(r)
+        expected_status_codes = {200, 400}
+        if r.status_code in expected_status_codes:
+            logger.debug("Process eligiblity verification response")
+            return self._tokenize_response(r)
+        else:
+            logger.info(f"Unexpected eligibility verification response status code: {r.status_code}")
+            raise ApiError("Unexpected eligibility verification response")
 
     def verify(self, sub, name):
         """Check eligibility for the subject and name."""

--- a/benefits/eligibility/api.py
+++ b/benefits/eligibility/api.py
@@ -159,7 +159,7 @@ class Client:
             logger.debug("Process eligiblity verification response")
             return self._tokenize_response(r)
         else:
-            logger.info(f"Unexpected eligibility verification response status code: {r.status_code}")
+            logger.warning(f"Unexpected eligibility verification response status code: {r.status_code}")
             raise ApiError("Unexpected eligibility verification response")
 
     def verify(self, sub, name):


### PR DESCRIPTION
Fixes #279 

### Local testing
I modified my local `eligibility-server` instance to return a 403 for the `/verify` endpoint. Then, I modified the `benefits` compose.yml file so that it would point at `eligibility_server:latest` for the `server` service. I rebuilt all the images and then launched `benefits` with the debugger.

My hard-coded 403 was returned and raised an `ApiError` as expected.

Screenshots:
![image](https://user-images.githubusercontent.com/25497886/148454982-b32f9d71-ce4d-4269-85a0-97ae2351da69.png)

![image](https://user-images.githubusercontent.com/25497886/148454996-d0d9543b-8362-430c-a07d-377e1ec3da5c.png)
