### PR TITLE
Feat: create template for eligibility start page

### DIFF
--- a/benefits/eligibility/templates/eligibility/start.html
+++ b/benefits/eligibility/templates/eligibility/start.html
@@ -1,0 +1,1 @@
+{% extends "core/page.html" %}

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -3,6 +3,7 @@ The eligibility application: view definitions for the eligibility verification f
 """
 from django.contrib import messages
 from django.shortcuts import redirect
+from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.decorators import decorator_from_middleware
 from django.utils.translation import pgettext, gettext as _
@@ -79,7 +80,7 @@ def start(request):
         button=viewmodels.Button.primary(text=_("eligibility.buttons.continue"), url=reverse("eligibility:confirm")),
     )
 
-    return PageTemplateResponse(request, page)
+    return TemplateResponse(request, "eligibility/start.html", page.context_dict())
 
 
 @decorator_from_middleware(middleware.AgencySessionRequired)


### PR DESCRIPTION
This closes #374.

This PR simply creates the template and makes the view use it. This will be the basis of most of the other work for the Login.gov milestone, as this is the key page in the flow that needs to adapt to the new requirements.