### PR TITLE
fix: ignore migrations from test coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = benefits/core/migrations/*


### PR DESCRIPTION
Broken out from https://github.com/cal-itp/benefits/pull/487.