### PR TITLE
Fix/copy: Enrollment Index & Success

### DIFF
--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -159,7 +159,7 @@ def success(request):
             page = viewmodels.Page(
                 title=_("enrollment.pages.success.title"),
                 icon=viewmodels.Icon("bankcardcheck", pgettext("image alt text", "core.icons.bankcardcheck")),
-                content_title=_("enrollment.pages.success.title"),
+                content_title=_("enrollment.pages.success.content_title"),
                 button=button,
                 classes="logged-in",
             )
@@ -172,8 +172,8 @@ def success(request):
     else:
         page = viewmodels.Page(
             title=_("enrollment.pages.success.title"),
+            content_title=_("enrollment.pages.success.content_title"),
             icon=viewmodels.Icon("bankcardcheck", pgettext("image alt text", "core.icons.bankcardcheck")),
-            content_title=_("enrollment.pages.success.title"),
         )
 
     help_link = reverse("core:help")

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -26,20 +26,16 @@ def _index(request):
     tokenize_retry_form = forms.CardTokenizeFailForm("enrollment:retry")
     tokenize_success_form = forms.CardTokenizeSuccessForm(auto_id=True, label_suffix="")
 
-    help_page = reverse("core:help")
     page = viewmodels.Page(
         title=_("enrollment.pages.index.title"),
         content_title=_("enrollment.pages.index.content_title"),
         icon=viewmodels.Icon("idcardcheck", pgettext("image alt text", "core.icons.idcardcheck")),
-        paragraphs=[_("enrollment.pages.index.p[0]"), _("enrollment.pages.index.p[1]")],
+        paragraphs=[_("enrollment.pages.index.p[0]"), _("enrollment.pages.index.p[1]"), _("enrollment.pages.index.p[2]")],
         classes="text-lg-center",
         forms=[tokenize_retry_form, tokenize_success_form],
         buttons=[
             viewmodels.Button.primary(
                 text=_("enrollment.buttons.payment_partner"), id=tokenize_button, url=f"#{tokenize_button}"
-            ),
-            viewmodels.Button.link(
-                classes="btn-sm", text=_("enrollment.buttons.payment_options"), url=f"{help_page}#payment-options"
             ),
         ],
     )

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -391,7 +391,7 @@ msgstr "Tapping bank card on the bus reader"
 
 #: benefits/enrollment/views.py:29
 msgid "enrollment.pages.index.title"
-msgstr "Eligibility Confirmed!"
+msgstr "Connect card"
 
 #: benefits/enrollment/views.py:30
 msgid "enrollment.pages.index.content_title"
@@ -400,17 +400,18 @@ msgstr "Great! You’re eligible for a discount!"
 #: benefits/enrollment/views.py:32
 msgid "enrollment.pages.index.p[0]"
 msgstr ""
-"Next, we need to attach your discount to your bank card. We don’t store your "
-"information, and you won’t be charged. When you use this card to pay for "
-"transit, you will always receive your discount."
+"Next, we need to link your discount to your bank-issued card through our payment partner LittlePay."
 
 #: benefits/enrollment/views.py:32
 msgid "enrollment.pages.index.p[1]"
-msgstr "Use a bank-issued credit or debit card."
+msgstr "We don’t store your information, and you won’t be charged. When you use this card to pay for transit, you will always receive your discount."
+
+msgid "enrollment.pages.index.p[2]"
+msgstr "Please use a bank-issued contactless Visa or Mastercard credit or debit card."
 
 #: benefits/enrollment/views.py:37
 msgid "enrollment.buttons.payment_partner"
-msgstr "Continue to our payment partner"
+msgstr "Connect Your Card"
 
 #: benefits/enrollment/views.py:40
 msgid "enrollment.buttons.payment_options"

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -400,7 +400,7 @@ msgstr "Great! You’re eligible for a discount!"
 #: benefits/enrollment/views.py:32
 msgid "enrollment.pages.index.p[0]"
 msgstr ""
-"Next, we need to link your discount to your bank-issued card through our payment partner LittlePay."
+"Next, we need to link your discount to your bank-issued card through our payment partner Littlepay."
 
 #: benefits/enrollment/views.py:32
 msgid "enrollment.pages.index.p[1]"

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -434,8 +434,11 @@ msgstr ""
 msgid "core.buttons.retry"
 msgstr "Try again"
 
-#: benefits/enrollment/views.py:147 benefits/enrollment/views.py:149
 msgid "enrollment.pages.success.title"
+msgstr "Success"
+
+#: benefits/enrollment/views.py:147 benefits/enrollment/views.py:149
+msgid "enrollment.pages.success.content_title"
 msgstr "Success! Your discount is now linked to your bank card."
 
 msgid "enrollment.pages.success.logout.title"
@@ -447,7 +450,7 @@ msgstr "You were not charged anything today."
 
 #: benefits/enrollment/views.py:150
 msgid "enrollment.pages.success.p2"
-msgstr "When boarding transit, pay with this same card, and your discount will automatically be applied to your fare purchase."
+msgstr "When boarding transit, pay with this same physical card and your discount will automatically be applied to your fare purchase."
 
 msgid "enrollment.pages.success.p3"
 msgstr "If you are on a public or shared computer, please sign out of your"
