### PR TITLE
Tests: OAuth login flow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,6 @@ include = '\.pyi?$'
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "benefits.settings"
+markers = [
+    "request_path: use with session_request to initialize with the given path",
+]

--- a/tests/pytest/oauth/test_views.py
+++ b/tests/pytest/oauth/test_views.py
@@ -31,10 +31,8 @@ def test_login(mocker, session_request):
 
 
 @pytest.mark.request_path("/oauth/login")
-def test_authorize(mocker, session_request):
+def test_authorize_fail(mocker, session_request):
     mock_client = mocker.patch.object(benefits.oauth.views, "oauth_client")
-
-    # first test when the token cannot be authorized
     mock_client.authorize_access_token.return_value = None
 
     assert session.oauth_token(session_request) is None
@@ -46,7 +44,10 @@ def test_authorize(mocker, session_request):
     assert result.status_code == 302
     assert result.url == reverse(ROUTE_START)
 
-    # next test when an id_token is returned
+
+@pytest.mark.request_path("/oauth/login")
+def test_authorize_success(mocker, session_request):
+    mock_client = mocker.patch.object(benefits.oauth.views, "oauth_client")
     mock_client.authorize_access_token.return_value = {"id_token": "token"}
 
     result = authorize(session_request)

--- a/tests/pytest/oauth/test_views.py
+++ b/tests/pytest/oauth/test_views.py
@@ -2,10 +2,23 @@ from django.http import HttpResponse
 from django.urls import reverse
 
 from benefits.core import session
-from benefits.oauth.views import logout, post_logout, _deauthorize_redirect, _generate_redirect_uri
+from benefits.oauth.views import login, logout, post_logout, _deauthorize_redirect, _generate_redirect_uri
 import benefits.oauth.views
 
 import pytest
+
+
+@pytest.mark.request_path("/oauth/login")
+def test_login(mocker, session_request):
+    mock_client = mocker.patch.object(benefits.oauth.views, "oauth_client")
+    mock_client.authorize_redirect.return_value = HttpResponse("authorize redirect")
+
+    assert session.oauth_token(session_request) is None
+
+    login(session_request)
+
+    mock_client.authorize_redirect.assert_called_with(session_request, "https://testserver/oauth/authorize")
+    assert session.oauth_token(session_request) is None
 
 
 @pytest.mark.request_path("/oauth/logout")


### PR DESCRIPTION
Closes #476 
Closes #477 

## `login` Test

* `authorize_redirect` is called, with a redirect for `/oauth/authorize`
* login status is not updated

## `authorize` Tests

* When `authorize_access_token` fails, login status not updated and redirected back to start page
* When `authorize_access_token` succeeds, login status updated and redirect to confirm page
