### PR TITLE
fix(css): right-align continue button on eligibility start

### DIFF
--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -302,6 +302,11 @@ footer .footer-links a {
   justify-content: right;
 }
 
+.eligibility-start .container.content .buttons .btn {
+  margin-left: initial;
+  margin-right: initial;
+}
+
 .eligibility-start .container.content .buttons label {
   margin: 0 0.8rem 0 0;
   line-height: 1;


### PR DESCRIPTION
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/165822353-e4a58df3-5b24-4ebd-a3b5-dbe55b5b25b6.png">


<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/165822411-d6061a3f-dadb-44c4-aaac-d6d66a7e0576.png">

closes #511 

## How to test this PR
- Check Eligibility Start page in MST Courtesy Cardholder flow
- Check Eligibility Start page in Senior Discount flow by going through Login.gov, entering an invalid/unverified credential, clicking Try Again and going _back_ to Eligibility Start _after_ already being logged in to Login.gov