### PR TITLE
format Python files using black extension

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get install -qq curl jq ssh
 USER $USER
 
 RUN python -m pip install --upgrade pip && \
-    pip install black flake8 pre-commit
+    pip install flake8 pre-commit
 
 COPY docs/requirements.txt docs/requirements.txt
 RUN pip install -r docs/requirements.txt

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,6 +22,7 @@
     "eamodio.gitlens",
     "mhutchie.git-graph",
     "ms-python.python",
+    "ms-python.black-formatter",
     "ms-python.vscode-pylance",
     "esbenp.prettier-vscode"
   ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,10 +8,11 @@
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,
   "files.trimTrailingWhitespace": true,
+  // https://github.com/microsoft/vscode-black-formatter/issues/82#issuecomment-1155492426
   "[python]": {
-    "editor.defaultFormatter": "ms-python.python"
+    "editor.defaultFormatter": "ms-python.black-formatter"
   },
-  "python.formatting.provider": "black",
+  "python.formatting.provider": "none",
   "python.languageServer": "Pylance",
   "python.linting.enabled": true,
   "python.linting.flake8Enabled": true,


### PR DESCRIPTION
~~This does a few things:~~

- ~~Sets the default formatter to be Prettier, which will also apply it to things like Markdown.~~
- Installs the Black extension to enable formatting Python files on save.
- ~~Formats on save by default, which is fine because formatting HTML is still disabled, protecting the Jinja templates.~~
- ~~Formats the settings files (with Prettier).~~

The rest has been moved to https://github.com/cal-itp/benefits/pull/746.