### PR TITLE
Chore: init deletes existing db

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -eu
 
+# remove existing (old) database file
+# -f forces the delete (and avoids an error when the file doesn't exist)
+
+rm -f django.db
+
 # run database migrations
 
 python manage.py migrate

--- a/docs/configuration/fixtures.md
+++ b/docs/configuration/fixtures.md
@@ -59,8 +59,6 @@ The file is called `django.db` and the following commands will rebuild it.
 Run these commands from within the repository root, inside the devcontainer:
 
 ```bash
-rm django.db
-
 bin/init.sh
 ```
 


### PR DESCRIPTION
This is another area that can trip up new devs (and, me...:blush:), especially with all the extra warning messages that can be printed. Then if you have a mismatch in data/migrations and existing schema there can be all kinds of annoying errors.

In development mode, it's nice (e.g. when the devcontainer starts) to have the init script clear out any existing database file before rebuilding the whole thing.

In production, this should be a noop since the database file won't exist yet.