### PR TITLE
Track sign in status in user session

### DIFF
--- a/benefits/core/session.py
+++ b/benefits/core/session.py
@@ -53,7 +53,7 @@ def active_agency(request):
 
 def auth(request):
     """Get the auth from the request's session, or None"""
-    logger.debug("Get auth token")
+    logger.debug("Get session auth")
     return request.get(_AUTH)
 
 

--- a/benefits/core/session.py
+++ b/benefits/core/session.py
@@ -51,6 +51,12 @@ def active_agency(request):
     return a and a.active
 
 
+def auth(request):
+    """Get the auth from the request's session, or None"""
+    logger.debug("Get auth token")
+    return request.get(_AUTH)
+
+
 def context_dict(request):
     """The request's session context as a dict."""
     logger.debug("Get session context dict")
@@ -138,6 +144,7 @@ def reset(request):
     """Reset the session for the request."""
     logger.debug("Reset session")
     request.session[_AGENCY] = None
+    request.session[_AUTH] = None
     request.session[_ELIGIBILITY] = None
     request.session[_ORIGIN] = reverse("core:index")
     request.session[_TOKEN] = None
@@ -193,11 +200,24 @@ def uid(request):
     return u
 
 
-def update(request, agency=None, debug=None, eligibility_types=None, origin=None, token=None, token_exp=None, verifier=None):
+def update(
+    request,
+    agency=None,
+    auth=False,
+    debug=None,
+    eligibility_types=None,
+    origin=None,
+    token=None,
+    token_exp=None,
+    verifier=None,
+):
     """Update the request's session with non-null values."""
     if agency is not None and isinstance(agency, models.TransitAgency):
         logger.debug(f"Update session {_AGENCY}")
         request.session[_AGENCY] = agency.id
+    if auth is not None and type(auth) == bool:
+        logger.debug(f"Update session {_AUTH}")
+        request.session[_AUTH] = auth
     if debug is not None:
         logger.debug(f"Update session {_DEBUG}")
         request.session[_DEBUG] = debug

--- a/benefits/core/session.py
+++ b/benefits/core/session.py
@@ -145,7 +145,7 @@ def reset(request):
     """Reset the session for the request."""
     logger.debug("Reset session")
     request.session[_AGENCY] = None
-    request.session[_AUTH] = None
+    request.session[_AUTH] = False
     request.session[_ELIGIBILITY] = None
     request.session[_ORIGIN] = reverse("core:index")
     request.session[_TOKEN] = None
@@ -204,7 +204,7 @@ def uid(request):
 def update(
     request,
     agency=None,
-    auth=False,
+    auth=None,
     debug=None,
     eligibility_types=None,
     origin=None,

--- a/benefits/core/session.py
+++ b/benefits/core/session.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 _AGENCY = "agency"
+_AUTH = "auth"
 _DEBUG = "debug"
 _DID = "did"
 _ELIGIBILITY = "eligibility"

--- a/benefits/core/session.py
+++ b/benefits/core/session.py
@@ -54,7 +54,7 @@ def active_agency(request):
 def auth(request):
     """Get the auth from the request's session, or None"""
     logger.debug("Get session auth")
-    return request.get(_AUTH)
+    return request.session.get(_AUTH)
 
 
 def context_dict(request):
@@ -62,6 +62,7 @@ def context_dict(request):
     logger.debug("Get session context dict")
     return {
         _AGENCY: agency(request).slug if active_agency(request) else None,
+        _AUTH: auth(request),
         _LIMITCOUNTER: rate_limit_counter(request),
         _DEBUG: debug(request),
         _DID: did(request),


### PR DESCRIPTION
closes #370 


## What this PR does

- [x] Add a [new key `_AUTH = "auth"`](https://github.com/cal-itp/benefits/blob/dev/benefits/core/session.py#L26) for use elsewhere
- [x] Create a new function `auth()` that uses the key to get the stored `bool` corresponding to whether the user is signed in via or not
- [x] Update the [`update()`](https://github.com/cal-itp/benefits/blob/dev/benefits/core/session.py#L192) function to accept a new kwarg `auth=False`; if it's a bool, store in the request's session using the key
- [x] Update the [`reset()`](https://github.com/cal-itp/benefits/blob/dev/benefits/core/session.py#L134) function to set the key to `False` by default
- [x] Update the [`context_dict()`](https://github.com/cal-itp/benefits/blob/dev/benefits/core/session.py#L52) function to add the new key/value - this shows up in the debug bar
- Adds new logs messages: `Get session auth`, `Update session auth`

## Screenshots

- Auth key/value pair now in DEBUG_MODE: `"auth": "None"`

<img width="1404" alt="image" src="https://user-images.githubusercontent.com/3673236/161646825-e4d5b2dd-9093-41d3-90fd-25cac143f167.png">
