### PR TITLE
Fix index content title to match Figma mockup

### DIFF
--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -243,7 +243,7 @@ msgstr "Please wait..."
 #: benefits/core/views.py:20
 msgid "core.pages.index.content_title"
 msgstr ""
-"Cal-ITP Benefits makes it easy to use your public transit discount everytime you ride. "
+"Cal-ITP Benefits makes it easy to use your public transit discount every time you ride."
 
 msgid "core.pages.agency_index.content_title"
 msgstr ""

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -245,7 +245,7 @@ msgstr "Espere por favor..."
 #: benefits/core/views.py:20
 msgid "core.pages.index.content_title"
 msgstr ""
-"TODO: Cal-ITP Benefits makes it easy to use your public transit discount everytime you ride."
+"TODO: Cal-ITP Benefits makes it easy to use your public transit discount every time you ride."
 
 msgid "core.pages.agency_index.content_title"
 msgstr ""


### PR DESCRIPTION
Related to #433 

The change made in #437 was missing a space in between `every` and `time`. This was noticeable when the user selects their transit agency since both pages should have the same content title.