### PR TITLE
Feat: sign out link

### DIFF
--- a/benefits/core/context_processors.py
+++ b/benefits/core/context_processors.py
@@ -2,6 +2,7 @@
 The core application: context processors for enriching request context data.
 """
 from django.conf import settings
+from django.urls import reverse
 
 from . import session
 
@@ -9,6 +10,38 @@ from . import session
 def analytics(request):
     """Context processor adds some analytics information to request context."""
     return {"analytics": {"api_key": settings.ANALYTICS_KEY, "uid": session.uid(request), "did": session.did(request)}}
+
+
+def authentication(request):
+    """Context processor adds authentication information to request context."""
+    verifier = session.verifier(request)
+
+    if verifier:
+        return {
+            "authentication": {
+                "required": verifier.requires_authentication,
+                "logged_in": session.logged_in(request),
+                "sign_out_route": reverse("oauth:logout"),
+            }
+        }
+    else:
+        return {}
+
+
+def auth_provider(request):
+    """Context processor adds auth_provider information to request context."""
+    verifier = session.verifier(request)
+
+    if verifier and verifier.requires_authentication:
+        auth_provider = verifier.auth_provider
+        return {
+            "auth_provider": {
+                "sign_in_button_label": auth_provider.sign_in_button_label,
+                "sign_out_button_label": auth_provider.sign_out_button_label,
+            }
+        }
+    else:
+        return {}
 
 
 def debug(request):

--- a/benefits/core/context_processors.py
+++ b/benefits/core/context_processors.py
@@ -17,29 +17,18 @@ def authentication(request):
     verifier = session.verifier(request)
 
     if verifier:
-        return {
-            "authentication": {
-                "required": verifier.requires_authentication,
-                "logged_in": session.logged_in(request),
-                "sign_out_route": reverse("oauth:logout"),
-            }
+        data = {
+            "required": verifier.requires_authentication,
+            "logged_in": session.logged_in(request),
+            "sign_out_route": reverse("oauth:logout"),
         }
-    else:
-        return {}
 
+        if verifier.requires_authentication:
+            auth_provider = verifier.auth_provider
+            data["sign_in_button_label"] = auth_provider.sign_in_button_label
+            data["sign_out_button_label"] = auth_provider.sign_out_button_label
 
-def auth_provider(request):
-    """Context processor adds auth_provider information to request context."""
-    verifier = session.verifier(request)
-
-    if verifier and verifier.requires_authentication:
-        auth_provider = verifier.auth_provider
-        return {
-            "auth_provider": {
-                "sign_in_button_label": auth_provider.sign_in_button_label,
-                "sign_out_button_label": auth_provider.sign_out_button_label,
-            }
-        }
+        return {"authentication": data}
     else:
         return {}
 

--- a/benefits/core/templates/core/includes/sign-out-link.html
+++ b/benefits/core/templates/core/includes/sign-out-link.html
@@ -2,6 +2,10 @@
 
 {% if authentication %}
     {% if authentication.required and authentication.logged_in %}
-    <a href="{{ authentication.sign_out_route }}">{% translate auth_provider.sign_out_button_label %}</a>
+        <div class="signout-row">
+            <div class="container">
+                <a class="signout-link" href="{{ authentication.sign_out_route }}">{% translate auth_provider.sign_out_button_label %}</a>
+            </div>
+        </div>
     {% endif %}
 {% endif %}

--- a/benefits/core/templates/core/includes/sign-out-link.html
+++ b/benefits/core/templates/core/includes/sign-out-link.html
@@ -4,7 +4,7 @@
     {% if authentication.required and authentication.logged_in %}
         <div class="signout-row">
             <div class="container">
-                <a class="signout-link" href="{{ authentication.sign_out_route }}">{% translate auth_provider.sign_out_button_label %}</a>
+                <a class="signout-link" href="{{ authentication.sign_out_route }}">{% translate authentication.sign_out_button_label %}</a>
             </div>
         </div>
     {% endif %}

--- a/benefits/core/templates/core/includes/sign-out-link.html
+++ b/benefits/core/templates/core/includes/sign-out-link.html
@@ -1,0 +1,7 @@
+{% load i18n %}
+
+{% if authentication %}
+    {% if authentication.required and authentication.logged_in %}
+    <a href="{{ authentication.sign_out_route }}">{% translate auth_provider.sign_out_button_label %}</a>
+    {% endif %}
+{% endif %}

--- a/benefits/eligibility/templates/eligibility/confirm.html
+++ b/benefits/eligibility/templates/eligibility/confirm.html
@@ -1,1 +1,9 @@
 {% extends "core/page.html" %}
+
+{% block container_content %}
+
+    {% include "core/includes/sign-out-link.html" %}
+
+    {{ block.super }}
+
+{% endblock %}

--- a/benefits/eligibility/templates/eligibility/confirm.html
+++ b/benefits/eligibility/templates/eligibility/confirm.html
@@ -1,0 +1,1 @@
+{% extends "core/page.html" %}

--- a/benefits/eligibility/templates/eligibility/confirm.html
+++ b/benefits/eligibility/templates/eligibility/confirm.html
@@ -1,9 +1,6 @@
 {% extends "core/page.html" %}
 
-{% block container_content %}
-
+{% block main_content %}
     {% include "core/includes/sign-out-link.html" %}
-
     {{ block.super }}
-
 {% endblock %}

--- a/benefits/eligibility/templates/eligibility/unverified.html
+++ b/benefits/eligibility/templates/eligibility/unverified.html
@@ -1,1 +1,9 @@
 {% extends "core/page.html" %}
+
+{% block container_content %}
+
+    {% include "core/includes/sign-out-link.html" %}
+
+    {{ block.super }}
+
+{% endblock %}

--- a/benefits/eligibility/templates/eligibility/unverified.html
+++ b/benefits/eligibility/templates/eligibility/unverified.html
@@ -1,0 +1,1 @@
+{% extends "core/page.html" %}

--- a/benefits/eligibility/templates/eligibility/unverified.html
+++ b/benefits/eligibility/templates/eligibility/unverified.html
@@ -1,9 +1,6 @@
 {% extends "core/page.html" %}
 
-{% block container_content %}
-
+{% block main_content %}
     {% include "core/includes/sign-out-link.html" %}
-
     {{ block.super }}
-
 {% endblock %}

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -167,7 +167,7 @@ def confirm(request):
         eligibility = session.eligibility(request)
         response = verified(request, [eligibility.name])
     else:
-        response = PageTemplateResponse(request, page)
+        response = TemplateResponse(request, "eligibility/confirm.html", page.context_dict())
 
     return response
 
@@ -233,4 +233,4 @@ def unverified(request):
         buttons=buttons,
     )
 
-    return PageTemplateResponse(request, page)
+    return TemplateResponse(request, "eligibility/unverified.html", page.context_dict())

--- a/benefits/enrollment/templates/enrollment/index.html
+++ b/benefits/enrollment/templates/enrollment/index.html
@@ -1,5 +1,10 @@
 {% extends "core/page.html" %}
 
+{% block icon_title %}
+{% include "core/includes/sign-out-link.html" %}
+{{ block.super }}
+{% endblock%}
+
 {% block paragraph_content %}
 {{ block.super }}
 {% if payment_processor %}

--- a/benefits/enrollment/templates/enrollment/index.html
+++ b/benefits/enrollment/templates/enrollment/index.html
@@ -1,8 +1,12 @@
 {% extends "core/page.html" %}
 
+{% block main_content %}
+    {% include "core/includes/sign-out-link.html" %}
+    {{ block.super }}
+{% endblock %}
+
 {% block icon_title %}
-{% include "core/includes/sign-out-link.html" %}
-{{ block.super }}
+    {{ block.super }}
 {% endblock%}
 
 {% block paragraph_content %}

--- a/benefits/enrollment/templates/enrollment/retry.html
+++ b/benefits/enrollment/templates/enrollment/retry.html
@@ -1,1 +1,9 @@
 {% extends "core/page.html" %}
+
+{% block container_content %}
+
+    {% include "core/includes/sign-out-link.html" %}
+
+    {{ block.super }}
+
+{% endblock %}

--- a/benefits/enrollment/templates/enrollment/retry.html
+++ b/benefits/enrollment/templates/enrollment/retry.html
@@ -1,0 +1,1 @@
+{% extends "core/page.html" %}

--- a/benefits/enrollment/templates/enrollment/retry.html
+++ b/benefits/enrollment/templates/enrollment/retry.html
@@ -1,9 +1,6 @@
 {% extends "core/page.html" %}
 
-{% block container_content %}
-
+{% block main_content %}
     {% include "core/includes/sign-out-link.html" %}
-
     {{ block.super }}
-
 {% endblock %}

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -12,7 +12,6 @@ from django.utils.translation import pgettext, gettext as _
 
 from benefits.core import models, session, viewmodels
 from benefits.core.middleware import EligibleSessionRequired, VerifierSessionRequired, pageview_decorator
-from benefits.core.views import PageTemplateResponse
 from . import api, forms
 
 
@@ -136,7 +135,7 @@ def retry(request):
                 buttons=viewmodels.Button.agency_contact_links(agency),
             )
             page.buttons.append(viewmodels.Button.primary(text=_("enrollment.buttons.retry"), url=session.origin(request)))
-            return PageTemplateResponse(request, page)
+            return TemplateResponse(request, "enrollment/retry.html", page.context_dict())
         else:
             raise Exception("Invalid retry submission.")
     else:

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -105,7 +105,6 @@ template_ctx_processors = [
     "django.contrib.messages.context_processors.messages",
     "benefits.core.context_processors.analytics",
     "benefits.core.context_processors.authentication",
-    "benefits.core.context_processors.auth_provider",
     "benefits.core.context_processors.recaptcha",
 ]
 

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -104,6 +104,8 @@ template_ctx_processors = [
     "django.template.context_processors.request",
     "django.contrib.messages.context_processors.messages",
     "benefits.core.context_processors.analytics",
+    "benefits.core.context_processors.authentication",
+    "benefits.core.context_processors.auth_provider",
     "benefits.core.context_processors.recaptcha",
 ]
 

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -96,6 +96,8 @@ footer .footer-links a {
   border-width: 2px;
 }
 
+/* Log In */
+
 #login {
   background: #046b99;
   border: 0;
@@ -127,6 +129,28 @@ footer .footer-links a {
 
 .fallback-text {
   color: transparent;
+}
+
+/* Sign Out */
+
+.signout-row {
+  position: absolute;
+  width: 100%;
+  z-index: 100;
+}
+
+.signout-row .container {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.signout-row .container .signout-link {
+  font-size: 12px;
+  text-decoration: underline;
+  color: #2b6597;
+  letter-spacing: 0.05rem;
+  padding-top: 18px;
+  display: block;
 }
 
 .btn-link {
@@ -620,7 +644,7 @@ footer .footer-links a {
   .container.content {
     padding-left: 5rem;
     padding-right: 5rem;
-    padding-top: 2rem;
+    padding-top: 4.5rem;
     padding-bottom: 2rem;
     margin: 0;
   }


### PR DESCRIPTION
Closes #428 

### Summary
 - Adds new context processors
    - `authentication`: Adds information about authentication requirement and status to context for use in templates
    - `auth_provider`: Adds information about auth_provider to context
 - Adds a new includes `sign-out-link.html` that shows only if authentication is required and user is signed in
 - Adds usage to the pages that need it
    - `eligibility:confirm`
    - `eligibility` unverified
    - `enrollment:index`
    - `enrollment:retry`