### PR TITLE
refactor(tests): make more explicit that the default app_request path is arbitrary

### DIFF
--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -22,10 +22,7 @@ def app_request(request, rf):
 
     # see if a request_path was provided via marker
     marker = request.node.get_closest_marker("request_path")
-    if marker is None:
-        request_path = "/"
-    else:
-        request_path = marker.args[0]
+    request_path = marker.args[0] if marker else "/some/arbitrary/path"
 
     # create a request for the path, initialize
     app_request = rf.get(request_path)


### PR DESCRIPTION
It was causing confusion for various members of the team (including me); hopefully this will make it more clear if the path is inspected in a test.