### PR TITLE
Fix: use recommended settings import approach

### DIFF
--- a/benefits/core/admin.py
+++ b/benefits/core/admin.py
@@ -1,10 +1,10 @@
 """
 The core application: Admin interface configuration.
 """
-from benefits.settings import ADMIN
+from django.conf import settings
 
 
-if ADMIN:
+if settings.ADMIN:
     import logging
     from django.contrib import admin
     from . import models

--- a/benefits/core/analytics.py
+++ b/benefits/core/analytics.py
@@ -8,10 +8,10 @@ import re
 import time
 import uuid
 
+from django.conf import settings
 import requests
 
 from benefits import VERSION
-from benefits.settings import ANALYTICS_KEY
 from . import session
 
 
@@ -122,6 +122,6 @@ class Client:
 def send_event(event):
     """Send an analytics event."""
     if isinstance(event, Event):
-        Client(ANALYTICS_KEY).send(event)
+        Client(settings.ANALYTICS_KEY).send(event)
     else:
         raise ValueError("event must be an Event instance")

--- a/benefits/core/context_processors.py
+++ b/benefits/core/context_processors.py
@@ -1,14 +1,14 @@
 """
 The core application: context processors for enriching request context data.
 """
-from benefits.settings import ANALYTICS_KEY, RECAPTCHA_API_URL, RECAPTCHA_ENABLED, RECAPTCHA_SITE_KEY
+from django.conf import settings
 
 from . import session
 
 
 def analytics(request):
     """Context processor adds some analytics information to request context."""
-    return {"analytics": {"api_key": ANALYTICS_KEY, "uid": session.uid(request), "did": session.did(request)}}
+    return {"analytics": {"api_key": settings.ANALYTICS_KEY, "uid": session.uid(request), "did": session.did(request)}}
 
 
 def debug(request):
@@ -18,4 +18,10 @@ def debug(request):
 
 def recaptcha(request):
     """Context processor adds recaptcha information to request context."""
-    return {"recaptcha": {"api_url": RECAPTCHA_API_URL, "enabled": RECAPTCHA_ENABLED, "site_key": RECAPTCHA_SITE_KEY}}
+    return {
+        "recaptcha": {
+            "api_url": settings.RECAPTCHA_API_URL,
+            "enabled": settings.RECAPTCHA_ENABLED,
+            "site_key": settings.RECAPTCHA_SITE_KEY,
+        }
+    }

--- a/benefits/core/recaptcha.py
+++ b/benefits/core/recaptcha.py
@@ -3,7 +3,7 @@ The core application: helpers to work with reCAPTCHA.
 """
 import requests
 
-from benefits.settings import RECAPTCHA_ENABLED, RECAPTCHA_SECRET_KEY, RECAPTCHA_VERIFY_URL
+from django.conf import settings
 
 
 _POST_DATA = "g-recaptcha-response"
@@ -19,13 +19,13 @@ def verify(form_data: dict) -> bool:
     Check with Google reCAPTCHA if the given response is a valid user.
     See https://developers.google.com/recaptcha/docs/verify
     """
-    if not RECAPTCHA_ENABLED:
+    if not settings.RECAPTCHA_ENABLED:
         return True
 
     if not form_data or _POST_DATA not in form_data:
         return False
 
-    payload = dict(secret=RECAPTCHA_SECRET_KEY, response=form_data[_POST_DATA])
-    response = requests.post(RECAPTCHA_VERIFY_URL, payload).json()
+    payload = dict(secret=settings.RECAPTCHA_SECRET_KEY, response=form_data[_POST_DATA])
+    response = requests.post(settings.RECAPTCHA_VERIFY_URL, payload).json()
 
     return bool(response["success"])

--- a/benefits/core/session.py
+++ b/benefits/core/session.py
@@ -6,9 +6,9 @@ import logging
 import time
 import uuid
 
+from django.conf import settings
 from django.urls import reverse
 
-from benefits.settings import RATE_LIMIT_PERIOD
 from . import models
 
 
@@ -166,7 +166,7 @@ def reset_rate_limit(request):
     logger.debug("Reset rate limit")
     request.session[_LIMITCOUNTER] = 0
     # get the current time in Unix seconds, then add RATE_LIMIT_PERIOD seconds
-    request.session[_LIMITUNTIL] = int(time.time()) + RATE_LIMIT_PERIOD
+    request.session[_LIMITUNTIL] = int(time.time()) + settings.RATE_LIMIT_PERIOD
 
 
 def start(request):

--- a/benefits/eligibility/api.py
+++ b/benefits/eligibility/api.py
@@ -6,10 +6,9 @@ import json
 import logging
 import uuid
 
+from django.conf import settings
 from jwcrypto import common as jwcrypto, jwe, jws, jwt
 import requests
-
-from benefits.settings import ALLOWED_HOSTS
 
 
 logger = logging.getLogger(__name__)
