### PR TITLE
Feature: Add Alert for Recaptcha failure

### DIFF
--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -23,6 +23,11 @@
             <div id="skip-to-content">
                 <a href="#main-content">{% translate "core.skip" %}</a>
             </div>
+            {% if messages %}
+            {% for message in messages %}
+            {% include "core/includes/alert.html" with message=message %}
+            {% endfor %}
+            {% endif %}
 
             <div class="nocookies d-none" >
             {% include "core/includes/nocookies.html" %}
@@ -69,6 +74,7 @@
             </div>
         </footer>
 
+        <script src="https://california.azureedge.net/cdt/statetemplate/6.0.2/js/cagov.core.js"></script>
         <script>
             $(function() {
                 document.cookie = "testcookie"

--- a/benefits/core/templates/core/includes/alert.html
+++ b/benefits/core/templates/core/includes/alert.html
@@ -1,0 +1,27 @@
+<div class="alert
+
+{% if message.level_tag == "error" %}
+ alert-danger
+{% elif message.level_tag == "warning" %}
+ alert-warning
+{% elif message.level_tag == "success" %}
+ alert-success
+{% elif message.level_tag == "info" %}
+ alert-info
+{% elif message.level_tag == "debug" %}
+ alert-severe
+{% endif %}
+
+alert-dismissible alert-banner" role="alert">
+
+    <div class="container">
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+            <span class="ca-gov-icon-close-mark" aria-hidden="true"></span>
+        </button>
+        <span class="alert-level">
+            <span class="ca-gov-icon-important" aria-hidden="true"></span>
+            {{ message.level_tag | upper}}
+        </span>
+        <span class="alert-text">{{ message }}</span>
+    </div>
+</div>

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -79,7 +79,7 @@ def _verify(request, form):
 
     if not form.is_valid():
         if recaptcha.has_error(form):
-            messages.error(request, "reCAPTCHA failed")
+            messages.error(request, "Recaptcha failed. Please try again.")
         return None
 
     sub, name = form.cleaned_data.get("sub"), form.cleaned_data.get("name")

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -217,7 +217,7 @@ CSP_FONT_SRC = list(env_font_src)
 
 CSP_FRAME_ANCESTORS = ["'none'"]
 CSP_FRAME_SRC = ["'none'"]
-env_frame_src = _filter_empty(os.environ.get("DJANGO_CSP_FRAME_SRC")).split(",")
+env_frame_src = _filter_empty(os.environ.get("DJANGO_CSP_FRAME_SRC", "").split(","))
 if any(env_frame_src):
     CSP_FRAME_SRC = list(env_frame_src)
 


### PR DESCRIPTION
## What this PR does
- Adds `alert` template, adds `alert` conditional rendering in `base` template. The alert is red with a close button. This requires `https://california.azureedge.net/cdt/statetemplate/6.0.2/js/cagov.core.js`
- Adds an alert that opens when `messages.error()` is called in a view template.

## To Dos
- [x] - Add alert to Recaptcha failure
- [x] - Change Recaptcha failure message

This is PR _into_ the main `feat/recaptcha` branch.

![image](https://user-images.githubusercontent.com/3673236/151240392-f2f415ef-7c8f-491e-8090-2e50db9a209b.png)
