### PR TITLE
fix(header): move debug bar out of <header>, remove header height css

### DIFF
--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -37,10 +37,6 @@
             {% include "core/includes/noscript.html" %}
             </noscript>
 
-            {% if debug %}
-            {% include "core/includes/debug.html" %}
-            {% endif %}
-
             <div class="navbar navbar-expand-sm navbar-dark bg-primary justify-content-between">
                 <div class="container">
                     <span class="navbar-brand">

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -19,6 +19,9 @@
         {% include "core/includes/analytics.html" with api_key=analytics.api_key uid=analytics.uid did=analytics.did %}
     </head>
     <body>
+        {% if debug %}
+        {% include "core/includes/debug.html" %}
+        {% endif %}
         <header role="banner" id="header" class="global-header">
             <div id="skip-to-content">
                 <a href="#main-content">{% translate "core.buttons.skip" %}</a>

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -435,10 +435,6 @@ footer .footer-links a {
 }
 
 @media (min-width: 992px) {
-  /* lg+ */
-  header {
-    height: 80px;
-  }
   /* undoing the sticky footer for pages with header image
        the backup plan is to color the body the same as the footer
        to avoid the floating footer look


### PR DESCRIPTION
#435 

Fixes most of 435.

Moves the `DEBUG BAR` _out_ of the `<header>` HTML element, which has a lot of CSS added on it. 

## Test this PR

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/163850927-0755691f-c028-48b9-b0fa-d6c7bdb535eb.png">

Open any page _with_ this PR, and then open another tab of the same page -- with the Debug bar entirely removed. (You can remove it by commenting out the Debug bar HTML code, or also removing it from the DOM within DevTools). The spacing of everything under the header _should remain the same_.