### PR TITLE
Fix: Unverified page copy and design

### DIFF
--- a/benefits/core/viewmodels.py
+++ b/benefits/core/viewmodels.py
@@ -48,8 +48,11 @@ class Button:
         ]
 
     @staticmethod
-    def home(request, text=_("core.buttons.return_home")):
+    def home(request, text=None):
         """Create a button back to this session's origin."""
+        if text is None:
+            text = _("core.buttons.return_home")
+
         return Button.primary(text=text, url=session.origin(request))
 
     @staticmethod

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -231,7 +231,7 @@ def unverified(request):
     # tel: link to agency phone number
     agency = session.agency(request)
     buttons = viewmodels.Button.agency_contact_links(agency)
-    buttons.append(viewmodels.Button.home(request, _("core.buttons.retry")))
+    buttons.append(viewmodels.Button.home(request))
 
     verifier = session.verifier(request)
 
@@ -241,7 +241,7 @@ def unverified(request):
         classes="with-agency-links",
         content_title=_(verifier.unverified_content_title),
         icon=viewmodels.Icon("idcardquestion", pgettext("image alt text", "core.icons.idcardquestion")),
-        paragraphs=[_(verifier.unverified_blurb), _("eligibility.pages.unverified.p[1]")],
+        paragraphs=[_(verifier.unverified_blurb)],
         buttons=buttons,
     )
 

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -236,6 +236,7 @@ def unverified(request):
     verifier = session.verifier(request)
 
     page = viewmodels.Page(
+        noimage=True,
         title=_(verifier.unverified_title),
         classes="with-agency-links",
         content_title=_(verifier.unverified_content_title),

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -420,8 +420,7 @@ msgstr "Your eligibility could not be verified."
 
 msgid "eligibility.pages.unverified.oauth.p[0]"
 msgstr ""
-"You may still be eligible for a discount, but we can’t verify your age "
-"with Login.gov."
+"That’s okay! You may still be eligible for our program. Please reach out to your local transit provider for assistance."
 
 #: benefits/eligibility/views.py:172
 msgctxt "image alt text"

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -427,10 +427,6 @@ msgctxt "image alt text"
 msgid "core.icons.idcardquestion"
 msgstr "Identification card icon with question mark"
 
-#: benefits/eligibility/views.py:173
-msgid "eligibility.pages.unverified.p[1]"
-msgstr "That’s okay! You may still be eligible for our program. Please reach out to your local transit provider for assistance."
-
 #: benefits/enrollment/templates/enrollment/success.html:7
 msgctxt "image alt text"
 msgid "enrollment.pages.success.image"

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -145,7 +145,7 @@ msgstr ""
 #: benefits/core/templates/core/includes/noscript.html:8
 #: benefits/core/viewmodels.py:48
 msgid "core.buttons.return_home"
-msgstr "Regresar a la pantalla de inicio"
+msgstr "Regresar a la página principal"
 
 #: benefits/core/templates/core/includes/noscript.html:6
 msgid "core.includes.noscript.brand"
@@ -408,16 +408,12 @@ msgstr "No se pudo verificar su elegibilidad."
 
 msgid "eligibility.pages.unverified.oauth.p[0]"
 msgstr ""
-"¡Esta bien! Aún puede ser elegible para nuestro programa. "
+"¡Esta bien! Aún puede ser elegible para nuestro programa. Comuníquese con su proveedor de tránsito local para obtener asistencia."
 
 #: benefits/eligibility/views.py:172
 msgctxt "image alt text"
 msgid "core.icons.idcardquestion"
 msgstr "Icono de tarjeta de identificación con signo de interrogación"
-
-#: benefits/eligibility/views.py:173
-msgid "eligibility.pages.unverified.p[1]"
-msgstr "Comuníquese con su proveedor de tránsito local para obtener asistencia."
 
 #: benefits/enrollment/templates/enrollment/success.html:7
 msgctxt "image alt text"

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -489,12 +489,27 @@ footer.global-footer .footer-links a:active {
 .container.content h1.icon-title {
   padding-bottom: 1.5rem;
   line-height: 36px;
+  text-align: center;
 }
 
 .container.content h1.icon-title span.icon {
   text-align: center;
   display: block;
   padding-bottom: 3rem;
+}
+
+.container.content h1.icon-title img.icon {
+  width: 150px;
+  height: 150px;
+}
+
+.with-image .container.content h1.icon-title img.icon {
+  width: 92px;
+  height: 92px;
+}
+
+.with-image .container.content h1.icon-title {
+  text-align: left;
 }
 
 .container.content.help {


### PR DESCRIPTION
closes #759


For /unverified page:
- Update copy
- Make the icon bigger (from 92px to 150px)
- Center all the text
- Remove side image

For the pages *with* the image:
- Make sure the icon stays at 92px
- Make sure the text is not centered