### PR TITLE
Send logs to Azure Monitor

### DIFF
--- a/benefits/logging.py
+++ b/benefits/logging.py
@@ -1,0 +1,28 @@
+def get_config(level):
+    return {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "default": {
+                "format": "[{asctime}] {levelname} {name}:{lineno} {message}",
+                "datefmt": "%d/%b/%Y %H:%M:%S",
+                "style": "{",
+            },
+        },
+        "handlers": {
+            "default": {
+                "class": "logging.StreamHandler",
+                "formatter": "default",
+            },
+        },
+        "root": {
+            "handlers": ["default"],
+            "level": level,
+        },
+        "loggers": {
+            "django": {
+                "handlers": ["default"],
+                "propagate": False,
+            },
+        },
+    }

--- a/benefits/logging.py
+++ b/benefits/logging.py
@@ -1,7 +1,4 @@
-import os
-
-
-def get_config(level):
+def get_config(level="INFO", enable_azure=False):
     config = {
         "version": 1,
         "disable_existing_loggers": False,
@@ -30,7 +27,7 @@ def get_config(level):
         },
     }
 
-    if "APPLICATIONINSIGHTS_CONNECTION_STRING" in os.environ:
+    if enable_azure:
         # enable Azure Insights logging
 
         # https://docs.microsoft.com/en-us/azure/azure-monitor/app/opencensus-python#configure-logging-for-django-applications
