### PR TITLE
IAL2 Login.gov Flow: Redirect users to Eligibility Start

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,7 +29,7 @@
     "editor.formatOnSave": true
   },
   "python.testing.pytestArgs": [
-    "tests/pytest"
+    "tests/pytest", "--import-mode=importlib"
   ],
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true

--- a/benefits/core/views.py
+++ b/benefits/core/views.py
@@ -59,6 +59,9 @@ def agency_index(request, agency):
     session.reset(request)
     session.update(request, agency=agency, origin=agency.index_url)
 
+    if len(agency.eligibility_verifiers.all()) == 1:
+        return redirect(reverse("eligibility:index"))
+
     button = viewmodels.Button.primary(text=_("core.pages.index.continue"), url=reverse("eligibility:index"))
     button.label = _("core.pages.agency_index.button.label")
 

--- a/tests/cypress/specs/ui/eligibility-no-auth.cy.js
+++ b/tests/cypress/specs/ui/eligibility-no-auth.cy.js
@@ -9,7 +9,6 @@ describe("Single verifier: Eligibility confirmation page spec", () => {
     cy.visit("/");
     // Selecting DEFTl will go down the single verifier flow
     cy.contains(agencies[1].fields.short_name).click();
-    // cy.contains("Get started").click();
     cy.contains("Continue").click();
     cy.url().should("include", eligibility_confirm_url);
   });

--- a/tests/cypress/specs/ui/eligibility-no-auth.cy.js
+++ b/tests/cypress/specs/ui/eligibility-no-auth.cy.js
@@ -9,7 +9,7 @@ describe("Single verifier: Eligibility confirmation page spec", () => {
     cy.visit("/");
     // Selecting DEFTl will go down the single verifier flow
     cy.contains(agencies[1].fields.short_name).click();
-    cy.contains("Get started").click();
+    // cy.contains("Get started").click();
     cy.contains("Continue").click();
     cy.url().should("include", eligibility_confirm_url);
   });

--- a/tests/cypress/specs/ui/enrollment.cy.js
+++ b/tests/cypress/specs/ui/enrollment.cy.js
@@ -5,7 +5,6 @@ describe("Single Verifier, No AuthProvider: Enrollment success page", () => {
     cy.visit("/");
     // Selecting DEFTl will go down the single verifier flow
     cy.contains(agencies[1].fields.short_name).click();
-    cy.contains("Get started").click();
     cy.contains("Continue").click();
     // https://github.com/cypress-io/cypress/issues/18690
     cy.window().then((win) => (win.location.href = "/enrollment/success"));

--- a/tests/pytest/core/test_views.py
+++ b/tests/pytest/core/test_views.py
@@ -25,6 +25,23 @@ def test_homepage_single_agency(mocker, client):
 
 
 @pytest.mark.django_db
+def test_homepage_single_agency_single_verifier(mocker, client):
+    # Agency set to DEFTl, which only has 1 verifier
+    agencies = TransitAgency.all_active()[1:]
+    mocker.patch("benefits.core.models.TransitAgency.all_active", return_value=agencies)
+
+    assert len(agencies) == 1
+    assert len(agencies[0].eligibility_verifiers.all()) == 1
+
+    path = reverse("core:index")
+    response = client.get(path)
+
+    assert response.status_code == 302
+    assert response.url == reverse("eligibility:start")
+    # assert response.url == agencies[0].index_url
+
+
+@pytest.mark.django_db
 def test_help(client):
     path = reverse("core:help")
     response = client.get(path)

--- a/tests/pytest/core/test_views.py
+++ b/tests/pytest/core/test_views.py
@@ -36,7 +36,7 @@ def test_homepage_single_agency_single_verifier(mocker, client):
     # https://docs.djangoproject.com/en/3.2/topics/testing/tools/#making-requests
     assert response.redirect_chain[0] == ("/deftl", 302)
     assert response.redirect_chain[1] == ("/eligibility/", 302)
-    assert response.redirect_chain[2] == ("/eligibility/start", 302)
+    assert response.redirect_chain[-1] == ("/eligibility/start", 302)
 
 
 @pytest.mark.django_db

--- a/tests/pytest/core/test_views.py
+++ b/tests/pytest/core/test_views.py
@@ -30,15 +30,13 @@ def test_homepage_single_agency_single_verifier(mocker, client):
     agencies = TransitAgency.all_active()[1:]
     mocker.patch("benefits.core.models.TransitAgency.all_active", return_value=agencies)
 
-    assert len(agencies) == 1
-    assert len(agencies[0].eligibility_verifiers.all()) == 1
+    response = client.get(reverse("core:index"), follow=True)
 
-    path = reverse("core:index")
-    response = client.get(path)
-
-    assert response.status_code == 302
-    assert response.url == reverse("eligibility:start")
-    # assert response.url == agencies[0].index_url
+    # Setting follow to True allows the test to go thorugh redirects and returns the redirect_chain attr
+    # https://docs.djangoproject.com/en/3.2/topics/testing/tools/#making-requests
+    assert response.redirect_chain[0] == ("/deftl", 302)
+    assert response.redirect_chain[1] == ("/eligibility/", 302)
+    assert response.redirect_chain[2] == ("/eligibility/start", 302)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
closes #656 

As a senior with a Social Security Number, when I go to benefits.calitp.org, I should get redirected to the Eligibility Start page.

## What this PR does
- Applies this new view logic: When there is only 1 agency and 1 verifier, redirect the user to the eligibility start page
- [x] Adds Pytest for this view logic

## To test this feature locally

You will have to change your database data to reflect a scenario in which there is only 1 agency and 1 verifier. There are 2 ways to do this -

### Code way

1. Remove `DefTL` agency from the `05_transitagency.json` file
2. For the `ABC` agency, Change `"eligibility_verifiers": [1,2]` to `"eligibility_verifiers": [1]`
3. Run `bin/init.sh` - This should remove your current database, create a new database and run the necessary migrations
4. Go to `localhost:8000`
5. The site should redirect you to `localhost:8000/eligibility/start`

### Admin UI way

1. Turn on Admin by adding `DJANGO_ADMIN=true`
2. Run `bin/init.sh` and set your username/password
3. Go to http://localhost:9000/admin/ 
4. Go to http://localhost:9000/admin/core/transitagency/1/change/- Uncheck **Active**, to mark ABC Transit as inactive.
5. Click **Save**
<img width="1191" alt="image" src="https://user-images.githubusercontent.com/3673236/173001036-b97d2014-8ebc-4bb4-ae92-bc5eb7c710d0.png">
