### PR TITLE
Terraform: override App Service Cipher Suite

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   constraints = "~> 3.14.0"
   hashes = [
     "h1:UPoCjHOmnfO3IrPPM39yXGMcs5+re8qrUt/YcCVkvy8=",
+    "h1:zZ/8oe/dfY6AB+f8ARxb4I63Thgwdf9CUgZsURF3bYo=",
     "zh:03b0dfe15cca2fc44c5f3bc62dedd921765cb3b0e66763ae6de433d332f8038b",
     "zh:0691f8182f7c6a1ba0f985a5504f455390ab046776cc3e545d7334cbe8559edd",
     "zh:162d254fd1a111858f336d502ee1aa3020c3bcfe2ac62d99904784cb582a3cb7",

--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -1,9 +1,10 @@
 resource "azurerm_service_plan" "main" {
-  name                = "ASP-CDT-PUB-VIP-CALITP-P-001"
-  location            = data.azurerm_resource_group.prod.location
-  resource_group_name = data.azurerm_resource_group.prod.name
-  os_type             = "Linux"
-  sku_name            = "P2v2"
+  name                       = "ASP-CDT-PUB-VIP-CALITP-P-001"
+  location                   = data.azurerm_resource_group.prod.location
+  resource_group_name        = data.azurerm_resource_group.prod.name
+  os_type                    = "Linux"
+  sku_name                   = "P2v2"
+  app_service_environment_id = azurerm_app_service_environment_v3.main.id
 
   lifecycle {
     ignore_changes = [tags]

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -8,3 +8,20 @@ data "azurerm_subnet" "main" {
   virtual_network_name = "VNET-CDT-PUB-SHRD-W-P-001"
   resource_group_name  = local.network_resource_group_name
 }
+
+resource "azurerm_app_service_environment_v3" "main" {
+  name                = "ASE-CDT-PUB-CALITP-P-001"
+  resource_group_name = local.network_resource_group_name
+  subnet_id           = data.azurerm_subnet.main.id
+
+  # override the default Cipher suite as a remediation to vulnerability scanning
+  # https://github.com/cal-itp/benefits/issues/771
+  cluster_setting {
+    name  = "FrontEndSSLCipherSuiteOrder"
+    value = "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+  }
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}


### PR DESCRIPTION
Closes #771 

We're currently getting an error trying to `terraform apply` these changes:

> Error: checking for presence of existing App Service Environment: (Hosting Environment Name "ASE-CDT-PUB-CALITP-P-001" / Resource Group "RG-CDT-PUB-SHRD-W-P-001"): web.AppServiceEnvironmentsClient#Get: Failure responding to request: StatusCode=403 -- Original Error: autorest/azure: Service returned an error. Status=403 Code="AuthorizationFailed" Message="The client 'kegan@compiler.la' with object id '[REDACTED]' does not have authorization to perform action 'Microsoft.Web/hostingEnvironments/read' over scope '/subscriptions/[REDACTED]/resourceGroups/RG-CDT-PUB-SHRD-W-P-001/providers/Microsoft.Web/hostingEnvironments/ASE-CDT-PUB-CALITP-P-001' or the scope is invalid. If access was recently granted, please refresh your credentials."
