### PR TITLE
Refactor: bring back eligibility API helper module

### DIFF
--- a/benefits/eligibility/api.py
+++ b/benefits/eligibility/api.py
@@ -1,0 +1,47 @@
+"""
+The eligibility application: Eligibility Verification API helpers.
+"""
+
+from django.conf import settings
+
+from eligibility_api.client import Client
+
+from benefits.core import session
+
+
+def get_verified_types(request, form):
+    """
+    Helper calls the eligibility verification API with user input.
+    Returns None and updates form with user input error(s).
+    Returns a list of verified eligibility types, or an empty list when no types were verified.
+    """
+
+    sub, name = form.cleaned_data.get("sub"), form.cleaned_data.get("name")
+
+    agency = session.agency(request)
+    verifier = session.verifier(request)
+
+    client = Client(
+        verify_url=verifier.api_url,
+        headers={verifier.api_auth_header: verifier.api_auth_key},
+        issuer=settings.ALLOWED_HOSTS[0],
+        agency=agency.agency_id,
+        jws_signing_alg=agency.jws_signing_alg,
+        client_private_key=agency.private_key_data,
+        jwe_encryption_alg=verifier.jwe_encryption_alg,
+        jwe_cek_enc=verifier.jwe_cek_enc,
+        server_public_key=verifier.public_key_data,
+    )
+
+    # get the eligibility type names to check
+    types = list(map(lambda t: t.name, agency.types_to_verify(verifier)))
+
+    response = client.verify(sub, name, types)
+
+    if response.error and any(response.error):
+        form.add_api_errors(response.error)
+        return None
+    elif any(response.eligibility):
+        return list(response.eligibility)
+    else:
+        return []

--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -6,6 +6,7 @@ import pytest
 from pytest_socket import disable_socket
 
 from benefits.core import session
+from benefits.core.models import TransitAgency
 
 
 def pytest_runtest_setup():
@@ -57,6 +58,24 @@ def initialize_request(request):
     request.session.save()
 
     session.reset(request)
+
+
+def set_agency(mocker):
+    agency = TransitAgency.objects.first()
+    assert agency
+    with_agency(mocker, agency)
+    return agency
+
+
+def set_verifier(mocker):
+    agency = set_agency(mocker)
+
+    mock = mocker.patch("benefits.core.session.verifier", autospec=True)
+    verifier = agency.eligibility_verifiers.first()
+    mocker.patch.object(verifier, "api_url", "http://localhost/verify")
+    assert verifier
+    mock.return_value = verifier
+    return (agency, verifier)
 
 
 def with_agency(mocker, agency):

--- a/tests/pytest/eligibility/test_api.py
+++ b/tests/pytest/eligibility/test_api.py
@@ -6,3 +6,7 @@ from benefits.eligibility.forms import EligibilityVerificationForm
 @pytest.fixture
 def form(mocker):
     return mocker.Mock(spec=EligibilityVerificationForm, cleaned_data={"name": "Garcia", "sub": "A1234567"})
+
+
+def mock_api_client_verify(mocker, response):
+    return mocker.patch("benefits.eligibility.api.Client.verify", return_value=response)

--- a/tests/pytest/eligibility/test_api.py
+++ b/tests/pytest/eligibility/test_api.py
@@ -1,6 +1,9 @@
 import pytest
 
+from benefits.eligibility.api import get_verified_types
 from benefits.eligibility.forms import EligibilityVerificationForm
+
+from tests.pytest.conftest import set_verifier
 
 
 @pytest.fixture
@@ -12,8 +15,19 @@ def mock_api_client_verify(mocker, response):
     return mocker.patch("benefits.eligibility.api.Client.verify", return_value=response)
 
 
+@pytest.mark.django_db
 def test_get_verified_types_error(mocker, app_request, form):
-    pass
+    set_verifier(mocker)
+
+    api_errors = {"name": "Name error"}
+    api_response = mocker.Mock(error=api_errors)
+
+    mock_api_client_verify(mocker, api_response)
+
+    response = get_verified_types(app_request, form)
+
+    assert response is None
+    form.add_api_errors.assert_called_once_with(api_errors)
 
 
 def test_get_verified_types_verified_types(mocker, app_request, form):

