### PR TITLE
Fix: ensure docs are republished for code changes

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -5,7 +5,9 @@ on:
     branches:
       - dev
     paths:
+      - 'benefits/**'
       - 'docs/**'
+      - 'tests/pytest/**'
       - 'mkdocs.yml'
       - '.github/workflows/mkdocs.yml'
 


### PR DESCRIPTION
The `coverage` report may change when the docs themselves do not, see e.g. the recent merge for #470.

* The `pytest` workflow ran (regenerating the coverage report): https://github.com/cal-itp/benefits/actions/runs/2235886669
* But `mkdocs` didn't run because the docs weren't updated, latest run is here: https://github.com/cal-itp/benefits/actions/runs/2235620027

This PR ensures the `mkdocs` workflow runs for all code/test changes, to ensure the latest `coverage` report is always picked up.