### PR TITLE
Feat: analytics for IAL2

### DIFF
--- a/benefits/oauth/analytics.py
+++ b/benefits/oauth/analytics.py
@@ -20,6 +20,13 @@ class StartedSignInEvent(OAuthEvent):
         super().__init__(request, "started sign in")
 
 
+class CanceledSignInEvent(OAuthEvent):
+    """Analytics event representing the canceling of application sign in."""
+
+    def __init__(self, request):
+        super().__init__(request, "canceled sign in")
+
+
 class FinishedSignInEvent(OAuthEvent):
     """Analytics event representing the end of the OAuth sign in flow."""
 
@@ -31,7 +38,7 @@ class StartedSignOutEvent(OAuthEvent):
     """Analytics event representing the beginning of application sign out."""
 
     def __init__(self, request):
-        super().__init__(request, "started signed out")
+        super().__init__(request, "started sign out")
 
 
 class FinishedSignOutEvent(OAuthEvent):
@@ -45,6 +52,11 @@ class FinishedSignOutEvent(OAuthEvent):
 def started_sign_in(request):
     """Send the "started sign in" analytics event."""
     core.send_event(StartedSignInEvent(request))
+
+
+def canceled_sign_in(request):
+    """Send the "canceled sign in" analytics event."""
+    core.send_event(CanceledSignInEvent(request))
 
 
 def finished_sign_in(request):

--- a/benefits/oauth/views.py
+++ b/benefits/oauth/views.py
@@ -80,6 +80,9 @@ def authorize(request):
 
 def cancel(request):
     """View implementing cancellation of OIDC authorization."""
+
+    analytics.canceled_sign_in(request)
+
     return redirect(ROUTE_UNVERIFIED)
 
 

--- a/tests/pytest/oauth/test_views.py
+++ b/tests/pytest/oauth/test_views.py
@@ -135,11 +135,12 @@ def test_authorize_success_without_claim(mocked_session_verifier_auth_required, 
     assert result.url == reverse(ROUTE_CONFIRM)
 
 
-def test_cancel(app_request):
+def test_cancel(mocked_analytics_module, app_request):
     unverified_route = reverse(ROUTE_UNVERIFIED)
 
     result = cancel(app_request)
 
+    mocked_analytics_module.canceled_sign_in.assert_called_once()
     assert result.status_code == 302
     assert result.url == unverified_route
 


### PR DESCRIPTION
Closes #644 

Send an event if the user cancels out of identity proofing.