### PR TITLE
refactor: speed up Docker image rebuild times

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,12 @@ RUN useradd --create-home --shell /bin/bash $USER && \
 
 # enter app directory
 WORKDIR /home/$USER/app
+# switch to non-root $USER
+USER $USER
+
+# install python dependencies
+COPY requirements.txt requirements.txt
+RUN pip install -r requirements.txt
 
 # copy config files
 COPY gunicorn.conf.py gunicorn.conf.py
@@ -36,22 +42,17 @@ COPY manage.py manage.py
 # overwrite default nginx.conf
 COPY nginx.conf /etc/nginx/nginx.conf
 
+# update PATH for local pip installs
+ENV PATH "$PATH:/home/$USER/.local/bin"
+
 # copy source files
 COPY bin/ bin/
 COPY benefits/ benefits/
 
 # ensure $USER can compile messages in the locale directories
+USER root
 RUN chmod -R 777 benefits/locale
-
-# switch to non-root $USER
 USER $USER
-
-# update PATH for local pip installs
-ENV PATH "$PATH:/home/$USER/.local/bin"
-
-# install python dependencies
-COPY requirements.txt requirements.txt
-RUN pip install -r requirements.txt
 
 # configure container executable
 ENTRYPOINT ["/bin/bash"]

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -29,6 +29,12 @@ cp .env.sample .env
 ## Build image using Docker Compose
 
 ```bash
+docker compose build client
+```
+
+If you need all layers to rebuild, use:
+
+```bash
 docker compose build --no-cache client
 ```
 


### PR DESCRIPTION
Switching branches was getting time-consuming; this moves the expensive operation of installing the Python packages earlier in the `Dockerfile` so that changes to application/configuration files don't require all packages to be reinstalled.