### PR TITLE
Fix: gitattributes to force LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# force LF for everyone
+text eol=lf


### PR DESCRIPTION
This code is run in a Linux environment, and expects LF line-endings. The `.gitattributes` file forces all cloners to use LF regardless of their OS.

See https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings