### PR TITLE
Fix database setup for pytests

### DIFF
--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -62,6 +62,15 @@ def model_AuthProvider():
 
 
 @pytest.fixture
+def model_AuthProvider_with_verification(model_AuthProvider):
+    model_AuthProvider.scope = "scope"
+    model_AuthProvider.claim = "claim"
+    model_AuthProvider.save()
+
+    return model_AuthProvider
+
+
+@pytest.fixture
 def model_EligibilityType():
     eligibility = EligibilityType(id=999, name="test", label="Test Eligibility Type", group_id="1234")
     eligibility.save()
@@ -98,6 +107,14 @@ def model_EligibilityVerifier(model_PemData, model_EligibilityType):
     verifier.save()
 
     return verifier
+
+
+@pytest.fixture
+def model_EligibilityVerifier_AuthProvider_with_verification(model_AuthProvider_with_verification, model_EligibilityVerifier):
+    model_EligibilityVerifier.auth_provider = model_AuthProvider_with_verification
+    model_EligibilityVerifier.save()
+
+    return model_EligibilityVerifier
 
 
 @pytest.fixture
@@ -189,6 +206,13 @@ def mocked_session_oauth_token(mocker):
 @pytest.fixture
 def mocked_session_verifier(mocker, model_EligibilityVerifier):
     return mocker.patch("benefits.core.session.verifier", autospec=True, return_value=model_EligibilityVerifier)
+
+
+@pytest.fixture
+def mocked_session_verifier_oauth(mocker, model_EligibilityVerifier_AuthProvider_with_verification):
+    return mocker.patch(
+        "benefits.core.session.verifier", autospec=True, return_value=model_EligibilityVerifier_AuthProvider_with_verification
+    )
 
 
 @pytest.fixture

--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -71,6 +71,15 @@ def model_AuthProvider_with_verification(model_AuthProvider):
 
 
 @pytest.fixture
+def model_AuthProvider_without_verification(model_AuthProvider):
+    model_AuthProvider.scope = None
+    model_AuthProvider.claim = None
+    model_AuthProvider.save()
+
+    return model_AuthProvider
+
+
+@pytest.fixture
 def model_EligibilityType():
     eligibility = EligibilityType(id=999, name="test", label="Test Eligibility Type", group_id="1234")
     eligibility.save()

