### PR TITLE
Button: Large Button centering/height fixes

### DIFF
--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -373,7 +373,8 @@ footer .footer-links a {
 .container.content .btn-lg {
   font-weight: 500;
   margin-bottom: 1rem;
-  padding: 1rem;
+  padding: 0.8125rem;
+  /* btn-lg height is 60px */
   width: 100%;
 }
 

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -119,7 +119,6 @@ footer .footer-links a {
 
 .btn-primary {
   text-transform: uppercase;
-  height: 60px;
   letter-spacing: 0.05em;
 }
 


### PR DESCRIPTION
This CSS change affects:

- _Every_ button/button-like link (**Get started**, **Continue**, **Check status,** **Back**), in the Main Container (`.container.content .btn-lg`) now has a height of 60px. All of these buttons have a height of 60px with text vertically and horizontally centered.
- This means it does not affect the Español/English button in the Header. (The Español/English button _also_ uses `.btn-lg` class, but this button is 38px high.


| Figma | After | 
| ------ | ------|
| <img width="172" alt="image" src="https://user-images.githubusercontent.com/3673236/164308290-1c26249d-6fb4-4922-9de8-83402af3944c.png"> | <img width="675" alt="image" src="https://user-images.githubusercontent.com/3673236/164308813-d971d2ab-0b27-48bc-8096-8ee49443047b.png"> |

To test this PR:
- Check _all_ buttons on all pages.
