### PR TITLE
Chore: run pytest in CI

### DIFF
--- a/.github/workflows/tests-pytest.yml
+++ b/.github/workflows/tests-pytest.yml
@@ -1,0 +1,34 @@
+name: Pytest
+
+on: push
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Install system packages
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y gettext
+
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+          cache: pip
+          cache-dependency-path: '**/requirements.txt'
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt -r tests/pytest/requirements.txt
+
+      - name: Load environment variables
+        uses: cardinalby/export-env-action@v1
+        with:
+          envFile: .devcontainer/.env.sample
+
+      - name: Run setup
+        run: ./bin/init.sh
+
+      - name: Run tests
+        run: pytest

--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+@pytest.fixture(scope="session")
+def django_db_setup():
+    # use existing database since it's read-only
+    pass

--- a/tests/pytest/test_views.py
+++ b/tests/pytest/test_views.py
@@ -1,0 +1,10 @@
+import pytest
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+def test_homepage(client):
+    homepage = reverse("core:index")
+    response = client.get(homepage)
+    assert response.status_code == 200
+    assert "transit" in str(response.content)


### PR DESCRIPTION
Also add configuration to run Django tests in GitHub Actions. Want a baseline test that works as a starting place for adding tests in https://github.com/cal-itp/benefits/pull/445. Merged in https://github.com/cal-itp/benefits/pull/455 to build off of those.