### PR TITLE
Style: agency index

### DIFF
--- a/benefits/core/templates/core/agency_index.html
+++ b/benefits/core/templates/core/agency_index.html
@@ -1,5 +1,6 @@
 {% extends 'core/page.html' %}
 {% load i18n %}
+{% block classes %}{{ block.super |add:" agency-index"}}{% endblock %}
 
 {% block container_content %}
 <h1>{{ page.content_title }}</h1>

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -254,7 +254,7 @@ msgid "core.pages.agency_index.p[0]%(info_link)s"
 msgstr "With new contactless payment options, you can tap "
 "your bank-issued contactless credit or debit card when you "
 "board, and your discount will automatically apply every "
-"time you ride. <a href=\"%(info_link)s\">Learn more about Cal-ITP Benefits.</a>"
+"time you ride. <strong><a href=\"%(info_link)s\">Learn more about Cal-ITP Benefits.</a></strong>"
 
 msgid "core.pages.agency_index.p[1]"
 msgstr "The Cal-ITP Benefits program is currently only open to those <strong>ages 65 or older</strong>."

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -256,7 +256,7 @@ msgid "core.pages.agency_index.p[0]%(info_link)s"
 msgstr "TODO: With new contactless payment options, you can tap "
 "your bank-issued contactless credit or debit card when you "
 "board, and your discount will automatically apply every "
-"time you ride. <a href=\"%(info-link)s\">Learn more about Cal-ITP Benefits.</a>"
+"time you ride. <strong><a href=\"%(info-link)s\">Learn more about Cal-ITP Benefits.</a></strong>"
 
 msgid "core.pages.agency_index.p[1]"
 msgstr "TODO: The Cal-ITP Benefits program is currently only open to those <strong>ages 65 or older</strong>."

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -48,6 +48,12 @@ p {
   letter-spacing: 0.05em;
 }
 
+label {
+  font-size: 18px;
+  line-height: 26px;
+  letter-spacing: 0.05em;
+}
+
 /* making the sticky footer */
 
 html,
@@ -470,13 +476,6 @@ footer .footer-links a {
 
   h1.icon-title {
     text-align: center;
-  }
-
-  .home p,
-  .home label {
-    font-size: 18px;
-    line-height: 26px;
-    letter-spacing: 0.05em;
   }
 
   .image[class*="col-"] {

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -455,24 +455,15 @@ footer .footer-links a {
     padding-bottom: 0.138rem;
   }
 
-  h1 {
-    font-size: 36px;
-    line-height: 45px;
-  }
-
   h1.icon-title {
     text-align: center;
   }
 
-  h2 {
-    font-size: 30px;
-    line-height: 36px;
-  }
-
   .home p,
   .home label {
-    font-size: 24px;
-    line-height: 30px;
+    font-size: 18px;
+    line-height: 26px;
+    letter-spacing: 0.05em;
   }
 
   .image[class*="col-"] {

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -168,6 +168,19 @@ footer .footer-links a {
   background: #212121;
 }
 
+.agency-index h1 {
+  margin-bottom: 7vh;
+}
+
+.agency-index p {
+  margin-bottom: 5vh;
+}
+
+.agency-index label {
+  margin-top: 15vh;
+  margin-bottom: 7vh;
+}
+
 .media-title {
   margin-top: 0;
   font-size: 24px;


### PR DESCRIPTION
Related to #435 , but does not close it entirely.

This PR makes the `agency_index` page better match the Figma mockup. 

I noticed that #397 did not actually change the font-size, letter-spacing, and line-height for this page (at least for the resolution/screen size that I normally use). This was because the `@media (min-width: 992px)` styles were overriding the changes made in #397. I fixed that (which probably fixes it for other pages too?) and then added styles for better spacing on the title, paragraphs, and button label.

| Before | After |
| ------- | ------ |
| ![image](https://user-images.githubusercontent.com/25497886/163654489-044cfb98-8238-4734-9412-bdcdb8dd81b8.png) | ![image](https://user-images.githubusercontent.com/25497886/163654414-ab51dc15-f700-48ca-9774-deb156eebc81.png) |

That's on Firefox with Windows set to 150% scaling and 1920 x 1200 resolution:
![image](https://user-images.githubusercontent.com/25497886/163654432-35609279-1685-4876-afc1-8acb2900096a.png)

At 125% scaling, the **After** screen looks like this:
![image](https://user-images.githubusercontent.com/25497886/163654451-a491b24b-baa4-41e7-91c7-d51f1be7134b.png)

Compare the 125% scaling screenshot with the Figma mockup:
| How I see it at 125% scaling on Windows | Figma mockup |
| --------------------------------------------- |----------------- |
| ![image](https://user-images.githubusercontent.com/25497886/163654451-a491b24b-baa4-41e7-91c7-d51f1be7134b.png) | ![image](https://user-images.githubusercontent.com/25497886/163654681-d693ad10-a35e-4132-af1f-31e099a3f633.png) |
