### PR TITLE
chore: better integrate infrastructure documentation

### DIFF
--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -1,5 +1,9 @@
 # Overview
 
+[dev-benefits.calitp.org][dev-benefits] is currently deployed into a Microsoft Azure account provided by [California Department of Technology (CDT)'s Office of Enterprise Technology (OET)][oet], a.k.a. the "DevSecOps" team. More specifically, it uses [custom containers][app-service-containers] on [Azure App Service][app-service]. [More about the infrastructure.](infrastructure.md)
+
+## Deployment process
+
 The Django application gets built into a [Docker image][dockerfile] with [NGINX](https://www.nginx.com/) and
 [Gunicorn](https://gunicorn.org/). SQLite is used within that same container to store configuration data and Azure Blobs are
 used for secrets; there is no external database.
@@ -18,7 +22,10 @@ Azure to restart the app and pull the latest image.
 [Configuration settings](../configuration/README.md) are stored as Application Configuration variables in Azure.
 [Fixtures](../configuration/fixtures.md) are stored as blobs in in Azure Storage, and [mounted into the Web App container][az-mount].
 
-[arch-overview]: https://docs.google.com/document/d/1rwYcp2ps_JNn9WmjqUfYpPeuMoj1FZu5DTUloQEQ5iQ/edit#heading=h.afetf83gz28y
+[dev-benefits]: https://dev-benefits.calitp.org
+[oet]: https://techblog.cdt.ca.gov/2020/06/cdt-taking-the-lead-in-digital-transformation/
+[app-service-containers]: https://docs.microsoft.com/en-us/azure/app-service/configure-custom-container
+[app-service]: https://docs.microsoft.com/en-us/azure/app-service/overview
 [dockerfile]: https://github.com/cal-itp/benefits/blob/dev/Dockerfile
 [az-webapp]: https://azure.microsoft.com/en-us/services/app-service/containers/
 [az-mount]: https://docs.microsoft.com/en-us/azure/app-service/configure-connect-to-azure-storage?tabs=portal&pivots=container-linux

--- a/docs/deployment/infrastructure.md
+++ b/docs/deployment/infrastructure.md
@@ -1,8 +1,8 @@
-# Azure
+# Infrastructure
 
-[dev-benefits.calitp.org](https://dev-benefits.calitp.org) is currently deployed into a Microsoft Azure account provided by [California Department of Technology (CDT)'s Office of Enterprise Technology (OET)](https://techblog.cdt.ca.gov/2020/06/cdt-taking-the-lead-in-digital-transformation/), a.k.a. the "DevSecOps" team. More specifically, it uses [custom containers](https://docs.microsoft.com/en-us/azure/app-service/configure-custom-container) on [Azure App Service](https://docs.microsoft.com/en-us/azure/app-service/overview).
+The infrastructure is configured as code via [Terraform](https://www.terraform.io/), for [various reasons](https://techcommunity.microsoft.com/t5/fasttrack-for-azure/the-benefits-of-infrastructure-as-code/ba-p/2069350). All Azure resources under the `RG-CDT-PUB-VIP-CALITP-P-001` [resource group](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/manage-resource-groups-portal) should be represented in this repository. The exception is secrets, such as values under [Key Vault](https://azure.microsoft.com/en-us/services/key-vault/) and [App Service application settings](https://docs.microsoft.com/en-us/azure/app-service/configure-common#configure-app-settings).
 
-The infrastructure is configured as code via [Terraform](https://www.terraform.io/), for [various reasons](https://techcommunity.microsoft.com/t5/fasttrack-for-azure/the-benefits-of-infrastructure-as-code/ba-p/2069350). We are adding existing resources to the configuration progressively. In other words, not _all_ our resources in Azure show up under [`terraform/`][terraform-dir], but we are [moving that direction](https://github.com/cal-itp/benefits/issues/618).
+For browsing the [Azure portal](https://portal.azure.com), [switching your `Default subscription filter`](https://docs.microsoft.com/en-us/azure/azure-portal/set-preferences) to only `CDT/ODI Production` is recommended.
 
 ## Architecture
 
@@ -64,23 +64,31 @@ We have [ping tests](https://docs.microsoft.com/en-us/azure/azure-monitor/app/mo
 
 1. Get access to the Azure account through the DevSecOps team.
 1. Install dependencies:
-    - [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
-    - [Terraform](https://www.terraform.io/downloads)
+   - [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
+   - [Terraform](https://www.terraform.io/downloads)
 1. [Authenticate using the Azure CLI](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli), specifying the `CDT/ODI Production` Subscription.
 1. Outside the [dev container](../../getting-started/), navigate to the [`terraform/`][terraform-dir] directory.
 1. [Initialize Terraform.](https://www.terraform.io/cli/commands/init)
 
-    ```sh
-    terraform init
-    ```
+   ```sh
+   terraform init
+   ```
 
 1. Make changes to Terraform files.
 1. [Plan](https://www.terraform.io/cli/commands/plan)/[apply](https://www.terraform.io/cli/commands/apply) the changes, as necessary.
 
-    ```sh
-    terraform apply
-    ```
+   ```sh
+   terraform apply
+   ```
 
 1. [Submit the changes via pull request.](../development/commits-branches-merging/) Be sure to specify whether they've been applied, i.e. whether they're live or not.
+
+For Azure resources, you need to [ignore changes](https://www.terraform.io/language/meta-arguments/lifecycle#ignore_changes) to tags, since they are [automatically created by Azure Policy](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/tag-policies).
+
+```hcl
+lifecycle {
+  ignore_changes = [tags]
+}
+```
 
 [terraform-dir]: https://github.com/cal-itp/benefits/tree/dev/terraform

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ plugins:
   - awesome-pages
   - redirects:
       redirect_maps:
+        "deployment/azure.md": "deployment/infrastructure.md"
         "getting-started/development.md": "development/README.md"
         "getting-started/docker-dynamic-ports.md": "development/docker-dynamic-ports.md"
 


### PR DESCRIPTION
Based on suggestion in https://github.com/cal-itp/benefits/pull/623#pullrequestreview-1002047322, changed the "Azure" page to be more generally about "Infrastructure", and moved the intro paragraph to the top-level Deployment page.