### PR TITLE
Fix: Ensure HTTPS redirect_uri when app is deployed

### DIFF
--- a/benefits/oauth/views.py
+++ b/benefits/oauth/views.py
@@ -83,7 +83,7 @@ def post_logout(request):
     return redirect(origin)
 
 
-def _deauthorize_redirect(token, redirect_url):
+def _deauthorize_redirect(token, redirect_uri):
     """Helper implements OIDC signout via the `end_session_endpoint`."""
 
     # Authlib has not yet implemented `end_session_endpoint` as the OIDC Session Management 1.0 spec is still in draft
@@ -97,7 +97,7 @@ def _deauthorize_redirect(token, redirect_url):
     metadata = oauth_client.load_server_metadata()
     end_session_endpoint = metadata.get("end_session_endpoint")
 
-    params = dict(id_token_hint=token, post_logout_redirect_uri=redirect_url)
+    params = dict(id_token_hint=token, post_logout_redirect_uri=redirect_uri)
     encoded_params = urlencode(params)
     end_session_url = f"{end_session_endpoint}?{encoded_params}"
 

--- a/tests/pytest/oauth/test_views.py
+++ b/tests/pytest/oauth/test_views.py
@@ -1,7 +1,7 @@
 from django.http import HttpResponse
 
 from benefits.core import session
-from benefits.oauth.views import logout
+from benefits.oauth.views import logout, _generate_redirect_uri
 
 import pytest
 
@@ -18,7 +18,25 @@ def test_logout(mocker, session_request):
 
     result = logout(session_request)
 
-    spy.assert_called_with("token", "http://testserver/oauth/post_logout")
+    spy.assert_called_with("token", "https://testserver/oauth/post_logout")
     assert result.status_code == 200
     assert "logout successful" in str(result.content)
     assert session.oauth_token(session_request) is False
+
+
+def test_generate_redirect_uri_default(rf):
+    request = rf.get("/oauth/login")
+    path = "/test"
+
+    redirect_uri = _generate_redirect_uri(request, path)
+
+    assert redirect_uri == "https://testserver/test"
+
+
+def test_generate_redirect_uri_localhost(rf):
+    request = rf.get("/oauth/login", SERVER_NAME="localhost")
+    path = "/test"
+
+    redirect_uri = _generate_redirect_uri(request, path)
+
+    assert redirect_uri == "http://localhost/test"

--- a/tests/pytest/oauth/test_views.py
+++ b/tests/pytest/oauth/test_views.py
@@ -1,0 +1,24 @@
+from django.http import HttpResponse
+
+from benefits.core import session
+from benefits.oauth.views import logout
+
+import pytest
+
+
+@pytest.mark.request_path("/oauth/logout")
+def test_logout(mocker, session_request):
+    # logout internally calls _deauthorize_redirect
+    # this mocks that function and a success response
+    # and returns a spy object we can use to validate calls
+    spy = mocker.patch("benefits.oauth.views._deauthorize_redirect", return_value=HttpResponse("logout successful"))
+
+    session.update(session_request, oauth_token="token")
+    assert session.oauth_token(session_request) == "token"
+
+    result = logout(session_request)
+
+    spy.assert_called_with("token", "http://testserver/oauth/post_logout")
+    assert result.status_code == 200
+    assert "logout successful" in str(result.content)
+    assert session.oauth_token(session_request) is False


### PR DESCRIPTION
This is a follow-up to #442 (PR #447).

The current AWS architecture has SSL terminating _before_ the request reaches nginx. So the fix in #447 doesn't have the desired effect.

This is a temporary fix that just looks at the redirect URI, and when it _does not_ contain `localhost`, enforce HTTPS.

Note: targeting the `feat/oauth-signout` branch for now until #436 is merged.