### PR TITLE
Style: Help page button width

### DIFF
--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -487,9 +487,11 @@ footer .footer-links a {
 
   .container.content input[type="submit"],
   .container.content .btn {
-    width: 70%;
-    margin-left: 15%;
-    margin-right: 15%;
+    width: fit-content;
+    min-width: 250px;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
   }
 }
 


### PR DESCRIPTION
Part of #456, only addresses the button

Note that all buttons in the app are using the same style, so we have to be careful to not introduce regressions/undesired results.

Some details from my commit message:
> The main goal here was to make the "Go back" button on the Help page
> smaller. Most of the buttons in the Figma mockup are around 250px, so
> set that as min-width. Use margin:auto for better centering.