### PR TITLE
fix(copy): update copy on eligibility start

### DIFF
--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -475,7 +475,7 @@ msgid "eligibility.pages.start.dmv.items[0].title"
 msgstr "Provide your California ID number"
 
 msgid "eligibility.pages.start.dmv.items[0].text"
-msgstr "You will need to verify your age with a driver’s license or ID card"
+msgstr "You will need to verify your age with a driver’s license or ID card."
 
 msgid "eligibility.pages.confirm.dmv.p[0]"
 msgstr ""

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -469,7 +469,7 @@ msgid "eligibility.pages.index.mst.description"
 msgstr "(includes MST RIDES Paratransit Eligibility cardholders)"
 
 msgid "eligibility.pages.confirm.dmv.content_title"
-msgstr "Let’s see if we can confirm your age with the DMV"
+msgstr "Let’s see if we can confirm your age with the DMV."
 
 msgid "eligibility.pages.start.dmv.items[0].title"
 msgstr "Provide your California ID number"
@@ -479,8 +479,7 @@ msgstr "You will need to verify your age with a driver’s license or ID card"
 
 msgid "eligibility.pages.confirm.dmv.p[0]"
 msgstr ""
-"If you’re 65 or older, we can confirm you are eligible for a senior "
-"discount when you ride transit. We don’t save your information."
+"Please enter your license/ID number and last name below. If you’re 65 or older, we can confirm that you are eligible for a senior discount when you ride transit. We do not save the information you enter here."
 
 msgid "eligibility.forms.confirm.dmv.fields.sub"
 msgstr "CA driver’s license or ID number"
@@ -498,7 +497,7 @@ msgstr ""
 "discount programs."
 
 msgid "eligibility.pages.confirm.dmv.title"
-msgstr "Confirm your age"
+msgstr "Confirm Eligibility"
 
 msgid "eligibility.pages.unverified.dmv.p[0]"
 msgstr ""

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -316,7 +316,7 @@ msgstr "Select the discount option that best applies to you:"
 
 #: benefits/eligibility/views.py:64
 msgid "eligibility.pages.start.title"
-msgstr "Getting started"
+msgstr "Get Started"
 
 #: benefits/eligibility/views.py:68 benefits/enrollment/views.py:31
 msgctxt "image alt text"
@@ -351,10 +351,10 @@ msgid "eligibility.buttons.continue"
 msgstr "Continue"
 
 msgid "eligibility.pages.start.oauth.heading"
-msgstr "Sign in to your Login.gov account"
+msgstr "Sign in to Login.gov"
 
 msgid "eligibility.pages.start.oauth.details"
-msgstr "You will be able to create an account if you’re not already signed up."
+msgstr "Login.gov is a safe way to sign in to government services."
 
 msgid "eligibility.pages.start.oauth.link_text"
 msgstr "Learn more about Login.gov"
@@ -475,7 +475,7 @@ msgid "eligibility.pages.start.dmv.items[0].title"
 msgstr "Provide your California ID number"
 
 msgid "eligibility.pages.start.dmv.items[0].text"
-msgstr "You will verify your age with a driver’s license or ID card"
+msgstr "You will need to verify your age with a driver license or ID card"
 
 msgid "eligibility.pages.confirm.dmv.p[0]"
 msgstr ""
@@ -489,7 +489,7 @@ msgid "eligibility.forms.confirm.dmv.fields.name"
 msgstr "Last name (as it appears on ID)"
 
 msgid "eligibility.pages.start.dmv.content_title"
-msgstr "Great, you’ll need to do three things to link your transit discount to your bank card."
+msgstr "There are three steps to link your transit discount to your bank card."
 
 msgid "eligibility.pages.start.dmv.p[0]"
 msgstr ""

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -475,7 +475,7 @@ msgid "eligibility.pages.start.dmv.items[0].title"
 msgstr "Provide your California ID number"
 
 msgid "eligibility.pages.start.dmv.items[0].text"
-msgstr "You will need to verify your age with a driver license or ID card"
+msgstr "You will need to verify your age with a driver’s license or ID card"
 
 msgid "eligibility.pages.confirm.dmv.p[0]"
 msgstr ""

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -318,7 +318,7 @@ msgstr "TODO"
 
 #: benefits/eligibility/views.py:64
 msgid "eligibility.pages.start.title"
-msgstr "Preparación"
+msgstr "TODO: Preparación"
 
 #: benefits/eligibility/views.py:68 benefits/enrollment/views.py:31
 msgctxt "image alt text"
@@ -354,10 +354,10 @@ msgid "eligibility.buttons.continue"
 msgstr "Continuar"
 
 msgid "eligibility.pages.start.oauth.heading"
-msgstr "TODO: Sign in to your Login.gov account"
+msgstr "TODO: Sign in to Login.gov"
 
 msgid "eligibility.pages.start.oauth.details"
