### PR TITLE
Refactor: remove jwcrypto

### DIFF
--- a/benefits/core/models.py
+++ b/benefits/core/models.py
@@ -6,8 +6,6 @@ import logging
 from django.db import models
 from django.urls import reverse
 
-from jwcrypto import jwk
-
 
 logger = logging.getLogger(__name__)
 
@@ -21,12 +19,6 @@ class PemData(models.Model):
 
     def __str__(self):
         return self.label
-
-    @property
-    def jwk(self):
-        """jwcrypto.jwk.JWK instance from this PemData."""
-        pem_bytes = bytes(self.text, "utf-8")
-        return jwk.JWK.from_pem(pem_bytes)
 
 
 class AuthProvider(models.Model):
@@ -100,9 +92,9 @@ class EligibilityVerifier(models.Model):
         return self.name
 
     @property
-    def public_jwk(self):
-        """jwcrypto.jwk.JWK instance of this Verifier's public key"""
-        return self.public_key.jwk
+    def public_key_data(self):
+        """This Verifier's public key as a string."""
+        return self.public_key.text
 
     @property
     def requires_authentication(self):
@@ -189,9 +181,9 @@ class TransitAgency(models.Model):
         return reverse("core:agency_index", args=[self.slug])
 
     @property
-    def private_jwk(self):
-        """jwcrypto.jwk.JWK instance of this Agency's private key"""
-        return self.private_key.jwk
+    def private_key_data(self):
+        """This Agency's private key as a string."""
+        return self.private_key.text
 
     @staticmethod
     def by_id(id):

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -193,10 +193,10 @@ def _verify(request, form):
         issuer=settings.ALLOWED_HOSTS[0],
         agency=agency.agency_id,
         jws_signing_alg=agency.jws_signing_alg,
-        client_private_jwk=agency.private_jwk,
+        client_private_key=agency.private_key_data,
         jwe_encryption_alg=verifier.jwe_encryption_alg,
         jwe_cek_enc=verifier.jwe_cek_enc,
-        server_public_jwk=verifier.public_jwk,
+        server_public_key=verifier.public_key_data,
     )
 
     # get the eligibility type names

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Authlib==1.0.1
 cryptography==37.0.2
 Django==3.2.13
 django-csp==3.7
-git+https://github.com/cal-itp/eligibility-api#egg=eligibility_api
+git+https://github.com/cal-itp/eligibility-api@a2f9932d074d10afc21713ada32eebe3841a1a3d#egg=eligibility_api
 gunicorn==20.1.0
 jwcrypto==1.3
 requests==2.27.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,7 @@
 Authlib==1.0.1
-cryptography==37.0.2
 Django==3.2.13
 django-csp==3.7
 git+https://github.com/cal-itp/eligibility-api@a2f9932d074d10afc21713ada32eebe3841a1a3d#egg=eligibility_api
 gunicorn==20.1.0
-jwcrypto==1.3
 requests==2.27.1
 six==1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Authlib==1.0.1
 Django==3.2.13
 django-csp==3.7
-git+https://github.com/cal-itp/eligibility-api@a2f9932d074d10afc21713ada32eebe3841a1a3d#egg=eligibility_api
+git+https://github.com/cal-itp/eligibility-api#egg=eligibility_api
 gunicorn==20.1.0
 requests==2.27.1
 six==1.16.0

--- a/tests/pytest/eligibility/test_views.py
+++ b/tests/pytest/eligibility/test_views.py
@@ -8,7 +8,6 @@ import os
 import uuid
 
 from pathlib import Path
-from jwcrypto import jwk
 
 from benefits.core import session
 from benefits.core.models import TransitAgency
@@ -88,10 +87,10 @@ def test_confirm_success(mocker, rf):
                 "eligibility": ["type1"],
             },
             verifier.jws_signing_alg,
-            _get_jwk("server.key"),
+            _get_key("server.key"),
             verifier.jwe_encryption_alg,
             verifier.jwe_cek_enc,
-            _get_jwk("client.pub"),
+            _get_key("client.pub"),
         ),
     )
 
@@ -108,12 +107,12 @@ def test_confirm_success(mocker, rf):
     assert response.url == reverse("enrollment:index")
 
 
-def _get_jwk(filename):
+def _get_key(filename):
     current_path = Path(os.path.dirname(os.path.realpath(__file__)))
     file_path = current_path / "keys" / filename
 
     with file_path.open(mode="rb") as pemfile:
-        key = jwk.JWK.from_pem(pemfile.read())
+        key = str(pemfile.read(), "utf-8")
 
     return key
 
@@ -190,10 +189,10 @@ def _tokenize_response_error_scenarios():
                     "eligibility": ["type1"],
                 },
                 "RS512",  # signing algorithm that doesn't match verifier.jws_signing_alg
-                _get_jwk("server.key"),
+                _get_key("server.key"),
                 verifier.jwe_encryption_alg,
                 verifier.jwe_cek_enc,
-                _get_jwk("client.pub"),
+                _get_key("client.pub"),
             ),
             id='TokenError("JWS token signature verification failed")',
         ),


### PR DESCRIPTION
Closes #617 

### Reviewing this PR
 - First, review [cal-itp/eligibility-api#31](https://github.com/cal-itp/eligibility-api/pull/31)
 - Then, on this branch, make sure the `eligibility-api` package is installed by either:
    - rebuilding the `client` image and the devcontainer
    - OR running `pip install -r requirements.txt` (run `pip uninstall eligibility-api` first if you previously installed it and want to re-install it)
 - Run the Pytests at [`tests/pytest/eligibility/test_views.py`](https://github.com/cal-itp/benefits/blob/b48eaa7bca8bac2c7da2567cb67ca7f30982bbe7/tests/pytest/eligibility/test_views.py) to see that eligibility verification still works