### PR TITLE
fix: remove deprecated Docker Compose volume option

### DIFF
--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -9,7 +9,7 @@ services:
       - "${DJANGO_LOCAL_PORT}:8000"
     volumes:
       - ../.aws/config:/home/calitp/app/config:ro
-      - ../fixtures:/home/calitp/app/fixtures:cached
+      - ../fixtures:/home/calitp/app/fixtures:ro
 
   dev:
     build:
@@ -24,7 +24,7 @@ services:
     ports:
       - "${DJANGO_LOCAL_PORT}:8000"
     volumes:
-      - ../:/home/calitp/app:cached
+      - ../:/home/calitp/app
 
   docs:
     image: benefits_client:dev
@@ -33,7 +33,7 @@ services:
     ports:
       - "8000"
     volumes:
-      - ../:/home/calitp/app:cached
+      - ../:/home/calitp/app
 
   server:
     image: ghcr.io/cal-itp/eligibility-server@sha256:337d5b2beb1e458980be49a778efd4a47f8daa8decc5e8329c0d528596e2f196


### PR DESCRIPTION
https://stackoverflow.com/a/70957456/358804

Extracted from https://github.com/cal-itp/benefits/pull/398.