### PR TITLE
Fix: start page "Learn about Login.gov" link

### DIFF
--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -104,7 +104,6 @@ def start(request):
                         classes="btn-text btn-link",
                         text=_("eligibility.pages.start.oauth.link_text"),
                         url=_("eligibility.pages.start.oauth.link_url"),
-                        target="_blank",
                         rel="noopener noreferrer",
                     )
                 ],

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -72,18 +72,18 @@ def start(request):
         ),
         dict(
             icon=viewmodels.Icon("bankcardcheck", pgettext("image alt text", "core.icons.bankcardcheck")),
-            heading=_("eligibility.pages.start.items[1].title"),
-            details=_("eligibility.pages.start.items[1].text"),
+            heading=_("eligibility.pages.start.bankcard.title"),
+            details=_("eligibility.pages.start.bankcard.text"),
             links=[
                 viewmodels.Button.link(
                     classes="btn-text btn-link",
-                    text=_("eligibility.pages.start.items[1].button[0].link"),
-                    url=_("eligibility.pages.start.items[1].button[0].url"),
+                    text=_("eligibility.pages.start.bankcard.button[0].link"),
+                    url=_("eligibility.pages.start.bankcard.button[0].url"),
                 ),
                 viewmodels.Button.link(
                     classes="btn-text btn-link",
-                    text=_("eligibility.pages.start.items[1].button[1].link"),
-                    url=_("eligibility.pages.start.items[1].button[1].url"),
+                    text=_("eligibility.pages.start.bankcard.button[1].link"),
+                    url=_("eligibility.pages.start.bankcard.button[1].url"),
                 ),
             ],
         ),
