### PR TITLE
Fix: Spanish copy on agency index

### DIFF
--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -256,7 +256,7 @@ msgid "core.pages.agency_index.p[0]%(info_link)s"
 msgstr "TODO: With new contactless payment options, you can tap "
 "your bank-issued contactless credit or debit card when you "
 "board, and your discount will automatically apply every "
-"time you ride. <strong><a href=\"%(info-link)s\">Learn more about Cal-ITP Benefits.</a></strong>"
+"time you ride. <strong><a href=\"%(info_link)s\">Learn more about Cal-ITP Benefits.</a></strong>"
 
 msgid "core.pages.agency_index.p[1]"
 msgstr "TODO: The Cal-ITP Benefits program is currently only open to those <strong>ages 65 or older</strong>."


### PR DESCRIPTION
This PR fixes a current bug where `core.pages.agency_index.p[0]/help#about` is being displayed instead of the actual copy on the Agency Index page.

|Current | Fixed   |
|--------|--------|
|<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/164566766-c78f6c4f-5c8e-4f92-baf4-6aff0c729abf.png">|<img width="1511" alt="image" src="https://user-images.githubusercontent.com/3673236/164566793-f993fb9a-a688-471a-b070-b33ec3569257.png">|
