### PR TITLE
Chore: Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -3,9 +3,11 @@ name: Bug report
 about: Report a bug
 labels: bug
 ---
+
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+## To Reproduce
+
 Steps to reproduce the behavior:
 
 1. Go to '...'
@@ -13,24 +15,27 @@ Steps to reproduce the behavior:
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
+## Expected behavior
+
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
+## Screenshots
+
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
+## Desktop (please complete the following information)
 
 - OS: [e.g. iOS]
 - Browser [e.g. chrome, safari]
 - Version [e.g. 22]
 
-**Smartphone (please complete the following information):**
+## Smartphone (please complete the following information)
 
 - Device: [e.g. iPhone6]
 - OS: [e.g. iOS8.1]
 - Browser [e.g. stock browser, safari]
 - Version [e.g. 22]
 
-**Additional context**
+## Additional context
+
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Report a bug
+labels: bug
+---
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser [e.g. stock browser, safari]
+- Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/deliverable.md
+++ b/.github/ISSUE_TEMPLATE/deliverable.md
@@ -1,0 +1,15 @@
+---
+name: Deliverable
+about: Create a task for a deliverable
+labels: deliverable
+---
+
+## Acceptance Criteria
+
+- [ ]
+
+## Additional context
+
+<!-- Include information about scope, time frame, person who requested the task, links to resources  -->
+
+## What is the definition of done?

--- a/.github/ISSUE_TEMPLATE/deliverable.md
+++ b/.github/ISSUE_TEMPLATE/deliverable.md
@@ -1,6 +1,6 @@
 ---
 name: Deliverable
-about: Create a task for a deliverable
+about: Create a task for a non-code deliverable (e.g. Google doc)
 labels: deliverable
 ---
 

--- a/.github/ISSUE_TEMPLATE/epic-decision-record.md
+++ b/.github/ISSUE_TEMPLATE/epic-decision-record.md
@@ -1,15 +1,16 @@
 ---
-name: Epic / Decision Record template
-about: This template provides a basic structure for epics.
+name: Epic / Decision Record
+about: A basic structure for epics
 label: epic
 ---
+
 <!-- An epic represents a group of user stories/tasks on the roadmap, to be deployed together, as a part of a new feature set. -->
 
 **Date**:
 **Writers**:
 **Status**:
 
-# Background
+## Background
 
 <!-- [Describe the context and problem statement, e.g., in free form using two to three sentences. You may want to articulate the problem in form of a question.] -->
 
@@ -27,26 +28,30 @@ label: epic
 
 <!-- Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | … | comes out best (see below)]. You may discuss positive and negative consequences of each option considered. -->
 
-# Acceptance criteria
+## Acceptance criteria
+
+- [ ] Acceptance criteria
+
+## Definition of Done
+
+A clear and concise description of what "Done" means for this Epic.
 
 ## User Stories
 
-- [ ] This is something that can be verified to show that this epic is satisfied.
+- [ ] As a User Story, I want to be verifiable, so that this epic can be satisfied
 
 ## Tasks
 
-- [ ] This is something that can be verified to show that this epic is satisfied.
+- [ ] Code and non-code tasks that work towards a solution to to this epic
 
 ## Implementation Ready Checklist
 
 - [ ] Acceptance criteria defined
 - [ ] Team understands acceptance criteria
-- [ ] User workflows defined / designed
 - [ ] Acceptance criteria is verifiable
+- [ ] User workflows defined / designed
 - [ ] External / 3rd Party dependencies identified
 
 ## Links, resources
 
 - Other links here
-
-# Definition of Done

