### PR TITLE
Feat: anchor link analytics

### DIFF
--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -95,7 +95,7 @@
                     });
                 }
 
-                $("a[href^='https'], a[href^='tel']").on("click", function(e) {
+                $("a[href^='https'], a[href^='tel'], [href*='#']").on("click", function(e) {
                     amplitude.getInstance().logEvent('clicked link', {'href': e.target.href, 'path': window.location.pathname});
                 });
             });


### PR DESCRIPTION
Closes #377

## Summary
#452 took care of sending Amplitude events when executing server-side logic for sign-in and sign-out. 

This PR finishes out the goal of #377 by sending Amplitude events for which help links the user clicks so we can see where they might be getting distracted and/or dropping off. This is done on the client-side so that the event data includes the hash and URL fragment (e.g. #payment-options), which is not available server-side.

## How to test this PR
 - Launch the app
 - Navigate through the flow to the `eligibility:start` page
 - Open dev tools, and put a breakpoint in the Javascript for `amplitude.getInstance().logEvent('clicked link', {'href'...`
 - Click one of the three help links:
    - "Learn more about Login.gov"
    - "Don't have a bank card?"
    - "Unsure if you have a contactless card?"
 - In the debugger console, evaluate `e.target.href` and notice that it contains the URL fragment

![image](https://user-images.githubusercontent.com/25497886/165635126-c291f837-b907-484d-901d-47f2ecdfd27d.png)


## Todo
* [ ] Send page view events for the new pages
* [x] Update ~~page view event~~ clicked link event to capture query hash