### PR TITLE
Fix: link to coverage report in docs

### DIFF
--- a/docs/.pages
+++ b/docs/.pages
@@ -2,6 +2,6 @@ nav:
   - Home: README.md
   - Getting started: getting-started
   - Development: development
-  - Testing: tests
+  - Tests: tests
   - Configuration: configuration
   - Deployment: deployment

--- a/docs/tests/.pages
+++ b/docs/tests/.pages
@@ -1,3 +1,3 @@
 nav:
   - Introduction: README.md
-  - Coverage report: coverage
+  - Coverage report: ./tests/coverage


### PR DESCRIPTION
It was linking to a non-existent top-level directory.