### PR TITLE
Feature: set up uptime monitoring

### DIFF
--- a/docs/deployment/azure.md
+++ b/docs/deployment/azure.md
@@ -56,13 +56,17 @@ flowchart LR
 
 WAF: [Web Application Firewall](https://azure.microsoft.com/en-us/services/web-application-firewall/)
 
+## Monitoring
+
+We have [ping tests](https://docs.microsoft.com/en-us/azure/azure-monitor/app/monitor-web-app-availability) set up to notify about availability of the dev, test, and prod deployments. Alerts go to [#benefits-notify](https://cal-itp.slack.com/archives/C022HHSEE3F).
+
 ## Making changes
 
 1. Get access to the Azure account through the DevSecOps team.
 1. Install dependencies:
     - [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
     - [Terraform](https://www.terraform.io/downloads)
-1. [Authenticate using the Azure CLI](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli).
+1. [Authenticate using the Azure CLI](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli), specifying the `CDT/ODI Production` Subscription.
 1. Outside the [dev container](../../getting-started/), navigate to the [`terraform/`][terraform-dir] directory.
 1. [Initialize Terraform.](https://www.terraform.io/cli/commands/init)
 

--- a/docs/deployment/azure.md
+++ b/docs/deployment/azure.md
@@ -2,6 +2,8 @@
 
 [dev-benefits.calitp.org](https://dev-benefits.calitp.org) is currently deployed into a Microsoft Azure account provided by [California Department of Technology (CDT)'s Office of Enterprise Technology (OET)](https://techblog.cdt.ca.gov/2020/06/cdt-taking-the-lead-in-digital-transformation/), a.k.a. the "DevSecOps" team. More specifically, it uses [custom containers](https://docs.microsoft.com/en-us/azure/app-service/configure-custom-container) on [Azure App Service](https://docs.microsoft.com/en-us/azure/app-service/overview).
 
+The infrastructure is configured as code via [Terraform](https://www.terraform.io/), for [various reasons](https://techcommunity.microsoft.com/t5/fasttrack-for-azure/the-benefits-of-infrastructure-as-code/ba-p/2069350). We are adding existing resources to the configuration progressively. In other words, not _all_ our resources in Azure show up under [`terraform/`][terraform-dir], but we are [moving that direction](https://github.com/cal-itp/benefits/issues/618).
+
 ## Architecture
 
 ### System interconnections
@@ -53,3 +55,28 @@ flowchart LR
 ```
 
 WAF: [Web Application Firewall](https://azure.microsoft.com/en-us/services/web-application-firewall/)
+
+## Making changes
+
+1. Get access to the Azure account through the DevSecOps team.
+1. Install dependencies:
+    - [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
+    - [Terraform](https://www.terraform.io/downloads)
+1. [Authenticate using the Azure CLI](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli).
+1. Outside the [dev container](../../getting-started/), navigate to the [`terraform/`][terraform-dir] directory.
+1. [Initialize Terraform.](https://www.terraform.io/cli/commands/init)
+
+    ```sh
+    terraform init
+    ```
+
+1. Make changes to Terraform files.
+1. [Plan](https://www.terraform.io/cli/commands/plan)/[apply](https://www.terraform.io/cli/commands/apply) the changes, as necessary.
+
+    ```sh
+    terraform apply
+    ```
+
+1. [Submit the changes via pull request.](../development/commits-branches-merging/) Be sure to specify whether they've been applied, i.e. whether they're live or not.
+
+[terraform-dir]: https://github.com/cal-itp/benefits/tree/dev/terraform

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,36 @@
+# https://github.com/github/gitignore/blob/e5323759e387ba347a9d50f8b0ddd16502eb71d4/Terraform.gitignore
+
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "3.7.0"
+  constraints = "~> 3.7.0"
+  hashes = [
+    "h1:rsnOB8uq9SsniYpL4J2aYpZGFwDoTME7n/Tpqo5erl0=",
+    "zh:14904a421cc543a48c72cb0728bdab4ac054ef134bc4e6b5f06998814f1264ba",
+    "zh:1b5f88bf8ee9ce1cf80ad2d774be23df7a22371586029e7cfd34509aa6695371",
+    "zh:2554e8dd4612071c771be43bd33c7a4e75ede70fd647b435dcf0d36bc8cddb2c",
+    "zh:5730d02d44c112d2eea5878b7fb7dba8da3f9e95fa4b1074f4fc45ad900b17fe",
+    "zh:5a225f06f4a699dcce0707b1879f75029bcf80a4e7833d049a09dc69889b14cd",
+    "zh:7678453db283dd5e3ca85ecfba98ca0a0f4e77be79dc227d07be70f6ac658aab",
+    "zh:a71561b277651924853cc63438dfa81ed5cfc4fce402798ce30f732976c50091",
+    "zh:c4efdb587d42f443242078b288c222990d1e3d31df08485a48c360b2afc9e1e8",
+    "zh:d481fb61cc0070413789522181f1ab056ec33729bfc8cb7e4ea9855686f31049",
+    "zh:ed8810a90c11e27c8722a134e17b270199ab2246a957392c628956a8ed95edac",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fe5f87a7e9635d4bfc2b8d662efd6a85eb3047ae4bc9d7cf2d7c1ccc3a16d075",
+  ]
+}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,1 @@
+[Documentation](https://docs.calitp.org/benefits/deployment/azure/)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -5,6 +5,13 @@ terraform {
       version = "~> 3.7.0"
     }
   }
+
+  backend "azurerm" {
+    resource_group_name  = "RG-CDT-PUB-VIP-CALITP-D-001"
+    storage_account_name = "sacalitpd001"
+    container_name       = "tfstate"
+    key                  = "terraform.tfstate"
+  }
 }
 
 # Configure the Microsoft Azure Provider

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -7,17 +7,20 @@ terraform {
   }
 
   backend "azurerm" {
-    resource_group_name  = "RG-CDT-PUB-VIP-CALITP-D-001"
-    storage_account_name = "sacalitpd001"
+    resource_group_name  = "RG-CDT-PUB-VIP-CALITP-P-001"
+    storage_account_name = "sacdtcalitpp001"
     container_name       = "tfstate"
     key                  = "terraform.tfstate"
   }
 }
 
 provider "azurerm" {
+  # temporary workaround for permissions issue
+  skip_provider_registration = true
+
   features {}
 }
 
 data "azurerm_resource_group" "benefits" {
-  name = "RG-CDT-PUB-VIP-CALITP-D-001"
+  name = "RG-CDT-PUB-VIP-CALITP-P-001"
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -14,7 +14,6 @@ terraform {
   }
 }
 
-# Configure the Microsoft Azure Provider
 provider "azurerm" {
   features {}
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.7.0"
+    }
+  }
+}
+
+# Configure the Microsoft Azure Provider
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_resource_group" "benefits" {
+  name = "RG-CDT-PUB-VIP-CALITP-D-001"
+}

--- a/terraform/monitor.tf
+++ b/terraform/monitor.tf
@@ -1,5 +1,5 @@
 data "azurerm_key_vault" "main" {
-  name                = "kv-cdt-pub-calitp-d-001"
+  name                = "KV-CDT-PUB-CALITP-P-001"
   resource_group_name = data.azurerm_resource_group.benefits.name
 }
 

--- a/terraform/monitor.tf
+++ b/terraform/monitor.tf
@@ -1,0 +1,26 @@
+data "azurerm_key_vault" "main" {
+  name                = "kv-cdt-pub-calitp-d-001"
+  resource_group_name = data.azurerm_resource_group.benefits.name
+}
+
+# created manually
+# https://slack.com/help/articles/206819278-Send-emails-to-Slack
+data "azurerm_key_vault_secret" "slack_benefits_notify_email" {
+  name         = "slack-benefits-notify-email"
+  key_vault_id = data.azurerm_key_vault.main.id
+}
+
+resource "azurerm_monitor_action_group" "dev_email" {
+  name                = "benefits-notify Slack channel email"
+  resource_group_name = data.azurerm_resource_group.benefits.name
+  short_name          = "slack-notify"
+
+  email_receiver {
+    name          = "Benefits engineering team"
+    email_address = data.azurerm_key_vault_secret.slack_benefits_notify_email.value
+  }
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}

--- a/terraform/uptime.tf
+++ b/terraform/uptime.tf
@@ -33,21 +33,6 @@ XML
   }
 }
 
-resource "azurerm_monitor_action_group" "dev_email" {
-  name                = "Benefits engineering team email"
-  resource_group_name = data.azurerm_resource_group.benefits.name
-  short_name          = "p0action"
-
-  email_receiver {
-    name          = "Benefits engineering team"
-    email_address = "aidan@compiler.la"
-  }
-
-  lifecycle {
-    ignore_changes = [tags]
-  }
-}
-
 resource "azurerm_monitor_metric_alert" "uptime" {
   name                = "uptime"
   resource_group_name = data.azurerm_resource_group.benefits.name

--- a/terraform/uptime.tf
+++ b/terraform/uptime.tf
@@ -1,10 +1,28 @@
 module "dev_healthcheck" {
   source = "./uptime"
 
-  action_group_id = azurerm_monitor_action_group.dev_email.id
-  name                    = "dev-healthcheck"
+  action_group_id     = azurerm_monitor_action_group.dev_email.id
+  name                = "dev-healthcheck"
   resource_group_name = data.azurerm_resource_group.benefits.name
-  url = "https://dev-benefits.calitp.org/healthcheck"
+  url                 = "https://dev-benefits.calitp.org/healthcheck"
+}
+
+module "test_healthcheck" {
+  source = "./uptime"
+
+  action_group_id     = azurerm_monitor_action_group.dev_email.id
+  name                = "test-healthcheck"
+  resource_group_name = data.azurerm_resource_group.benefits.name
+  url                 = "https://test-benefits.calitp.org/healthcheck"
+}
+
+module "prod_healthcheck" {
+  source = "./uptime"
+
+  action_group_id     = azurerm_monitor_action_group.dev_email.id
+  name                = "prod-healthcheck"
+  resource_group_name = data.azurerm_resource_group.benefits.name
+  url                 = "https://benefits.calitp.org/healthcheck"
 }
 
 # migrations
@@ -16,5 +34,5 @@ moved {
 
 moved {
   from = azurerm_monitor_metric_alert.uptime
-  to = module.dev_healthcheck.azurerm_monitor_metric_alert.uptime
+  to   = module.dev_healthcheck.azurerm_monitor_metric_alert.uptime
 }

--- a/terraform/uptime.tf
+++ b/terraform/uptime.tf
@@ -1,0 +1,36 @@
+data "azurerm_application_insights" "benefits" {
+  name                = "AS-CDT-CALITP-D-001"
+  resource_group_name = data.azurerm_resource_group.benefits.name
+}
+
+
+resource "azurerm_application_insights_web_test" "dev_healthcheck" {
+  name                    = "dev-healthcheck"
+  location                = data.azurerm_application_insights.benefits.location
+  resource_group_name     = data.azurerm_resource_group.benefits.name
+  application_insights_id = data.azurerm_application_insights.benefits.id
+  kind                    = "ping"
+  enabled                 = true
+  geo_locations = [
+    "us-fl-mia-edge", # Central US
+    "us-va-ash-azr",  # East US
+    "us-il-ch1-azr",  # North Central US
+    "us-tx-sn1-azr",  # South Central US
+    "us-ca-sjc-azr",  # West US
+  ]
+
+  configuration = <<XML
+<WebTest Name="dev-healthcheck" Enabled="True" CssProjectStructure="" CssIteration="" Timeout="120" WorkItemIds=""
+  xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010" Description="" CredentialUserName="" CredentialPassword="" PreAuthenticate="True" Proxy="default" StopOnError="False" RecordedResultFile="" ResultsLocale="">
+  <Items>
+    <Request Method="GET" Version="1.1" Url="https://dev-benefits.calitp.org/healthcheck" ThinkTime="0" Timeout="300" ParseDependentRequests="True" FollowRedirects="True" RecordResult="True" Cache="False" ResponseTimeGoal="0" Encoding="utf-8" ExpectedHttpStatusCode="200" ExpectedResponseUrl="" ReportingName="" IgnoreHttpStatusCode="False" />
+  </Items>
+</WebTest>
+XML
+
+  lifecycle {
+    ignore_changes = [
+      tags,
+    ]
+  }
+}

--- a/terraform/uptime.tf
+++ b/terraform/uptime.tf
@@ -11,6 +11,9 @@ resource "azurerm_application_insights_web_test" "dev_healthcheck" {
   application_insights_id = data.azurerm_application_insights.benefits.id
   kind                    = "ping"
   enabled                 = true
+
+  # "We strongly recommend testing from … a minimum of five locations."
+  # https://docs.microsoft.com/en-us/azure/azure-monitor/app/monitor-web-app-availability#create-a-test
   geo_locations = [
     "us-fl-mia-edge", # Central US
     "us-va-ash-azr",  # East US
@@ -45,7 +48,9 @@ resource "azurerm_monitor_metric_alert" "uptime" {
   application_insights_web_test_location_availability_criteria {
     web_test_id           = azurerm_application_insights_web_test.dev_healthcheck.id
     component_id          = data.azurerm_application_insights.benefits.id
-    failed_location_count = 3
+    # "the optimal configuration is to have the number of test locations be equal to the alert location threshold + 2"
+    # https://docs.microsoft.com/en-us/azure/azure-monitor/app/monitor-web-app-availability#create-a-test
+    failed_location_count = length(azurerm_application_insights_web_test.dev_healthcheck.geo_locations) - 2
   }
 
   action {

--- a/terraform/uptime.tf
+++ b/terraform/uptime.tf
@@ -1,63 +1,20 @@
-data "azurerm_application_insights" "benefits" {
-  name                = "AS-CDT-CALITP-D-001"
-  resource_group_name = data.azurerm_resource_group.benefits.name
-}
+module "dev_healthcheck" {
+  source = "./uptime"
 
-
-resource "azurerm_application_insights_web_test" "dev_healthcheck" {
+  action_group_id = azurerm_monitor_action_group.dev_email.id
   name                    = "dev-healthcheck"
-  location                = data.azurerm_application_insights.benefits.location
-  resource_group_name     = data.azurerm_resource_group.benefits.name
-  application_insights_id = data.azurerm_application_insights.benefits.id
-  kind                    = "ping"
-  enabled                 = true
-
-  # "We strongly recommend testing from … a minimum of five locations."
-  # https://docs.microsoft.com/en-us/azure/azure-monitor/app/monitor-web-app-availability#create-a-test
-  geo_locations = [
-    "us-fl-mia-edge", # Central US
-    "us-va-ash-azr",  # East US
-    "us-il-ch1-azr",  # North Central US
-    "us-tx-sn1-azr",  # South Central US
-    "us-ca-sjc-azr",  # West US
-  ]
-
-  configuration = <<XML
-<WebTest Name="dev-healthcheck" Enabled="True" CssProjectStructure="" CssIteration="" Timeout="120" WorkItemIds=""
-  xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010" Description="" CredentialUserName="" CredentialPassword="" PreAuthenticate="True" Proxy="default" StopOnError="False" RecordedResultFile="" ResultsLocale="">
-  <Items>
-    <Request Method="GET" Version="1.1" Url="https://dev-benefits.calitp.org/healthcheck" ThinkTime="0" Timeout="300" ParseDependentRequests="True" FollowRedirects="True" RecordResult="True" Cache="False" ResponseTimeGoal="0" Encoding="utf-8" ExpectedHttpStatusCode="200" ExpectedResponseUrl="" ReportingName="" IgnoreHttpStatusCode="False" />
-  </Items>
-</WebTest>
-XML
-
-  lifecycle {
-    ignore_changes = [tags]
-  }
+  resource_group_name = data.azurerm_resource_group.benefits.name
+  url = "https://dev-benefits.calitp.org/healthcheck"
 }
 
-resource "azurerm_monitor_metric_alert" "uptime" {
-  name                = "uptime"
-  resource_group_name = data.azurerm_resource_group.benefits.name
-  scopes = [
-    azurerm_application_insights_web_test.dev_healthcheck.id,
-    data.azurerm_application_insights.benefits.id
-  ]
-  severity = 1
+# migrations
 
-  application_insights_web_test_location_availability_criteria {
-    web_test_id           = azurerm_application_insights_web_test.dev_healthcheck.id
-    component_id          = data.azurerm_application_insights.benefits.id
-    # "the optimal configuration is to have the number of test locations be equal to the alert location threshold + 2"
-    # https://docs.microsoft.com/en-us/azure/azure-monitor/app/monitor-web-app-availability#create-a-test
-    failed_location_count = length(azurerm_application_insights_web_test.dev_healthcheck.geo_locations) - 2
-  }
+moved {
+  from = azurerm_application_insights_web_test.dev_healthcheck
+  to   = module.dev_healthcheck.azurerm_application_insights_web_test.healthcheck
+}
 
-  action {
-    action_group_id = azurerm_monitor_action_group.dev_email.id
-  }
-
-  lifecycle {
-    ignore_changes = [tags]
-  }
+moved {
+  from = azurerm_monitor_metric_alert.uptime
+  to = module.dev_healthcheck.azurerm_monitor_metric_alert.uptime
 }

--- a/terraform/uptime.tf
+++ b/terraform/uptime.tf
@@ -29,8 +29,45 @@ resource "azurerm_application_insights_web_test" "dev_healthcheck" {
 XML
 
   lifecycle {
-    ignore_changes = [
-      tags,
-    ]
+    ignore_changes = [tags]
+  }
+}
+
+resource "azurerm_monitor_action_group" "dev_email" {
+  name                = "Benefits engineering team email"
+  resource_group_name = data.azurerm_resource_group.benefits.name
+  short_name          = "p0action"
+
+  email_receiver {
+    name          = "Benefits engineering team"
+    email_address = "aidan@compiler.la"
+  }
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+
+resource "azurerm_monitor_metric_alert" "uptime" {
+  name                = "uptime"
+  resource_group_name = data.azurerm_resource_group.benefits.name
+  scopes = [
+    azurerm_application_insights_web_test.dev_healthcheck.id,
+    data.azurerm_application_insights.benefits.id
+  ]
+  severity = 1
+
+  application_insights_web_test_location_availability_criteria {
+    web_test_id           = azurerm_application_insights_web_test.dev_healthcheck.id
+    component_id          = data.azurerm_application_insights.benefits.id
+    failed_location_count = 3
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.dev_email.id
+  }
+
+  lifecycle {
+    ignore_changes = [tags]
   }
 }

--- a/terraform/uptime/README.md
+++ b/terraform/uptime/README.md
@@ -1,1 +1,1 @@
-Terraform module to set up [ping tests](https://docs.microsoft.com/en-us/azure/azure-monitor/app/monitor-web-app-availability).
+[Terraform module](https://www.terraform.io/language/modules) to set up [ping tests](https://docs.microsoft.com/en-us/azure/azure-monitor/app/monitor-web-app-availability).

--- a/terraform/uptime/README.md
+++ b/terraform/uptime/README.md
@@ -1,0 +1,1 @@
+Terraform module to set up [ping tests](https://docs.microsoft.com/en-us/azure/azure-monitor/app/monitor-web-app-availability).

--- a/terraform/uptime/main.tf
+++ b/terraform/uptime/main.tf
@@ -21,6 +21,7 @@ resource "azurerm_application_insights_web_test" "healthcheck" {
     "us-ca-sjc-azr",  # West US
   ]
 
+  # boilerplate configuration
   configuration = <<XML
 <WebTest Name="dev-healthcheck" Enabled="True" CssProjectStructure="" CssIteration="" Timeout="120" WorkItemIds=""
   xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010" Description="" CredentialUserName="" CredentialPassword="" PreAuthenticate="True" Proxy="default" StopOnError="False" RecordedResultFile="" ResultsLocale="">

--- a/terraform/uptime/main.tf
+++ b/terraform/uptime/main.tf
@@ -1,0 +1,62 @@
+data "azurerm_application_insights" "benefits" {
+  name                = "AS-CDT-CALITP-D-001"
+  resource_group_name = var.resource_group_name
+}
+
+resource "azurerm_application_insights_web_test" "healthcheck" {
+  name                    = var.name
+  location                = data.azurerm_application_insights.benefits.location
+  resource_group_name     = var.resource_group_name
+  application_insights_id = data.azurerm_application_insights.benefits.id
+  kind                    = "ping"
+  enabled                 = true
+
+  # "We strongly recommend testing from … a minimum of five locations."
+  # https://docs.microsoft.com/en-us/azure/azure-monitor/app/monitor-web-app-availability#create-a-test
+  geo_locations = [
+    "us-fl-mia-edge", # Central US
+    "us-va-ash-azr",  # East US
+    "us-il-ch1-azr",  # North Central US
+    "us-tx-sn1-azr",  # South Central US
+    "us-ca-sjc-azr",  # West US
+  ]
+
+  configuration = <<XML
+<WebTest Name="dev-healthcheck" Enabled="True" CssProjectStructure="" CssIteration="" Timeout="120" WorkItemIds=""
+  xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010" Description="" CredentialUserName="" CredentialPassword="" PreAuthenticate="True" Proxy="default" StopOnError="False" RecordedResultFile="" ResultsLocale="">
+  <Items>
+    <Request Method="GET" Version="1.1" Url="${var.url}" ThinkTime="0" Timeout="300" ParseDependentRequests="True" FollowRedirects="True" RecordResult="True" Cache="False" ResponseTimeGoal="0" Encoding="utf-8" ExpectedHttpStatusCode="200" ExpectedResponseUrl="" ReportingName="" IgnoreHttpStatusCode="False" />
+  </Items>
+</WebTest>
+XML
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+
+resource "azurerm_monitor_metric_alert" "uptime" {
+  name                = "uptime-${var.name}"
+  resource_group_name = var.resource_group_name
+  scopes = [
+    azurerm_application_insights_web_test.healthcheck.id,
+    data.azurerm_application_insights.benefits.id
+  ]
+  severity = var.severity
+
+  application_insights_web_test_location_availability_criteria {
+    web_test_id           = azurerm_application_insights_web_test.healthcheck.id
+    component_id          = data.azurerm_application_insights.benefits.id
+    # "the optimal configuration is to have the number of test locations be equal to the alert location threshold + 2"
+    # https://docs.microsoft.com/en-us/azure/azure-monitor/app/monitor-web-app-availability#create-a-test
+    failed_location_count = length(azurerm_application_insights_web_test.healthcheck.geo_locations) - 2
+  }
+
+  action {
+    action_group_id = var.action_group_id
+  }
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}

--- a/terraform/uptime/main.tf
+++ b/terraform/uptime/main.tf
@@ -1,5 +1,5 @@
 data "azurerm_application_insights" "benefits" {
-  name                = "AS-CDT-CALITP-D-001"
+  name                = "AI-CDT-PUB-VIP-CALITP-P-001"
   resource_group_name = var.resource_group_name
 }
 

--- a/terraform/uptime/variables.tf
+++ b/terraform/uptime/variables.tf
@@ -3,7 +3,7 @@ variable "action_group_id" {
 }
 
 variable "name" {
-  type = string
+  type        = string
   description = "What to call the ping test"
 }
 
@@ -12,8 +12,8 @@ variable "resource_group_name" {
 }
 
 variable "severity" {
-  type = number
-  default = 1
+  type        = number
+  default     = 1
   description = "https://docs.microsoft.com/en-us/azure/azure-monitor/best-practices-alerts#alert-severity"
 }
 

--- a/terraform/uptime/variables.tf
+++ b/terraform/uptime/variables.tf
@@ -1,0 +1,22 @@
+variable "action_group_id" {
+  type = string
+}
+
+variable "name" {
+  type = string
+  description = "What to call the ping test"
+}
+
+variable "resource_group_name" {
+  type = string
+}
+
+variable "severity" {
+  type = number
+  default = 1
+  description = "https://docs.microsoft.com/en-us/azure/azure-monitor/best-practices-alerts#alert-severity"
+}
+
+variable "url" {
+  type = string
+}

--- a/terraform/uptime/webtest.xml
+++ b/terraform/uptime/webtest.xml
@@ -1,0 +1,7 @@
+<!-- boilerplate configuration -->
+<WebTest Name="dev-healthcheck" Enabled="True" CssProjectStructure="" CssIteration="" Timeout="120" WorkItemIds=""
+  xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010" Description="" CredentialUserName="" CredentialPassword="" PreAuthenticate="True" Proxy="default" StopOnError="False" RecordedResultFile="" ResultsLocale="">
+  <Items>
+    <Request Method="GET" Version="1.1" Url="${url}" ThinkTime="0" Timeout="300" ParseDependentRequests="True" FollowRedirects="True" RecordResult="True" Cache="False" ResponseTimeGoal="0" Encoding="utf-8" ExpectedHttpStatusCode="200" ExpectedResponseUrl="" ReportingName="" IgnoreHttpStatusCode="False" />
+  </Items>
+</WebTest>


### PR DESCRIPTION
Closes https://github.com/cal-itp/benefits/issues/449.

This is a proof of concept to show two things:

- A [URL ping test](https://docs.microsoft.com/en-us/azure/azure-monitor/app/monitor-web-app-availability)
- Use of Terraform for #618 

~~About half~~ A lot of the additions in the pull request are just Terraform boilerplate. Uptime-specific stuff is in `terraform/uptime.tf`. Note this doesn't bring any existing Azure resources into management by Terraform.

If people are 👍 on the approach, I would want to do the following from here:

- [ ] Terraform stuff
  - [x] Set up a non-`local` [Terraform backend](https://www.terraform.io/language/settings/backends)
  - [x] Add documentation around use of Terraform
  - [x] Get buy-in from @cal-itp/cdt-devsecops that we will all start to work in Terraform
  - [ ] Look into how to tag Terraform-managed resources as such
- [x] Monitoring stuff
  - [x] Decide on the URLs we want to monitor, at least as URL ping tests
  - [x] Decide on how we want to be alerted — [options](https://docs.microsoft.com/en-us/azure/azure-monitor/best-practices-alerts#notifications)

Feedback welcome!