### PR TITLE
Chore: remove node/npm installation steps in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,13 +2,8 @@ FROM benefits_client:latest
 
 USER root
 
-# install node.js
-# see https://github.com/nodesource/distributions#installation-instructions
-
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash
-
-RUN apt-get install -qq nodejs npm libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev \
-    libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb curl jq ssh
+# install Linux CLI tools for development
+RUN apt-get install -qq curl jq ssh
 
 USER $USER
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,8 +12,7 @@
       "args": ["runserver", "--insecure", "0.0.0.0:8000"],
       "django": true,
       "env": {
-        "DJANGO_DEBUG": "true",
-        "CYPRESS_baseUrl": "http://localhost:8000"
+        "DJANGO_DEBUG": "true"
       }
     }
   ]


### PR DESCRIPTION
Since Cypress was removed from the devcontainer install in #671, we don't need all the node/npm bits in there anymore.

Snuck in another small removal from the `launch.json` file, we had an env override for `CYPRESS_baseUrl` that wasn't actually being used.