### PR TITLE
Fix: Use 1st sentence of help page for meta description

### DIFF
--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -6,7 +6,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <meta name="description" content="{% translate "core.pages.help.p[0]" %}">
+        <meta name="description" content="{% translate "core.pages.help.about.p[0]" %}">
         <title>{% block page_title %}{% endblock  %}Cal-ITP</title>
 
         <link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet" type="text/css">


### PR DESCRIPTION
close #597 

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/169187277-76c3b440-9b7c-4b86-a2b1-b84b0bf32ac0.png">
