### PR TITLE
fix(deps): revert django from 4.0.1 to 3.2.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cryptography==36.0.1
-Django==4.0.1
+Django==3.2.10
 django-csp==3.7
 gunicorn==20.1.0
 jwcrypto==1.0


### PR DESCRIPTION
closes #284 

- Reverts work from #256 and #276 
- Reverts to 3.2.10 because of outstanding bug #283 


## Testing
- Tested locally on 3.2.10
![image](https://user-images.githubusercontent.com/3673236/149393266-76ca0ae9-ccd6-4d14-9f13-4750d0e239f8.png)

