### PR TITLE
Spanish language links

### DIFF
--- a/benefits/core/templates/core/help.html
+++ b/benefits/core/templates/core/help.html
@@ -31,8 +31,8 @@
                 <p>{% translate "core.pages.help.login_gov.p[0]" %}</p>
                 <p>{% translate "core.pages.help.login_gov.p[1]" %}</p>
                 <p>
-                    {% blocktranslate with website="https://login.gov"%}core.pages.help.login_gov.p[2][0]{{ website }}{% endblocktranslate %}
-                    {% blocktranslate with website="https://login.gov/help/"%}core.pages.help.login_gov.p[2][1]{{ website }}{% endblocktranslate %}
+                    {% translate "core.pages.help.login_gov.p[2]" %}
+                    {% comment %} {% blocktranslate with website="https://login.gov/help/"%}core.pages.help.login_gov.p[2][1]{{ website }}{% endblocktranslate %} {% endcomment %}
                 </p>
 
                 <h2 id="login-gov-verify">{% translate "core.pages.help.login_gov_verify" %}</h2>

--- a/benefits/core/templates/core/help.html
+++ b/benefits/core/templates/core/help.html
@@ -30,10 +30,7 @@
                 <h2 id="login-gov">{% translate "core.pages.help.login_gov" %}</h2>
                 <p>{% translate "core.pages.help.login_gov.p[0]" %}</p>
                 <p>{% translate "core.pages.help.login_gov.p[1]" %}</p>
-                <p>
-                    {% translate "core.pages.help.login_gov.p[2]" %}
-                    {% comment %} {% blocktranslate with website="https://login.gov/help/"%}core.pages.help.login_gov.p[2][1]{{ website }}{% endblocktranslate %} {% endcomment %}
-                </p>
+                <p>{% translate "core.pages.help.login_gov.p[2]" %}</p>
 
                 <h2 id="login-gov-verify">{% translate "core.pages.help.login_gov_verify" %}</h2>
                 <p>{% translate "core.pages.help.login_gov_verify.p[0]" %}</p>

--- a/benefits/core/templates/core/help.html
+++ b/benefits/core/templates/core/help.html
@@ -36,7 +36,7 @@
                 <p>{% translate "core.pages.help.login_gov_verify.p[0]" %}</p>
                 <p>{% translate "core.pages.help.login_gov_verify.p[1]" %}</p>
                 <p>{% translate "core.pages.help.login_gov_verify.p[2]" %}</p>
-                <p>{% blocktranslate with website="https://login.gov/help/verify-your-identity/how-to-verify-your-identity/" %}core.pages.help.login_gov_verify.p[3]{{ website }}{% endblocktranslate %}</p>
+                <p>{% translate "core.pages.help.login_gov_verify.p[3]" %}</p>
 
                 <h2 id="littlepay">{% translate "core.pages.help.littlepay" %}</h2>
                 <p>{% translate "core.pages.help.littlepay.p[0]" %}</p>

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -69,12 +69,9 @@ msgstr "Creating an account is simple. You will need an email address and method
 "authenticating your account&mdash;which will use either a landline, mobile phone, or "
 "backup codes that must be printed or written down."
 
-msgid "core.pages.help.login_gov.p[2][0]%(website)s"
+msgid "core.pages.help.login_gov.p[2]"
 msgstr "To learn more about Login.gov, please visit the "
-"<a href=\"%(website)s\" target=\"_blank\" rel=\"noopener noreferrer\">Login.gov website</a> "
-
-msgid "core.pages.help.login_gov.p[2][1]%(website)s"
-msgstr "or the <a href=\"%(website)s\" target=\"_blank\" rel=\"noopener noreferrer\">Login.gov Help Center</a>."
+"<a href='https://login.gov/' target=\"_blank\" rel=\"noopener noreferrer\">Login.gov website</a> or the <a href='https://login.gov/help/' target=\"_blank\" rel=\"noopener noreferrer\">Login.gov Help Center</a>."
 
 msgid "core.pages.help.login_gov_verify"
 msgstr "How do I verify my identity on Login.gov?"

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -85,8 +85,8 @@ msgstr "You cannot verify your identity on Login.gov without a state-issued ID, 
 msgid "core.pages.help.login_gov_verify.p[2]"
 msgstr "If you do not have a phone plan that is in your name, Login.gov can send you the verification code by mail which takes approximately 3-5 days."
 
