### PR TITLE
Enrollment Success: Redesign page to have no image

### DIFF
--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -145,33 +145,26 @@ def success(request):
     request.path = "/enrollment/success"
     session.update(request, origin=reverse("enrollment:success"))
     verifier = session.verifier(request)
+    icon = viewmodels.Icon("bankcardcheck", pgettext("image alt text", "core.icons.bankcardcheck"))
+    page = viewmodels.Page(
+        title=_("enrollment.pages.success.title"),
+        content_title=_("enrollment.pages.success.content_title"),
+    )
 
     if verifier.requires_authentication:
         if settings.OAUTH_CLIENT_NAME is None:
             raise Exception("EligibilityVerifier requires authentication, but OAUTH_CLIENT_NAME is None")
 
         if session.logged_in(request):
-            button = viewmodels.Button.logout()
-            page = viewmodels.Page(
-                title=_("enrollment.pages.success.title"),
-                icon=viewmodels.Icon("bankcardcheck", pgettext("image alt text", "core.icons.bankcardcheck")),
-                content_title=_("enrollment.pages.success.content_title"),
-                button=button,
-                classes="logged-in",
-            )
+            page.buttons = [viewmodels.Button.logout()]
+            page.classes = ["logged-in"]
+            page.icon = icon
         else:
-            page = viewmodels.Page(
-                title=_("enrollment.pages.success.title"),
-                content_title=_("enrollment.pages.success.logout.title"),
-                classes="logged-out",
-                noimage=True,
-            )
+            page.classes = ["logged-out"]
+            page.content_title = _("enrollment.pages.success.logout.title")
+            page.noimage = True
     else:
-        page = viewmodels.Page(
-            title=_("enrollment.pages.success.title"),
-            content_title=_("enrollment.pages.success.content_title"),
-            icon=viewmodels.Icon("bankcardcheck", pgettext("image alt text", "core.icons.bankcardcheck")),
-        )
+        page.icon = icon
 
     help_link = reverse("core:help")
     context_dict = {**page.context_dict(), **{"help_link": help_link}}

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -164,6 +164,7 @@ def success(request):
                 title=_("enrollment.pages.success.title"),
                 content_title=_("enrollment.pages.success.logout.title"),
                 classes="logged-out",
+                noimage=True,
             )
     else:
         page = viewmodels.Page(

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -363,6 +363,10 @@ footer .footer-links a {
   padding-top: 20vh;
 }
 
+.logged-out.enrollment-success .container.content h1 {
+  text-align: center;
+}
+
 .radio-container {
   display: block;
   margin-left: 15%;


### PR DESCRIPTION
closes #565 
closes https://github.com/cal-itp/benefits/issues/513

## What this PR does

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/169188315-3b677762-8272-4c59-a925-90900f9b5e69.png">
<img width="552" alt="image" src="https://user-images.githubusercontent.com/3673236/169188348-e80351a7-2138-4704-8538-db4d64bcadc4.png">

## How to test
1. Test MST / Senior flow of getting to enrollment succecss page and then logging out from the success page
2. Test MST / Courtesy Card flow of getting to enrollment success page