### PR TITLE
fix(button): 

### DIFF
--- a/benefits/core/templates/core/includes/form.html
+++ b/benefits/core/templates/core/includes/form.html
@@ -68,7 +68,8 @@
                     $("button[data-action='submit']", this)
                         .attr("role", "status")
                         .attr("disabled", "true")
-                        .text("{{ form.submitting_value }}");
+                        .text("{{ form.submitting_value }}")
+                        .addClass("disabled");
                 }
             });
         });


### PR DESCRIPTION
fix https://github.com/cal-itp/benefits/issues/405

Google Recaptcha seems to be removing the `disabled` state from the button HTML (related issue: https://stackoverflow.com/questions/59546714/google-recaptcha-enables-disabled-submit-button#59567003). Instead of disabling the button with HTML, I'm using a Bootstrap CSS class to do it. The CSS class uses `pointer-events: none` (which has high cross-broswer compatibility: https://caniuse.com/pointer-events)

- add `.disabled` class to override recaptcha removing disabled state