### PR TITLE
Refactor: agency index

### DIFF
--- a/benefits/core/templates/core/agency_index.html
+++ b/benefits/core/templates/core/agency_index.html
@@ -4,7 +4,7 @@
 {% block container_content %}
 <h1>{{ page.content_title }}</h1>
 
-<p>{% translate "core.pages.agency_index.p[0]" %}</p>
+<p>{% blocktranslate with info_link=info_link%}core.pages.agency_index.p[0]{{ info_link }}{% endblocktranslate %}</p>
 <p>{% translate "core.pages.agency_index.p[1]" %}</p>
 
 {% block buttons%}

--- a/benefits/core/templates/core/agency_index.html
+++ b/benefits/core/templates/core/agency_index.html
@@ -1,0 +1,14 @@
+{% extends 'core/page.html' %}
+{% load i18n %}
+
+{% block container_content %}
+<h1>{{ page.content_title }}</h1>
+
+<p>{% translate "core.pages.agency_index.p[0]" %}</p>
+<p>{% translate "core.pages.agency_index.p[1]" %}</p>
+
+{% block buttons%}
+{{ block.super }}
+{% endblock buttons %}
+
+{% endblock container_content %}

--- a/benefits/core/views.py
+++ b/benefits/core/views.py
@@ -57,14 +57,16 @@ def agency_index(request, agency):
     session.reset(request)
     session.update(request, agency=agency, origin=agency.index_url)
 
+    button = viewmodels.Button.primary(text=_("core.pages.index.continue"), url=reverse("eligibility:index"))
+    button.label = _("core.pages.agency_index.button.label")
+
     page = viewmodels.Page(
-        content_title=_index_content_title(),
-        paragraphs=_index_paragraphs(),
-        button=viewmodels.Button.primary(text=_("core.pages.index.continue"), url=reverse("eligibility:index")),
+        content_title=_("core.pages.agency_index.content_title"),
+        button=button,
         classes="home",
     )
 
-    return PageTemplateResponse(request, page)
+    return TemplateResponse(request, "core/agency_index.html", page.context_dict())
 
 
 @middleware.pageview_decorator

--- a/benefits/core/views.py
+++ b/benefits/core/views.py
@@ -66,7 +66,10 @@ def agency_index(request, agency):
         classes="home",
     )
 
-    return TemplateResponse(request, "core/agency_index.html", page.context_dict())
+    help_page = reverse("core:help")
+    context_dict = {**page.context_dict(), **{"info_link": f"{help_page}#about"}}
+
+    return TemplateResponse(request, "core/agency_index.html", context_dict)
 
 
 @middleware.pageview_decorator

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -246,6 +246,23 @@ msgstr ""
 "The new way to pay for transit makes it easier to get your discount every "
 "time you ride"
 
+msgid "core.pages.agency_index.content_title"
+msgstr ""
+"Cal-ITP Benefits makes it easy to use your public transit discount "
+"every time you ride."
+
+msgid "core.pages.agency_index.p[0]"
+msgstr "With new contactless payment options, you can tap "
+"your bank-issued contactless credit or debit card when you "
+"board, and your discount will automatically apply every "
+"time you ride. Learn more about Cal-ITP Benefits."
+
+msgid "core.pages.agency_index.p[1]"
+msgstr "The Cal-ITP Benefits program is currently only open to those <strong>ages 65 or older</strong>."
+
+msgid "core.pages.agency_index.button.label"
+msgstr "Verify your discount and connect your bank card today!"
+
 #: benefits/core/views.py:25
 msgctxt "image alt text"
 msgid "core.pages.index.image"

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -251,11 +251,11 @@ msgstr ""
 "Cal-ITP Benefits makes it easy to use your public transit discount "
 "every time you ride."
 
-msgid "core.pages.agency_index.p[0]"
+msgid "core.pages.agency_index.p[0]%(info_link)s"
 msgstr "With new contactless payment options, you can tap "
 "your bank-issued contactless credit or debit card when you "
 "board, and your discount will automatically apply every "
-"time you ride. Learn more about Cal-ITP Benefits."
+"time you ride. <a href=\"%(info_link)s\">Learn more about Cal-ITP Benefits.</a>"
 
 msgid "core.pages.agency_index.p[1]"
 msgstr "The Cal-ITP Benefits program is currently only open to those <strong>ages 65 or older</strong>."

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -290,7 +290,7 @@ msgstr "Choose your transit provider"
 
 #: benefits/core/views.py:70
 msgid "core.pages.index.continue"
-msgstr "Let’s do it!"
+msgstr "Get started"
 
 #: benefits/core/views.py:86 benefits/core/views.py:106
 msgid "core.buttons.back"

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -248,6 +248,23 @@ msgstr ""
 "La nueva forma de pagar el transporte público hace que sea más fácil obtener "
 "su descuento cada vez que viaja"
 
