### PR TITLE
fix: Eligibility Start - Add h1, h2, h3

### DIFF
--- a/benefits/eligibility/templates/eligibility/start.html
+++ b/benefits/eligibility/templates/eligibility/start.html
@@ -12,7 +12,7 @@
         <p>{% blocktranslate with info_link=info_link%}core.pages.agency_index.p[0]{{ info_link }}{% endblocktranslate %}</p>
         <p>{% translate "core.pages.agency_index.p[2]" %}</p>
 
-        <h1 class="media-title">{{title}}</h1>
+        <h2 class="media-title">{{title}}</h2>
 
         {% block media_list %}
             {% if media|length_is:"0" %}{% else %}
@@ -23,9 +23,7 @@
                             {% include "core/includes/icon.html" with icon=item.icon %}
                         </div>
                         <div class="media-body">
-                            <div class="media-body--heading">
-                                <span>{{ item.heading }}</span>
-                            </div>
+                            <h3 class="media-body--heading">{{ item.heading }}</h3>
                             <div class="media-body--details">
                                 <p>{{ item.details }}</p>
                                 <div class="media-body--items">

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -266,6 +266,8 @@ footer.global-footer .footer-links a:active {
   margin-bottom: 60px;
   font-size: 24px;
   line-height: 36px;
+  letter-spacing: 0.05em;
+  font-weight: 700;
 }
 
 .media-list {
@@ -307,6 +309,7 @@ footer.global-footer .footer-links a:active {
   line-height: 26.1px;
   font-weight: 700;
   padding-left: 0;
+  margin-top: 0;
   margin-bottom: 16px;
 }
 


### PR DESCRIPTION
fixes #726 

Reorganize page's headlines into one h1, one h2, multiple h3 and adjust CSS as necessary

Ensure no regressions in styles between Staging and this PR:

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/176035312-ffd405da-4b0a-4a6e-ba0f-30547c9324c9.png">
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/176035366-3e5e0565-e1fd-423e-aa79-65231f63317c.png">


Note: This PR does not attempt to tackle refactoring the way the app's CSS styles H1, H2s. That is work for this future ticket: https://github.com/cal-itp/benefits/issues/751