### PR TITLE
Fix: add on.push for CodeQL runs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,6 +2,7 @@
 name: CodeQL
 
 on:
+  push:
   pull_request:
     branches: [ dev, test, prod ]
   schedule:


### PR DESCRIPTION
Per warning in action runs, e.g. https://github.com/cal-itp/benefits/runs/6161384923?check_suite_focus=true#step:3:10

Closes #393