### PR TITLE
fix: clean out old test coverage results

### DIFF
--- a/tests/pytest/run.sh
+++ b/tests/pytest/run.sh
@@ -3,6 +3,8 @@ set -eu
 
 pytest --cov=benefits --cov-branch
 
+# clean out old coverage results
+rm -rf benefits/static/coverage
 coverage html --directory benefits/static/coverage
 
 echo


### PR DESCRIPTION
Otherwise, it's easy to refresh the page and see old results. Broken out of https://github.com/cal-itp/benefits/pull/487.