### PR TITLE
fix: replace deprecated logger warning calls

### DIFF
--- a/benefits/core/middleware.py
+++ b/benefits/core/middleware.py
@@ -49,7 +49,7 @@ class RateLimit(MiddlewareMixin):
 
         if counter > settings.RATE_LIMIT:
             if reset_time > now:
-                logger.warn("Rate limit exceeded")
+                logger.warning("Rate limit exceeded")
                 home = viewmodels.Button.home(request)
                 page = viewmodels.ErrorPage.error(
                     title="Rate limit error",

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -59,7 +59,7 @@ def _index(request):
         name=f"{agency.long_name} {_('partnered with')} {agency.payment_processor.name}",
     )
     context.update(processor_vm.context_dict())
-    logger.warn(f"card_tokenize_url: {context['payment_processor'].card_tokenize_url}")
+    logger.warning(f"card_tokenize_url: {context['payment_processor'].card_tokenize_url}")
 
     # the tokenize form URLs are injected to page-generated Javascript
     context["forms"] = {


### PR DESCRIPTION
Was getting the warning

```
  /home/calitp/app/benefits/enrollment/views.py:62: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    logger.warn(f"card_tokenize_url: {context['payment_processor'].card_tokenize_url}")
```