### PR TITLE
Fix: help copy - update Payment Options

### DIFF
--- a/benefits/core/templates/core/help.html
+++ b/benefits/core/templates/core/help.html
@@ -20,7 +20,10 @@
                 </p>
 
                 <p>{% translate "core.pages.help.payment_options.p[1]" %}</p>
-                <p>{% translate "core.pages.help.payment_options.p[2]" %}</p>
+                <p>
+                    {% blocktranslate with website="https://cash.app/help/us/en-us/14425-cal-transit" %}core.pages.help.payment_options.p[2][0]{{ website }}{% endblocktranslate %}
+                    {% blocktranslate with website="https://venmo.com/about/debitcard/" %}core.pages.help.payment_options.p[2][1]{{ website }}{% endblocktranslate %}
+                </p>
                 <p>{% translate "core.pages.help.payment_options.p[3]" %}</p>
                 <p>{% translate "core.pages.help.payment_options.p[4]" %}</p>
 

--- a/benefits/core/templates/core/help.html
+++ b/benefits/core/templates/core/help.html
@@ -22,6 +22,7 @@
                 <p>{% translate "core.pages.help.payment_options.p[1]" %}</p>
                 <p>{% translate "core.pages.help.payment_options.p[2]" %}</p>
                 <p>{% translate "core.pages.help.payment_options.p[3]" %}</p>
+                <p>{% translate "core.pages.help.payment_options.p[4]" %}</p>
 
                 <h2 id="login-gov">{% translate "core.pages.help.login_gov" %}</h2>
                 <p>{% translate "core.pages.help.login_gov.p[0]" %}</p>

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -42,13 +42,17 @@ msgstr "A contactless bank card can be a credit card or a debit card and must "
 "include a Visa or Mastercard logo."
 
 msgid "core.pages.help.payment_options.p[2]"
-msgstr "We are working to add additional options for people who do not have access "
-"to a bank card. However, you can still get your discount by going through your "
-"local transit provider's application process."
+msgstr "Don’t have access to a bank card? You can request a contactless card "
+"from one of the companies that offer free contactless prepaid debit cards, "
+"such as the Cash App Visa debit card or the Venmo Mastercard debit card."
 
 msgid "core.pages.help.payment_options.p[3]"
-msgstr "For updates on additional options, please check back on this website, or "
-"get in touch with your local transit provider."
+msgstr "You can still get your discount by going through your local transit "
+"provider’s application process."
+
+msgid "core.pages.help.payment_options.p[4]"
+msgstr "For updates on additional options, please check back on this website, "
+"or get in touch with your local transit provider."
 
 msgid "core.pages.help.login_gov"
 msgstr "What is Login.gov?"

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -41,10 +41,13 @@ msgid "core.pages.help.payment_options.p[1]"
 msgstr "A contactless bank card can be a credit card or a debit card and must "
 "include a Visa or Mastercard logo."
 
-msgid "core.pages.help.payment_options.p[2]"
+msgid "core.pages.help.payment_options.p[2][0]%(website)s"
 msgstr "Don’t have access to a bank card? You can request a contactless card "
 "from one of the companies that offer free contactless prepaid debit cards, "
-"such as the Cash App Visa debit card or the Venmo Mastercard debit card."
+"such as the <a href=\"%(website)s\" target=\"_blank\" rel=\"noopener noreferrer\">Cash App Visa Debit Card</a> "
+
+msgid "core.pages.help.payment_options.p[2][1]%(website)s"
+msgstr "or the <a href=\"%(website)s\" target=\"_blank\" rel=\"noopener noreferrer\">Venmo Mastercard Debit Card</a>."
 
 msgid "core.pages.help.payment_options.p[3]"
 msgstr "You can still get your discount by going through your local transit "

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -34,21 +34,25 @@ msgid "core.pages.help.payment_options"
 msgstr "TODO: Payment options"
 
 msgid "core.pages.help.payment_options.p[0]"