+msgid "core.pages.agency_index.content_title"
+msgstr ""
+"TODO: Cal-ITP Benefits makes it easy to use your public transit discount "
+"every time you ride."
+
+msgid "core.pages.agency_index.p[0]"
+msgstr "TODO: With new contactless payment options, you can tap "
+"your bank-issued contactless credit or debit card when you "
+"board, and your discount will automatically apply every "
+"time you ride. Learn more about Cal-ITP Benefits."
+
+msgid "core.pages.agency_index.p[1]"
+msgstr "TODO: The Cal-ITP Benefits program is currently only open to those <strong>ages 65 or older</strong>."
+
+msgid "core.pages.agency_index.button.label"
+msgstr "TODO: Verify your discount and connect your bank card today!"
+
 #: benefits/core/views.py:25
 msgctxt "image alt text"
 msgid "core.pages.index.image"

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -253,11 +253,11 @@ msgstr ""
 "TODO: Cal-ITP Benefits makes it easy to use your public transit discount "
 "every time you ride."
 
-msgid "core.pages.agency_index.p[0]"
+msgid "core.pages.agency_index.p[0]%(info_link)s"
 msgstr "TODO: With new contactless payment options, you can tap "
 "your bank-issued contactless credit or debit card when you "
 "board, and your discount will automatically apply every "
-"time you ride. Learn more about Cal-ITP Benefits."
+"time you ride. <a href=\"%(info-link)s\">Learn more about Cal-ITP Benefits.</a>"
 
 msgid "core.pages.agency_index.p[1]"
 msgstr "TODO: The Cal-ITP Benefits program is currently only open to those <strong>ages 65 or older</strong>."

--- a/tests/cypress/specs/feature/eligibility.spec.js
+++ b/tests/cypress/specs/feature/eligibility.spec.js
@@ -7,7 +7,7 @@ describe("Eligibility confirmation flow", () => {
   beforeEach(() => {
     cy.visit("/");
     cy.contains(agencies[0].fields.short_name).click();
-    cy.contains("Let’s do it!").click();
+    cy.contains("Get started").click();
     cy.contains("Continue").click();
   });
 

--- a/tests/cypress/specs/ui/eligibility.spec.js
+++ b/tests/cypress/specs/ui/eligibility.spec.js
@@ -9,7 +9,7 @@ describe("Single verifier: Eligibility confirmation page spec", () => {
     cy.visit("/");
     // Selecting DEFTl will go down the single verifier flow
     cy.contains(agencies[1].fields.short_name).click();
-    cy.contains("Let’s do it!").click();
+    cy.contains("Get started").click();
     cy.contains("Continue").click();
     cy.url().should("include", eligibility_confirm_url);
   });
@@ -20,7 +20,7 @@ describe("Multiple Verifier, no AuthProvider: Verifier selection page spec", () 
     cy.visit("/");
     // Selecting ABC will go down the multiple verifier flow
     cy.contains(agencies[0].fields.short_name).click();
-    cy.contains("Let’s do it!").click();
+    cy.contains("Get started").click();
   });
 
   it("User can navigate to the Verifier Selection page", () => {
@@ -61,7 +61,7 @@ describe("Multiple verifier, no AuthProvider: Eligibility confirmation form spec
   beforeEach(() => {
     cy.visit("/");
     cy.contains(agencies[0].fields.short_name).click();
-    cy.contains("Let’s do it!").click();
+    cy.contains("Get started").click();
     cy.get("input:radio").last().click();
     cy.contains("Continue").click();
     cy.contains("You’ll need two things before we get started:");
@@ -90,7 +90,7 @@ describe("Multiple verifier, with AuthProvider: Eligibility start page spec", ()
   beforeEach(() => {
     cy.visit("/");
     cy.contains(agencies[0].fields.short_name).click();
-    cy.contains("Let’s do it!").click();
+    cy.contains("Get started").click();
     cy.get("input:radio").first().click();
     cy.contains("Continue").click();
     cy.url().should("include", eligibility_start_url);

--- a/tests/cypress/specs/ui/index.spec.js
+++ b/tests/cypress/specs/ui/index.spec.js
@@ -22,7 +22,7 @@ describe("Index page spec", () => {
   it("Clicking transit option link takes user to a transit provider page", () => {
     cy.contains(agencies[0].fields.short_name).click();
 
-    cy.contains("Let’s do it!").then(($e) => {
+    cy.contains("Get started").then(($e) => {
       expect($e).attr("href").to.include("/eligibility");
     });
   });


### PR DESCRIPTION
Closes #367 

Follows approach outlined in the ticket. Using a new template specific to `agency_index` gave us the flexibility to use `blocktranslate` for embedding the link to "Learn more about Cal-ITP Benefits."

Note that I didn't attempt to style the page. I think @machikoyasuda has an idea for doing a focused cleanup of styles in a separate ticket. Let me know though if that's not correct! 🙏 

Latest screen from Figma mockup:
![image](https://user-images.githubusercontent.com/25497886/163292292-31975ee4-5e3f-4a57-83b6-513c8e542716.png)

Current view on this branch:
![image](https://user-images.githubusercontent.com/25497886/163292623-4e8b4c12-9e1a-47f0-8c69-294a1a601cfd.png)

Here's the Before (from dev branch): 
![image](https://user-images.githubusercontent.com/25497886/163294685-282ac995-b12a-489b-815a-1f302370dc99.png)


### UI tests pass
![image](https://user-images.githubusercontent.com/25497886/163294608-46c48b87-7b0b-4484-9fd4-9d815258c6d1.png)

