### PR TITLE
Feat: redirect to agency's index if only one agency

### DIFF
--- a/benefits/core/views.py
+++ b/benefits/core/views.py
@@ -2,6 +2,7 @@
 The core application: view definition for the root of the webapp.
 """
 from django.http import HttpResponseBadRequest, HttpResponseNotFound, HttpResponseServerError
+from django.shortcuts import redirect
 from django.template import loader
 from django.template.response import TemplateResponse
 from django.urls import reverse
@@ -31,8 +32,13 @@ def index(request):
     """View handler for the main entry page."""
     session.reset(request)
 
-    # generate a button to the landing page for each active agency
     agencies = models.TransitAgency.all_active()
+
+    if len(agencies) == 1:
+        agency = agencies[0]
+        return redirect(agency.index_url)
+
+    # generate a button to the landing page for each active agency
     buttons = [viewmodels.Button.outline_primary(text=a.short_name, url=a.index_url) for a in agencies]
     buttons[0].classes.append("mt-3")
     buttons[0].label = _("core.pages.index.chooseprovider")

--- a/tests/pytest/core/test_views.py
+++ b/tests/pytest/core/test_views.py
@@ -6,11 +6,22 @@ from tests.pytest.conftest import with_agency
 
 
 @pytest.mark.django_db
-def test_homepage(client):
+def test_homepage_multiple_agencies(client):
+    """Assumes that fixture data contains multiple active agencies."""
     path = reverse("core:index")
     response = client.get(path)
     assert response.status_code == 200
     assert "transit" in str(response.content)
+
+
+@pytest.mark.django_db
+def test_homepage_single_agency(mocker, client):
+    agencies = TransitAgency.all_active()[:1]
+    mocker.patch("benefits.core.models.TransitAgency.all_active", return_value=agencies)
+    path = reverse("core:index")
+    response = client.get(path)
+    assert response.status_code == 302
+    assert response.url == agencies[0].index_url
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Closes #566

### Summary
 - Updates the core app's `index` function to redirect to the agency's index if there is only one active agency.
 - Also added a unit test for behavior of homepage with single agency.
 - Also launched the app and tested manually.
![image](https://user-images.githubusercontent.com/25497886/167968828-0498d350-e7b2-4556-bd60-4fca0480b896.png)