--- a/.github/ISSUE_TEMPLATE/epic-decision-record.md
+++ b/.github/ISSUE_TEMPLATE/epic-decision-record.md
@@ -1,0 +1,52 @@
+---
+name: Epic / Decision Record template
+about: This template provides a basic structure for epics.
+label: epic
+---
+<!-- An epic represents a group of user stories/tasks on the roadmap, to be deployed together, as a part of a new feature set. -->
+
+**Date**:
+**Writers**:
+**Status**:
+
+# Background
+
+<!-- [Describe the context and problem statement, e.g., in free form using two to three sentences. You may want to articulate the problem in form of a question.] -->
+
+## Decision drivers <!-- optional -->
+
+<!-- - [driver 1, e.g., a force, facing concern, …]
+- [driver 2, e.g., a force, facing concern, …] -->
+
+## Considered options
+
+<!-- - [option 1]
+- [option 2] -->
+
+## Decision outcome
+
+<!-- Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | … | comes out best (see below)]. You may discuss positive and negative consequences of each option considered. -->
+
+# Acceptance criteria
+
+## User Stories
+
+- [ ] This is something that can be verified to show that this epic is satisfied.
+
+## Tasks
+
+- [ ] This is something that can be verified to show that this epic is satisfied.
+
+## Implementation Ready Checklist
+
+- [ ] Acceptance criteria defined
+- [ ] Team understands acceptance criteria
+- [ ] User workflows defined / designed
+- [ ] Acceptance criteria is verifiable
+- [ ] External / 3rd Party dependencies identified
+
+## Links, resources
+
+- Other links here
+
+# Definition of Done

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,15 @@
+---
+name: Engineering task
+about: Create a task for the Engineering team
+---
+A clear and concise description of what the task is.
+
+## Acceptance Criteria
+
+- [ ]
+<!-- Remember to consider edge cases -->
+
+## Additional context
+
+- Add any other context about the task here.
+- Or here

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -2,14 +2,15 @@
 name: Engineering task
 about: Create a task for the Engineering team
 ---
-A clear and concise description of what the task is.
+
+A clear and concise description of the task.
 
 ## Acceptance Criteria
 
-- [ ]
 <!-- Remember to consider edge cases -->
+
+- [ ]
 
 ## Additional context
 
-- Add any other context about the task here.
-- Or here
+<!-- Add any other context about the task here -->

--- a/.github/ISSUE_TEMPLATE/user-story.md
+++ b/.github/ISSUE_TEMPLATE/user-story.md
@@ -1,0 +1,23 @@
+---
+name: User story
+about: Create a user story for a feature.
+labels: user story
+title: As a [persona], I [want to], [so that].
+assignees:
+---
+
+**User story**
+
+**Acceptance criteria**
+- [ ] Acceptance criteria
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Links to user research, designs and resources**
+<!-- Link to Figma files, Google Docs and more -->
+
+**Tasks**
+<!-- Engineering tasks required to complete this User Story -->
+
+**Definition of "Done"**

--- a/.github/ISSUE_TEMPLATE/user-story.md
+++ b/.github/ISSUE_TEMPLATE/user-story.md
@@ -3,21 +3,21 @@ name: User story
 about: Create a user story for a feature.
 labels: user story
 title: As a [persona], I [want to], [so that].
-assignees:
 ---
 
-**User story**
 
-**Acceptance criteria**
-- [ ] Acceptance criteria
+## Describe alternatives you've considered
 
-**Describe alternatives you've considered**
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Links to user research, designs and resources**
+## Acceptance criteria
+
+- [ ]
+
+## Definition of "Done"
+
+A clear and concise description of what "Done" means for this User Story.
+
+## Links to user research, designs and resources
+
 <!-- Link to Figma files, Google Docs and more -->
-
-**Tasks**
-<!-- Engineering tasks required to complete this User Story -->
-
-**Definition of "Done"**


### PR DESCRIPTION
closes #604 

Discussed at today's Developer Team meeting.

## What this PR does
Adds 5 (!!) more issue templates for the following scenarios:

1. bug report: for anyone to report bugs on the app (to be closed with a corresponding pull request)
2. user story: for product to write user stories for new features
3. task: task is for an individual engineering task (to be closed with a corresponding pull request)
4. deliverable: "deliverable" is our new word for any github issue that's not for a code change. it could be an issue to track work like: user testing, user research, writing planning documents for a meeting. these issues don't end up with a pull request.
5. epic decision record: this is for our big "epic" issues, which track a _group of_ related user stories, tasks and deliverables. epics can also contain relevant background information, checklist of items that need to be done before the feature can be delivered. epics should have a defined "definition of done", so we know when we can close it.