### PR TITLE
Fix/css - Header, Footer, Container spacing

### DIFF
--- a/benefits/core/templates/core/page.html
+++ b/benefits/core/templates/core/page.html
@@ -10,7 +10,7 @@
 
 {% block main_content %}
 <div class="container-fluid">
-    <div class="row">
+    <div class="row main-row">
         {% if page.noimage %}
         <div class="container">
         {% else %}

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -99,11 +99,6 @@ footer .footer-links a {
   position: relative;
 }
 
-.btn-external:hover {
-  background-color: #2b6597 !important;
-  border-color: #2b6597 !important;
-}
-
 .btn-external::after {
   content: url("/static/img/icon/rightarrow.svg");
   width: 25px;

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -266,6 +266,7 @@ footer .footer-links a {
 .media-list .media .media-body--details {
   font-size: 16px;
   letter-spacing: 0.05em;
+  padding-bottom: 0.4rem;
 }
 
 .media-list .media .media-body .media-body--links .btn-lg {

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -178,10 +178,6 @@ footer .footer-links a {
   background: #212121;
 }
 
-.home .buttons {
-  /* margin-top: 20vh; */
-}
-
 .agency-index h1 {
   margin-bottom: 7vh;
 }
@@ -338,10 +334,6 @@ footer .footer-links a {
   width: 274px;
 }
 
-.image[class*="col-"] {
-  /* min-height: 230px; */
-}
-
 .container.content {
   margin-top: 2rem;
   margin-bottom: 2rem;
@@ -482,8 +474,8 @@ footer .footer-links a {
     padding-bottom: 0.138rem;
   }
 
-  .image[class*="col-"] {
-    /* min-height: 725px; */
+  h1.icon-title {
+    text-align: center;
   }
 
   .container.content {

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -326,12 +326,21 @@ footer .footer-links a {
 
 /* context-specific overrides */
 
+.navbar.navbar-expand-sm.navbar-dark.bg-primary {
+  padding: 8.5px 1rem;
+}
+
+.navbar.navbar-expand-sm.navbar-dark.bg-primary .navbar-brand {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
 .navbar-brand img.sm {
   width: 120px;
 }
 
 .navbar-brand img.lg {
-  width: 274px;
+  width: 271px;
 }
 
 .container.content {
@@ -464,7 +473,7 @@ footer .footer-links a {
   }
 
   .main-primary .main-row {
-    height: calc(100vh - 128px);
+    height: calc(100vh - 120px);
     /* 128px is height of header + footer */
   }
 

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -179,7 +179,7 @@ footer .footer-links a {
 }
 
 .home .buttons {
-  margin-top: 20vh;
+  /* margin-top: 20vh; */
 }
 
 .agency-index h1 {
@@ -191,7 +191,7 @@ footer .footer-links a {
 }
 
 .agency-index label {
-  margin-top: 15vh;
+  /* margin-top: 15vh; */
   margin-bottom: 7vh;
 }
 
@@ -339,7 +339,7 @@ footer .footer-links a {
 }
 
 .image[class*="col-"] {
-  min-height: 230px;
+  /* min-height: 230px; */
 }
 
 .container.content {
@@ -470,24 +470,27 @@ footer .footer-links a {
   .with-image main {
     flex-shrink: unset;
   }
-  .with-image .container.content {
-    min-height: 800px;
+
+  .main-primary .main-row {
+    height: calc(100vh - 128px);
+    /* 128px is height of header + footer */
   }
-  .with-image footer {
+
+  footer {
     margin-top: unset;
     padding-top: 0.138rem;
     padding-bottom: 0.138rem;
   }
 
   .image[class*="col-"] {
-    min-height: 725px;
+    /* min-height: 725px; */
   }
 
   .container.content {
     padding-left: 3.5rem;
     padding-right: 3.5rem;
-    margin-top: 8rem;
-    margin-bottom: 7rem;
+    /* margin-top: 8rem;
+    margin-bottom: 7rem; */
   }
 
   .container.content input[type="submit"],

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -119,6 +119,7 @@ footer .footer-links a {
 
 .btn-primary {
   text-transform: uppercase;
+  height: 60px;
   letter-spacing: 0.05em;
 }
 
@@ -257,7 +258,6 @@ footer .footer-links a {
 .media-list .media .media-body--details {
   font-size: 16px;
   letter-spacing: 0.05em;
-  padding-bottom: 0.4rem;
 }
 
 .media-list .media .media-body .media-body--links .btn-lg {
@@ -476,11 +476,6 @@ footer .footer-links a {
     margin-top: unset;
     padding-top: 0.138rem;
     padding-bottom: 0.138rem;
-  }
-
-  /* Enrollment Success page icon title */
-  h1.icon-title {
-    text-align: left;
   }
 
   .container.content {

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -99,6 +99,11 @@ footer .footer-links a {
   position: relative;
 }
 
+.btn-external:hover {
+  background-color: #2b6597 !important;
+  border-color: #2b6597 !important;
+}
+
 .btn-external::after {
   content: url("/static/img/icon/rightarrow.svg");
   width: 25px;
@@ -119,7 +124,6 @@ footer .footer-links a {
 
 .btn-primary {
   text-transform: uppercase;
-  height: 60px;
   letter-spacing: 0.05em;
 }
 

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -54,7 +54,7 @@ label {
   letter-spacing: 0.05em;
 }
 
-/* making the sticky footer */
+/* Footer: Making the sticky footer */
 
 html,
 body {
@@ -79,6 +79,10 @@ footer {
 
 footer .footer-links a {
   font-size: 16px;
+}
+
+.global-footer {
+  background: #212121;
 }
 
 /* class styles */
@@ -170,22 +174,7 @@ footer .footer-links a {
   padding-left: 1rem;
 }
 
-.global-footer {
-  background: #212121;
-}
-
-.agency-index h1 {
-  margin-bottom: 7vh;
-}
-
-.agency-index p {
-  margin-bottom: 5vh;
-}
-
-.agency-index label {
-  /* margin-top: 15vh; */
-  margin-bottom: 7vh;
-}
+/* Eligibility Start Page */
 
 .media-title {
   margin-top: 0;
@@ -278,6 +267,8 @@ footer .footer-links a {
   margin: 0 0 77px 0;
 }
 
+/* Verifier Selection Page */
+
 .radio-container {
   display: block;
   margin-left: 15%;
@@ -319,7 +310,7 @@ footer .footer-links a {
   font-weight: normal;
 }
 
-/* context-specific overrides */
+/* Header */
 
 .navbar.navbar-expand-sm.navbar-dark.bg-primary {
   padding: 8.5px 1rem;
@@ -338,16 +329,35 @@ footer .footer-links a {
   width: 271px;
 }
 
-.container.content {
-  margin-top: 2rem;
-  margin-bottom: 2rem;
-}
+/* Main Primary Container */
 
 .container.content h1.icon-title span.icon {
   text-align: center;
   display: block;
-  margin-bottom: 1rem;
+  margin-bottom: 3.375rem;
 }
+
+.container.content h1 {
+  margin-bottom: 3rem;
+}
+
+.container.content h1 ~ p:nth-last-of-type(1) {
+  margin-bottom: 3.375rem;
+}
+
+/* All buttons, including Form Submit on Eligibility Confirm */
+.container.content .btn-lg {
+  font-weight: 500;
+  padding: 1rem;
+  width: 100%;
+}
+
+/* Does not include Eligibility Radio form, Eligibility Confirm, Help */
+.container.content .buttons .btn-lg:not(.btn-link) {
+  margin-top: 3.375rem;
+}
+
+/* Help Page */
 
 .container.content.help {
   margin-top: 4rem;
@@ -368,17 +378,6 @@ footer .footer-links a {
   margin-bottom: 2rem;
 }
 
-.container.content h1 ~ p:nth-last-of-type(1) {
-  margin-bottom: 2rem;
-}
-
-.container.content .btn-lg {
-  font-weight: 500;
-  margin-bottom: 1rem;
-  padding: 1rem;
-  width: 100%;
-}
-
 .container.content .btn-lg.agency-url {
   margin-bottom: 0;
   padding-bottom: 0;
@@ -395,6 +394,7 @@ footer .footer-links a {
 .text-lg-center form {
   text-align: left !important;
 }
+
 .text-lg-center .buttons label {
   width: 100%;
   text-align: center !important;
@@ -420,6 +420,13 @@ footer .footer-links a {
 }
 
 @media (max-width: 992px) {
+  .container.content {
+    padding-top: 3rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    padding-bottom: 2rem;
+  }
+
   .media-list {
     display: flex;
     flex-direction: column;
@@ -479,10 +486,9 @@ footer .footer-links a {
   }
 
   .container.content {
-    padding-left: 3.5rem;
-    padding-right: 3.5rem;
-    /* margin-top: 8rem;
-    margin-bottom: 7rem; */
+    padding-top: 4rem;
+    padding-left: 3rem;
+    padding-right: 3rem;
   }
 
   .container.content input[type="submit"],
@@ -496,6 +502,7 @@ footer .footer-links a {
 @media (min-width: 1200px) {
   /* xl+ */
   .container.content {
+    padding-top: 4rem;
     padding-left: 5rem;
     padding-right: 5rem;
   }

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -483,8 +483,9 @@ footer .footer-links a {
     padding-bottom: 0.138rem;
   }
 
+  /* Enrollment Success page icon title */
   h1.icon-title {
-    text-align: center;
+    text-align: left;
   }
 
   .container.content {


### PR DESCRIPTION
## What this PR does
- In desktop mode, the footer is now always 40px
- In all modes, the header is now always 80px
- On all pages (except for the Help page), the content container is now always the full height of the screen, minus 40px+80px.
- On all pages (except for the Help page), the content container's inner padding will now be set on the container itself, rather than set by the contents of the container.
- On all pages, the content container's main Button will have margins.

## Developer experience
- New class in `page.html`, `.main-row`, a child of `.main_content .container-fluid`.
- CSS: The styles.css page now has comments for various sections: Header, Footer, Main Primary Container (Applies to all pages, except Help page), Help Page
- `.container.content` padding: XL size screens (padding: 4rem 5rem), L size screens (padding: 4rem 3rem), S/M screens (padding: 3rem 1rem 2rem 1rem)