### PR TITLE
Fix: help copy - update Littlepay punctuation and link text

### DIFF
--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -70,12 +70,12 @@ msgid "core.pages.help.littlepay"
 msgstr "What is Littlepay?"
 
 msgid "core.pages.help.littlepay.p[0]"
-msgstr "Our payment partner, Littlepay is a secure, end-to-end payment processing "
+msgstr "Our payment partner, Littlepay, is a secure, end-to-end payment processing "
 "platform that allows us to seamlessly attach your transit discount to your bank card."
 
 msgid "core.pages.help.littlepay.p[1]%(website)s"
-msgstr "For more information on Littlepay, check out "
-"<a href=\"%(website)s\" target=\"_blank\" rel=\"noopener noreferrer\">their website</a>."
+msgstr "For more information on Littlepay, please visit the "
+"<a href=\"%(website)s\" target=\"_blank\" rel=\"noopener noreferrer\">Littlepay website</a>."
 
 msgid "core.pages.help.questions"
 msgstr "Questions?"

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -70,12 +70,12 @@ msgid "core.pages.help.littlepay"
 msgstr "TODO: What is Littlepay?"
 
 msgid "core.pages.help.littlepay.p[0]"
-msgstr "TODO: Our payment partner, Littlepay is a secure, end-to-end payment processing "
+msgstr "TODO: Our payment partner, Littlepay, is a secure, end-to-end payment processing "
 "platform that allows us to seamlessly attach your transit discount to your bank card."
 
 msgid "core.pages.help.littlepay.p[1]%(website)s"
-msgstr "<a href=\"%(website)s\" target=\"_blank\" rel=\"noopener noreferrer\">TODO</a>: "
-"For more information on Littlepay, check out their website."
+msgstr "TODO: For more information on Littlepay, please visit the "
+"<a href=\"%(website)s\" target=\"_blank\" rel=\"noopener noreferrer\">Littlepay website</a>."
 
 msgid "core.pages.help.questions"
 msgstr "TODO: Questions?"


### PR DESCRIPTION
closes part of #522 

## `core:help`

* [x] [What is Littlepay?](https://docs.google.com/document/d/1xSznvvHuhOdtXUuOq1QNMseyfry3PD5oVSvokI9a-E4/edit#bookmark=id.bxgsdvu4vgyv)

![image](https://user-images.githubusercontent.com/1783439/166063369-293f6dfa-9b81-44aa-a706-a79f76ec23c2.png)
