### PR TITLE
Fix: Eligibility Start - Links

### DIFF
--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -158,6 +158,7 @@ def start(request):
     ctx = page.context_dict()
     ctx["title"] = _(verifier.start_content_title)
     ctx["media"] = media
+    ctx["info_link"] = f"{reverse(ROUTE_HELP)}#about"
 
     return TemplateResponse(request, TEMPLATE_START, ctx)
 

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -269,7 +269,7 @@ msgstr ""
 msgid "core.pages.agency_index.p[0]%(info_link)s"
 msgstr "You can tap your credit or debit card when you board, "
 "and your discount will automatically apply every time you ride."
-" <strong><a href=\"%(info_link)s\">Learn more about Cal-ITP Benefits</a></strong><span class='period'>.</span>"
+" <strong><a class='info-link' href=\"%(info_link)s\">Learn more about Cal-ITP Benefits</a></strong><span class='period'>.</span>"
 
 msgid "core.pages.agency_index.p[1]"
 msgstr "You will need your California driver’s license or ID "

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -254,7 +254,7 @@ msgstr ""
 
 
 msgid "core.pages.agency_index.p[0]%(info_link)s"
-msgstr "Puede acercar su tarjeta de crédito o débito cuando aborde, y su descuento se aplicará automáticamente cada vez que viaje. <strong><a href=\"%(info_link)s\">Conozca más sobre beneficios de Cal-ITP</a></strong><span class='period'>.</span>"
+msgstr "Puede acercar su tarjeta de crédito o débito cuando aborde, y su descuento se aplicará automáticamente cada vez que viaje. <strong><a class='info-link' href=\"%(info_link)s\">Conozca más sobre beneficios de Cal-ITP</a></strong><span class='period'>.</span>"
 
 msgid "core.pages.agency_index.p[1]"
 msgstr "Necesitará su licencia de conducir o tarjeta de identificación de California y su tarjeta sin contacto emitida por el banco para comenzar."

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -704,22 +704,8 @@ footer.global-footer .footer-links a:active {
     float: right;
   }
 
-  .eligibility-start .main-content .container strong a {
-    display: block;
-    line-height: 15px;
-    letter-spacing: 0.05em;
-    padding: 6px;
-    text-align: left;
-    width: 100%;
-    margin: 18px 0;
-    font-size: 18px;
-    text-decoration: none !important;
-    letter-spacing: 0.2px;
-    border: 2px solid #046b99;
-    border-radius: 0.3rem;
-    font-weight: 500;
-    width: 212px;
-    line-height: 22.5px;
+  .eligibility-start .main-content .container strong .info-link {
+    display: none;
   }
 
   .media-list .media .media-body .media-body--links .btn-lg {

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -338,8 +338,9 @@ footer.global-footer .footer-links a:active {
   letter-spacing: 0.05em;
   padding: 0 0 6px 0;
   text-align: left;
-  width: 100%;
   margin: 0;
+  display: block;
+  width: fit-content;
 }
 
 .media-list .media .media-body .media-body--links .btn-lg:hover {


### PR DESCRIPTION
closes other part of #689 

```
- Touch targets on desktop Help URLs span the page, which can create a misleading or unexpected hover effect
- On mobile, we took out the text link "Learn more about Cal-ITP benefits" entirely, as it links to the same location as the Help button at the bottom
```

