### PR TITLE
Feat: re-introduce static Docker port config

### DIFF
--- a/.devcontainer/.env.sample
+++ b/.devcontainer/.env.sample
@@ -23,6 +23,7 @@ DJANGO_CSP_STYLE_SRC=https://example1.com,https://example2.com
 DJANGO_DB=django
 DJANGO_DEBUG=true
 DJANGO_INIT_PATH=fixtures/??_*.json
+DJANGO_LOCAL_PORT=8000
 DJANGO_LOG_LEVEL=DEBUG
 DJANGO_RECAPTCHA_API_URL=https://www.google.com/recaptcha/api.js
 DJANGO_RECAPTCHA_SITE_KEY=recaptcha-site-key

--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -6,7 +6,7 @@ services:
     image: benefits_client:latest
     env_file: .env
     ports:
-      - "8000"
+      - "${DJANGO_LOCAL_PORT}:8000"
     volumes:
       - ../.aws/config:/home/calitp/app/config:ro
       - ../fixtures:/home/calitp/app/fixtures:cached
@@ -22,7 +22,7 @@ services:
     depends_on:
       - server
     ports:
-      - "8000"
+      - "${DJANGO_LOCAL_PORT}:8000"
     volumes:
       - ../:/home/calitp/app:cached
 


### PR DESCRIPTION
For the upcoming SSO integration, we need to be able to pin a static localhost port for testing with the dev environment.

But only for the app container and devcontainer, the others can still be dynamic.

This only affects the _host machine_ port and only at development time; internally in the containers, the ports are unaffected.