### PR TITLE
Desktop: Agency Index - Center the label over button on Agency Index page

### DIFF
--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -426,7 +426,9 @@ footer .footer-links a {
 }
 
 .container.content .buttons label {
+  display: block;
   margin-bottom: 2rem;
+  text-align: center;
 }
 
 .container.content h1.icon-title {


### PR DESCRIPTION
closes #571 

Center the button's label on the Agency Index page, and only that page. 

| **Desktop**         | **Mobile**     |
|--------------|-----------|
| <img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/167941380-11a62a45-afab-4078-9b60-991963440926.png"> |<img width="450" alt="image" src="https://user-images.githubusercontent.com/3673236/167941412-d1abb91a-0f1c-44bf-9a4b-488b3d3573de.png">      |
