### PR TITLE
Fix: mkdocs runs after Pytest

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -1,13 +1,18 @@
 name: Publish docs
 on:
   workflow_dispatch:
+  workflow_run:
+    workflows:
+      - Pytest
+    types:
+      - completed
+    branches:
+      - dev
   push:
     branches:
       - dev
     paths:
-      - 'benefits/**'
       - 'docs/**'
-      - 'tests/pytest/**'
       - 'mkdocs.yml'
       - '.github/workflows/mkdocs.yml'
 
@@ -15,6 +20,7 @@ jobs:
   docs:
     name: Publish docs
     runs-on: ubuntu-latest
+    if: github.event.workflow_run == null || github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Following on to #500 and #509, trying to publish the latest `coverage` report to our docs site.

#509 introduced what amounted to a race condition between the `mkdocs` and `pytest` workflows - if `pytest` took too long, `mkdocs` would run and deploy before the `coverage` report was updated.

This PR makes the relationship explicit: `mkdocs` now runs after `pytest` has run and is successful, in addition to running in response to real docs updates.

Read more about triggering with `workflow_run`: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run