### PR TITLE
Feat: IAL2 help copy

### DIFF
--- a/benefits/core/templates/core/help.html
+++ b/benefits/core/templates/core/help.html
@@ -35,6 +35,12 @@
                     {% blocktranslate with website="https://login.gov/help/"%}core.pages.help.login_gov.p[2][1]{{ website }}{% endblocktranslate %}
                 </p>
 
+                <h2 id="login-gov-verify">{% translate "core.pages.help.login_gov_verify" %}</h2>
+                <p>{% translate "core.pages.help.login_gov_verify.p[0]" %}</p>
+                <p>{% translate "core.pages.help.login_gov_verify.p[1]" %}</p>
+                <p>{% translate "core.pages.help.login_gov_verify.p[2]" %}</p>
+                <p>{% blocktranslate with website="https://login.gov/help/" %}core.pages.help.login_gov_verify.p[3]{{ website }}{% endblocktranslate %}</p>
+
                 <h2 id="littlepay">{% translate "core.pages.help.littlepay" %}</h2>
                 <p>{% translate "core.pages.help.littlepay.p[0]" %}</p>
                 <p>{% blocktranslate with website="https://littlepay.com" %}core.pages.help.littlepay.p[1]{{ website }}{% endblocktranslate %}</p>

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -25,8 +25,8 @@ msgstr ""
 
 msgid "core.pages.help.about.p[1]"
 msgstr ""
-"We partner with the California DMV to confirm age for age-based discounts and "
-"local transporation agencies to confirm specific discount programs. Once verified, "
+"We partner with Login.gov to confirm age for age-based discounts, and we "
+"partner with local transporation agencies to confirm specific discount programs. Once verified, "
 "discounts are attached to your bank card through our payment partner, Littlepay, so "
 "that when you pay for your transit ride, you get your discount automatically."
 

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -76,6 +76,21 @@ msgstr "To learn more about Login.gov, please visit the "
 msgid "core.pages.help.login_gov.p[2][1]%(website)s"
 msgstr "or the <a href=\"%(website)s\" target=\"_blank\" rel=\"noopener noreferrer\">Login.gov Help Center</a>."
 
+msgid "core.pages.help.login_gov_verify"
+msgstr "How do I verify my identity on Login.gov?"
+
+msgid "core.pages.help.login_gov_verify.p[0]"
+msgstr "To verify your identity, Login.gov asks that you upload a photograph of your state-issued ID and share your phone number and other personal information, which is then verified against authoritative sources. These requirements are in addition to meeting the requirements for two-factor authentication."
+
+msgid "core.pages.help.login_gov_verify.p[1]"
+msgstr "You cannot verify your identity on Login.gov without a state-issued ID, which can be either a driver’s license or non-driver’s license state-issued ID card."
+
+msgid "core.pages.help.login_gov_verify.p[2]"
+msgstr "If you do not have a phone plan that is in your name, Login.gov can send you the verification code by mail which takes approximately 3-5 days."
+
+msgid "core.pages.help.login_gov_verify.p[3]%(website)s"
+msgstr "Verifying your identity makes sure the right person has access to the right information. We are using Login.gov’s simple and secure process to keep your sensitive information safe. To learn more about identity verification on Login.gov, please visit their <a href=\"%(website)s\" target=\"_blank\" rel=\"noopener noreferrer\">Help Center.</a>"
+
 msgid "core.pages.help.littlepay"
 msgstr "What is Littlepay?"
 

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -63,6 +63,21 @@ msgstr "Para obtener más información sobre Login.gov, visite "
 msgid "core.pages.help.login_gov.p[2][1]%(website)s"
 msgstr "o <a href=\"%(website)s\" target=\"_blank\" rel=\"noopener noreferrer\">Login.gov: Centro de ayuda</a>."
 
+msgid "core.pages.help.login_gov_verify"
+msgstr "TODO"
+
+msgid "core.pages.help.login_gov_verify.p[0]"
+msgstr "TODO"
+
+msgid "core.pages.help.login_gov_verify.p[1]"
+msgstr "TODO"
+
+msgid "core.pages.help.login_gov_verify.p[2]"
+msgstr "TODO"
+
+msgid "core.pages.help.login_gov_verify.p[3]%(website)s"
+msgstr "TODO"
+
 msgid "core.pages.help.littlepay"
 msgstr "¿Qué es Littlepay?"
 

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -23,7 +23,7 @@ msgstr ""
 
 msgid "core.pages.help.about.p[1]"
 msgstr ""
-"Nos asociamos con el DMV de California para confirmar la edad para los descuentos basados en la edad y las agencias de transporte locales para confirmar los programas de descuento específicos. Una vez verificados, los descuentos se adjuntan a su tarjeta bancaria a través de nuestro socio de pago, Littlepay, para que cuando pague su viaje en transporte, obtenga su descuento automáticamente.?"
+"Nos asociamos con Login.gov para confirmar la edad para los descuentos basados en la edad y las agencias de transporte locales para confirmar los programas de descuento específicos. Una vez verificados, los descuentos se adjuntan a su tarjeta bancaria a través de nuestro socio de pago, Littlepay, para que cuando pague su viaje en transporte, obtenga su descuento automáticamente."
 
 msgid "core.pages.help.payment_options"
 msgstr "Opciones de pago"

--- a/tests/cypress/specs/ui/help.cy.js
+++ b/tests/cypress/specs/ui/help.cy.js
@@ -62,6 +62,7 @@ describe("Help page spec", () => {
     cy.get("h2").contains("What is Cal-ITP Benefits?");
     cy.get("h2").contains("Payment options");
     cy.get("h2").contains("What is Login.gov?");
+    cy.get("h2").contains("How do I verify my identity on Login.gov?");
     cy.get("h2").contains("What is Littlepay?");
     cy.get("h2").contains("Questions?");
   });


### PR DESCRIPTION
Closes #705

Updates a body paragraph in "What is Cal-ITP Benefits?" section to say Login.gov will verify age.

Adds a section for "How do I verify my identity on Login.gov?".

Updates made using finalized English copy and any Spanish copy update that was available.

## Screenshots
### Desktop
| Before | After |
| ------- | ----- |
| ![705_old_help](https://user-images.githubusercontent.com/25497886/174192563-df2a18e7-2ccc-4117-b522-a04eaaf598f2.png) | ![705_new_help](https://user-images.githubusercontent.com/25497886/174192592-dafba3a3-db0c-45f3-aa18-f2f1996dbc3f.png) |

### Mobile
| Before | After |
| ------- | ----- |
| ![705_old_help_mobile](https://user-images.githubusercontent.com/25497886/174193415-ecd0acfa-2a3f-4439-85f9-6f2e79ffc51a.png) | ![705_new_help_mobile](https://user-images.githubusercontent.com/25497886/174193438-58e7adf2-9b72-45cf-ac1c-430ce7d39c8f.png) |
