### PR TITLE
CI: add issues and Dependabot PRs to Project Board

### DIFF
--- a/.github/workflows/add-to-project-dependabot.yml
+++ b/.github/workflows/add-to-project-dependabot.yml
@@ -1,0 +1,16 @@
+name: "Project triage: Dependabot"
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-to-project-dependabot:
+    runs-on: ubuntu-latest
+    # see https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#responding-to-events
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/cal-itp/projects/${{ secrets.GH_PROJECT }}
+          github-token: ${{ secrets.GH_PROJECTS_TOKEN }}

--- a/.github/workflows/add-to-project-issues.yml
+++ b/.github/workflows/add-to-project-issues.yml
@@ -1,0 +1,14 @@
+name: "Project triage: Issues"
+
+on:
+  issues:
+    types: [opened, transferred]
+
+jobs:
+  add-to-project-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/cal-itp/projects/${{ secrets.GH_PROJECT }}
+          github-token: ${{ secrets.GH_PROJECTS_TOKEN }}


### PR DESCRIPTION
Closes #570.

There are two separate workflows:

* One for newly opened or transferred issues
* Another for PRs opened by Dependabot

See the [`add-to-project`](https://github.com/actions/add-to-project#usage) docs for more.

See also [Automating Dependabot with GitHub Actions](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions).