### PR TITLE
Fix: configure test eligibility server

### DIFF
--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -37,6 +37,7 @@ services:
 
   server:
     image: ghcr.io/cal-itp/eligibility-server:main
+    env_file: server/.env.server
     ports:
       - "5000"
 

--- a/.devcontainer/server/.env.server
+++ b/.devcontainer/server/.env.server
@@ -1,0 +1,1 @@
+IMPORT_FILE_PATH=.devcontainer/server/data.csv

--- a/.devcontainer/server/data.csv
+++ b/.devcontainer/server/data.csv
@@ -1,0 +1,4 @@
+A1234567;Garcia;['type1']
+B2345678;Hernandez;['type2']
+C3456789;Smith;[]
+D4567890;Jones;['type1', 'type2']


### PR DESCRIPTION
The `server` Docker Compose service has been failing to start since https://github.com/cal-itp/eligibility-server/pull/58 introduced loading from a CSV file and expects an environment variable.

This PR provides the environment variable and a file to load with our sample data in the required format.