### PR TITLE
Mobile: All action buttons on mobile are now 72px height.

### DIFF
--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -536,6 +536,7 @@ footer .footer-links a {
 
 @media (max-width: 767px) {
   /* xs and sm */
+
   .global-footer ul li {
     text-align: center;
   }
@@ -557,6 +558,10 @@ footer .footer-links a {
 }
 
 @media (max-width: 992px) {
+  .container.content .btn-lg {
+    padding: 1.1875rem 0.813rem;
+  }
+
   /* Mobile With Image */
 
   .with-image main .main-row .col-lg-6.image {


### PR DESCRIPTION
closes #632 
 
## What this PR does
- all mobile action buttons are now 72px height.
- login.gov/getting started page buttons remain the same. header Spanish language button remains the same.

## How to test
- Check buttons on:
- Agency page
- Home page
- Help page
- Form pages


## Screenshots

- iPhone SE
<img width="1506" alt="image" src="https://user-images.githubusercontent.com/3673236/172439734-e50c3e70-b122-49fa-8d94-a675776bd49a.png">
<img width="542" alt="image" src="https://user-images.githubusercontent.com/3673236/172439789-001c8eb3-f4f0-4eb4-b655-5b16fbed963e.png">


- iPad, vertical
<img width="907" alt="image" src="https://user-images.githubusercontent.com/3673236/172439948-ca4271d1-7c49-4d96-89f8-724fce11cd09.png">
