### PR TITLE
chore: update deployment/release documentation

### DIFF
--- a/docs/deployment/release.md
+++ b/docs/deployment/release.md
@@ -17,10 +17,10 @@ A new release implies a new version.
 `benefits` uses the [CalVer](https://calver.org/) versioning scheme, where
 version numbers look like: `YYYY.0M.R`
 
-* `YYYY` is the 4-digit year of the release; e.g. `2021`, `2022`
-* `0M` is the 2-digit, 0-padded month of the release; e.g. `02` is February, `12`
+- `YYYY` is the 4-digit year of the release; e.g. `2021`, `2022`
+- `0M` is the 2-digit, 0-padded month of the release; e.g. `02` is February, `12`
   is December.
-* `R` is the 1-based release counter for the given year and month;
+- `R` is the 1-based release counter for the given year and month;
   e.g. `1` for the first release of the month, `2` for the second, and so on.
 
 ## 1. Prepare release in a branch
@@ -90,3 +90,7 @@ git tag YYYY.0M.R
 
 git push --tags
 ```
+
+## 6. [Generate release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes)
+
+Also add a written description, and include screenshots/animations of new/updated pages/workflows.

--- a/docs/deployment/workflows.md
+++ b/docs/deployment/workflows.md
@@ -1,10 +1,6 @@
 # Workflows
 
-There are three different GitHub Actions deployment workflows, one for each environment:
-
-* [`.github/workflows/deploy-dev.yml`][deploy-dev]
-* [`.github/workflows/deploy-test.yml`][deploy-test]
-* [`.github/workflows/deploy-prod.yml`][deploy-prod]
+The GitHub Actions deployment workflow configuration lives at [`.github/workflows/deploy.yml`][deploy].
 
 !!! info
 
@@ -13,8 +9,7 @@ There are three different GitHub Actions deployment workflows, one for each envi
 
 ## Deployment steps
 
-Each of the three workflows are [triggered][gh-actions-trigger] with a `push` to the corresponding branch. Each workflow also
-responds to the `workflow_dispatch` event to allow manually triggering via the GitHub Actions UI.
+The workflow is [triggered][gh-actions-trigger] with a `push` to the corresponding branch. It also responds to the `workflow_dispatch` event to allow manually triggering via the GitHub Actions UI.
 
 When a deployment workflow runs, the following steps are taken:
 
@@ -26,15 +21,18 @@ From the tip of the corresponding branch (e.g. `dev`)
 
 Using the `github.actor` and built-in `GITHUB_TOKEN` secret
 
-### 3. Build and push image to GHCR
+### 3. Build and push image to GitHub Container Registry (GHCR)
 
-Build the root [`Dockerfile`][Dockerfile], tagging with both the branch name (e.g. `dev`) and the SHA from the HEAD commit.
+Build the root [`Dockerfile`][dockerfile], tagging with both the branch name (e.g. `dev`) and the SHA from the HEAD commit.
 
 Push this image:tag into [GHCR][ghcr].
 
-[deploy-dev]: https://github.com/cal-itp/benefits/blob/dev/.github/workflows/deploy-dev.yml
-[deploy-test]: https://github.com/cal-itp/benefits/blob/dev/.github/workflows/deploy-test.yml
-[deploy-prod]: https://github.com/cal-itp/benefits/blob/dev/.github/workflows/deploy-prod.yml
+### 4. App Service deploy
+
+Each Azure App Service slot is configured to [listen to a webhook from GitHub, then deploy the image][webhook].
+
+[deploy]: https://github.com/cal-itp/benefits/blob/dev/.github/workflows/deploy.yml
 [dockerfile]: https://github.com/cal-itp/benefits/blob/dev/Dockerfile
 [ghcr]: https://github.com/features/packages
 [gh-actions-trigger]: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+[webhook]: https://docs.microsoft.com/en-us/azure/app-service/deploy-ci-cd-custom-container


### PR DESCRIPTION
Forgot to update the pipeline docs after consolidating them in https://github.com/cal-itp/benefits/pull/744.