--- a/tests/pytest/eligibility/test_api.py
+++ b/tests/pytest/eligibility/test_api.py
@@ -45,5 +45,16 @@ def test_get_verified_types_verified_types(mocker, app_request, form):
     form.add_api_errors.assert_not_called()
 
 
+@pytest.mark.django_db
 def test_get_verified_types_no_verified_types(mocker, app_request, form):
-    pass
+    set_verifier(mocker)
+
+    verified_types = []
+    api_response = mocker.Mock(eligibility=verified_types, error=None)
+
+    mock_api_client_verify(mocker, api_response)
+
+    response = get_verified_types(app_request, form)
+
+    assert response == verified_types
+    form.add_api_errors.assert_not_called()

--- a/tests/pytest/eligibility/test_api.py
+++ b/tests/pytest/eligibility/test_api.py
@@ -1,0 +1,8 @@
+import pytest
+
+from benefits.eligibility.forms import EligibilityVerificationForm
+
+
+@pytest.fixture
+def form(mocker):
+    return mocker.Mock(spec=EligibilityVerificationForm, cleaned_data={"name": "Garcia", "sub": "A1234567"})

--- a/tests/pytest/eligibility/test_api.py
+++ b/tests/pytest/eligibility/test_api.py
@@ -30,8 +30,19 @@ def test_get_verified_types_error(mocker, app_request, form):
     form.add_api_errors.assert_called_once_with(api_errors)
 
 
+@pytest.mark.django_db
 def test_get_verified_types_verified_types(mocker, app_request, form):
-    pass
+    set_verifier(mocker)
+
+    verified_types = ["type1", "type2"]
+    api_response = mocker.Mock(eligibility=verified_types, error=None)
+
+    mock_api_client_verify(mocker, api_response)
+
+    response = get_verified_types(app_request, form)
+
+    assert response == verified_types
+    form.add_api_errors.assert_not_called()
 
 
 def test_get_verified_types_no_verified_types(mocker, app_request, form):

--- a/tests/pytest/eligibility/test_api.py
+++ b/tests/pytest/eligibility/test_api.py
@@ -10,3 +10,15 @@ def form(mocker):
 
 def mock_api_client_verify(mocker, response):
     return mocker.patch("benefits.eligibility.api.Client.verify", return_value=response)
+
+
+def test_get_verified_types_error(mocker, app_request, form):
+    pass
+
+
+def test_get_verified_types_verified_types(mocker, app_request, form):
+    pass
+
+
+def test_get_verified_types_no_verified_types(mocker, app_request, form):
+    pass

--- a/tests/pytest/eligibility/test_views.py
+++ b/tests/pytest/eligibility/test_views.py
@@ -1,38 +1,19 @@
+import datetime
+import os
+import uuid
+from pathlib import Path
+
 from django.urls import reverse
+
 import pytest
 import httpretty
 import requests
 
-import datetime
-import os
-import uuid
-
-from pathlib import Path
-
 from benefits.core import session
-from benefits.core.models import TransitAgency
 from eligibility_api.client import ApiError, TokenError
 from eligibility_api.server import make_token
 from benefits.eligibility.views import confirm
-from tests.pytest.conftest import with_agency, initialize_request
-
-
-def set_agency(mocker):
-    agency = TransitAgency.objects.first()
-    assert agency
-    with_agency(mocker, agency)
-    return agency
-
-
-def set_verifier(mocker):
-    agency = set_agency(mocker)
-
-    mock = mocker.patch("benefits.core.session.verifier", autospec=True)
-    verifier = agency.eligibility_verifiers.first()
-    mocker.patch.object(verifier, "api_url", "http://localhost/verify")
-    assert verifier
-    mock.return_value = verifier
-    return (agency, verifier)
+from tests.pytest.conftest import initialize_request, set_agency, set_verifier, with_agency
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Simplifies logic in the Eligibility views by wrapping the API Client and request/response parsing into a helper function.

Closes #622 