### PR TITLE
Feat: Add validation fields to verifier model

### DIFF
--- a/benefits/core/migrations/0001_initial.py
+++ b/benefits/core/migrations/0001_initial.py
@@ -34,6 +34,7 @@ class Migration(migrations.Migration):
                 ("api_auth_header", models.TextField()),
                 ("api_auth_key", models.TextField()),
                 # fmt: off
+                ("sub_regex", models.TextField(help_text="A regular expression used to validate the 'sub' API field before sending to this verifier", null=True)),  # noqa: E501
                 ("public_key", models.ForeignKey(help_text="The Verifier's public key, used to encrypt requests targeted at this Verifier and to verify signed responses from this verifier.", on_delete=models.deletion.PROTECT, related_name="+", to="core.PemData")),  # noqa: E501
                 ("jwe_cek_enc", models.TextField(help_text="The JWE-compatible Content Encryption Key (CEK) key-length and mode")),  # noqa: E501
                 ("jwe_encryption_alg", models.TextField(help_text="The JWE-compatible encryption algorithm")),

--- a/benefits/core/migrations/0001_initial.py
+++ b/benefits/core/migrations/0001_initial.py
@@ -35,6 +35,7 @@ class Migration(migrations.Migration):
                 ("api_auth_key", models.TextField()),
                 # fmt: off
                 ("sub_regex", models.TextField(help_text="A regular expression used to validate the 'sub' API field before sending to this verifier", null=True)),  # noqa: E501
+                ("name_max_length", models.PositiveSmallIntegerField(help_text="The maximum length accepted for the 'name' API field before sending to this verifier", null=True)),  # noqa: E501
                 ("public_key", models.ForeignKey(help_text="The Verifier's public key, used to encrypt requests targeted at this Verifier and to verify signed responses from this verifier.", on_delete=models.deletion.PROTECT, related_name="+", to="core.PemData")),  # noqa: E501
                 ("jwe_cek_enc", models.TextField(help_text="The JWE-compatible Content Encryption Key (CEK) key-length and mode")),  # noqa: E501
                 ("jwe_encryption_alg", models.TextField(help_text="The JWE-compatible encryption algorithm")),

--- a/benefits/core/models.py
+++ b/benefits/core/models.py
@@ -67,6 +67,7 @@ class EligibilityVerifier(models.Model):
     jwe_cek_enc = models.TextField(help_text="The JWE-compatible Content Encryption Key (CEK) key-length and mode")
     jwe_encryption_alg = models.TextField(help_text="The JWE-compatible encryption algorithm")
     jws_signing_alg = models.TextField(help_text="The JWS-compatible signing algorithm")
+    sub_regex = models.TextField(null=True, help_text="A regular expression used to validate the 'sub' API field before sending to this verifier")  # noqa: 503
     # fmt: on
 
     def __str__(self):

--- a/benefits/core/models.py
+++ b/benefits/core/models.py
@@ -68,6 +68,7 @@ class EligibilityVerifier(models.Model):
     jwe_encryption_alg = models.TextField(help_text="The JWE-compatible encryption algorithm")
     jws_signing_alg = models.TextField(help_text="The JWS-compatible signing algorithm")
     sub_regex = models.TextField(null=True, help_text="A regular expression used to validate the 'sub' API field before sending to this verifier")  # noqa: 503
+    name_max_length = models.PositiveSmallIntegerField(null=True, help_text="The maximum length accepted for the 'name' API field before sending to this verifier")  # noqa: 503
     # fmt: on
 
     def __str__(self):

--- a/fixtures/02_eligibilityverifier.json
+++ b/fixtures/02_eligibilityverifier.json
@@ -15,7 +15,8 @@
       "jwe_cek_enc": "A256CBC-HS512",
       "jwe_encryption_alg": "RSA-OAEP",
       "jws_signing_alg": "RS256",
-      "sub_regex": ".+"
+      "sub_regex": ".+",
+      "name_max_length": 255
     }
   }
 ]

--- a/fixtures/02_eligibilityverifier.json
+++ b/fixtures/02_eligibilityverifier.json
@@ -14,7 +14,8 @@
       "public_key": 1,
       "jwe_cek_enc": "A256CBC-HS512",
       "jwe_encryption_alg": "RSA-OAEP",
-      "jws_signing_alg": "RS256"
+      "jws_signing_alg": "RS256",
+      "sub_regex": ".+"
     }
   }
 ]


### PR DESCRIPTION
Closes #208.

Note this PR only modifies the `EligiblityVerifier` model to add the fields that capture the validation settings. In the follow-up for #324, the form will be updated to use these new settings for validation.