### PR TITLE
Feat: dynamic OAuth scope from verifier

### DIFF
--- a/benefits/oauth/client.py
+++ b/benefits/oauth/client.py
@@ -8,9 +8,14 @@ from authlib.integrations.django_client import OAuth
 logger = logging.getLogger(__name__)
 
 
-def instance():
+_OPENID_SCOPE = "openid"
+
+
+def instance(scope=None):
     """
     Get an OAuth client instance using the OAUTH_CLIENT_NAME setting.
+
+    Optionally configure with a (space-separated) scope.
     """
     if settings.OAUTH_CLIENT_NAME:
         logger.debug(f"Using OAuth client configuration: {settings.OAUTH_CLIENT_NAME}")
@@ -20,5 +25,12 @@ def instance():
         client = oauth.create_client(settings.OAUTH_CLIENT_NAME)
     else:
         raise Exception("OAUTH_CLIENT_NAME is not configured")
+
+    scopes = [_OPENID_SCOPE]
+
+    if scope:
+        scopes.append(scope)
+
+    client.client_kwargs["scope"] = " ".join(scopes)
 
     return client

--- a/benefits/oauth/client.py
+++ b/benefits/oauth/client.py
@@ -5,25 +5,20 @@ from django.conf import settings
 from authlib.integrations.django_client import OAuth
 
 
-_OAUTH_CLIENT = None
-
-
 logger = logging.getLogger(__name__)
 
 
 def instance():
     """
-    Get the OAuth client instance using the OAUTH_CLIENT_NAME setting.
+    Get an OAuth client instance using the OAUTH_CLIENT_NAME setting.
     """
-    global _OAUTH_CLIENT
-    if not _OAUTH_CLIENT:
-        if settings.OAUTH_CLIENT_NAME:
-            logger.debug(f"Using OAuth client configuration: {settings.OAUTH_CLIENT_NAME}")
+    if settings.OAUTH_CLIENT_NAME:
+        logger.debug(f"Using OAuth client configuration: {settings.OAUTH_CLIENT_NAME}")
 
-            _oauth = OAuth()
-            _oauth.register(settings.OAUTH_CLIENT_NAME)
-            _OAUTH_CLIENT = _oauth.create_client(settings.OAUTH_CLIENT_NAME)
-        else:
-            raise Exception("OAUTH_CLIENT_NAME is not configured")
+        oauth = OAuth()
+        oauth.register(settings.OAUTH_CLIENT_NAME)
+        client = oauth.create_client(settings.OAUTH_CLIENT_NAME)
+    else:
+        raise Exception("OAUTH_CLIENT_NAME is not configured")
 
-    return _OAUTH_CLIENT
+    return client

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -177,7 +177,7 @@ if OAUTH_CLIENT_NAME:
         OAUTH_CLIENT_NAME: {
             "client_id": OAUTH_CLIENT_ID,
             "server_metadata_url": f"{OAUTH_AUTHORITY}/.well-known/openid-configuration",
-            "client_kwargs": {"code_challenge_method": "S256", "scope": "openid"},
+            "client_kwargs": {"code_challenge_method": "S256"},
         }
     }
 

--- a/tests/pytest/oauth/conftest.py
+++ b/tests/pytest/oauth/conftest.py
@@ -5,6 +5,9 @@ import pytest
 
 @pytest.fixture
 def mocked_oauth_client(mocker):
-    mock_client = mocker.Mock(spec=DjangoOAuth2App)
-    mocker.patch("benefits.oauth.client.instance", return_value=mock_client)
-    return mock_client
+    return mocker.Mock(spec=DjangoOAuth2App)
+
+
+@pytest.fixture
+def mocked_oauth_client_instance(mocker, mocked_oauth_client):
+    return mocker.patch("benefits.oauth.client.instance", return_value=mocked_oauth_client)

--- a/tests/pytest/oauth/test_client.py
+++ b/tests/pytest/oauth/test_client.py
@@ -23,3 +23,30 @@ def test_instance():
     assert oauth_client
     assert oauth_client2
     assert oauth_client is not oauth_client2
