### PR TITLE
Fix: explicit blocks in start template

### DIFF
--- a/benefits/eligibility/templates/eligibility/start.html
+++ b/benefits/eligibility/templates/eligibility/start.html
@@ -1,1 +1,21 @@
 {% extends "core/page.html" %}
+
+{% block container_content %}
+
+    {% block icon_title %}
+    {{ block.super }}
+    {% endblock %}
+
+    {% block media_list %}
+    {{ block.super }}
+    {% endblock %}
+
+    {% block paragraph_content %}
+    {{ block.super }}
+    {% endblock %}
+
+    {% block buttons %}
+    {{ block.super }}
+    {% endblock %}
+
+{% endblock %}


### PR DESCRIPTION
Quick follow on to #391, these are the blocks that are used in this template. Easier to refactor them now as a basis for other work on this page.