### PR TITLE
Feat: implement auth button with OIDC

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,12 +2,8 @@ FROM benefits_client:latest
 
 USER root
 
-# install node.js
-# see https://github.com/nodesource/distributions#installation-instructions
-
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash
-
-RUN apt-get install -qq nodejs npm libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev \
+# install Cypress prereqs and other dev tooling
+RUN apt-get install -qq libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev \
     libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb curl git jq ssh
 
 USER $USER

--- a/.devcontainer/postAttach.sh
+++ b/.devcontainer/postAttach.sh
@@ -1,14 +1,18 @@
 #!/usr/bin/env bash
 set -eu
 
-# initialize hook environments
+echo [initialize hook environments]
 pre-commit install --install-hooks --overwrite
 
-# manage commit-msg hooks
+echo [manage commit-msg hooks]
 pre-commit install --hook-type commit-msg
 
-# copy Login.gov client library
+echo [install npm packages for app]
+npm ci
+mkdir -p benefits/static/js
 cp node_modules/oidc-client-ts/dist/browser/oidc-client-ts* benefits/static/js
 
-# install cypress
-cd tests/cypress && npm install && npx cypress install
+echo [install npm packages for tests]
+cd tests/cypress
+npm ci
+npx cypress install

--- a/.devcontainer/postAttach.sh
+++ b/.devcontainer/postAttach.sh
@@ -7,5 +7,8 @@ pre-commit install --install-hooks --overwrite
 # manage commit-msg hooks
 pre-commit install --hook-type commit-msg
 
+# copy Login.gov client library
+cp node_modules/oidc-client-ts/dist/browser/oidc-client-ts* benefits/static/js
+
 # install cypress
 cd tests/cypress && npm install && npx cypress install

--- a/.devcontainer/postAttach.sh
+++ b/.devcontainer/postAttach.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 set -eu
 
+echo [install npm packages for app]
+npm ci
+mkdir -p benefits/static/js
+cp node_modules/oidc-client-ts/dist/browser/oidc-client-ts* benefits/static/js
+
 echo [initialize hook environments]
 pre-commit install --install-hooks --overwrite
 
 echo [manage commit-msg hooks]
 pre-commit install --hook-type commit-msg
-
-echo [install npm packages for app]
-npm ci
-mkdir -p benefits/static/js
-cp node_modules/oidc-client-ts/dist/browser/oidc-client-ts* benefits/static/js
 
 echo [install npm packages for tests]
 cd tests/cypress

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 *.db
 *.env
 *.mo
