### PR TITLE
Fix: Fixes for Eligibility Start Link Style, Debug Bar-related improvements

### DIFF
--- a/benefits/core/templates/core/includes/debug.html
+++ b/benefits/core/templates/core/includes/debug.html
@@ -3,7 +3,7 @@
 {% block content %}
 <span class="navbar-brand">DEBUG MODE</span>
 {% if debug %}
-    <code class="navbar-text text-white">
+    <code class="navbar-text text-white text-break">
     { {% for key, value in debug.items %}"{{ key }}": "{{ value }}"{% if not forloop.last %}, {% endif %}{% endfor %} }
     </code>
 {% endif %}

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -82,6 +82,10 @@ main {
   flex-shrink: 0 !important;
 }
 
+main#main-content.main-content {
+  position: relative;
+}
+
 /* All pages but the Start Page */
 main .main-row {
   min-height: calc(100vh - 120px);
@@ -663,11 +667,11 @@ footer.global-footer .footer-links a:active {
   }
 
   .signout-row {
-    top: 308px;
+    top: 240px;
   }
 
   .no-image-mobile .signout-row {
-    top: 80px;
+    top: 0;
   }
 
   .no-image-mobile .main-primary .container-fluid {

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -333,12 +333,9 @@ footer.global-footer .footer-links a:active {
 
 .media-list .media .media-body .media-body--links .btn-lg {
   font-size: 16px;
-  line-height: 20px;
   letter-spacing: 0.05em;
   padding: 0 0 6px 0;
   text-align: left;
-  margin: 0;
-  display: block;
   width: fit-content;
 }
 
@@ -723,11 +720,18 @@ footer.global-footer .footer-links a:active {
     line-height: 30px;
   }
 
-  .media-list .media .media-body--details {
+  .media-list .media .media-body--details p {
     padding-bottom: 25px;
     margin-left: 0;
     font-size: 20px;
     line-height: 30px;
+    letter-spacing: 0.05em;
+  }
+
+  .media-list .media .media-body--items li {
+    font-size: 20px;
+    line-height: 30px;
+    letter-spacing: 0.05em;
   }
 
   .media-list .media .media-body--links {
@@ -740,20 +744,10 @@ footer.global-footer .footer-links a:active {
   }
 
   .media-list .media .media-body .media-body--links .btn-lg {
-    letter-spacing: 0.02em;
-    padding: 6px;
-    text-align: left;
-    width: 100%;
-    margin: 0;
     font-size: 18px;
-    text-decoration: none;
-    letter-spacing: 0.2px;
-    border: 2px solid #046b99;
-    margin-bottom: 24px;
-    font-weight: 500;
-    width: 212px;
-    line-height: 22.5px;
-    border-radius: 3px;
+    line-height: 27px;
+    font-weight: 700;
+    letter-spacing: 0.05em;
     display: block;
   }
 


### PR DESCRIPTION
closes #716 

## Screenshots

### Link Style (and font changes)

- Font size increased to 20px on mobile
- Double-checked no regression on Desktop for links

| Before            | After     |
|--------------|-----------|
|![Screenshot 2022-06-22 at 14-06-38 Transit Benefits Get Started Cal-ITP](https://user-images.githubusercontent.com/3673236/175136150-b15f37d6-1f9d-4785-b591-29e2affb2c81.png)  | ![Screenshot 2022-06-22 at 13-47-43 Transit Benefits Get Started Cal-ITP](https://user-images.githubusercontent.com/3673236/175133230-81885013-fa17-49d6-a922-dba35d701a65.png)    |


### Sign Out button with Debug Bar / without Debug Bar

Before: Sign Out button would go over the Debug Bar
After: Debug Bar won't affect the Sign Out button position


### Non-overflowing Debug Bar

Before: Enrollment page would have white-space to the right and bottom

After:

![Screen Shot 2022-06-22 at 13 57 05](https://user-images.githubusercontent.com/3673236/175136542-68535d7c-b6cb-439f-9f25-e8b276ff5654.png)

