### PR TITLE
Fix: add SECURE_PROXY_SSL_HEADER for nginx

### DIFF
--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -90,6 +90,14 @@ if not DEBUG:
 
 SECURE_BROWSER_XSS_FILTER = True
 
+# the NGINX reverse proxy sits in front of the application in deployed environments
+# SSL terminates before getting to Django, and NGINX adds this header to indicate
+# if the original request was secure or not
+#
+# See https://docs.djangoproject.com/en/3.2/ref/settings/#secure-proxy-ssl-header
+if not DEBUG:
+    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
 ROOT_URLCONF = "benefits.urls"
 
 template_ctx_processors = [


### PR DESCRIPTION
Closes #442 

The nginx reverse proxy sits in front of the application in deployed environments, and SSL terminates before getting to Django. 

We already add this header in the [nginx configuration](https://github.com/cal-itp/benefits/blob/dev/nginx.conf#L55) using the value of the request `$scheme`.

Adding the setting allows Django to determine if the original request was secure or not, if the header value (set by nginx on the request) matches the setting value (`https`).

See https://docs.djangoproject.com/en/3.2/ref/settings/#secure-proxy-ssl-header