### PR TITLE
Mobile: Image and Sign Out Link

### DIFF
--- a/benefits/core/templates/core/page.html
+++ b/benefits/core/templates/core/page.html
@@ -15,7 +15,7 @@
         <div class="container">
         {% else %}
         {% load static %}
-        <div class="col-lg-6 image" style="background: 48% 75% url('{% static page.image %}') no-repeat; background-size: cover;">
+        <div class="col-lg-6 image">
         </div>
         <div class="col-md-8 offset-md-2 col-lg-6 offset-lg-0">
         {% endif %}

--- a/benefits/core/viewmodels.py
+++ b/benefits/core/viewmodels.py
@@ -141,7 +141,6 @@ class Page:
         if not isinstance(self.classes, list):
             self.classes = self.classes.split(" ")
         if not self.noimage:
-            self.image = "img/ridertappingbankcard.png"
             self.classes.append("with-image")
 
     def context_dict(self):

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -551,7 +551,7 @@ footer .footer-links a {
     background-position: center bottom;
     height: 240px;
     background-size: cover;
-    margin-bottom: 40px;
+    margin-bottom: 60px;
   }
 
   .signout-row .container .signout-link {
@@ -569,7 +569,7 @@ footer .footer-links a {
   }
 
   .signout-row {
-    top: 368px;
+    top: 308px;
   }
 
   /* Eligibility Start */

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -75,6 +75,11 @@ main .main-row {
   min-height: calc(100vh - 120px);
 }
 
+main .main-row .col-lg-6.image {
+  background: 48% 75% url("/static/img/ridertappingbankcard.png") no-repeat;
+  background-size: cover;
+}
+
 footer {
   margin-top: auto;
   padding-top: 1rem;
@@ -540,6 +545,15 @@ footer .footer-links a {
 }
 
 @media (max-width: 992px) {
+  /* With Image */
+
+  .with-image main .main-row .col-lg-6.image {
+    background: center bottom url("/static/img/ridertappingbankcard.png")
+      no-repeat;
+    height: 300px;
+    background-size: cover;
+  }
+
   /* Eligibility Start */
 
   .media-list {

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -548,11 +548,10 @@ footer .footer-links a {
   /* Mobile With Image */
 
   .with-image main .main-row .col-lg-6.image {
-    background: center bottom url("/static/img/ridertappingbankcard.png")
-      no-repeat;
-    height: 300px;
+    background-position: center bottom;
+    height: 240px;
     background-size: cover;
-    margin-bottom: 60px;
+    margin-bottom: 40px;
   }
 
   .signout-row .container .signout-link {

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -545,13 +545,32 @@ footer .footer-links a {
 }
 
 @media (max-width: 992px) {
-  /* With Image */
+  /* Mobile With Image */
 
   .with-image main .main-row .col-lg-6.image {
     background: center bottom url("/static/img/ridertappingbankcard.png")
       no-repeat;
     height: 300px;
     background-size: cover;
+    margin-bottom: 60px;
+  }
+
+  .signout-row .container .signout-link {
+    font-size: 16px;
+    color: #2b6597;
+    background: none;
+    padding: 10px 30px;
+    border-radius: 3px;
+    border: 2px solid #2b6597;
+    margin-top: 20px;
+  }
+
+  .signout-row .container .signout-link:hover {
+    background: none;
+  }
+
+  .signout-row {
+    top: 368px;
   }
 
   /* Eligibility Start */


### PR DESCRIPTION
closes #535 

## What this PR does

### Code changes
- Move image logic from the HTML template and the Page object into CSS only
- Add new updated image display styles for screens under the 992px width breakpoint.

### Design changes
- Image on mobile screens is now set to 240px in height, from the bottom. This allows the hand, the card with the VISA logo, the contactless pay logo on the card reader all to be shown: 
<img width="422" alt="image" src="https://user-images.githubusercontent.com/3673236/168149321-184c083c-d82c-4e39-aa65-559a26333ee0.png">
- The button now has 2px solid #2b6597 borders, with a 3px border radius and 10px top and bottom/30px left and right padding, resulting in a button that's 231px by 46px. The button is 20px below the bottom of the image. <img width="476" alt="image" src="https://user-images.githubusercontent.com/3673236/167921623-a699ac31-d4c4-442c-8bb3-5b1a67de32c6.png">

### Screenshots


## Testing this PR, for Engineers:

- You must turn off Debug mode or hide the Debug bar, or else the button gets placed like this.
<img width="930" alt="image" src="https://user-images.githubusercontent.com/3673236/168150408-528c212c-92d8-4703-bd3a-5fcf19a137b9.png">

Add this code or delete the element from Developer Tools.
```css
.bg-danger {
  display: none !important;
}
```
