### PR TITLE
Fix: add SRI attributes for jQuery

### DIFF
--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -14,7 +14,7 @@
         <link href="{% static "css/styles.css" %}" rel="stylesheet">
         <link href="{% static "img/favicon.ico" %}" rel="icon" type="image/x-icon" />
 
-        <script src="https://code.jquery.com/jquery-3.6.0.min.js" type="text/javascript"></script>
+        <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
 
         {% include "core/includes/analytics.html" with api_key=analytics.api_key uid=analytics.uid did=analytics.did %}
     </head>


### PR DESCRIPTION
Makes it safer to rely on a third-party CDN.

https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity

Fixes https://github.com/cal-itp/benefits/security/code-scanning/474.