@@ -456,7 +459,7 @@ msgid "enrollment.pages.success.p4"
 msgstr "account."
 
 msgid "enrollment.pages.success.p3%(help_link)s"
-msgstr "For additional information on what to expect when using your connected bank card, please reach out to your transit provider, or check out our "
+msgstr "For more information on what to expect when using your connected bank card please reach out to your local transit provider or check out our "
 "<a href=\"%(help_link)s\" rel=\"noopener noreferrer\">help page</a>."
 
 msgid "eligibility.pages.index.dmv.label"

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -394,7 +394,7 @@ msgstr "Tocando la tarjeta bancaria para pagar"
 
 #: benefits/enrollment/views.py:29
 msgid "enrollment.pages.index.title"
-msgstr "¡Elegibilidad confirmada!"
+msgstr "TODO: ¡Elegibilidad confirmada!"
 
 #: benefits/enrollment/views.py:30
 msgid "enrollment.pages.index.content_title"
@@ -403,17 +403,20 @@ msgstr "¡Genial! ¡Eres elegible para un descuento!"
 #: benefits/enrollment/views.py:32
 msgid "enrollment.pages.index.p[0]"
 msgstr ""
-"Ahora, tenemos que vincular su descuento a su tarjeta bancaria. Nosotros no "
+"TODO: Ahora, tenemos que vincular su descuento a su tarjeta bancaria. Nosotros no "
 "guardamos su información y no se le cobrará. Cuando utilice esta tarjeta "
 "para pagar el transporte público, siempre recibirá su descuento."
 
 #: benefits/enrollment/views.py:32
 msgid "enrollment.pages.index.p[1]"
-msgstr "Use una tarjeta de crédito o débito emitida por su banco."
+msgstr "TODO: Use una tarjeta de crédito o débito emitida por su banco."
+
+msgid "enrollment.pages.index.p[2]"
+msgstr "TODO: Please use a bank-issued contactless Visa or Mastercard credit or debit card."
 
 #: benefits/enrollment/views.py:37
 msgid "enrollment.buttons.payment_partner"
-msgstr "Continúe con nuestro socio de pago"
+msgstr "TODO: Continúe con nuestro socio de pago"
 
 #: benefits/enrollment/views.py:40
 msgid "enrollment.buttons.payment_options"
@@ -456,11 +459,11 @@ msgstr "No te cobraron nada hoy."
 #: benefits/enrollment/views.py:150
 msgid "enrollment.pages.success.p2"
 msgstr ""
-"Al abordar el transporte público, pague con esta misma tarjeta física y su descuento se aplicará automáticamente a la compra de su tarifa."
+"TODO: Al abordar el transporte público, pague con esta misma tarjeta física y su descuento se aplicará automáticamente a la compra de su tarifa."
 
 msgid "enrollment.pages.success.p3%(help_link)s"
 msgstr ""
-"Para obtener información adicional sobre qué esperar al usar su tarjeta bancaria conectada, comuníquese con su proveedor de transporte público o consulte nuestra "
+"TODO: Para obtener información adicional sobre qué esperar al usar su tarjeta bancaria conectada, comuníquese con su proveedor de transporte público o consulte nuestra "
 "<a href=\"%(help_link)s\" rel=\"noopener noreferrer\">página de ayuda</a>."
 
 msgid "enrollment.pages.success.p3"

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -439,8 +439,11 @@ msgstr ""
 msgid "core.buttons.retry"
 msgstr "Inténtalo de nuevo"
 
-#: benefits/enrollment/views.py:147 benefits/enrollment/views.py:149
 msgid "enrollment.pages.success.title"
+msgstr "TODO: Success"
+
+#: benefits/enrollment/views.py:147 benefits/enrollment/views.py:149
+msgid "enrollment.pages.success.content_title"
 msgstr "Felicidades! Su descuento ahora está vinculado a su tarjeta bancaria."
 
 msgid "enrollment.pages.success.logout.title"


### PR DESCRIPTION
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/166062169-7477fdea-6ab2-4cd7-b0f6-c744990f39b9.png">
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/166062278-2a4c2113-5e70-413a-a217-6e8c67b9581d.png">

## What this PR does
- Adds a success page Title that's separate from Content Title for English and Spanish
- Removes a button link, removes variable for that link

## `enrollment:index`

* [x] Page title to: `Connect Card`
* [x] [Body paragraphs](https://docs.google.com/document/d/1xSznvvHuhOdtXUuOq1QNMseyfry3PD5oVSvokI9a-E4/edit#bookmark=id.94514dyrbb8g)
* [x] Button text: `CONNECT YOUR CARD`
* [x] Remove "What if I don't have a bank card?" link

## `enrollment:success`

* [x] Page title to: `Success`
* [x] [Body paragraphs](https://docs.google.com/document/d/1xSznvvHuhOdtXUuOq1QNMseyfry3PD5oVSvokI9a-E4/edit#bookmark=id.w3undjeu1dm2)