@@ -44,7 +41,7 @@ def get_config(level):
         # https://github.com/census-instrumentation/opencensus-python/issues/1130#issuecomment-1161898856
         config["loggers"]["azure"] = {
             "handlers": ["azure"],
-            "level": "INFO",
+            "level": level,
         }
 
     return config

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -2,6 +2,7 @@
 Django settings for benefits project.
 """
 import os
+import benefits.logging
 
 
 def _filter_empty(ls):
@@ -192,27 +193,8 @@ STATICFILES_STORAGE = "django.contrib.staticfiles.storage.ManifestStaticFilesSto
 STATIC_ROOT = os.path.join(BASE_DIR, "static")
 
 # Logging configuration
-
 LOG_LEVEL = os.environ.get("DJANGO_LOG_LEVEL", "DEBUG" if DEBUG else "WARNING")
-LOGGING = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "formatters": {
-        "default": {
-            "format": "[{asctime}] {levelname} {name}:{lineno} {message}",
-            "datefmt": "%d/%b/%Y %H:%M:%S",
-            "style": "{",
-        },
-    },
-    "handlers": {
-        "default": {"class": "logging.StreamHandler", "formatter": "default"},
-    },
-    "root": {
-        "handlers": ["default"],
-        "level": LOG_LEVEL,
-    },
-    "loggers": {"django": {"handlers": ["default"], "propagate": False}},
-}
+LOGGING = benefits.logging.get_config(LOG_LEVEL)
 
 # Analytics configuration
 

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -65,7 +65,24 @@ if ADMIN:
     )
 
 if DEBUG:
-    MIDDLEWARE.extend(["benefits.core.middleware.DebugSession"])
+    MIDDLEWARE.append("benefits.core.middleware.DebugSession")
+
+
+# Azure Insights
+# https://docs.microsoft.com/en-us/azure/azure-monitor/app/opencensus-python-request#tracking-django-applications
+
+ENABLE_AZURE_INSIGHTS = "APPLICATIONINSIGHTS_CONNECTION_STRING" in os.environ
+if ENABLE_AZURE_INSIGHTS:
+    MIDDLEWARE.append("opencensus.ext.django.middleware.OpencensusMiddleware")
+
+# only used if enabled above
+OPENCENSUS = {
+    "TRACE": {
+        "SAMPLER": "opencensus.trace.samplers.ProbabilitySampler(rate=1)",
+        "EXPORTER": "opencensus.ext.azure.trace_exporter.AzureExporter()",
+    }
+}
+
 
 CSRF_COOKIE_AGE = None
 CSRF_COOKIE_SAMESITE = "Strict"
@@ -194,7 +211,7 @@ STATIC_ROOT = os.path.join(BASE_DIR, "static")
 
 # Logging configuration
 LOG_LEVEL = os.environ.get("DJANGO_LOG_LEVEL", "DEBUG" if DEBUG else "WARNING")
-LOGGING = benefits.logging.get_config(LOG_LEVEL)
+LOGGING = benefits.logging.get_config(LOG_LEVEL, enable_azure=ENABLE_AZURE_INSIGHTS)
 
 # Analytics configuration
 

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -149,3 +149,13 @@ devcontainer, check the [`DJANGO_LOCAL_PORT`](#django_local_port).
 
 [deployment]: ../deployment/README.md
 [getting-started_create-env]: ../getting-started/README.md#create-an-environment-file
+
+## Azure
+
+### `APPLICATIONINSIGHTS_CONNECTION_STRING`
+
+!!! tldr "Azure docs"
+
+    [Azure Monitor connection strings](https://docs.microsoft.com/en-us/azure/azure-monitor/app/sdk-connection-string)
+
+Enables [log collection](../../deployment/infrastructure/#logs). Set the value in quotes, e.g. `APPLICATIONINSIGHTS_CONNECTION_STRING="InstrumentationKey=…"`.

--- a/docs/deployment/infrastructure.md
+++ b/docs/deployment/infrastructure.md
@@ -63,6 +63,17 @@ flowchart LR
 
 We have [ping tests](https://docs.microsoft.com/en-us/azure/azure-monitor/app/monitor-web-app-availability) set up to notify about availability of the dev, test, and prod deployments. Alerts go to [#benefits-notify](https://cal-itp.slack.com/archives/C022HHSEE3F).
 
+## Logs
+
+We send application logs to [Azure Monitor Logs](https://docs.microsoft.com/en-us/azure/azure-monitor/logs/data-platform-logs). To find them:
+
+1. [Open Application Insights.](https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/microsoft.insights%2Fcomponents)
+1. Click the resource corresponding to the environment.
+1. In the navigation, under `Monitoring`, click `Logs`.
+1. In the Query Editor, type `traces`, and click `Run`.
+
+You should see recent log output. Note [there is some latency](https://docs.microsoft.com/en-us/azure/azure-monitor/logs/data-ingestion-time).
+
 ## Making changes
 
 1. Get access to the Azure account through the DevSecOps team.

--- a/docs/deployment/infrastructure.md
+++ b/docs/deployment/infrastructure.md
@@ -70,7 +70,8 @@ We send application logs to [Azure Monitor Logs](https://docs.microsoft.com/en-u
 1. [Open Application Insights.](https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/microsoft.insights%2Fcomponents)
 1. Click the resource corresponding to the environment.
 1. In the navigation, under `Monitoring`, click `Logs`.
-1. In the Query Editor, type `traces`, and click `Run`.
+1. In the Query Editor, type `requests` or `traces`, and click `Run`.
+    - [What each means](https://docs.microsoft.com/en-us/azure/azure-monitor/app/opencensus-python#telemetry-type-mappings)
 
 You should see recent log output. Note [there is some latency](https://docs.microsoft.com/en-us/azure/azure-monitor/logs/data-ingestion-time).
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ Django==3.2.13
 django-csp==3.7
 git+https://github.com/cal-itp/eligibility-api#egg=eligibility_api
 gunicorn==20.1.0
+opencensus-ext-azure==1.1.4
 requests==2.28.0
 six==1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ django-csp==3.7
 git+https://github.com/cal-itp/eligibility-api#egg=eligibility_api
 gunicorn==20.1.0
 opencensus-ext-azure==1.1.4
+opencensus-ext-django==0.7.6
 requests==2.28.0
 six==1.16.0

--- a/tests/pytest/test_logging.py
+++ b/tests/pytest/test_logging.py
@@ -1,0 +1,13 @@
+from benefits.logging import get_config
+
+
+def test_get_config_no_azure():
+    config = get_config()
+    assert "azure" not in config["handlers"]
+    assert "azure" not in config["loggers"]
+
+
+def test_get_config_with_azure():
+    config = get_config(enable_azure=True)
+    assert "azure" in config["handlers"]
+    assert "azure" in config["loggers"]


### PR DESCRIPTION
Closes https://github.com/cal-itp/benefits/issues/631. Keeps the logging otherwise the same.

Used the following instructions, to start:

- https://docs.microsoft.com/en-us/azure/azure-monitor/app/opencensus-python#configure-logging-for-django-applications
- https://docs.microsoft.com/en-us/azure/azure-monitor/app/opencensus-python-request#tracking-django-applications

## Before merge

- [x] Set `APPLICATIONINSIGHTS_CONNECTION_STRING` in `dev`

Added tasks for each environment in https://github.com/cal-itp/benefits/pull/734.