### PR TITLE
Feat: Implement OAuth/OIDC and app sign out

### DIFF
--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -110,7 +110,7 @@ def start(request):
             ),
         )
 
-        if not session.auth(request):
+        if not session.oauth_token(request):
             button = viewmodels.Button.external(
                 text=_(verifier.auth_provider.sign_in_button_label),
                 url=reverse("oauth:login"),

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -198,10 +198,9 @@ def verified(request, verified_types):
 
     analytics.returned_success(request)
 
-    enrollment_index = reverse("enrollment:index")
-    session.update(request, eligibility_types=verified_types, origin=enrollment_index)
+    session.update(request, eligibility_types=verified_types)
 
-    return redirect(enrollment_index)
+    return redirect("enrollment:index")
 
 
 @decorator_from_middleware(middleware.AgencySessionRequired)

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -109,6 +109,8 @@ def token(request):
 @decorator_from_middleware(middleware.EligibleSessionRequired)
 def index(request):
     """View handler for the enrollment landing page."""
+    session.update(request, origin=reverse("enrollment:index"))
+
     if request.method == "POST":
         response = _enroll(request)
     else:

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -96,12 +96,12 @@ def _enroll(request):
 @decorator_from_middleware(middleware.EligibleSessionRequired)
 def token(request):
     """View handler for the enrollment auth token."""
-    if not session.valid_token(request):
+    if not session.valid_enrollment_token(request):
         agency = session.agency(request)
         response = api.Client(agency).access_token()
-        session.update(request, token=response.access_token, token_exp=response.expiry)
+        session.update(request, enrollment_token=response.access_token, enrollment_token_exp=response.expiry)
 
-    data = {"token": session.token(request)}
+    data = {"token": session.enrollment_token(request)}
 
     return JsonResponse(data)
 

--- a/benefits/oauth/urls.py
+++ b/benefits/oauth/urls.py
@@ -8,4 +8,5 @@ urlpatterns = [
     # /oauth
     path("login", views.login, name="login"),
     path("authorize", views.authorize, name="authorize"),
+    path("logout", views.logout, name="logout"),
 ]

--- a/benefits/oauth/urls.py
+++ b/benefits/oauth/urls.py
@@ -9,4 +9,5 @@ urlpatterns = [
     path("login", views.login, name="login"),
     path("authorize", views.authorize, name="authorize"),
     path("logout", views.logout, name="logout"),
+    path("post_logout", views.post_logout, name="post_logout"),
 ]

--- a/benefits/oauth/views.py
+++ b/benefits/oauth/views.py
@@ -2,6 +2,7 @@ import logging
 
 from django.shortcuts import redirect
 from django.urls import reverse
+from django.utils.http import urlencode
 
 from authlib.integrations.django_client import OAuth
 
@@ -59,3 +60,24 @@ def logout(request):
 
     session.update(request, auth=False)
     return redirect(ROUTE_START)
+
+
+def _deauthorize_redirect(token, redirect_url):
+    """Helper implements OIDC signout via the `end_session_endpoint`."""
+
+    # Authlib has not yet implemented `end_session_endpoint` as the OIDC Session Management 1.0 spec is still in draft
+    # See https://github.com/lepture/authlib/issues/331#issuecomment-827295954 for more
+    #
+    # The implementation here was adapted from the same ticket: https://github.com/lepture/authlib/issues/331#issue-838728145
+
+    if not oauth_client:
+        raise Exception("No OAuth client")
+
+    metadata = oauth_client.load_server_metadata()
+    end_session_endpoint = metadata.get("end_session_endpoint")
+
+    params = dict(id_token_hint=token["id_token"], post_logout_redirect_uri=redirect_url)
+    encoded_params = urlencode(params)
+    end_session_url = f"{end_session_endpoint}?{encoded_params}"
+
+    return redirect(end_session_url)

--- a/benefits/oauth/views.py
+++ b/benefits/oauth/views.py
@@ -52,3 +52,10 @@ def authorize(request):
         logger.debug("OAuth access token authorized")
         session.update(request, auth=True)
         return redirect(ROUTE_CONFIRM)
+
+
+def logout(request):
+    """View implementing application signout, e.g. updating the Django session."""
+
+    session.update(request, auth=False)
+    return redirect(ROUTE_START)

--- a/benefits/oauth/views.py
+++ b/benefits/oauth/views.py
@@ -83,7 +83,7 @@ def post_logout(request):
     return redirect(origin)
 
 
-def _deauthorize_redirect(token, redirect_url):
+def _deauthorize_redirect(token, redirect_uri):
     """Helper implements OIDC signout via the `end_session_endpoint`."""
 
     # Authlib has not yet implemented `end_session_endpoint` as the OIDC Session Management 1.0 spec is still in draft
@@ -97,7 +97,7 @@ def _deauthorize_redirect(token, redirect_url):
     metadata = oauth_client.load_server_metadata()
     end_session_endpoint = metadata.get("end_session_endpoint")
 
-    params = dict(id_token_hint=token, post_logout_redirect_uri=redirect_url)
+    params = dict(id_token_hint=token, post_logout_redirect_uri=redirect_uri)
     encoded_params = urlencode(params)
     end_session_url = f"{end_session_endpoint}?{encoded_params}"
 

--- a/benefits/oauth/views.py
+++ b/benefits/oauth/views.py
@@ -24,6 +24,7 @@ if OAUTH_CLIENT_NAME:
 ROUTE_AUTH = "oauth:authorize"
 ROUTE_START = "eligibility:start"
 ROUTE_CONFIRM = "eligibility:confirm"
+ROUTE_POST_LOGOUT = "oauth:post_logout"
 
 
 def login(request):
@@ -65,14 +66,21 @@ def logout(request):
     token = session.oauth_token(request)
     session.update(request, oauth_token=False)
 
-    origin = session.origin(request)
-    redirect_uri = request.build_absolute_uri(origin)
+    route = reverse(ROUTE_POST_LOGOUT)
+    redirect_uri = request.build_absolute_uri(route)
 
     logger.debug(f"OAuth end_session_endpoint with redirect_uri: {redirect_uri}")
 
     # send the user through the end_session_endpoint, redirecting back to
-    # their origin within the app (where they clicked the sign out button)
+    # the post_logout route
     return _deauthorize_redirect(token, redirect_uri)
+
+
+def post_logout(request):
+    """View routes the user to their origin after sign out."""
+
+    origin = session.origin(request)
+    return redirect(origin)
 
 
 def _deauthorize_redirect(token, redirect_url):

--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -1,3 +1,5 @@
+from django.contrib.sessions.middleware import SessionMiddleware
+
 import pytest
 
 
@@ -5,3 +7,28 @@ import pytest
 def django_db_setup():
     # use existing database since it's read-only
     pass
+
+
+@pytest.fixture
+def session_request(request, rf):
+    """
+    Fixture creates a new Django request object and initializes its session.
+
+    Optionally use @pytest.mark.request_path(path: str) to customize the request's path.
+    """
+
+    # see if a request_path was provided via marker
+    marker = request.node.get_closest_marker("request_path")
+    if marker is None:
+        request_path = "/"
+    else:
+        request_path = marker.args[0]
+
+    # create a request for the path, initialize session
+    # https://stackoverflow.com/a/55530933/358804
+    session_request = rf.get(request_path)
+    middleware = SessionMiddleware(lambda x: x)
+    middleware.process_request(session_request)
+    session_request.session.save()
+
+    return session_request

--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -25,10 +25,16 @@ def session_request(request, rf):
         request_path = marker.args[0]
 
     # create a request for the path, initialize session
-    # https://stackoverflow.com/a/55530933/358804
     session_request = rf.get(request_path)
-    middleware = SessionMiddleware(lambda x: x)
-    middleware.process_request(session_request)
-    session_request.session.save()
+    initialize_session(session_request)
 
     return session_request
+
+
+def initialize_session(request):
+    """Helper initializes a Django request object's session."""
+
+    # https://stackoverflow.com/a/55530933/358804
+    middleware = SessionMiddleware(lambda x: x)
+    middleware.process_request(request)
+    request.session.save()

--- a/tests/pytest/oauth/test_views.py
+++ b/tests/pytest/oauth/test_views.py
@@ -2,7 +2,7 @@ from django.http import HttpResponse
 from django.urls import reverse
 
 from benefits.core import session
-from benefits.oauth.views import logout, post_logout
+from benefits.oauth.views import logout, post_logout, _generate_redirect_uri
 
 import pytest
 
@@ -21,7 +21,7 @@ def test_logout(mocker, session_request):
 
     result = logout(session_request)
 
-    spy.assert_called_with(token, "http://testserver/oauth/post_logout")
+    spy.assert_called_with(token, "https://testserver/oauth/post_logout")
     assert result.status_code == 200
     assert message in str(result.content)
     assert session.oauth_token(session_request) is False
@@ -36,3 +36,21 @@ def test_post_logout(session_request):
 
     assert result.status_code == 302
     assert result.url == origin
+
+
+def test_generate_redirect_uri_default(rf):
+    request = rf.get("/oauth/login")
+    path = "/test"
+
+    redirect_uri = _generate_redirect_uri(request, path)
+
+    assert redirect_uri == "https://testserver/test"
+
+
+def test_generate_redirect_uri_localhost(rf):
+    request = rf.get("/oauth/login", SERVER_NAME="localhost")
+    path = "/test"
+
+    redirect_uri = _generate_redirect_uri(request, path)
+
+    assert redirect_uri == "http://localhost/test"

--- a/tests/pytest/oauth/test_views.py
+++ b/tests/pytest/oauth/test_views.py
@@ -1,0 +1,26 @@
+from django.http import HttpResponse
+
+from benefits.core import session
+from benefits.oauth.views import logout
+
+import pytest
+
+
+@pytest.mark.request_path("/oauth/logout")
+def test_logout(mocker, session_request):
+    # logout internally calls _deauthorize_redirect
+    # this mocks that function and a success response
+    # and returns a spy object we can use to validate calls
+    message = "logout successful"
+    spy = mocker.patch("benefits.oauth.views._deauthorize_redirect", return_value=HttpResponse(message))
+
+    token = "token"
+    session.update(session_request, oauth_token=token)
+    assert session.oauth_token(session_request) == token
+
+    result = logout(session_request)
+
+    spy.assert_called_with(token, "http://testserver/oauth/post_logout")
+    assert result.status_code == 200
+    assert message in str(result.content)
+    assert session.oauth_token(session_request) is False

--- a/tests/pytest/oauth/test_views.py
+++ b/tests/pytest/oauth/test_views.py
@@ -1,7 +1,8 @@
 from django.http import HttpResponse
+from django.urls import reverse
 
 from benefits.core import session
-from benefits.oauth.views import logout
+from benefits.oauth.views import logout, post_logout
 
 import pytest
 
@@ -24,3 +25,14 @@ def test_logout(mocker, session_request):
     assert result.status_code == 200
     assert message in str(result.content)
     assert session.oauth_token(session_request) is False
+
+
+@pytest.mark.request_path("/oauth/post_logout")
+def test_post_logout(session_request):
+    origin = reverse("core:index")
+    session.update(session_request, origin=origin)
+
+    result = post_logout(session_request)
+
+    assert result.status_code == 302
+    assert result.url == origin

--- a/tests/pytest/requirements.txt
+++ b/tests/pytest/requirements.txt
@@ -1,2 +1,3 @@
 pytest
 pytest-django
+pytest-mock


### PR DESCRIPTION
Closes #368.

Consolidated #464 into this PR.

## Summary

This PR adds a new route `/oauth/logout` that signs the user out of all 3 environments: Login.gov, the auth server, and the Django app.

We have to store the `id_token` that we get back as part of the `/oauth/authorize` callback, in order to later be able to sign the user out. Because of this, session management was updated to differentiate between the `oauth_token` and the `enrollment_token`.

The sign out flow is:

1. User clicks the sign out button (#428)
2. `/oauth/logout` retrieves the (now stored) OAuth token from user's Django session
3. User's Django session OAuth token is cleared 
4. A redirect URI is generated for `/oauth/post_logout`
5. User is redirected through the auth server's `end_session_endpoint` with their token and the redirect URI
6. Once back in the app, `/oauth/post_logout` redirects the user to `session.origin()`

We have a number of places the user can sign out from:

* The `/eligibility/confirm` page - redirects back to `/eligibility/start`
* The `/enrollment` page - redirects back to `/enrollment`
* The `/enrollment/success` page - redirects back to `/enrollment/success`

* ~Each of these post-logout redirect URIs has to be registered with the auth server~

🔎 **Important to call out:** once the user passes eligibility verification (they are verified as eligible for the discount) we don't _need_ to make them sign in with OAuth again (since the "OAuth gate" has already been crossed and the protected page already completed).

When the user makes it to the `/enrollment` phase, their session will indicate they have been verified as eligible. So on sign out, we can redirect them back into the `/enrollment` phase vs. making them restart with `/eligibility`.

## Tests

`logout` test added in [`5272f5b`](https://github.com/cal-itp/benefits/pull/436/commits/5272f5b82156560aeedd5670a7a5bdeb2effd918):

* Creates a mock of `_deauthorize_redirect` to avoid going to the real auth server
* Verifies `oauth_token` is cleared from session
* Verifies the token and correct `post_logout` redirect URI are sent to `_deauthorize_redirect` 

`post_logout` test added in [`d360f48`](https://github.com/cal-itp/benefits/pull/436/commits/d360f48379514d24ff7a7e4f746dfa18eff07ae5):

* Updates session `origin`
* Checks that `post_logout` redirects to `origin`

`_deauthorize_redirect` tests added in [`3f8db89`](https://github.com/cal-itp/benefits/pull/436/commits/3f8db89cfd997dae4c897e5a25b53f21e63bdef1):

* Load mock server metadata
* Checks redirect to `end_session_endpoint` with correct `id_token_hint` and `post_logout_redirect_uri`

`_generate_redirect_uri` tests added in [`2e291f2`](https://github.com/cal-itp/benefits/pull/436/commits/2e291f2c50007e743fb19aba389bdee41149d4a8):

* HTTP redirect is generated for `localhost`
* HTTPS redirect is generated otherwise

Also added a general helper fixture [`session_request`](https://github.com/cal-itp/benefits/pull/436/files#diff-b4308b616ed5ec54421fc66ee8b3a76c4d2f4272ea20a48808c7f6a9d3f00a32) based on @afeld work in #445 to initialize a mock request with a session.

Note I added the [`pytest-mock`](https://github.com/pytest-dev/pytest-mock/) package to `tests/pytest/requirements.txt` so you will want to `pip install` before running this test.

## Reviewing

1. Run the app locally with the configuration for the dev CDT auth server
2. Sign in through the Login.gov sandbox with your test account
3. Once back in the app, there are 3 different logout scenarios (see list above) - manually update the URL to `/oauth/logout` for each:
    * from the Eligibility Confirm page
    * from the Enrollment index (update `compose.yml` for `server`, `image: ghcr.io/cal-itp/eligibility-server@sha256:337d5b2beb1e458980be49a778efd4a47f8daa8decc5e8329c0d528596e2f196` and restart devcontainer to get a server running. `A1234567` / `Garcia` for test data)
    * from the Enrollment success (after passing Eligibility, manually update URL to `/enrollment/success`)
4. You should briefly see a "You are now logged out" message from the auth server, before being redirected back to the corresponding page (see above list)