### PR TITLE
Fix: signout link on Eligibility Confirm resubmission page

### DIFF
--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -162,7 +162,7 @@ def confirm(request):
             # form was not valid, allow for correction/resubmission
             analytics.returned_error(request, form.errors)
             page.forms = [form]
-            response = PageTemplateResponse(request, page)
+            response = TemplateResponse(request, "eligibility/confirm.html", page.context_dict())
     elif session.eligible(request):
         eligibility = session.eligibility(request)
         response = verified(request, [eligibility.name])


### PR DESCRIPTION
### Steps to reproduce
From @machikoyasuda in Slack:

> ***Sign out button issue*** When I go through Login.gov, I get to the Eligibility Confirm page and see the Sign out of Login.gov button. Then, I make a mistake on my form (either put in a bad ID number or a bad last name), the page refreshes and shows me my errors. At that point, the Sign out of Login.gov link disappears

![image](https://user-images.githubusercontent.com/25497886/166080109-2d1dc4c2-5a4a-464c-8715-449da017e0e2.png)

### Expected result / screenshot of fixed behavior
![image](https://user-images.githubusercontent.com/25497886/166080081-e6fff831-0b5a-49dd-8be5-7f46d7deff04.png)