+
+
+@pytest.mark.django_db
+def test_instance_scope():
+    scope1 = "scope1"
+    oauth_client = client.instance(scope1)
+    client_scope = oauth_client.client_kwargs["scope"]
+
+    assert scope1 in client_scope
+    assert client._OPENID_SCOPE in client_scope
+
+    scope2 = "scope2"
+    oauth_client2 = client.instance(scope2)
+    client_scope = oauth_client2.client_kwargs["scope"]
+
+    assert scope1 not in client_scope
+    assert scope2 in client_scope
+    assert client._OPENID_SCOPE in client_scope
+
+    scope3 = " ".join((scope1, scope2))
+    oauth_client3 = client.instance(scope3)
+    client_scope = oauth_client3.client_kwargs["scope"]
+
+    assert scope1 in client_scope
+    assert scope2 in client_scope
+    assert scope3 in client_scope
+    assert client._OPENID_SCOPE in client_scope

--- a/tests/pytest/oauth/test_client.py
+++ b/tests/pytest/oauth/test_client.py
@@ -16,14 +16,10 @@ def test_instance_no_oauth_client_name():
 
 
 @pytest.mark.django_db
-def test_instance_oauth_client_name():
-    assert not client._OAUTH_CLIENT
-
+def test_instance():
     oauth_client = client.instance()
-
-    assert oauth_client
-    assert client._OAUTH_CLIENT is oauth_client
-
     oauth_client2 = client.instance()
 
-    assert oauth_client is oauth_client2
+    assert oauth_client
+    assert oauth_client2
+    assert oauth_client is not oauth_client2

--- a/tests/pytest/oauth/test_redirects.py
+++ b/tests/pytest/oauth/test_redirects.py
@@ -1,7 +1,8 @@
 from benefits.oauth.redirects import deauthorize_redirect, generate_redirect_uri
 
 
-def test_deauthorize_redirect(mocked_oauth_client):
+def test_deauthorize_redirect(mocked_oauth_client_instance):
+    mocked_oauth_client = mocked_oauth_client_instance.return_value
     mocked_oauth_client.load_server_metadata.return_value = {"end_session_endpoint": "https://server/endsession"}
 
     result = deauthorize_redirect("token", "https://localhost/redirect_uri")

--- a/tests/pytest/oauth/test_views.py
+++ b/tests/pytest/oauth/test_views.py
@@ -15,9 +15,10 @@ def mocked_analytics_module(mocked_analytics_module):
     return mocked_analytics_module(benefits.oauth.views)
 
 
-def test_login(mocked_oauth_client, mocked_analytics_module, app_request):
+def test_login(mocked_oauth_client_instance, mocked_analytics_module, app_request):
     assert not session.logged_in(app_request)
 
+    mocked_oauth_client = mocked_oauth_client_instance.return_value
     mocked_oauth_client.authorize_redirect.return_value = HttpResponse("authorize redirect")
 
     login(app_request)
@@ -27,7 +28,8 @@ def test_login(mocked_oauth_client, mocked_analytics_module, app_request):
     assert not session.logged_in(app_request)
 
 
-def test_authorize_fail(mocked_oauth_client, app_request):
+def test_authorize_fail(mocked_oauth_client_instance, app_request):
+    mocked_oauth_client = mocked_oauth_client_instance.return_value
     mocked_oauth_client.authorize_access_token.return_value = None
 
     assert not session.logged_in(app_request)
@@ -40,7 +42,8 @@ def test_authorize_fail(mocked_oauth_client, app_request):
     assert result.url == reverse(ROUTE_START)
 
 
-def test_authorize_success(mocked_oauth_client, mocked_analytics_module, app_request):
+def test_authorize_success(mocked_oauth_client_instance, mocked_analytics_module, app_request):
+    mocked_oauth_client = mocked_oauth_client_instance.return_value
     mocked_oauth_client.authorize_access_token.return_value = {"id_token": "token"}
 
     result = authorize(app_request)


### PR DESCRIPTION
Closes #640.

The refactor in #668 make this a lot easier - it created a helper function `benefits.oauth.client.instance()` to get the client instance. This PR makes two changes to that helper:

1. Each returned instance is now distinct; before it was a singleton
2. The helper accepts a `scope` param and adds it to the list of scopes configured in the client's `client_kwargs` attribute

The hardcoded scope (`openid`) in `settings.py` was removed in favor of always adding it in this helper.