@@ -39,7 +38,7 @@ class RequestToken:
         # craft the main token payload
         payload = dict(
             jti=str(uuid.uuid4()),
-            iss=ALLOWED_HOSTS[0],
+            iss=settings.ALLOWED_HOSTS[0],
             iat=int(datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).timestamp()),
             agency=agency.agency_id,
             eligibility=types,

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -1,6 +1,7 @@
 """
 The eligibility application: view definitions for the eligibility verification flow.
 """
+from django.conf import settings
 from django.contrib import messages
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
@@ -11,7 +12,6 @@ from django.utils.translation import pgettext, gettext as _
 from benefits.core import middleware, recaptcha, session, viewmodels
 from benefits.core.models import EligibilityVerifier
 from benefits.core.views import PageTemplateResponse
-from benefits.settings import OAUTH_CLIENT_NAME
 from . import analytics, api, forms
 
 
@@ -89,7 +89,7 @@ def start(request):
     ]
 
     if verifier.requires_authentication:
-        if OAUTH_CLIENT_NAME is None:
+        if settings.OAUTH_CLIENT_NAME is None:
             raise Exception("EligibilityVerifier requires authentication, but OAUTH_CLIENT_NAME is None")
 
         media.insert(

--- a/benefits/oauth/views.py
+++ b/benefits/oauth/views.py
@@ -1,23 +1,22 @@
 import logging
 
+from django.conf import settings
 from django.shortcuts import redirect
 from django.urls import reverse
 
 from authlib.integrations.django_client import OAuth
 
 from benefits.core import session
-from benefits.settings import OAUTH_CLIENT_NAME
 
 
 logger = logging.getLogger(__name__)
 
-
-if OAUTH_CLIENT_NAME:
-    logger.debug(f"Using OAuth client configuration: {OAUTH_CLIENT_NAME}")
+if settings.OAUTH_CLIENT_NAME:
+    logger.debug(f"Using OAuth client configuration: {settings.OAUTH_CLIENT_NAME}")
 
     _oauth = OAuth()
-    _oauth.register(OAUTH_CLIENT_NAME)
-    oauth_client = _oauth.create_client(OAUTH_CLIENT_NAME)
+    _oauth.register(settings.OAUTH_CLIENT_NAME)
+    oauth_client = _oauth.create_client(settings.OAUTH_CLIENT_NAME)
 
 
 ROUTE_AUTH = "oauth:authorize"

--- a/benefits/urls.py
+++ b/benefits/urls.py
@@ -6,10 +6,8 @@ The `urlpatterns` list routes URLs to views. For more information please see:
 """
 import logging
 
+from django.conf import settings
 from django.urls import include, path
-
-from benefits.settings import ADMIN, OAUTH_CLIENT_NAME
-
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +23,7 @@ urlpatterns = [
     path("i18n/", include("django.conf.urls.i18n")),
 ]
 
-if ADMIN:
+if settings.ADMIN:
     from django.contrib import admin
 
     logger.debug("Register admin urls")
@@ -33,7 +31,7 @@ if ADMIN:
 else:
     logger.debug("Skip url registrations for admin")
 
-if OAUTH_CLIENT_NAME:
+if settings.OAUTH_CLIENT_NAME:
     logger.info("Register oauth urls")
     urlpatterns.append(path("oauth/", include("benefits.oauth.urls")))
 else:

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -38,18 +38,22 @@ are loaded for every app command and run.
 
 ## Using configuration in app code
 
-From within the application, the Django settings file and the Django models are the two interfaces for application code to
+!!! tldr "Django docs"
+
+    [Using settings in Python code][django-using-settings]
+
+From within the application, the Django settings object and the Django models are the two interfaces for application code to
 read configuration data.
 
-The settings file defines a number of "constants" (they aren't strictly _constant_, but should be treated as such) that
-can be imported directly by application code, for example:
+Rather than importing the app's settings module, Django recommends importing the `django.conf.settings` object, which provides
+an abstraction and better handles default values:
 
 ```python
-from benefits.settings import ADMIN
+from django.config import settings
 
 # ...
 
-if ADMIN:
+if settings.ADMIN:
     # do something when admin is enabled
 else:
     # do something else when admin is disabled
@@ -73,6 +77,7 @@ else:
 [benefits-wsgi]: https://github.com/cal-itp/benefits/blob/dev/benefits/wsgi.py
 [django-model]: https://docs.djangoproject.com/en/3.2/topics/db/models/
 [django-settings]: https://docs.djangoproject.com/en/3.2/topics/settings/
+[django-using-settings]: https://docs.djangoproject.com/en/3.2/topics/settings/#using-settings-in-python-code
 [env-vars]: environment-variables.md
 [fixtures]: fixtures.md
 [getting-started]: ../getting-started/README.md


### PR DESCRIPTION
Before this PR, we were importing settings variables directly from our own `benefits.settings` module.

According to Django best practice on [Using settings in Python code](https://docs.djangoproject.com/en/3.2/topics/settings/#using-settings-in-python-code), instead we should import the `django.conf.settings` object and use attributes off of that.

This PR updates everywhere we had imported `benefits.settings` or variables to use the recommended approach.

Also updated our docs guidance around using settings in application code.