-msgstr "TODO: You will be able to create an account if you’re not already signed up."
+msgstr "TODO: Login.gov is a safe way to sign in to government services."
 
 msgid "eligibility.pages.start.oauth.link_text"
 msgstr "TODO: Learn more about Login.gov"
@@ -476,22 +476,20 @@ msgid "eligibility.pages.index.mst.description"
 msgstr "TODO: (includes MST RIDES Paratransit Eligibility cardholders)"
 
 msgid "eligibility.pages.confirm.dmv.content_title"
-msgstr "Veamos si podemos verificar su edad con el DMV"
+msgstr "Let’s see if we can confirm your age with the DMV."
 
 msgid "eligibility.pages.start.dmv.items[0].title"
 msgstr "Tu identificación de California"
 
 msgid "eligibility.pages.start.dmv.items[0].text"
-msgstr "Licencia de conducir o tarjeta de identificación"
+msgstr "TODO: You will need to verify your age with a driver’s license or ID card."
 
 msgid "eligibility.pages.confirm.dmv.p[0]"
 msgstr ""
-"Si tiene 65 años o más, podemos confirmar que es elegible para un "
-"descuento para personas mayores cuando viaja en transporte público. "
-"Nosotros no guardamos su información."
+"TODO: Please enter your license/ID number and last name below. If you’re 65 or older, we can confirm that you are eligible for a senior discount when you ride transit. We do not save the information you enter here."
 
 msgid "eligibility.pages.start.dmv.content_title"
-msgstr "TODO: Genial, necesitarás tres cosas antes de comenzar..."
+msgstr "TODO: There are three steps to link your transit discount to your bank card."
 
 msgid "eligibility.forms.confirm.dmv.fields.sub"
 msgstr "Licencia de conducir de CA o número de identificación"
@@ -507,7 +505,7 @@ msgstr ""
 "descuento disponibles."
 
 msgid "eligibility.pages.confirm.dmv.title"
-msgstr "Verificar su edad"
+msgstr "TODO: Confirm Eligibility"
 
 msgid "eligibility.pages.unverified.dmv.p[0]"
 msgstr ""

--- a/tests/cypress/specs/ui/eligibility-auth.spec.js
+++ b/tests/cypress/specs/ui/eligibility-auth.spec.js
@@ -27,9 +27,7 @@ describe("Multiple verifier, with AuthProvider: Eligibility start page spec", ()
 
   it("Has the correct copy for Authorization instructions", () => {
     cy.get(".media-list").contains("Sign in to Login.gov");
-    cy.contains(
-      "You will be able to create an account if you’re not already signed up."
-    );
+    cy.contains("Login.gov is a safe way to sign in to government services.");
     cy.contains("Learn more about Login.gov");
   });
 

--- a/tests/cypress/specs/ui/eligibility-auth.spec.js
+++ b/tests/cypress/specs/ui/eligibility-auth.spec.js
@@ -19,14 +19,14 @@ describe("Multiple verifier, with AuthProvider: Eligibility start page spec", ()
 
   it("Has the correct copy for Senior Discount Program instructions", () => {
     cy.contains(
-      "Great, you’ll need to do three things to link your transit discount to your bank card."
+      "There are three steps to link your transit discount to your bank card."
     );
     cy.contains("Provide your California ID number");
     cy.get(".media-list").children().should("have.length", 3);
   });
 
   it("Has the correct copy for Authorization instructions", () => {
-    cy.get(".media-list").contains("Sign in to your Login.gov account");
+    cy.get(".media-list").contains("Sign in to Login.gov");
     cy.contains(
       "You will be able to create an account if you’re not already signed up."
     );


### PR DESCRIPTION
closes part of #522 

## `eligibility:start`

* [x] Page title to: `Get Started`
* [x] Main heading: `There are three steps to link your transit discount to your bank card.`
* [x] Item 1
  * [x] Label: `1. Sign in to Login.gov`
  * [x] Body: `Login.gov is a safe way to sign in to government services.`
* [x] Item 2:
  * [x] Body: `You will need to verify your age with a driver’s license or ID card.`

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/166058375-bd3ccf1a-758c-464a-a097-d8515b060369.png">
<img width="444" alt="image" src="https://user-images.githubusercontent.com/3673236/166058398-da56bec1-faf7-442d-a404-63c1725f3b4f.png">

## `eligibility:confirm`

* [x] Page title to: Confirm Eligibility
* [x] Main heading: Let’s see if we can confirm your age with the DMV.
* [x] [Body paragraph](https://docs.google.com/document/d/1xSznvvHuhOdtXUuOq1QNMseyfry3PD5oVSvokI9a-E4/edit#bookmark=id.94514dyrbb8g)
* I did not change the driver license 

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/166059424-bbd1152a-ab0d-4dee-b84d-8da241d24ad2.png">
