### PR TITLE
Test: default user session values

### DIFF
--- a/benefits/core/analytics.py
+++ b/benefits/core/analytics.py
@@ -25,13 +25,17 @@ class Event:
     def __init__(self, request, event_type, **kwargs):
         """Analytics event of the given type, including attributes from request's session."""
         self.app_version = VERSION
+        # device_id is generated based on the user_id, and both are set explicitly (per session)
         self.device_id = session.did(request)
         self.event_properties = {}
         self.event_type = str(event_type).lower()
         self.insert_id = str(uuid.uuid4())
         self.language = session.language(request)
+        # Amplitude tracks sessions using the start time as the session_id
         self.session_id = session.start(request)
         self.time = int(time.time() * 1000)
+        # Although Amplitude advises *against* setting user_id for anonymous users, here a value is set on anonymous
+        # users anyway, as the users never sign-in and become de-anonymized to this app / Amplitude.
         self.user_id = session.uid(request)
         self.user_properties = {}
         self.__dict__.update(kwargs)

--- a/benefits/core/session.py
+++ b/benefits/core/session.py
@@ -76,7 +76,16 @@ def debug(request):
 
 
 def did(request):
-    """Get the session's device ID, a hashed version of the unique ID."""
+    """
+    Get the session's device ID, a hashed version of the unique ID. If unset,
+    the session is reset to initialize a value.
+
+    This value, like UID, is randomly generated per session and is needed for
+    Amplitude to accurately track that a sequence of events came from a unique
+    user.
+
+    See more: https://help.amplitude.com/hc/en-us/articles/115003135607-Track-unique-users-in-Amplitude
+    """
     logger.debug("Get session did")
     d = request.session.get(_DID)
     if not d:
@@ -205,7 +214,16 @@ def reset(request):
 
 
 def start(request):
-    """Get the start time from the request's session, as integer milliseconds since Epoch."""
+    """
+    Get the start time from the request's session, as integer milliseconds since
+    Epoch. If unset, the session is reset to initialize a value.
+
+    Once started, does not reset after subsequent calls to session.reset() or
+    session.start(). This value is needed for Amplitude to accurately track
+    sessions.
+
+    See more: https://help.amplitude.com/hc/en-us/articles/115002323627-Tracking-Sessions
+    """
     logger.debug("Get session time")
     s = request.session.get(_START)
     if not s:
@@ -215,7 +233,19 @@ def start(request):
 
 
 def uid(request):
-    """Get the session's unique ID, generating a new one if necessary."""
+    """
+    Get the session's unique ID, a randomly generated UUID4 string. If unset,
+    the session is reset to initialize a value.
+
+    This value, like DID, is needed for Amplitude to accurately track that a
+    sequence of events came from a unique user.
+
+    See more: https://help.amplitude.com/hc/en-us/articles/115003135607-Track-unique-users-in-Amplitude
+
+    Although Amplitude advises *against* setting user_id for anonymous users,
+    here a value is set on anonymous users anyway, as the users never sign-in
+    and become de-anonymized to this app / Amplitude.
+    """
     logger.debug("Get session uid")
     u = request.session.get(_UID)
     if not u:

--- a/tests/pytest/core/test_session.py
+++ b/tests/pytest/core/test_session.py
@@ -38,11 +38,18 @@ def test_debug_default(app_request):
 
 
 @pytest.mark.django_db
-def test_did(app_request):
+def test_did_default(app_request, mocker):
+    # did() resets and returns a value when user is not configured
+    spy = mocker.spy(session, "reset")
+    app_request.session[session._DID] = None
+    app_request.session[session._UID] = None
+
     did = session.did(app_request)
 
+    spy.assert_called_once()
     assert did
     assert isinstance(did, str)
+    assert did != "None"
 
 
 @pytest.mark.django_db
@@ -282,20 +289,32 @@ def test_reset_user(app_request):
 
 
 @pytest.mark.django_db
-def test_start_default(app_request):
+def test_start_default(app_request, mocker):
+    # start() resets and returns a value when user is not configured
+    spy = mocker.spy(session, "reset")
+    app_request.session[session._START] = None
+    app_request.session[session._UID] = None
+
     t0 = time.time()
     start = session.start(app_request)
 
+    spy.assert_called_once()
     assert isinstance(start, int)
     assert start >= t0
 
 
 @pytest.mark.django_db
-def test_uid(app_request):
+def test_uid_default(app_request, mocker):
+    # uid() resets and returns a value when user is not configured
+    spy = mocker.spy(session, "reset")
+    app_request.session[session._UID] = None
+
     uid = session.uid(app_request)
 
+    spy.assert_called_once()
     assert uid
     assert isinstance(uid, str)
+    assert uid != "None"
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Follow-on to #474.

Fixes "default" tests for the 3 user-info session functions:

* `did` (device ID)
* `start` (session start time)
* `uid` (user ID)

Checks that in each case, `session.reset()` is called when no value is initially present, so that a value is always returned.