+.DS_Store
+benefits/static/js/oidc-client-ts*
 fixtures/*.json
 !fixtures/??_*.json
+node_modules/
 static/
 !benefits/static
 __pycache__/
-.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,9 @@ USER $USER
 
 # install node dependencies
 COPY package*.json .
-RUN npm ci && cp node_modules/oidc-client-ts/dist/browser/oidc-client-ts* benefits/static/js
+RUN npm ci && \
+    mkdir -p benefits/static/js && \
+    cp node_modules/oidc-client-ts/dist/browser/oidc-client-ts* benefits/static/js
 
 # update PATH for local pip installs
 ENV PATH "$PATH:/home/$USER/.local/bin"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     USER=calitp
 
-    # create non-root $USER and home directory
+# create non-root $USER and home directory
 RUN useradd --create-home --shell /bin/bash $USER && \
     # setup $USER permissions for nginx
     mkdir -p /var/cache/nginx && \
@@ -42,11 +42,15 @@ COPY nginx.conf /etc/nginx/nginx.conf
 COPY bin/ bin/
 COPY benefits/ benefits/
 
-# ensure $USER can compile messages in the locale directories
-RUN chmod -R 777 benefits/locale
+# ensure $USER can compile messages and copy static files
+RUN chmod -R 777 benefits/locale benefits/static
 
 # switch to non-root $USER
 USER $USER
+
+# install node dependencies
+COPY package*.json .
+RUN npm ci && cp node_modules/oidc-client-ts/dist/browser/oidc-client-ts* benefits/static/js
 
 # update PATH for local pip installs
 ENV PATH "$PATH:/home/$USER/.local/bin"

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,11 @@ RUN useradd --create-home --shell /bin/bash $USER && \
     mkdir -p /home/$USER/app/run && \
     mkdir -p /home/$USER/app/static && \
     chown -R $USER /home/$USER && \
-    # install server components
+    # install server components, nodejs
+    # see https://github.com/nodesource/distributions#installation-instructions
+    curl -fsSL https://deb.nodesource.com/setup_16.x | bash && \
     apt-get update && \
-    apt-get install -qq --no-install-recommends gettext nginx
+    apt-get install -qq --no-install-recommends gettext nginx nodejs npm
 
 # enter app directory
 WORKDIR /home/$USER/app

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -102,5 +102,6 @@
                 });
             });
         </script>
+        {% block scripts %}{% endblock %}
     </body>
 </html>

--- a/benefits/eligibility/templates/eligibility/start.html
+++ b/benefits/eligibility/templates/eligibility/start.html
@@ -26,14 +26,6 @@
 
 {% load static %}
 
-<div class="navbar navbar-expand-sm navbar-dark bg-info">
-    <pre>
-    config = {
-        "client_id": {{ auth_provider.client_id }},
-    }
-    </pre>
-</div>
-
 <script src="{% static "js/oidc-client-ts.min.js" %}" type="text/javascript"></script>
 
 <script type="text/javascript">

--- a/benefits/eligibility/templates/eligibility/start.html
+++ b/benefits/eligibility/templates/eligibility/start.html
@@ -19,3 +19,19 @@
     {% endblock %}
 
 {% endblock %}
+
+{% block scripts %}
+
+{% if auth_provider %}
+
+<div class="navbar navbar-expand-sm navbar-dark bg-info">
+    <pre>
+    config = {
+        "client_id": {{ auth_provider.client_id }},
+    }
+    </pre>
+</div>
+
+{% endif %}
+
+{% endblock %}

--- a/benefits/eligibility/templates/eligibility/start.html
+++ b/benefits/eligibility/templates/eligibility/start.html
@@ -24,6 +24,8 @@
 
 {% if auth_provider %}
 
+{% load static %}
+
 <div class="navbar navbar-expand-sm navbar-dark bg-info">
     <pre>
     config = {
@@ -32,6 +34,7 @@
     </pre>
 </div>
 
+<script src="{% static "js/oidc-client-ts.min.js" %}" type="text/javascript"></script>
 {% endif %}
 
 {% endblock %}

--- a/benefits/eligibility/templates/eligibility/start.html
+++ b/benefits/eligibility/templates/eligibility/start.html
@@ -46,6 +46,11 @@
             response_type: "{{ auth_provider.response_type }}",
             scope: "{{ auth_provider.scope }}",
         };
+
+        $("#login").on("click", function() {
+            var mgr = new oidc.UserManager(settings);
+            mgr.signinRedirect();
+        });
     });
 </script>
 

--- a/benefits/eligibility/templates/eligibility/start.html
+++ b/benefits/eligibility/templates/eligibility/start.html
@@ -35,6 +35,20 @@
 </div>
 
 <script src="{% static "js/oidc-client-ts.min.js" %}" type="text/javascript"></script>
+
+<script type="text/javascript">
+    $(function() {
+        var settings = {
+            authority: "{{ auth_provider.authority }}",
+            client_id: "{{ auth_provider.client_id }}",
+            redirect_uri: "{{ auth_provider.redirect_uri }}",
+            post_logout_redirect_uri: "{{ auth_provider.post_logout_redirect_uri }}",
+            response_type: "{{ auth_provider.response_type }}",
+            scope: "{{ auth_provider.scope }}",
+        };
+    });
+</script>
+
 {% endif %}
 
 {% endblock %}

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -59,11 +59,14 @@ def start(request):
     """View handler for the eligibility verification getting started screen."""
 
     session.update(request, eligibility_types=[])
+
     verifier = session.verifier(request)
+    ctx = {}
 
     if verifier.requires_authentication:
         auth_provider = verifier.auth_provider
         button = viewmodels.Button.external(text=_(auth_provider.sign_in_button_label), url="#", id="login")
+        ctx["auth_provider"] = auth_provider
     else:
         button = viewmodels.Button.primary(text=_("eligibility.buttons.continue"), url=reverse("eligibility:confirm"))
 
@@ -85,8 +88,9 @@ def start(request):
         paragraphs=[_(verifier.start_blurb)],
         button=button,
     )
+    ctx.update(page.context_dict())
 
-    return TemplateResponse(request, "eligibility/start.html", page.context_dict())
+    return TemplateResponse(request, "eligibility/start.html", ctx)
 
 
 @decorator_from_middleware(middleware.AgencySessionRequired)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,58 @@
+{
+  "name": "benefits",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "benefits",
+      "version": "1.0.0",
+      "dependencies": {
+        "oidc-client-ts": "^2.0.2"
+      }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
+    },
+    "node_modules/jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+    },
+    "node_modules/oidc-client-ts": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-2.0.2.tgz",
+      "integrity": "sha512-NO640b7L+A+3++0UVGC00PgT2xsH870uiwrXOYLm2q3xXuCFnGHI/ViwAL9EVuGhKhMH7J0LXyNGSIZnpPAd4Q==",
+      "dependencies": {
+        "crypto-js": "^4.1.1",
+        "jwt-decode": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    }
+  },
+  "dependencies": {
+    "crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
+    },
+    "jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+    },
+    "oidc-client-ts": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-2.0.2.tgz",
+      "integrity": "sha512-NO640b7L+A+3++0UVGC00PgT2xsH870uiwrXOYLm2q3xXuCFnGHI/ViwAL9EVuGhKhMH7J0LXyNGSIZnpPAd4Q==",
+      "requires": {
+        "crypto-js": "^4.1.1",
+        "jwt-decode": "^3.1.2"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "benefits",
+  "version": "1.0.0",
+  "description": "Benefits app",
+  "dependencies": {
+    "oidc-client-ts": "^2.0.2"
+  }
+}


### PR DESCRIPTION
Closes #375.

## Choosing a client library

We need to reference an OIDC Client library, which does the heavy lifting for authentication with Login.gov. There were at least three options:

* The original, but deprecated since June 2021 [`oidc-client-js`](https://github.com/IdentityModel/oidc-client-js)
* A TypeScript fork of the original, still actively maintained [`oidc-client-ts`](https://github.com/authts/oidc-client-ts)
* Perhaps more overall users, but not as recently updated [`AppAuth-JS`](https://github.com/openid/AppAuth-JS)

Since the original was initially recommended but no longer maintained, we decided on the TypeScript fork `oidc-client-ts`

## Referencing the client library

`oidc-client-ts` is an NPM package and expects to be consumed through that ecosystem; `node` and `npm` had to be installed in the _application_ container in order to bring this dependency in. The installation was moved from the _devcontainer_, where it was previously needed only for the Cypress tests.

This is tricky though: Django needs static files (like JavaScript, CSS, images) to live inside the `benefits/static/` directory. This is because During [application startup, Django compiles static assets](https://github.com/cal-itp/benefits/blob/dev/bin/init.sh#L27) for serving, the behavior differing between app container and devcontainer runs. Read more about [Deploying static files in Django](https://docs.djangoproject.com/en/3.2/howto/static-files/deployment/). 

Since `npm` installs its packages in `node_modules/` at the root of the project directory (repo), we have to do some creative copying of files during the right time (app container build, devcontainer postAttach) to get the library in the right folder, making it referenceable from a template. Entries in `.gitignore` ensure we don't commit the library as part of our source code.

## Using the client library

The configuration data needed to make use of the library is modeled by the `AuthProvider` model, which was defined in #392 and a sample added in #402. The `EligibilityVerifier` model was extended with a "feature flag" that indicates if auth is required: we make use of that here to opt-in to requiring auth and referencing the client library.

When auth is required, the `AuthProvider` model instance is sent to the Start page template, where it can be used to generate the JavaScript block that will execute when the user eventually clicks the button.

## Result of this PR

Assuming the correct `AuthProvider` settings (e.g. edit the sample added in #402), clicking the "Continue with Login.gov" button takes the user through the login flow with Login.gov. After successfully signing in, the user is redirected to the (currently pre-configured) `redirect_uri`, which does not yet exist in this app. See #373.

## Reviewing this PR / after merging

You'll want to rebuild both the application and devcontainers on your host machine after pulling these changes in. If you're updating your `fixtures/` to configure an `AuthProvider`, delete the Django database as well:

```
rm django.db

cd .devcontainer/

docker compose build --no-cache client

docker compose build --no-cache dev
```

Then *Reopen in Devcontainer* with VS Code.