@@ -97,13 +97,13 @@ def start(request):
             0,
             dict(
                 icon=viewmodels.Icon("idscreencheck", pgettext("image alt text", "core.icons.idscreencheck")),
-                heading=_("eligibility.media.heading"),
-                details=_("eligibility.media.details"),
+                heading=_("eligibility.pages.start.oauth.heading"),
+                details=_("eligibility.pages.start.oauth.details"),
                 links=[
                     viewmodels.Button.link(
                         classes="btn-text btn-link",
-                        text=_("eligibility.media.link_text"),
-                        url=_("eligibility.media.link_url"),
+                        text=_("eligibility.pages.start.oauth.link_text"),
+                        url=_("eligibility.pages.start.oauth.link_url"),
                         target="_blank",
                         rel="noopener noreferrer",
                     )

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -64,6 +64,8 @@ def start(request):
     verifier = session.verifier(request)
 
     button = viewmodels.Button.primary(text=_("eligibility.buttons.continue"), url=reverse("eligibility:confirm"))
+
+    payment_options_link = f"{reverse('core:help')}#payment-options"
     media = [
         dict(
             icon=viewmodels.Icon("idcardcheck", pgettext("image alt text", "core.icons.idcardcheck")),
@@ -78,12 +80,12 @@ def start(request):
                 viewmodels.Button.link(
                     classes="btn-text btn-link",
                     text=_("eligibility.pages.start.bankcard.button[0].link"),
-                    url=_("eligibility.pages.start.bankcard.button[0].url"),
+                    url=payment_options_link,
                 ),
                 viewmodels.Button.link(
                     classes="btn-text btn-link",
                     text=_("eligibility.pages.start.bankcard.button[1].link"),
-                    url=_("eligibility.pages.start.bankcard.button[1].url"),
+                    url=payment_options_link,
                 ),
             ],
         ),
@@ -92,6 +94,8 @@ def start(request):
     if verifier.requires_authentication:
         if settings.OAUTH_CLIENT_NAME is None:
             raise Exception("EligibilityVerifier requires authentication, but OAUTH_CLIENT_NAME is None")
+
+        oauth_help_link = f"{reverse('core:help')}#login-gov"
 
         media.insert(
             0,
@@ -103,7 +107,7 @@ def start(request):
                     viewmodels.Button.link(
                         classes="btn-text btn-link",
                         text=_("eligibility.pages.start.oauth.link_text"),
-                        url=_("eligibility.pages.start.oauth.link_url"),
+                        url=oauth_help_link,
                         rel="noopener noreferrer",
                     )
                 ],

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -366,7 +366,7 @@ msgid "eligibility.pages.start.oauth.link_text"
 msgstr "Learn more about Login.gov"
 
 msgid "eligibility.pages.start.oauth.link_url"
-msgstr "https://login.gov/"
+msgstr "/help#login-gov"
 
 #: benefits/eligibility/views.py:80
 msgid "eligibility.buttons.signin"

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -343,14 +343,8 @@ msgstr "Must be a contactless debit or credit card issued by Visa or Mastercard.
 msgid "eligibility.pages.start.bankcard.button[0].link"
 msgstr "Don’t have a bank card?"
 
-msgid "eligibility.pages.start.bankcard.button[0].url"
-msgstr "/help#payment-options"
-
 msgid "eligibility.pages.start.bankcard.button[1].link"
 msgstr "Unsure if you have a contactless card?"
-
-msgid "eligibility.pages.start.bankcard.button[1].url"
-msgstr "/help#payment-options"
 
 #: benefits/eligibility/views.py:80
 msgid "eligibility.buttons.continue"
@@ -364,9 +358,6 @@ msgstr "You will be able to create an account if you’re not already signed up.
 
 msgid "eligibility.pages.start.oauth.link_text"
 msgstr "Learn more about Login.gov"
-
-msgid "eligibility.pages.start.oauth.link_url"
-msgstr "/help#login-gov"
 
 #: benefits/eligibility/views.py:80
 msgid "eligibility.buttons.signin"

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -333,39 +333,39 @@ msgid "core.icons.idscreencheck"
 msgstr "Computer monitor with checkmark"
 
 #: benefits/eligibility/views.py:74
-msgid "eligibility.pages.start.items[1].title"
+msgid "eligibility.pages.start.bankcard.title"
 msgstr "Provide your bank card details"
 
 #: benefits/eligibility/views.py:75
-msgid "eligibility.pages.start.items[1].text"
+msgid "eligibility.pages.start.bankcard.text"
 msgstr "Must be a contactless debit or credit card issued by Visa or Mastercard."
 
-msgid "eligibility.pages.start.items[1].button[0].link"
+msgid "eligibility.pages.start.bankcard.button[0].link"
 msgstr "Don’t have a bank card?"
 
-msgid "eligibility.pages.start.items[1].button[0].url"
+msgid "eligibility.pages.start.bankcard.button[0].url"
 msgstr "/help#payment-options"
 
-msgid "eligibility.pages.start.items[1].button[1].link"
+msgid "eligibility.pages.start.bankcard.button[1].link"
 msgstr "Unsure if you have a contactless card?"
 
-msgid "eligibility.pages.start.items[1].button[1].url"
+msgid "eligibility.pages.start.bankcard.button[1].url"
 msgstr "/help#payment-options"
 
 #: benefits/eligibility/views.py:80
 msgid "eligibility.buttons.continue"
 msgstr "Continue"
 
-msgid "eligibility.media.heading"
+msgid "eligibility.pages.start.oauth.heading"
 msgstr "Sign in to your Login.gov account"
 
-msgid "eligibility.media.details"
+msgid "eligibility.pages.start.oauth.details"
 msgstr "You will be able to create an account if you’re not already signed up."
 
-msgid "eligibility.media.link_text"
+msgid "eligibility.pages.start.oauth.link_text"
 msgstr "Learn more about Login.gov"
 
-msgid "eligibility.media.link_url"
+msgid "eligibility.pages.start.oauth.link_url"
 msgstr "https://login.gov/"
 
 #: benefits/eligibility/views.py:80

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -346,14 +346,8 @@ msgstr "TODO: Una tarjeta de débito o crédito"
 msgid "eligibility.pages.start.bankcard.button[0].link"
 msgstr "TODO: Don’t have a bank card?"
 
-msgid "eligibility.pages.start.bankcard.button[0].url"
-msgstr "TODO: /help#payment-options"
-
 msgid "eligibility.pages.start.bankcard.button[1].link"
 msgstr "TODO: Unsure if you have a contactless card?"
-
-msgid "eligibility.pages.start.bankcard.button[1].url"
-msgstr "TODO: /help#payment-options"
 
 #: benefits/eligibility/views.py:80
 msgid "eligibility.buttons.continue"
@@ -367,9 +361,6 @@ msgstr "TODO: You will be able to create an account if you’re not already sign
 
 msgid "eligibility.pages.start.oauth.link_text"
 msgstr "TODO: Learn more about Login.gov"
-
-msgid "eligibility.pages.start.oauth.link_url"
-msgstr "/help#login-gov"
 
 #: benefits/eligibility/views.py:80
 msgid "eligibility.buttons.signin"

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -336,39 +336,39 @@ msgid "core.icons.idscreencheck"
 msgstr "TODO: Computer monitor with checkmark"
 
 #: benefits/eligibility/views.py:74
-msgid "eligibility.pages.start.items[1].title"
+msgid "eligibility.pages.start.bankcard.title"
 msgstr "TODO: Tu tarjeta bancaria"
 
 #: benefits/eligibility/views.py:75
-msgid "eligibility.pages.start.items[1].text"
+msgid "eligibility.pages.start.bankcard.text"
 msgstr "TODO: Una tarjeta de débito o crédito"
 
-msgid "eligibility.pages.start.items[1].button[0].link"
+msgid "eligibility.pages.start.bankcard.button[0].link"
 msgstr "TODO: Don’t have a bank card?"
 
-msgid "eligibility.pages.start.items[1].button[0].url"
+msgid "eligibility.pages.start.bankcard.button[0].url"
 msgstr "TODO: /help#payment-options"
 
-msgid "eligibility.pages.start.items[1].button[1].link"
+msgid "eligibility.pages.start.bankcard.button[1].link"
 msgstr "TODO: Unsure if you have a contactless card?"
 
-msgid "eligibility.pages.start.items[1].button[1].url"
+msgid "eligibility.pages.start.bankcard.button[1].url"
 msgstr "TODO: /help#payment-options"
 
 #: benefits/eligibility/views.py:80
 msgid "eligibility.buttons.continue"
 msgstr "Continuar"
 
-msgid "eligibility.media.heading"
+msgid "eligibility.pages.start.oauth.heading"
 msgstr "TODO: Sign in to your Login.gov account"
 
-msgid "eligibility.media.details"
+msgid "eligibility.pages.start.oauth.details"
 msgstr "TODO: You will be able to create an account if you’re not already signed up."
 
-msgid "eligibility.media.link_text"
+msgid "eligibility.pages.start.oauth.link_text"
 msgstr "TODO: Learn more about Login.gov"
 
-msgid "eligibility.media.link_url"
+msgid "eligibility.pages.start.oauth.link_url"
 msgstr "https://login.gov/es/"
 
 #: benefits/eligibility/views.py:80

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -369,7 +369,7 @@ msgid "eligibility.pages.start.oauth.link_text"
 msgstr "TODO: Learn more about Login.gov"
 
 msgid "eligibility.pages.start.oauth.link_url"
-msgstr "https://login.gov/es/"
+msgstr "/help#login-gov"
 
 #: benefits/eligibility/views.py:80
 msgid "eligibility.buttons.signin"


### PR DESCRIPTION
Fixes #506 

### Summary
The main fix needed was to change the URL. I also noticed the code wasn't using `reverse()` to get the URLs for the Eligibility Start page, so I went ahead and did that small refactor.