### PR TITLE
Send exceptions to Azure Monitor

### DIFF
--- a/benefits/core/middleware.py
+++ b/benefits/core/middleware.py
@@ -147,3 +147,18 @@ class LoginRequired(MiddlewareMixin):
             return None
 
         return redirect("oauth:login")
+
+
+# https://github.com/census-instrumentation/opencensus-python/issues/766
+class LogErrorToAzure(MiddlewareMixin):
+    def __init__(self, get_response):
+        self.get_response = get_response
+        # wait to do this here to be sure the handler is initialized
+        self.azure_logger = logging.getLogger("azure")
+
+    def process_exception(self, request, exception):
+        # https://stackoverflow.com/a/45532289
+        msg = getattr(exception, "message", repr(exception))
+        self.azure_logger.exception(msg, exc_info=exception)
+
+        return None

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -73,7 +73,12 @@ if DEBUG:
 
 ENABLE_AZURE_INSIGHTS = "APPLICATIONINSIGHTS_CONNECTION_STRING" in os.environ
 if ENABLE_AZURE_INSIGHTS:
-    MIDDLEWARE.append("opencensus.ext.django.middleware.OpencensusMiddleware")
+    MIDDLEWARE.extend(
+        [
+            "opencensus.ext.django.middleware.OpencensusMiddleware",
+            "benefits.core.middleware.LogErrorToAzure",
+        ]
+    )
 
 # only used if enabled above
 OPENCENSUS = {

--- a/docs/deployment/infrastructure.md
+++ b/docs/deployment/infrastructure.md
@@ -75,6 +75,8 @@ We send application logs to [Azure Monitor Logs](https://docs.microsoft.com/en-u
 
 You should see recent log output. Note [there is some latency](https://docs.microsoft.com/en-us/azure/azure-monitor/logs/data-ingestion-time).
 
+See [`Failures`](https://docs.microsoft.com/en-us/azure/azure-monitor/app/asp-net-exceptions#diagnose-failures-using-the-azure-portal) in the sidebar (or `exceptions` under `Logs`) for application errors/exceptions.
+
 ## Making changes
 
 1. Get access to the Azure account through the DevSecOps team.


### PR DESCRIPTION
Builds on https://github.com/cal-itp/benefits/pull/719. Closes #448.

Got exceptions to flow to Insights. The `exceptions` table under `Logs`:

<img width="1044" alt="Screen Shot 2022-06-23 at 5 05 20 PM" src="https://user-images.githubusercontent.com/86842/175401258-3b9a8e49-6f97-4b8f-bb15-14d8858c2067.png">

`Failures` screen:

<img width="1610" alt="Screen Shot 2022-06-23 at 5 07 22 PM" src="https://user-images.githubusercontent.com/86842/175401251-be23bd10-ca02-4fec-812f-ca70fc3b1318.png">

After clicking into an exception:

<img width="1613" alt="Screen Shot 2022-06-23 at 5 08 26 PM" src="https://user-images.githubusercontent.com/86842/175401243-af02ed65-2c21-4535-b880-e06b532d15db.png">