### PR TITLE
Fix: Align Desktop Header/Container/Footer heights

### DIFF
--- a/benefits/core/templates/core/page.html
+++ b/benefits/core/templates/core/page.html
@@ -10,7 +10,7 @@
 
 {% block main_content %}
 <div class="container-fluid">
-    <div class="row">
+    <div class="row main-row">
         {% if page.noimage %}
         <div class="container">
         {% else %}

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -350,7 +350,7 @@ footer .footer-links a {
 }
 
 .container.content.help {
-  margin-top: 4rem;
+  margin: 4rem auto 2rem auto;
 }
 
 .container.content.help h1 {
@@ -457,6 +457,11 @@ footer .footer-links a {
     width: 100%;
     float: none;
   }
+
+  /* Override for only the Agency Index page */
+  .agency-index .container.content h1 ~ p:nth-last-of-type(1) {
+    margin-bottom: 2rem;
+  }
 }
 
 @media (min-width: 992px) {
@@ -490,6 +495,11 @@ footer .footer-links a {
     margin-left: auto;
     margin-right: auto;
   }
+
+  /* Override for only the Agency Index page */
+  .agency-index .container.content h1 ~ p:nth-last-of-type(1) {
+    margin-bottom: 4rem;
+  }
 }
 
 @media (min-width: 1200px) {
@@ -500,5 +510,10 @@ footer .footer-links a {
     padding-top: 2rem;
     padding-bottom: 2rem;
     margin: 0;
+  }
+
+  /* Override for only the Agency Index page */
+  .agency-index .container.content h1 ~ p:nth-last-of-type(1) {
+    margin-bottom: 5rem;
   }
 }

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -42,7 +42,7 @@ h1 {
 }
 
 p {
-  margin-bottom: 1rem;
+  margin-bottom: 1.5rem;
   font-size: 18px;
   line-height: 27px;
   letter-spacing: 0.05em;
@@ -343,10 +343,14 @@ footer .footer-links a {
   margin-bottom: 2rem;
 }
 
+.container.content h1.icon-title {
+  padding-bottom: 1.5rem;
+}
+
 .container.content h1.icon-title span.icon {
   text-align: center;
   display: block;
-  margin-bottom: 1rem;
+  padding-bottom: 3rem;
 }
 
 .container.content.help {

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -339,6 +339,10 @@ footer .footer-links a {
   margin-bottom: 2rem;
 }
 
+.container.content .buttons label {
+  margin-bottom: 2rem;
+}
+
 .container.content h1.icon-title span.icon {
   text-align: center;
   display: block;
@@ -473,6 +477,9 @@ footer .footer-links a {
   .container.content {
     padding-left: 3.5rem;
     padding-right: 3.5rem;
+    padding-top: 2rem;
+    padding-bottom: 2rem;
+    margin: 0;
   }
 
   .container.content input[type="submit"],
@@ -490,5 +497,8 @@ footer .footer-links a {
   .container.content {
     padding-left: 5rem;
     padding-right: 5rem;
+    padding-top: 2rem;
+    padding-bottom: 2rem;
+    margin: 0;
   }
 }

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -329,16 +329,23 @@ footer .footer-links a {
 
 /* context-specific overrides */
 
+/* Header */
+
+.navbar.navbar-expand-sm.navbar-dark.bg-primary {
+  padding: 8.5px 1rem;
+}
+
+.navbar-brand {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
 .navbar-brand img.sm {
   width: 120px;
 }
 
 .navbar-brand img.lg {
-  width: 274px;
-}
-
-.image[class*="col-"] {
-  min-height: 230px;
+  width: 271px;
 }
 
 .container.content {

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -71,6 +71,10 @@ main {
   flex-shrink: 0 !important;
 }
 
+main .main-row {
+  min-height: calc(100vh - 120px);
+}
+
 footer {
   margin-top: auto;
   padding-top: 1rem;

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -173,23 +173,6 @@ footer .footer-links a {
   background: #212121;
 }
 
-.home .buttons {
-  margin-top: 20vh;
-}
-
-.agency-index h1 {
-  margin-bottom: 7vh;
-}
-
-.agency-index p {
-  margin-bottom: 5vh;
-}
-
-.agency-index label {
-  margin-top: 15vh;
-  margin-bottom: 7vh;
-}
-
 .media-title {
   margin-top: 0;
   font-size: 24px;
@@ -283,7 +266,6 @@ footer .footer-links a {
   width: fit-content;
   float: right;
   padding: 16px 29px;
-  margin: 0 0 77px 0;
 }
 
 .radio-container {
@@ -477,9 +459,6 @@ footer .footer-links a {
   .with-image main {
     flex-shrink: unset;
   }
-  .with-image .container.content {
-    min-height: 800px;
-  }
 
   footer {
     margin-top: unset;
@@ -487,15 +466,9 @@ footer .footer-links a {
     padding-bottom: 0.138rem;
   }
 
-  .image[class*="col-"] {
-    min-height: 725px;
-  }
-
   .container.content {
     padding-left: 3.5rem;
     padding-right: 3.5rem;
-    margin-top: 8rem;
-    margin-bottom: 7rem;
   }
 
   .container.content input[type="submit"],

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -473,7 +473,8 @@ footer .footer-links a {
   .with-image .container.content {
     min-height: 800px;
   }
-  .with-image footer {
+
+  footer {
     margin-top: unset;
     padding-top: 0.138rem;
     padding-bottom: 0.138rem;

--- a/tests/cypress/cypress.json
+++ b/tests/cypress/cypress.json
@@ -6,5 +6,7 @@
   "pluginsFile": "plugins/index.js",
   "screenshotsFolder": "screenshots",
   "supportFile": false,
+  "viewportWidth": 1280,
+  "viewportHeight": 960,
   "videosFolder": "videos"
 }


### PR DESCRIPTION
## What this PR does
### Code & Styles
- Desktop header height should always be 80px.
- Desktop footer height should always be 40px. Currently, the Help page and Eligibility Start page footers are not 40px.
- Desktop's main container (that is, anything between the Header and Footer) should now be 100% of the viewport height, minus 120px (80px header + 40px footer).

### What to Test For

0. Help Page and Eligibility Start Page's  footers should be 40px now, along with the rest of the app.

| Footer         | Footer     | 
|--------------|-----------|
|<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/164540612-88f47356-000e-4a9d-98cd-13ad79115d57.png">|<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/164540717-a9cb806a-748f-4b2a-911e-eebfad51bbd0.png">|
| Help Page | Eligibility Start|

1. Header should be 80px on all pages now



3. Agency Index, Eligibility Confirm - the H1 should start at the same level


| H1         | H1     | 
|--------------|-----------|
| <img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/164539312-882e4887-c2ab-4307-9f89-df823d5acd5f.png">|<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/164539600-364579d2-e0b1-4fb8-a3e2-65993e6545ca.png">|
| Agency Index | Eligibility Confirm|


4. Enrollment pages

The spacing above and below the icon, and also the spacing between the paragraphs should be the same.

|Icon spacing      | Icon spacing     | 
|--------------|-----------|
|<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/164571543-86c0e98a-b40d-43bf-af50-8fbf63c50025.png">|<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/164571559-5696aaf4-1d91-4846-82a0-8ad36128c8d7.png">|
| Enrollment Success | Enrollment |



### Developer experience
- Developer experience: This PR changes Cypress test's resolution to 1280x960, which is the most commonly used size for the users of this app.
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/164361887-f335f2bf-8b52-44ea-977b-5621f4bd8ab9.png">


## Test this PR:
- All pages that are part of the eligibility, enrollment flow on Desktop
- Help page on Desktop
- Ensure no changes on Mobile
