### PR TITLE
chore: disable network requests in pytests

### DIFF
--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -3,8 +3,13 @@ from django.contrib.sessions.middleware import SessionMiddleware
 from django.middleware.locale import LocaleMiddleware
 
 import pytest
+from pytest_socket import disable_socket
 
 from benefits.core import session
+
+
+def pytest_runtest_setup():
+    disable_socket()
 
 
 @pytest.fixture(scope="session")

--- a/tests/pytest/requirements.txt
+++ b/tests/pytest/requirements.txt
@@ -2,3 +2,4 @@ pytest
 pytest-cov
 pytest-django
 pytest-mock
+pytest-socket


### PR DESCRIPTION
Want to ensure that we're not making any calls to external APIs. Confirmed it worked by sticking in a call to `requests.get()`.