### PR TITLE
Fix: help copy - update Login.gov section/links

### DIFF
--- a/benefits/core/templates/core/help.html
+++ b/benefits/core/templates/core/help.html
@@ -26,7 +26,10 @@
                 <h2 id="login-gov">{% translate "core.pages.help.login_gov" %}</h2>
                 <p>{% translate "core.pages.help.login_gov.p[0]" %}</p>
                 <p>{% translate "core.pages.help.login_gov.p[1]" %}</p>
-                <p>{% blocktranslate with website="https://login.gov"%}core.pages.help.login_gov.p[2]{{ website }}{% endblocktranslate %}</p>
+                <p>
+                    {% blocktranslate with website="https://login.gov"%}core.pages.help.login_gov.p[2][0]{{ website }}{% endblocktranslate %}
+                    {% blocktranslate with website="https://login.gov/help/"%}core.pages.help.login_gov.p[2][1]{{ website }}{% endblocktranslate %}
+                </p>
 
                 <h2 id="littlepay">{% translate "core.pages.help.littlepay" %}</h2>
                 <p>{% translate "core.pages.help.littlepay.p[0]" %}</p>

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -62,9 +62,12 @@ msgstr "Creating an account is simple. You will need an email address and method
 "authenticating your account&mdash;which will use either a landline, mobile phone, or "
 "backup codes that must be printed or written down."
 
-msgid "core.pages.help.login_gov.p[2]%(website)s"
-msgstr "For more information on Login.gov, check out "
-"<a href=\"%(website)s\" target=\"_blank\" rel=\"noopener noreferrer\">their website</a>."
+msgid "core.pages.help.login_gov.p[2][0]%(website)s"
+msgstr "To learn more about Login.gov, please visit the "
+"<a href=\"%(website)s\" target=\"_blank\" rel=\"noopener noreferrer\">Login.gov website</a> "
+
+msgid "core.pages.help.login_gov.p[2][1]%(website)s"
+msgstr "or the <a href=\"%(website)s\" target=\"_blank\" rel=\"noopener noreferrer\">Login.gov Help Center</a>."
 
 msgid "core.pages.help.littlepay"
 msgstr "What is Littlepay?"

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -62,9 +62,12 @@ msgstr "TODO: Creating an account is simple. You will need an email address and 
 "authenticating your account&mdash;which will use either a landline, mobile phone, or "
 "backup codes that must be printed or written down."
 
-msgid "core.pages.help.login_gov.p[2]%(website)s"
-msgstr "<a href=\"%(website)s\" target=\"_blank\" rel=\"noopener noreferrer\">TODO</a>: "
-"For more information on Login.gov, check out their website."
+msgid "core.pages.help.login_gov.p[2][0]%(website)s"
+msgstr "TODO: To learn more about Login.gov, please visit the "
+"<a href=\"%(website)s\" target=\"_blank\" rel=\"noopener noreferrer\">Login.gov website</a> "
+
+msgid "core.pages.help.login_gov.p[2][1]%(website)s"
+msgstr "TODO: or the <a href=\"%(website)s\" target=\"_blank\" rel=\"noopener noreferrer\">Login.gov Help Center</a>."
 
 msgid "core.pages.help.littlepay"
 msgstr "TODO: What is Littlepay?"


### PR DESCRIPTION
closes part of #522 

## `core:help`

* [x] [What is Login.gov?](https://docs.google.com/document/d/1xSznvvHuhOdtXUuOq1QNMseyfry3PD5oVSvokI9a-E4/edit#bookmark=id.nr9mfymb0b7i)

![image](https://user-images.githubusercontent.com/1783439/166062988-9a119da6-a74e-4fe8-a394-a5bbfbc5adab.png)