-msgid "core.pages.help.login_gov_verify.p[3]%(website)s"
-msgstr "Verifying your identity makes sure the right person has access to the right information. We are using Login.gov’s simple and secure process to keep your sensitive information safe. To learn more about identity verification on Login.gov, please visit their <a href=\"%(website)s\" target=\"_blank\" rel=\"noopener noreferrer\">Help Center.</a>"
+msgid "core.pages.help.login_gov_verify.p[3]"
+msgstr "Verifying your identity makes sure the right person has access to the right information. We are using Login.gov’s simple and secure process to keep your sensitive information safe. To learn more about identity verification on Login.gov, please visit their <a href='https://login.gov/help/verify-your-identity/how-to-verify-your-identity/' target=\"_blank\" rel=\"noopener noreferrer\">Help Center.</a>"
 
 msgid "core.pages.help.littlepay"
 msgstr "What is Littlepay?"

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -72,8 +72,8 @@ msgstr "No puede verificar su identidad en Login.gov sin una identificación emi
 msgid "core.pages.help.login_gov_verify.p[2]"
 msgstr "Si no tiene un plan telefónico que esté a su nombre, Login.gov puede enviarle el código de verificación por correo, lo que toma aproximadamente de 3 a 5 días."
 
-msgid "core.pages.help.login_gov_verify.p[3]%(website)s"
-msgstr "Verificar su identidad asegura que la persona adecuada tenga acceso a la información correcta. Estamos utilizando el proceso simple y seguro de Login.gov’s para mantener segura su información confidencial. Para obtener más información sobre la verificación de identidad en Login.gov, visite su <a href=\"%(website)s\" target=\"_blank\" rel=\"noopener noreferrer\">Login.gov: Centro de ayuda</a>."
+msgid "core.pages.help.login_gov_verify.p[3]"
+msgstr "Verificar su identidad asegura que la persona adecuada tenga acceso a la información correcta. Estamos utilizando el proceso simple y seguro de Login.gov’s para mantener segura su información confidencial. Para obtener más información sobre la verificación de identidad en Login.gov, visite su <a href='https://login.gov/es/help/verify-your-identity/how-to-verify-your-identity/' target=\"_blank\" rel=\"noopener noreferrer\">Login.gov: Centro de ayuda</a>."
 
 msgid "core.pages.help.littlepay"
 msgstr "¿Qué es Littlepay?"

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -56,12 +56,9 @@ msgstr "Login.gov es una forma segura de iniciar sesión en las agencias guberna
 msgid "core.pages.help.login_gov.p[1]"
 msgstr "Crear una cuenta es simple. Necesitará una dirección de correo electrónico y un método para autenticar su cuenta—que utilizará un teléfono fijo o un teléfono móvil o códigos de seguridad que deben imprimirse o anotarse."
 
-msgid "core.pages.help.login_gov.p[2][0]%(website)s"
+msgid "core.pages.help.login_gov.p[2]"
 msgstr "Para obtener más información sobre Login.gov, visite "
-"<a href=\"%(website)s\" target=\"_blank\" rel=\"noopener noreferrer\">Login.gov</a> "
-
-msgid "core.pages.help.login_gov.p[2][1]%(website)s"
-msgstr "o <a href=\"%(website)s\" target=\"_blank\" rel=\"noopener noreferrer\">Login.gov: Centro de ayuda</a>."
+"<a href='https://login.gov/es' target=\"_blank\" rel=\"noopener noreferrer\">Login.gov</a> o <a href='https://login.gov/es/help/' target=\"_blank\" rel=\"noopener noreferrer\">Login.gov: Centro de ayuda</a>."
 
 msgid "core.pages.help.login_gov_verify"
 msgstr "¿Cómo verifico mi identidad en Login.gov?"


### PR DESCRIPTION
closes #730 


## How to test this PR

These three links should go to the following URLs: https://login.gov/es/, https://login.gov/es/help/, https://login.gov/es/help/verify-your-identity/how-to-verify-your-identity/  And in English mode, it should go to the English version of these URLs.

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/175395698-402f358f-bb0b-435d-88db-f37438ae69b2.png">
