### PR TITLE
chore: improve formatting behavior

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,24 +1,12 @@
 // For format details, see https://aka.ms/vscode-remote/devcontainer.json
 {
   "name": "cal-itp/benefits",
-  "dockerComposeFile": [
-    "compose.yml"
-  ],
+  "dockerComposeFile": ["compose.yml"],
   "service": "dev",
-  "runServices": [
-    "dev",
-    "docs",
-    "server"
-  ],
+  "runServices": ["dev", "docs", "server"],
   "workspaceFolder": "/home/calitp/app",
-  "postStartCommand": [
-    "/bin/bash",
-    "bin/init.sh"
-  ],
-  "postAttachCommand": [
-    "/bin/bash",
-    ".devcontainer/postAttach.sh"
-  ],
+  "postStartCommand": ["/bin/bash", "bin/init.sh"],
+  "postAttachCommand": ["/bin/bash", ".devcontainer/postAttach.sh"],
   // Set *default* container specific settings.json values on container create.
   "settings": {
     "terminal.integrated.defaultProfile.linux": "bash",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,5 @@
 {
-  "[css]": {
-    "editor.formatOnSave": true,
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
-  "editor.defaultFormatter": null,
-  "editor.formatOnSave": false,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
   "[html]": {
     "editor.formatOnSave": false
   },
@@ -13,24 +8,14 @@
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,
   "files.trimTrailingWhitespace": true,
-  "[javascript]": {
-    "editor.formatOnSave": true,
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
-  "[json]": {
-    "editor.formatOnSave": true,
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.python"
   },
   "python.formatting.provider": "black",
-  "python.linting.flake8Enabled": true,
-  "python.linting.enabled": true,
   "python.languageServer": "Pylance",
-  "[python]": {
-    "editor.formatOnSave": true
-  },
-  "python.testing.pytestArgs": [
-    "tests/pytest", "--import-mode=importlib"
-  ],
-  "python.testing.unittestEnabled": false,
-  "python.testing.pytestEnabled": true
+  "python.linting.enabled": true,
+  "python.linting.flake8Enabled": true,
+  "python.testing.pytestArgs": ["tests/pytest", "--import-mode=importlib"],
+  "python.testing.pytestEnabled": true,
+  "python.testing.unittestEnabled": false
 }


### PR DESCRIPTION
Split out from https://github.com/cal-itp/benefits/pull/669, excluding the use of the new extension.

This does a few things:

- Sets the default formatter to be Prettier, which will also apply it to things like Markdown.
- Formats on save by default, which is fine because formatting HTML is still disabled, protecting the Jinja templates.
- Formats the settings files (with Prettier).