### PR TITLE
Test: test admin route is not registered

### DIFF
--- a/tests/pytest/test_settings.py
+++ b/tests/pytest/test_settings.py
@@ -1,0 +1,11 @@
+import pytest
+
+from django.conf import settings
+
+
+@pytest.mark.django_db
+def test_admin_not_registered(client):
+    response = client.get("/admin")
+
+    assert settings.ADMIN is False
+    assert response.status_code == 404


### PR DESCRIPTION
Tests that a user cannot access the `/admin` page when `settings.ADMIN` is set to `False`.