--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -177,6 +177,14 @@ def model_TransitAgency(model_PemData, model_EligibilityType, model_EligibilityV
 
 
 @pytest.fixture
+def model_TransitAgency_inactive(model_TransitAgency):
+    model_TransitAgency.active = False
+    model_TransitAgency.save()
+
+    return model_TransitAgency
+
+
+@pytest.fixture
 def mocked_analytics_module(mocker):
     """
     Fixture returns a helper function to mock the analytics module imported on another given module.

--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -35,7 +35,7 @@ def app_request(rf):
 @pytest.fixture
 def model_PemData():
     data = PemData.objects.create(
-        id=999, text="-----BEGIN PUBLIC KEY-----\nPEM DATA\n-----END PUBLIC KEY-----\n", label="Test public key"
+        text="-----BEGIN PUBLIC KEY-----\nPEM DATA\n-----END PUBLIC KEY-----\n", label="Test public key"
     )
 
     return data
@@ -44,7 +44,6 @@ def model_PemData():
 @pytest.fixture
 def model_AuthProvider():
     auth_provider = AuthProvider.objects.create(
-        id=999,
         sign_in_button_label="Sign in",
         sign_out_button_label="Sign out",
         client_name="Client",
@@ -75,7 +74,7 @@ def model_AuthProvider_without_verification(model_AuthProvider):
 
 @pytest.fixture
 def model_EligibilityType():
-    eligibility = EligibilityType.objects.create(id=999, name="test", label="Test Eligibility Type", group_id="1234")
+    eligibility = EligibilityType.objects.create(name="test", label="Test Eligibility Type", group_id="1234")
 
     return eligibility
 
@@ -83,7 +82,6 @@ def model_EligibilityType():
 @pytest.fixture
 def model_EligibilityVerifier(model_PemData, model_EligibilityType):
     verifier = EligibilityVerifier.objects.create(
-        id=999,
         name="Test Verifier",
         api_url="https://example.com/verify",
         api_auth_header="X-API-AUTH",
@@ -121,7 +119,6 @@ def model_EligibilityVerifier_AuthProvider_with_verification(model_AuthProvider_
 @pytest.fixture
 def model_PaymentProcessor(model_PemData):
     payment_processor = PaymentProcessor.objects.create(
-        id=999,
         name="Test Payment Processor",
         api_base_url="https://example.com/payments",
         api_access_token_endpoint="token",
@@ -144,7 +141,6 @@ def model_PaymentProcessor(model_PemData):
 @pytest.fixture
 def model_TransitAgency(model_PemData, model_EligibilityType, model_EligibilityVerifier, model_PaymentProcessor):
     agency = TransitAgency.objects.create(
-        id=999,
         slug="test",
         short_name="TEST",
         long_name="Test Transit Agency",

--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -13,12 +13,6 @@ def pytest_runtest_setup():
     disable_socket()
 
 
-@pytest.fixture(scope="session")
-def django_db_setup():
-    # use existing database since it's read-only
-    pass
-
-
 @pytest.fixture
 def app_request(rf):
     """

--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -171,35 +171,14 @@ def mocked_view():
 
 
 @pytest.fixture
-def first_agency():
-    agency = TransitAgency.objects.first()
-    assert agency
-    return agency
+def mocked_session_agency(mocker, model_TransitAgency):
+    return mocker.patch("benefits.core.session.agency", autospec=True, return_value=model_TransitAgency)
 
 
 @pytest.fixture
-def first_eligibility(first_agency):
-    eligibility = first_agency.eligibility_types.first()
-    assert eligibility
-    return eligibility
-
-
-@pytest.fixture
-def first_verifier(first_agency):
-    verifier = first_agency.eligibility_verifiers.first()
-    assert verifier
-    return verifier
-
-
-@pytest.fixture
-def mocked_session_agency(mocker, first_agency):
-    return mocker.patch("benefits.core.session.agency", autospec=True, return_value=first_agency)
-
-
-@pytest.fixture
-def mocked_session_eligibility(mocker, first_eligibility):
+def mocked_session_eligibility(mocker, model_EligibilityType):
     mocker.patch("benefits.core.session.eligible", autospec=True, return_value=True)
-    return mocker.patch("benefits.core.session.eligibility", autospec=True, return_value=first_eligibility)
+    return mocker.patch("benefits.core.session.eligibility", autospec=True, return_value=model_EligibilityType)
 
 
 @pytest.fixture
@@ -208,13 +187,13 @@ def mocked_session_oauth_token(mocker):
 
 
 @pytest.fixture
-def mocked_session_verifier(mocker, first_verifier):
-    return mocker.patch("benefits.core.session.verifier", autospec=True, return_value=first_verifier)
+def mocked_session_verifier(mocker, model_EligibilityVerifier):
+    return mocker.patch("benefits.core.session.verifier", autospec=True, return_value=model_EligibilityVerifier)
 
 
 @pytest.fixture
-def mocked_session_verifier_auth_required(mocker, first_verifier, mocked_session_verifier):
-    mock_verifier = mocker.Mock(spec=first_verifier)
+def mocked_session_verifier_auth_required(mocker, model_EligibilityVerifier, mocked_session_verifier):
+    mock_verifier = mocker.Mock(spec=model_EligibilityVerifier)
     mock_verifier.is_auth_required = True
     mocked_session_verifier.return_value = mock_verifier
     return mocked_session_verifier
@@ -222,7 +201,7 @@ def mocked_session_verifier_auth_required(mocker, first_verifier, mocked_session
 
 @pytest.fixture
 def mocked_session_verifier_auth_not_required(mocked_session_verifier_auth_required):
-    # mocked_session_verifier_auth_required.return_value is the Mock(spec=first_verifier) from that fixture
+    # mocked_session_verifier_auth_required.return_value is the Mock(spec=model_EligibilityVerifier) from that fixture
     mocked_session_verifier_auth_required.return_value.is_auth_required = False
     mocked_session_verifier_auth_required.return_value.uses_auth_verification = False
     return mocked_session_verifier_auth_required

--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -34,15 +34,16 @@ def app_request(rf):
 
 @pytest.fixture
 def model_PemData():
-    data = PemData(id=999, text="-----BEGIN PUBLIC KEY-----\nPEM DATA\n-----END PUBLIC KEY-----\n", label="Test public key")
-    data.save()
+    data = PemData.objects.create(
+        id=999, text="-----BEGIN PUBLIC KEY-----\nPEM DATA\n-----END PUBLIC KEY-----\n", label="Test public key"
+    )
 
     return data
 
 
 @pytest.fixture
 def model_AuthProvider():
-    auth_provider = AuthProvider(
+    auth_provider = AuthProvider.objects.create(
         id=999,
         sign_in_button_label="Sign in",
         sign_out_button_label="Sign out",
@@ -50,7 +51,6 @@ def model_AuthProvider():
         client_id="1234",
         authority="https://example.com",
     )
-    auth_provider.save()
 
     return auth_provider
 
@@ -75,15 +75,14 @@ def model_AuthProvider_without_verification(model_AuthProvider):
 
 @pytest.fixture
 def model_EligibilityType():
-    eligibility = EligibilityType(id=999, name="test", label="Test Eligibility Type", group_id="1234")
-    eligibility.save()
+    eligibility = EligibilityType.objects.create(id=999, name="test", label="Test Eligibility Type", group_id="1234")
 
     return eligibility
 
 
 @pytest.fixture
 def model_EligibilityVerifier(model_PemData, model_EligibilityType):
-    verifier = EligibilityVerifier(
+    verifier = EligibilityVerifier.objects.create(
         id=999,
         name="Test Verifier",
         api_url="https://example.com/verify",
@@ -107,7 +106,6 @@ def model_EligibilityVerifier(model_PemData, model_EligibilityType):
         unverified_content_title="Unverified",
         unverified_blurb="Unverified Blurb",
     )
-    verifier.save()
 
     return verifier
 
@@ -122,7 +120,7 @@ def model_EligibilityVerifier_AuthProvider_with_verification(model_AuthProvider_
 
 @pytest.fixture
 def model_PaymentProcessor(model_PemData):
-    payment_processor = PaymentProcessor(
+    payment_processor = PaymentProcessor.objects.create(
         id=999,
         name="Test Payment Processor",
         api_base_url="https://example.com/payments",
@@ -139,14 +137,13 @@ def model_PaymentProcessor(model_PemData):
         customers_endpoint="customers",
         group_endpoint="group",
     )
-    payment_processor.save()
 
     return payment_processor
 
 
 @pytest.fixture
 def model_TransitAgency(model_PemData, model_EligibilityType, model_EligibilityVerifier, model_PaymentProcessor):
-    agency = TransitAgency(
+    agency = TransitAgency.objects.create(
         id=999,
         slug="test",
         short_name="TEST",
@@ -160,9 +157,8 @@ def model_TransitAgency(model_PemData, model_EligibilityType, model_EligibilityV
         private_key=model_PemData,
         jws_signing_alg="alg",
     )
-    # save first before adding many-to-many relationships, need ID on both sides
-    agency.save()
 
+    # add many-to-many relationships after creation, need ID on both sides
     agency.eligibility_types.add(model_EligibilityType)
     agency.eligibility_verifiers.add(model_EligibilityVerifier)
     agency.save()

--- a/tests/pytest/core/test_middleware_login_required.py
+++ b/tests/pytest/core/test_middleware_login_required.py
@@ -34,12 +34,10 @@ def test_login_auth_required(app_request, mocked_view, decorated_view):
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("model_EligibilityVerifier")
-def test_login_auth_not_required(app_request, mocked_view, decorated_view):
-    verifier = EligibilityVerifier.objects.filter(auth_provider__isnull=True).first()
-    assert verifier
-    assert not verifier.is_auth_required
-    session.update(app_request, verifier=verifier)
+def test_login_auth_not_required(app_request, model_EligibilityVerifier, mocked_view, decorated_view):
+    model_EligibilityVerifier.auth_provider = None
+    assert not model_EligibilityVerifier.is_auth_required
+    session.update(app_request, verifier=model_EligibilityVerifier)
 
     decorated_view(app_request)
 

--- a/tests/pytest/core/test_middleware_login_required.py
+++ b/tests/pytest/core/test_middleware_login_required.py
@@ -34,6 +34,7 @@ def test_login_auth_required(app_request, mocked_view, decorated_view):
 
 
 @pytest.mark.django_db
+@pytest.mark.usefixtures("model_EligibilityVerifier")
 def test_login_auth_not_required(app_request, mocked_view, decorated_view):
     verifier = EligibilityVerifier.objects.filter(auth_provider__isnull=True).first()
     assert verifier

--- a/tests/pytest/core/test_models.py
+++ b/tests/pytest/core/test_models.py
@@ -2,12 +2,21 @@ import pytest
 
 
 @pytest.mark.django_db
-def test_EligibilityVerifier_uses_auth_verification_True(first_verifier):
-    assert first_verifier.uses_auth_verification
+def test_EligibilityVerifier_with_auth_verification(model_EligibilityVerifier, model_AuthProvider_with_verification):
+    model_EligibilityVerifier.auth_provider = model_AuthProvider_with_verification
+
+    assert model_EligibilityVerifier.uses_auth_verification
 
 
 @pytest.mark.django_db
-def test_EligibilityVerifier_uses_auth_verification_False(first_verifier):
-    first_verifier.auth_provider = None
+def test_EligibilityVerifier_without_auth_verification(model_EligibilityVerifier, model_AuthProvider_without_verification):
+    model_EligibilityVerifier.auth_provider = model_AuthProvider_without_verification
 
-    assert not first_verifier.uses_auth_verification
+    assert not model_EligibilityVerifier.uses_auth_verification
+
+
+@pytest.mark.django_db
+def test_EligibilityVerifier_without_AuthProvider(model_EligibilityVerifier):
+    model_EligibilityVerifier.auth_provider = None
+
+    assert not model_EligibilityVerifier.uses_auth_verification

--- a/tests/pytest/core/test_session.py
+++ b/tests/pytest/core/test_session.py
@@ -19,10 +19,9 @@ def test_active_agency_False(app_request, model_TransitAgency_inactive):
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("model_TransitAgency")
-def test_active_agency_True(app_request):
-    agency = models.TransitAgency.objects.filter(active=True).first()
-    session.update(app_request, agency=agency)
+def test_active_agency_True(model_TransitAgency, app_request):
+    assert model_TransitAgency.active
+    session.update(app_request, agency=model_TransitAgency)
 
     assert session.active_agency(app_request)
 

--- a/tests/pytest/core/test_session.py
+++ b/tests/pytest/core/test_session.py
@@ -8,16 +8,12 @@ from benefits.core.views import ROUTE_INDEX
 
 
 @pytest.mark.django_db
-def test_active_agency_False(app_request):
+def test_active_agency_False(app_request, model_TransitAgency_inactive):
     session.update(app_request, agency=None)
 
     assert not session.active_agency(app_request)
 
-    agency = models.TransitAgency.objects.first()
-    agency.active = False
-    agency.save()
-
-    session.update(app_request, agency=agency)
+    session.update(app_request, agency=model_TransitAgency_inactive)
 
     assert not session.active_agency(app_request)
 

--- a/tests/pytest/core/test_session.py
+++ b/tests/pytest/core/test_session.py
@@ -19,6 +19,7 @@ def test_active_agency_False(app_request, model_TransitAgency_inactive):
 
 
 @pytest.mark.django_db
+@pytest.mark.usefixtures("model_TransitAgency")
 def test_active_agency_True(app_request):
     agency = models.TransitAgency.objects.filter(active=True).first()
     session.update(app_request, agency=agency)
@@ -65,11 +66,10 @@ def test_eligibile_False(app_request):
 
 
 @pytest.mark.django_db
-def test_eligibile_True(app_request):
-    agency = models.TransitAgency.objects.first()
-    eligibility = agency.eligibility_types.first()
+def test_eligibile_True(model_TransitAgency, app_request):
+    eligibility = model_TransitAgency.eligibility_types.first()
 
-    session.update(app_request, agency=agency, eligibility_types=[eligibility.name])
+    session.update(app_request, agency=model_TransitAgency, eligibility_types=[eligibility.name])
 
     assert session.eligible(app_request)
 
@@ -202,9 +202,8 @@ def test_rate_limit_time_default(app_request):
 
 
 @pytest.mark.django_db
-def test_reset_agency(app_request):
-    agency = models.TransitAgency.objects.first()
-    session.update(app_request, agency=agency)
+def test_reset_agency(model_TransitAgency, app_request):
+    session.update(app_request, agency=model_TransitAgency)
 
     assert session.agency(app_request)
 
@@ -377,19 +376,16 @@ def test_update_eligibility_empty(app_request):
 
 
 @pytest.mark.django_db
-def test_update_eligibility_many(app_request):
-    eligiblity = models.EligibilityType.objects.all()
-
+def test_update_eligibility_many(model_EligibilityType, app_request):
     with pytest.raises(NotImplementedError):
-        assert session.update(app_request, eligibility_types=[e.name for e in eligiblity])
+        assert session.update(app_request, eligibility_types=[model_EligibilityType, model_EligibilityType])
 
 
 @pytest.mark.django_db
-def test_update_eligibility_single(app_request):
-    agency = models.TransitAgency.objects.first()
-    eligibility = agency.eligibility_types.first()
+def test_update_eligibility_single(model_TransitAgency, app_request):
+    eligibility = model_TransitAgency.eligibility_types.first()
 
-    session.update(app_request, agency=agency, eligibility_types=[eligibility.name])
+    session.update(app_request, agency=model_TransitAgency, eligibility_types=[eligibility.name])
 
     assert session.eligibility(app_request) == eligibility
 

--- a/tests/pytest/eligibility/test_verify.py
+++ b/tests/pytest/eligibility/test_verify.py
@@ -15,72 +15,78 @@ def mock_api_client_verify(mocker):
 
 
 @pytest.mark.django_db
-def test_eligibility_from_api_error(mocker, first_agency, first_verifier, mock_api_client_verify, form):
+def test_eligibility_from_api_error(mocker, model_TransitAgency, model_EligibilityVerifier, mock_api_client_verify, form):
     api_errors = {"name": "Name error"}
     api_response = mocker.Mock(error=api_errors)
     mock_api_client_verify.return_value = api_response
 
-    response = eligibility_from_api(first_verifier, form, first_agency)
+    response = eligibility_from_api(model_EligibilityVerifier, form, model_TransitAgency)
 
     assert response is None
     form.add_api_errors.assert_called_once_with(api_errors)
 
 
 @pytest.mark.django_db
-def test_eligibility_from_api_verified_types(mocker, first_agency, first_verifier, mock_api_client_verify, form):
+def test_eligibility_from_api_verified_types(
+    mocker, model_TransitAgency, model_EligibilityVerifier, mock_api_client_verify, form
+):
     verified_types = ["type1", "type2"]
     api_response = mocker.Mock(eligibility=verified_types, error=None)
     mock_api_client_verify.return_value = api_response
 
-    response = eligibility_from_api(first_verifier, form, first_agency)
+    response = eligibility_from_api(model_EligibilityVerifier, form, model_TransitAgency)
 
     assert response == verified_types
     form.add_api_errors.assert_not_called()
 
 
 @pytest.mark.django_db
-def test_eligibility_from_api_no_verified_types(mocker, first_agency, first_verifier, mock_api_client_verify, form):
+def test_eligibility_from_api_no_verified_types(
+    mocker, model_TransitAgency, model_EligibilityVerifier, mock_api_client_verify, form
+):
     verified_types = []
     api_response = mocker.Mock(eligibility=verified_types, error=None)
     mock_api_client_verify.return_value = api_response
 
-    response = eligibility_from_api(first_verifier, form, first_agency)
+    response = eligibility_from_api(model_EligibilityVerifier, form, model_TransitAgency)
 
     assert response == verified_types
     form.add_api_errors.assert_not_called()
 
 
 @pytest.mark.django_db
-def test_eligibility_from_oauth_auth_not_required(mocked_session_verifier_auth_not_required, first_agency):
+def test_eligibility_from_oauth_auth_not_required(mocked_session_verifier_auth_not_required, model_TransitAgency):
     # mocked_session_verifier_auth_not_required is Mocked version of the session.verifier() function
     # call it (with a None request) to return a verifier object
     verifier = mocked_session_verifier_auth_not_required(None)
 
-    types = eligibility_from_oauth(verifier, "claim", first_agency)
+    types = eligibility_from_oauth(verifier, "claim", model_TransitAgency)
 
     assert types == []
 
 
 @pytest.mark.django_db
-def test_eligibility_from_oauth_auth_claim_mismatch(mocked_session_verifier_auth_required, first_agency):
+def test_eligibility_from_oauth_auth_claim_mismatch(mocked_session_verifier_auth_required, model_TransitAgency):
     # mocked_session_verifier_auth_required is Mocked version of the session.verifier() function
     # call it (with a None request) to return a verifier object
     verifier = mocked_session_verifier_auth_required(None)
     verifier.auth_claim = "claim"
 
-    types = eligibility_from_oauth(verifier, "some_other_claim", first_agency)
+    types = eligibility_from_oauth(verifier, "some_other_claim", model_TransitAgency)
 
     assert types == []
 
 
 @pytest.mark.django_db
-def test_eligibility_from_oauth_auth_claim_match(mocked_session_verifier_auth_required, first_eligibility, first_agency):
+def test_eligibility_from_oauth_auth_claim_match(
+    mocked_session_verifier_auth_required, model_EligibilityType, model_TransitAgency
+):
     # mocked_session_verifier_auth_required is Mocked version of the session.verifier() function
     # call it (with a None request) to return a verifier object
     verifier = mocked_session_verifier_auth_required.return_value
     verifier.auth_provider.claim = "claim"
-    verifier.eligibility_type = first_eligibility
+    verifier.eligibility_type = model_EligibilityType
 
-    types = eligibility_from_oauth(verifier, "claim", first_agency)
+    types = eligibility_from_oauth(verifier, "claim", model_TransitAgency)
 
-    assert types == [first_eligibility.name]
+    assert types == [model_EligibilityType.name]

--- a/tests/pytest/eligibility/test_views.py
+++ b/tests/pytest/eligibility/test_views.py
@@ -57,10 +57,12 @@ def disable_rate_limit(mocker):
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_session_agency")
-def test_index_get_agency_multiple_verifiers(mocker, first_agency, first_verifier, mocked_session_agency, client):
+def test_index_get_agency_multiple_verifiers(
+    mocker, model_TransitAgency, model_EligibilityVerifier, mocked_session_agency, client
+):
     # override the mocked session agency with a mock agency that has multiple verifiers
-    mock_agency = mocker.Mock(spec=first_agency)
-    mock_agency.eligibility_verifiers.all.return_value = [first_verifier, first_verifier]
+    mock_agency = mocker.Mock(spec=model_TransitAgency)
+    mock_agency.eligibility_verifiers.all.return_value = [model_EligibilityVerifier, model_EligibilityVerifier]
     mock_agency.eligibility_verifiers.count.return_value = 2
     mocked_session_agency.return_value = mock_agency
 
@@ -76,10 +78,12 @@ def test_index_get_agency_multiple_verifiers(mocker, first_agency, first_verifie
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_session_agency")
-def test_index_get_agency_single_verifier(mocker, first_agency, first_verifier, mocked_session_agency, client):
+def test_index_get_agency_single_verifier(
+    mocker, model_TransitAgency, model_EligibilityVerifier, mocked_session_agency, client
+):
     # override the mocked session agency with a mock agency that has a single verifier
-    mock_agency = mocker.Mock(spec=first_agency)
-    mock_agency.eligibility_verifiers.all.return_value = [first_verifier]
+    mock_agency = mocker.Mock(spec=model_TransitAgency)
+    mock_agency.eligibility_verifiers.all.return_value = [model_EligibilityVerifier]
     mock_agency.eligibility_verifiers.count.return_value = 1
     mocked_session_agency.return_value = mock_agency
 
@@ -110,14 +114,14 @@ def test_index_post_invalid_form(client):
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_session_agency")
-def test_index_post_valid_form(client, first_verifier, mocked_session_update):
+def test_index_post_valid_form(client, model_EligibilityVerifier, mocked_session_update):
     path = reverse(ROUTE_INDEX)
 
-    response = client.post(path, {"verifier": first_verifier.id})
+    response = client.post(path, {"verifier": model_EligibilityVerifier.id})
 
     assert response.status_code == 302
     assert response.url == reverse(ROUTE_START)
-    assert mocked_session_update.call_args.kwargs["verifier"] == first_verifier
+    assert mocked_session_update.call_args.kwargs["verifier"] == model_EligibilityVerifier
 
 
 @pytest.mark.django_db
@@ -195,9 +199,9 @@ def test_confirm_get_verified(client, mocked_session_update):
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("mocked_eligibility_auth_request")
-def test_confirm_get_oauth_verified(mocker, client, first_eligibility, mocked_session_update, mocked_analytics_module):
-    mocker.patch("benefits.eligibility.verify.eligibility_from_oauth", return_value=[first_eligibility])
+@pytest.mark.usefixtures("mocked_session_agency", "mocked_session_verifier", "mocked_session_oauth_token")
+def test_confirm_get_oauth_verified(mocker, client, model_EligibilityType, mocked_session_update, mocked_analytics_module):
+    mocker.patch("benefits.eligibility.verify.eligibility_from_oauth", return_value=[model_EligibilityType])
 
     path = reverse(ROUTE_CONFIRM)
     response = client.get(path)
@@ -209,7 +213,9 @@ def test_confirm_get_oauth_verified(mocker, client, first_eligibility, mocked_se
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("mocked_eligibility_auth_request", "mocked_session_update")
+@pytest.mark.usefixtures(
+    "mocked_session_agency", "mocked_session_verifier", "mocked_session_oauth_token", "mocked_session_update"
+)
 def test_confirm_get_oauth_unverified(mocker, client, mocked_analytics_module):
     mocker.patch("benefits.eligibility.verify.eligibility_from_oauth", return_value=[])
 

--- a/tests/pytest/eligibility/test_views.py
+++ b/tests/pytest/eligibility/test_views.py
@@ -199,7 +199,7 @@ def test_confirm_get_verified(client, mocked_session_update):
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("mocked_session_agency", "mocked_session_verifier", "mocked_session_oauth_token")
+@pytest.mark.usefixtures("mocked_session_agency", "mocked_session_verifier_oauth", "mocked_session_oauth_token")
 def test_confirm_get_oauth_verified(mocker, client, model_EligibilityType, mocked_session_update, mocked_analytics_module):
     mocker.patch("benefits.eligibility.verify.eligibility_from_oauth", return_value=[model_EligibilityType])
 
@@ -214,7 +214,7 @@ def test_confirm_get_oauth_verified(mocker, client, model_EligibilityType, mocke
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures(
-    "mocked_session_agency", "mocked_session_verifier", "mocked_session_oauth_token", "mocked_session_update"
+    "mocked_session_agency", "mocked_session_verifier_oauth", "mocked_session_oauth_token", "mocked_session_update"
 )
 def test_confirm_get_oauth_unverified(mocker, client, mocked_analytics_module):
     mocker.patch("benefits.eligibility.verify.eligibility_from_oauth", return_value=[])

--- a/tests/pytest/enrollment/test_api_Client.py
+++ b/tests/pytest/enrollment/test_api_Client.py
@@ -9,8 +9,8 @@ REQUESTS_ERRORS = [requests.ConnectionError, requests.Timeout, requests.TooManyR
 
 
 @pytest.fixture
-def api_client(first_agency):
-    return Client(first_agency)
+def api_client(model_TransitAgency):
+    return Client(model_TransitAgency)
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR removes the dependency of pytests on our `django.db` database.

Many tests assumed the database existed with particular contents - specific `TransitAgency` configurations, multiple or single `EligibilityVerifier`, etc. Many tests queried the database for particular model instances (e.g. `ABC`).

Instead, this PR introduces a number of `@pytest.fixture` that create test data in the test database and return model instances. These are used throughout the test modules to simplify tests, clarify intent, and entirely separate our _JSON fixtures_ from our pytests.

This is prerequisite work and related to #723.