### PR TITLE
fix: override entrypoint in the Docker Compose config

### DIFF
--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -17,8 +17,8 @@ services:
       dockerfile: .devcontainer/Dockerfile
     image: benefits_client:dev
     env_file: .env
-    entrypoint: []
-    command: ["-c", "sleep infinity"]
+    # https://code.visualstudio.com/docs/remote/create-dev-container#_use-docker-compose
+    entrypoint: sleep infinity
     depends_on:
       - server
     ports:


### PR DESCRIPTION
Unclear what changed to make the previous configuration stop working on my machine (something in Docker, perhaps?), causing this error:

```
$ docker compose up dev
[+] Running 2/2
 ⠿ Container benefits-server-1  Created                                                       0.0s
 ⠿ Container benefits-dev-1     Recreated                                                     0.2s
Attaching to benefits-dev-1
Error response from daemon: failed to create shim: OCI runtime create failed: container_linux.go:380: starting container process caused: exec: "-c": executable file not found in $PATH: unknown
```

This seems to be [the recommended way to override the `ENTRYPOINT`](https://docs.docker.com/compose/compose-file/#entrypoint) and solved the problem.