### PR TITLE
Chore: Faster devcontainer start

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,3 +20,10 @@ RUN pip install -r docs/requirements.txt
 
 COPY tests/pytest/requirements.txt tests/pytest/requirements.txt
 RUN pip install -r tests/pytest/requirements.txt
+
+# install pre-commit environments in throwaway Git repository
+# https://stackoverflow.com/a/68758943
+COPY .pre-commit-config.yaml .
+RUN git init . && \
+    pre-commit install-hooks && \
+    rm -rf .git

--- a/.devcontainer/postAttach.sh
+++ b/.devcontainer/postAttach.sh
@@ -3,6 +3,3 @@ set -eu
 
 # initialize pre-commit
 pre-commit install --overwrite
-
-# install cypress
-cd tests/cypress && npm install && npx cypress install

--- a/.devcontainer/postAttach.sh
+++ b/.devcontainer/postAttach.sh
@@ -1,11 +1,8 @@
 #!/usr/bin/env bash
 set -eu
 
-# initialize hook environments
-pre-commit install --install-hooks --overwrite
-
-# manage commit-msg hooks
-pre-commit install --hook-type commit-msg
+# initialize pre-commit
+pre-commit install --overwrite
 
 # install cypress
 cd tests/cypress && npm install && npx cypress install

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+default_install_hook_types:
+  - pre-commit
+  - commit-msg
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v1.2.0

--- a/docs/tests/README.md
+++ b/docs/tests/README.md
@@ -7,28 +7,9 @@ Feature and user interface tests are implemented with [`cypress`](https://www.cy
 
 See the [`cypress` Command Line](https://docs.cypress.io/guides/guides/command-line) guide for more information.
 
-### Running in the Dev Container
+### Running
 
-`cypress` is installed and available to run directly in the [devcontainer](../development/README.md#vs-code-with-devcontainers).
-
-1. Ensure your `.env` file has an updated `CYPRESS_baseUrl` variable:
-
-    ```env
-    # using localhost since we're inside the container
-    CYPRESS_baseURL=http://localhost:8000
-    ```
-
-2. Rebuild and Reopen the devcontainer
-3. Start the `benefits` app with `F5`
-4. From within the `tests/cypress` directory:
-
-    ```bash
-    npm run cypress:ui
-    ```
-
-### Running outside of the Dev Container
-
-These are instructions for running `cypress` locally on your machine, *without* the devcontainer. These steps
+These are instructions for running `cypress` locally on your machine, *without* the [devcontainer](../development/README.md#vs-code-with-devcontainers). These steps
 will install `cypress` and its dependencies on your  machine. Make sure to run these commands in a Terminal.
 
 1. Ensure you have Node.js and NPM available on your local machine:


### PR DESCRIPTION
Punchline up front: This **speeds up devcontainer start time by around five minutes** on my machine.

The start time of a devcontainer was becoming a regular annoyance for me, enough so that I was finding myself working outside of it, which kinda defeats the purpose. I spent a bit of time to improve a couple of things that would make a big difference:

- Install pre-commit dependencies at `dev` image build time, which is infrequent/cached
- Don't bother installing Cypress in the devcontainer, since it wasn't being used (and maybe wasn't even working?) in there anyway. @machikoyasuda Can you confirm?

While it doesn't complete _all_ the tasks listed, I'm going to say this closes https://github.com/cal-itp/benefits/issues/495 as being "good enough."