### PR TITLE
Fix: typo in labels frontmatter in Epic issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic-decision-record.md
+++ b/.github/ISSUE_TEMPLATE/epic-decision-record.md
@@ -1,7 +1,7 @@
 ---
 name: Epic / Decision Record
 about: A basic structure for epics
-label: epic
+labels: epic
 ---
 
 <!-- An epic represents a group of user stories/tasks on the roadmap, to be deployed together, as a part of a new feature set. -->


### PR DESCRIPTION
Replace `label` with `labels` so the correct label is applied when using this issue template.