### PR TITLE
Docs: publish the coverage report with docs site

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -17,6 +17,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Download coverage report
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: tests-pytest.yml
+          branch: dev
+          event: push
+          name: coverage-report
+          path: docs/tests/coverage
+
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@master
         env:

--- a/docs/.pages
+++ b/docs/.pages
@@ -2,5 +2,6 @@ nav:
   - Home: README.md
   - Getting started: getting-started
   - Development: development
+  - Testing: tests
   - Configuration: configuration
   - Deployment: deployment

--- a/docs/getting-started/.pages
+++ b/docs/getting-started/.pages
@@ -1,4 +1,3 @@
 nav:
   - Local setup: README.md
-  - Automated tests: testing.md
   - Documentation: documentation.md

--- a/docs/tests/.pages
+++ b/docs/tests/.pages
@@ -1,0 +1,3 @@
+nav:
+  - Introduction: README.md
+  - Coverage report: coverage

--- a/docs/tests/README.md
+++ b/docs/tests/README.md
@@ -89,3 +89,7 @@ The helper script:
 The report can be viewed by launching the app and navigating to `http://localhost:$DJANGO_LOCAL_PORT/static/coverage/index.html`
 
 The report files include a local `.gitignore` file, so the entire directory is hidden from source control.
+
+### Latest coverage report
+
+We also make the latest (from `dev`) coverage report available online here: [Coverage report](./coverage)


### PR DESCRIPTION
Download the coverage report artifact (#499) and send it with the `mkdocs` publish.

The latest coverage report from dev will be available at https://docs.calitp.org/benefits/tests/coverage