### PR TITLE
Copy: remove second paragraph, update button text, fix default arg bug

### DIFF
--- a/benefits/core/viewmodels.py
+++ b/benefits/core/viewmodels.py
@@ -48,8 +48,11 @@ class Button:
         ]
 
     @staticmethod
-    def home(request, text=_("core.buttons.return_home")):
+    def home(request, text=None):
         """Create a button back to this session's origin."""
+        if text is None:
+            text = _("core.buttons.return_home")
+
         return Button.primary(text=text, url=session.origin(request))
 
     @staticmethod

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -231,7 +231,7 @@ def unverified(request):
     # tel: link to agency phone number
     agency = session.agency(request)
     buttons = viewmodels.Button.agency_contact_links(agency)
-    buttons.append(viewmodels.Button.home(request, _("core.buttons.retry")))
+    buttons.append(viewmodels.Button.home(request))
 
     verifier = session.verifier(request)
 

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -241,7 +241,7 @@ def unverified(request):
         classes="with-agency-links",
         content_title=_(verifier.unverified_content_title),
         icon=viewmodels.Icon("idcardquestion", pgettext("image alt text", "core.icons.idcardquestion")),
-        paragraphs=[_(verifier.unverified_blurb), _("eligibility.pages.unverified.p[1]")],
+        paragraphs=[_(verifier.unverified_blurb)],
         buttons=buttons,
     )
 

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -427,10 +427,6 @@ msgctxt "image alt text"
 msgid "core.icons.idcardquestion"
 msgstr "Identification card icon with question mark"
 
-#: benefits/eligibility/views.py:173
-msgid "eligibility.pages.unverified.p[1]"
-msgstr "That’s okay! You may still be eligible for our program. Please reach out to your local transit provider for assistance."
-
 #: benefits/enrollment/templates/enrollment/success.html:7
 msgctxt "image alt text"
 msgid "enrollment.pages.success.image"

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -408,16 +408,12 @@ msgstr "No se pudo verificar su elegibilidad."
 
 msgid "eligibility.pages.unverified.oauth.p[0]"
 msgstr ""
-"¡Esta bien! Aún puede ser elegible para nuestro programa. "
+"¡Esta bien! Aún puede ser elegible para nuestro programa. Comuníquese con su proveedor de tránsito local para obtener asistencia."
 
 #: benefits/eligibility/views.py:172
 msgctxt "image alt text"
 msgid "core.icons.idcardquestion"
 msgstr "Icono de tarjeta de identificación con signo de interrogación"
-
-#: benefits/eligibility/views.py:173
-msgid "eligibility.pages.unverified.p[1]"
-msgstr "Comuníquese con su proveedor de tránsito local para obtener asistencia."
 
 #: benefits/enrollment/templates/enrollment/success.html:7
 msgctxt "image alt text"

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -145,7 +145,7 @@ msgstr ""
 #: benefits/core/templates/core/includes/noscript.html:8
 #: benefits/core/viewmodels.py:48
 msgid "core.buttons.return_home"
-msgstr "Regresar a la pantalla de inicio"
+msgstr "Regresar a la página principal"
 
 #: benefits/core/templates/core/includes/noscript.html:6
 msgid "core.includes.noscript.brand"


### PR DESCRIPTION
This is based off #762. In this case where we're just tweaking copy, it seemed better to go ahead and open this PR with my suggestions as changes.

### Changes

 - Remove second paragraph from `unverified`. It was redundant in the English copy and had an extra line break in the Spanish copy, which was not present in Figma.
(Redundant second paragraph)
![image](https://user-images.githubusercontent.com/25497886/176793604-719e7ee8-b0bc-4f59-87c3-5b60261df1e0.png)
 - Changed button text to use "core.buttons.return_home" so that it says "Return Home" when in English
 - Updated Spanish PO entry to match the [finalized copy](https://docs.google.com/document/d/1Ndai_9Ut6DLU86w6BpkmU23xzG1QF0a0-BeQ3_FWNoQ/edit#bookmark=kix.382mzwubv2r3) for the "core.buttons.return_home" button
 - Fixed a bug where switching the language didn't work for instances created from `Button.home()` static method
![image](https://user-images.githubusercontent.com/25497886/176793819-00da5b7a-af1a-4d10-8c28-63ae02dc3481.png)