-msgstr "TODO: In order to activate your discount, you need a bank card that has the "
+msgstr "In order to activate your discount, you need a bank card that has the "
 "contactless symbol on it. The contactless symbol is four curved lines that looks like this:"
 
 msgid "core.pages.help.payment_options.p[1]"
-msgstr "TODO: A contactless bank card can be a credit card or a debit card and must "
+msgstr "A contactless bank card can be a credit card or a debit card and must "
 "include a Visa or Mastercard logo."
 
 msgid "core.pages.help.payment_options.p[2]"
-msgstr "TODO: We are working to add additional options for people who do not have access "
-"to a bank card. However, you can still get your discount by going through your "
-"local transit provider's application process."
+msgstr "Don’t have access to a bank card? You can request a contactless card "
+"from one of the companies that offer free contactless prepaid debit cards, "
+"such as the Cash App Visa debit card or the Venmo Mastercard debit card."
 
 msgid "core.pages.help.payment_options.p[3]"
-msgstr "TODO: For updates on additional options, please check back on this website, or "
-"get in touch with your local transit provider."
+msgstr "You can still get your discount by going through your local transit "
+"provider’s application process."
+
+msgid "core.pages.help.payment_options.p[4]"
+msgstr "For updates on additional options, please check back on this website, "
+"or get in touch with your local transit provider."
 
 msgid "core.pages.help.login_gov"
 msgstr "TODO: What is Login.gov?"

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -34,24 +34,27 @@ msgid "core.pages.help.payment_options"
 msgstr "TODO: Payment options"
 
 msgid "core.pages.help.payment_options.p[0]"
-msgstr "In order to activate your discount, you need a bank card that has the "
+msgstr "TODO: In order to activate your discount, you need a bank card that has the "
 "contactless symbol on it. The contactless symbol is four curved lines that looks like this:"
 
 msgid "core.pages.help.payment_options.p[1]"
-msgstr "A contactless bank card can be a credit card or a debit card and must "
+msgstr "TODO: A contactless bank card can be a credit card or a debit card and must "
 "include a Visa or Mastercard logo."
 
-msgid "core.pages.help.payment_options.p[2]"
-msgstr "Don’t have access to a bank card? You can request a contactless card "
+msgid "core.pages.help.payment_options.p[2][0]%(website)s"
+msgstr "TODO: Don’t have access to a bank card? You can request a contactless card "
 "from one of the companies that offer free contactless prepaid debit cards, "
-"such as the Cash App Visa debit card or the Venmo Mastercard debit card."
+"such as the <a href=\"%(website)s\" target=\"_blank\" rel=\"noopener noreferrer\">Cash App Visa Debit Card</a> "
+
+msgid "core.pages.help.payment_options.p[2][1]%(website)s"
+msgstr "TODO: or the <a href=\"%(website)s\" target=\"_blank\" rel=\"noopener noreferrer\">Venmo Mastercard Debit Card</a>."
 
 msgid "core.pages.help.payment_options.p[3]"
-msgstr "You can still get your discount by going through your local transit "
+msgstr "TODO: You can still get your discount by going through your local transit "
 "provider’s application process."
 
 msgid "core.pages.help.payment_options.p[4]"
-msgstr "For updates on additional options, please check back on this website, "
+msgstr "TODO: For updates on additional options, please check back on this website, "
 "or get in touch with your local transit provider."
 
 msgid "core.pages.help.login_gov"


### PR DESCRIPTION
closes part of #522

~WIP: awaiting confirmation from @vykster if we should continue to link to Cash App / Venmo~

Just going to assume this is the same as the current app. We can change later if needed.

## `core:help`

* [x] [Payment options](https://docs.google.com/document/d/1xSznvvHuhOdtXUuOq1QNMseyfry3PD5oVSvokI9a-E4/edit#bookmark=id.5wc2xvotqhss)

![image](https://user-images.githubusercontent.com/1783439/166062532-8283dbb4-fd27-410c-a188-8aeceeba34b7.png)

**EDIT**

Added the links presuming we still want this behavior:

![image](https://user-images.githubusercontent.com/1783439/166064612-a60a4d16-6a10-479a-b5a7-d5fb2c8dcc8a.png)
