### PR TITLE
Tests: Update UI tests for multiple verifier flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ fixtures/*.json
 static/
 !benefits/static
 __pycache__/
+.DS_Store

--- a/docs/getting-started/testing.md
+++ b/docs/getting-started/testing.md
@@ -2,7 +2,7 @@
 
 ## Integration
 
-End-to-end integration tests are implemented with [`cypress`](https://www.cypress.io/) and can be found in the
+Feature and user interface tests are implemented with [`cypress`](https://www.cypress.io/) and can be found in the
 [`tests/cypress`](https://github.com/cal-itp/benefits/tree/dev/tests/cypress) directory in the repository.
 
 See the [`cypress` Command Line](https://docs.cypress.io/guides/guides/command-line) guide for more information.

--- a/docs/getting-started/testing.md
+++ b/docs/getting-started/testing.md
@@ -25,3 +25,39 @@ See the [`cypress` Command Line](https://docs.cypress.io/guides/guides/command-l
     ```bash
     npx cypress run
     ```
+
+### Running outside of the Dev Container
+
+These are instructions for running `cypress` locally on your machine, *without* the devcontainer. These steps
+will install `cypress` and its dependencies on your  machine. Make sure to run these commands in a Terminal.
+
+1. Ensure you have Node.js and NPM available on your local machine:
+
+```bash
+node -v
+npm -v
+```
+
+If not, install Node.js locally. Instructions [here](https://nodejs.org/en/download/).
+
+2. Get into the `cypress` directory:
+
+```bash
+cd tests/cypress
+```
+
+3. Install all packages and `cypress`. Verify `cypress` installation succeeds:
+
+```bash
+npm install
+cypress install
+npx cypress verify
+```
+
+4. Run `cypress` with test environment variables and configuration variables:
+
+```bash
+CYPRESS_baseUrl=http://localhost:8000 npm run cypress:open
+```
+
+See `tests/cypress/package.json` for more cypress scripts.

--- a/docs/getting-started/testing.md
+++ b/docs/getting-started/testing.md
@@ -1,6 +1,6 @@
 # Automated tests
 
-## Integration
+## Cypress
 
 Feature and user interface tests are implemented with [`cypress`](https://www.cypress.io/) and can be found in the
 [`tests/cypress`](https://github.com/cal-itp/benefits/tree/dev/tests/cypress) directory in the repository.

--- a/tests/cypress/package-lock.json
+++ b/tests/cypress/package-lock.json
@@ -408,7 +408,6 @@
       "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
       "dev": true,
       "dependencies": {
-        "colors": "1.4.0",
         "string-width": "^4.2.0"
       },
       "engines": {
@@ -749,7 +748,6 @@
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
       "dependencies": {
-        "@types/yauzl": "^2.9.1",
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
         "yauzl": "^2.10.0"
@@ -1113,7 +1111,6 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {

--- a/tests/cypress/package-lock.json
+++ b/tests/cypress/package-lock.json
@@ -408,6 +408,7 @@
       "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
       "dev": true,
       "dependencies": {
+        "colors": "1.4.0",
         "string-width": "^4.2.0"
       },
       "engines": {
@@ -748,6 +749,7 @@
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
       "dependencies": {
+        "@types/yauzl": "^2.9.1",
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
         "yauzl": "^2.10.0"
@@ -1111,6 +1113,7 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
+        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {

--- a/tests/cypress/specs/ui/eligibility.spec.js
+++ b/tests/cypress/specs/ui/eligibility.spec.js
@@ -40,7 +40,6 @@ describe("Multiple Verifier: Verifier selection page spec", () => {
     cy.get("input:radio:checked").should("have.length", 0);
     cy.contains("Continue").click();
     cy.url().should("include", verifier_selection_url);
-    cy.get("label").should("have.css", "color", "rgb(222, 12, 12)");
     cy.contains("This field is required.");
   });
 

--- a/tests/cypress/specs/ui/eligibility.spec.js
+++ b/tests/cypress/specs/ui/eligibility.spec.js
@@ -4,7 +4,7 @@ const verifier_selection_url = "/eligibility";
 const eligibility_confirm_url = "/eligibility/confirm";
 const eligibility_start_url = "/eligibility/start";
 
-describe.skip("Single verifier: Eligibility confirmation page spec", () => {
+describe("Single verifier: Eligibility confirmation page spec", () => {
   it("User can navigate to the confirmation page", () => {
     cy.visit("/");
     // Selecting DEFTl will go down the single verifier flow
@@ -57,7 +57,7 @@ describe("Multiple Verifier: Verifier selection page spec", () => {
   });
 });
 
-describe.skip("Multiple verifier: Eligibility confirmation form spec", () => {
+describe("Multiple verifier: Eligibility confirmation form spec", () => {
   beforeEach(() => {
     cy.visit("/");
     cy.contains(agencies[0].fields.short_name).click();

--- a/tests/cypress/specs/ui/eligibility.spec.js
+++ b/tests/cypress/specs/ui/eligibility.spec.js
@@ -1,14 +1,56 @@
 const agencies = require("../../fixtures/transit-agencies");
 
+const verifier_selection_url = "/eligibility";
 const eligibility_url = "/eligibility/confirm";
+const eligibility_start_url = "/eligibility/start";
 
-describe("Eligibility confirmation page spec", () => {
+describe("Single eligibility confirmation page spec", () => {
+  // This spec needs to be configured so that the Verifier Selection page
+  // Does NOT appear
+  // This spec should pass without any code changes
+  // When the app is configured for not having Verifier Selection
   it.skip("User can navigate to the confirmation page", () => {
     cy.visit("/");
     cy.contains(agencies[0].fields.short_name).click();
     cy.contains("Let’s do it!").click();
     cy.contains("Continue").click();
     cy.url().should("include", eligibility_url);
+  });
+});
+
+describe("Verifier selection page spec", () => {
+  beforeEach(() => {
+    cy.visit("/");
+    cy.contains(agencies[0].fields.short_name).click();
+    cy.contains("Let’s do it!").click();
+  });
+
+  it("User can navigate to the Verifier Selection page", () => {
+    cy.contains("Continue");
+    cy.url().should("include", verifier_selection_url);
+    cy.contains("Select the discount option that best applies to you:");
+  });
+
+  it("User sees two radio buttons", () => {
+    cy.get("input:radio").should("have.length", 2);
+    cy.contains("MST Courtesy Cardholder");
+    cy.contains("Senior Discount Program");
+  });
+
+  it("User must select a radio button, or else see a validation message", () => {
+    cy.get("input:radio").should("have.length", 2);
+    cy.get("input:radio:checked").should("have.length", 0);
+    cy.contains("Continue").click();
+    cy.url().should("include", verifier_selection_url);
+    cy.contains("This field is required.");
+  });
+
+  it("User can click a radio button and click Continue", () => {
+    cy.get("input:radio:checked").should("have.length", 0);
+    cy.contains("Senior Discount Program").click();
+    cy.get("input:radio:checked").should("have.length", 1);
+    cy.contains("Continue").click();
+    cy.url().should("include", eligibility_start_url);
   });
 });
 

--- a/tests/cypress/specs/ui/eligibility.spec.js
+++ b/tests/cypress/specs/ui/eligibility.spec.js
@@ -42,6 +42,7 @@ describe("Verifier selection page spec", () => {
     cy.get("input:radio:checked").should("have.length", 0);
     cy.contains("Continue").click();
     cy.url().should("include", verifier_selection_url);
+    cy.get("label").should("have.css", "color", "rgb(222, 12, 12)");
     cy.contains("This field is required.");
   });
 

--- a/tests/cypress/specs/ui/eligibility.spec.js
+++ b/tests/cypress/specs/ui/eligibility.spec.js
@@ -37,7 +37,7 @@ describe("Verifier selection page spec", () => {
     cy.contains("Senior Discount Program");
   });
 
-  it("User must select a radio button, or else see a validation message", () => {
+  it.skip("User must select a radio button, or else see a validation message", () => {
     cy.get("input:radio").should("have.length", 2);
     cy.get("input:radio:checked").should("have.length", 0);
     cy.contains("Continue").click();

--- a/tests/cypress/specs/ui/eligibility.spec.js
+++ b/tests/cypress/specs/ui/eligibility.spec.js
@@ -40,7 +40,11 @@ describe("Multiple Verifier: Verifier selection page spec", () => {
     cy.get("input:radio:checked").should("have.length", 0);
     cy.contains("Continue").click();
     cy.url().should("include", verifier_selection_url);
-    cy.contains("This field is required.");
+    cy.get("input:radio:checked").should("have.length", 0);
+    cy.get("input:radio:invalid").should("have.length", 2);
+    cy.get("input:radio"[0])
+      .invoke("prop", "validationMessage")
+      .should("equal", "Please select one of the options");
   });
 
   it("User can click a radio button and click Continue", () => {

--- a/tests/cypress/specs/ui/eligibility.spec.js
+++ b/tests/cypress/specs/ui/eligibility.spec.js
@@ -25,19 +25,19 @@ describe("Verifier selection page spec", () => {
     cy.contains("Let’s do it!").click();
   });
 
-  it.skip("User can navigate to the Verifier Selection page", () => {
+  it("User can navigate to the Verifier Selection page", () => {
     cy.contains("Continue");
     cy.url().should("include", verifier_selection_url);
     cy.contains("Select the discount option that best applies to you:");
   });
 
-  it.skip("User sees two radio buttons", () => {
+  it("User sees two radio buttons", () => {
     cy.get("input:radio").should("have.length", 2);
     cy.contains("MST Courtesy Cardholder");
     cy.contains("Senior Discount Program");
   });
 
-  it.skip("User must select a radio button, or else see a validation message", () => {
+  it("User must select a radio button, or else see a validation message", () => {
     cy.get("input:radio").should("have.length", 2);
     cy.get("input:radio:checked").should("have.length", 0);
     cy.contains("Continue").click();
@@ -46,7 +46,7 @@ describe("Verifier selection page spec", () => {
     cy.contains("This field is required.");
   });
 
-  it.skip("User can click a radio button and click Continue", () => {
+  it("User can click a radio button and click Continue", () => {
     cy.get("input:radio:checked").should("have.length", 0);
     cy.contains("Senior Discount Program").click();
     cy.get("input:radio:checked").should("have.length", 1);

--- a/tests/cypress/specs/ui/eligibility.spec.js
+++ b/tests/cypress/specs/ui/eligibility.spec.js
@@ -41,7 +41,7 @@ describe("Multiple Verifier: Verifier selection page spec", () => {
     cy.contains("Continue").click();
     cy.url().should("include", verifier_selection_url);
     cy.get("input:radio:checked").should("have.length", 0);
-    cy.get("input:radio:invalid").should("have.length", 2);
+    cy.get("input:invalid").should("have.length", 2);
     cy.get("input:radio"[0])
       .invoke("prop", "validationMessage")
       .should("equal", "Please select one of the options");

--- a/tests/cypress/specs/ui/eligibility.spec.js
+++ b/tests/cypress/specs/ui/eligibility.spec.js
@@ -1,10 +1,10 @@
 const agencies = require("../../fixtures/transit-agencies");
 
 const verifier_selection_url = "/eligibility";
-const eligibility_url = "/eligibility/confirm";
+const eligibility_confirm_url = "/eligibility/confirm";
 const eligibility_start_url = "/eligibility/start";
 
-describe("Single eligibility confirmation page spec", () => {
+describe("Single verifier: Eligibility confirmation page spec", () => {
   // This spec needs to be configured so that the Verifier Selection page
   // Does NOT appear
   // This spec should pass without any code changes
@@ -25,19 +25,19 @@ describe("Verifier selection page spec", () => {
     cy.contains("Let’s do it!").click();
   });
 
-  it("User can navigate to the Verifier Selection page", () => {
+  it.skip("User can navigate to the Verifier Selection page", () => {
     cy.contains("Continue");
     cy.url().should("include", verifier_selection_url);
     cy.contains("Select the discount option that best applies to you:");
   });
 
-  it("User sees two radio buttons", () => {
+  it.skip("User sees two radio buttons", () => {
     cy.get("input:radio").should("have.length", 2);
     cy.contains("MST Courtesy Cardholder");
     cy.contains("Senior Discount Program");
   });
 
-  it("User must select a radio button, or else see a validation message", () => {
+  it.skip("User must select a radio button, or else see a validation message", () => {
     cy.get("input:radio").should("have.length", 2);
     cy.get("input:radio:checked").should("have.length", 0);
     cy.contains("Continue").click();
@@ -46,7 +46,7 @@ describe("Verifier selection page spec", () => {
     cy.contains("This field is required.");
   });
 
-  it("User can click a radio button and click Continue", () => {
+  it.skip("User can click a radio button and click Continue", () => {
     cy.get("input:radio:checked").should("have.length", 0);
     cy.contains("Senior Discount Program").click();
     cy.get("input:radio:checked").should("have.length", 1);
@@ -55,25 +55,31 @@ describe("Verifier selection page spec", () => {
   });
 });
 
-describe("Eligibility confirmation form spec", () => {
+describe("Multiple verifier: Eligibility confirmation form spec", () => {
   beforeEach(() => {
     cy.visit("/");
     cy.contains(agencies[0].fields.short_name).click();
     cy.contains("Let’s do it!").click();
+    cy.contains("Senior Discount Program").click();
     cy.contains("Continue").click();
+    cy.contains("Great, you’ll need two things before we get started...");
   });
 
-  it.skip("Has a driver’s license or ID number form label and corresponding field", () => {
+  it("Has a driver’s license or ID number form label and corresponding field", () => {
+    cy.contains("Continue").click();
     cy.get("input:focus").should("have.length", 0);
     cy.contains("CA driver’s license or ID number *").click();
 
     cy.get("input:focus").should("have.length", 1);
+    cy.url().should("include", eligibility_confirm_url);
   });
 
-  it.skip("Has a last name form label and corresponding form field", () => {
+  it("Has a last name form label and corresponding form field", () => {
+    cy.contains("Continue").click();
     cy.get("input:focus").should("have.length", 0);
     cy.contains("Last name (as it appears on ID) *").click();
 
     cy.get("input:focus").should("have.length", 1);
+    cy.url().should("include", eligibility_confirm_url);
   });
 });

--- a/tests/cypress/specs/ui/eligibility.spec.js
+++ b/tests/cypress/specs/ui/eligibility.spec.js
@@ -4,7 +4,7 @@ const verifier_selection_url = "/eligibility";
 const eligibility_confirm_url = "/eligibility/confirm";
 const eligibility_start_url = "/eligibility/start";
 
-describe("Single verifier: Eligibility confirmation page spec", () => {
+describe.skip("Single verifier: Eligibility confirmation page spec", () => {
   it("User can navigate to the confirmation page", () => {
     cy.visit("/");
     // Selecting DEFTl will go down the single verifier flow
@@ -42,9 +42,10 @@ describe("Multiple Verifier: Verifier selection page spec", () => {
     cy.url().should("include", verifier_selection_url);
     cy.get("input:radio:checked").should("have.length", 0);
     cy.get("input:invalid").should("have.length", 2);
-    cy.get("input:radio"[0])
+    cy.get("input:radio")
+      .first()
       .invoke("prop", "validationMessage")
-      .should("equal", "Please select one of the options");
+      .should("not.equal", "");
   });
 
   it("User can click a radio button and click Continue", () => {
@@ -56,7 +57,7 @@ describe("Multiple Verifier: Verifier selection page spec", () => {
   });
 });
 
-describe("Multiple verifier: Eligibility confirmation form spec", () => {
+describe.skip("Multiple verifier: Eligibility confirmation form spec", () => {
   beforeEach(() => {
     cy.visit("/");
     cy.contains(agencies[0].fields.short_name).click();

--- a/tests/cypress/specs/ui/eligibility.spec.js
+++ b/tests/cypress/specs/ui/eligibility.spec.js
@@ -5,22 +5,20 @@ const eligibility_confirm_url = "/eligibility/confirm";
 const eligibility_start_url = "/eligibility/start";
 
 describe("Single verifier: Eligibility confirmation page spec", () => {
-  // This spec needs to be configured so that the Verifier Selection page
-  // Does NOT appear
-  // This spec should pass without any code changes
-  // When the app is configured for not having Verifier Selection
-  it.skip("User can navigate to the confirmation page", () => {
+  it("User can navigate to the confirmation page", () => {
     cy.visit("/");
-    cy.contains(agencies[0].fields.short_name).click();
+    // Selecting DEFTl will go down the single verifier flow
+    cy.contains(agencies[1].fields.short_name).click();
     cy.contains("Let’s do it!").click();
     cy.contains("Continue").click();
-    cy.url().should("include", eligibility_url);
+    cy.url().should("include", eligibility_confirm_url);
   });
 });
 
-describe("Verifier selection page spec", () => {
+describe("Multiple Verifier: Verifier selection page spec", () => {
   beforeEach(() => {
     cy.visit("/");
+    // Selecting ABC will go down the multiple verifier flow
     cy.contains(agencies[0].fields.short_name).click();
     cy.contains("Let’s do it!").click();
   });
@@ -37,7 +35,7 @@ describe("Verifier selection page spec", () => {
     cy.contains("Senior Discount Program");
   });
 
-  it.skip("User must select a radio button, or else see a validation message", () => {
+  it("User must select a radio button, or else see a validation message", () => {
     cy.get("input:radio").should("have.length", 2);
     cy.get("input:radio:checked").should("have.length", 0);
     cy.contains("Continue").click();


### PR DESCRIPTION
closes #339 


## What this PR does

### Tests
- Modifies existing UI specs for Eligibility Confirmation page, by having the user select `DEFtl` Transit (which is set to be the single-verifier path)
- Adds UI specs for the Verifier selection page, testing for:

After a user selects `ABC` Transit, a multiple verifier path:

1. Whether a user can click `Continue` to get to the Verifier selection page
2. Whether a user sees 2 radio buttons, with `MST Courtesy Cardholder` and `Senior Discount Program`*
3. Whether a user gets a validation message if they click `Continue` without choosing a radio button**
4. Whether a user can click `Continue` to get to the Eligibility start page, after selecting a radio button

- Modify the existing Eligibilty confirmation page spec to:

1. Add the actions of selecting a radio button (`Senior Discount Program`) to the `beforeEach`, so that the specs can run on the proper page
2. Add the next step of clicking `Continue` on the other specs so the specs can run on the proper page

*Note: The text of the radio buttons are hard-coded.
**Note: See extended note below


### Documentation
- update Cypress documentation to include instructions on how to run Cypress _outside_ of the devcontainer - which allows developers to use the Cypress Test Runner user interface.

### Chores
- update `.gitignore`
- check in latest `package-lock.json` for Cypress


## Development notes

1. In order to get the `eligibility-server` service running locally, I had to revert the image back to a version from several weeks ago: https://github.com/cal-itp/eligibility-server/pkgs/container/eligibility-server/13177499, before https://github.com/cal-itp/eligibility-server/pull/58 was merged

```diff
--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -36,7 +36,7 @@ services:
       - ../:/home/calitp/app:cached
 
   server:
-    image: ghcr.io/cal-itp/eligibility-server:main
+    image: ghcr.io/cal-itp/eligibility-server@sha256:337d5b2beb1e458980be49a778efd4a47f8daa8decc5e8329c0d528596e2f196
     ports:
       - "5000"
```

2. A browser bug was revealed during the development of this ticket.

On my Apple M1 Pro chip Macbook Pro from 2021, on all three browsers (Safari, Chrome, Firefox) and on Cypress Test Runner UI (Electron, Chrome, Firefox), at the Verifier Selection page, I am able to click `Continue` without having selected a radio button. The page then refreshes and shows me this screen: 
<img width="945" alt="image" src="https://user-images.githubusercontent.com/3673236/161160893-cb58114d-95f5-4cc4-acc8-1b674adfca2d.png">
 
On everyone else's non-M1 machines and on GitHub Actions CI, however, the _browser_ blocks users from clicking `Continue` without having selected one radio button, with a `required` HTML5 attribute. The _browser_ then displays a pop-up message with the `validationMessage`, like from this GitHub Actions CI screenshot:
![Multiple Verifier Verifier selection page spec -- User must select a radio button, or else see a validation message (failed)](https://user-images.githubusercontent.com/3673236/161161157-174cddc6-6595-46f6-86fb-c0f060eb4e57.png)

For the time being, we decided to change the way we are testing this validation, and continue improving this test case - both with UI tests and also manual browser testing - in future tickets (like #345).
  