### PR TITLE
Fix: enrollment overlay in Django 4.0.x

### DIFF
--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -114,6 +114,10 @@ if not DEBUG:
 
 SECURE_BROWSER_XSS_FILTER = True
 
+# required so that cross-origin pop-ups (like the enrollment overlay) have access to parent window context
+# https://github.com/cal-itp/benefits/pull/793
+SECURE_CROSS_ORIGIN_OPENER_POLICY = "same-origin-allow-popups"
+
 # the NGINX reverse proxy sits in front of the application in deployed environments
 # SSL terminates before getting to Django, and NGINX adds this header to indicate
 # if the original request was secure or not

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Authlib==1.0.1
-Django==3.2.14
+Django==4.0.6
 django-csp==3.7
 git+https://github.com/cal-itp/eligibility-api#egg=eligibility_api
 gunicorn==20.1.0


### PR DESCRIPTION
Closes #283 

### Summary

This PR sets [`SECURE_CROSS_ORIGIN_OPENER_POLICY`](https://docs.djangoproject.com/en/4.0/ref/middleware/#cross-origin-opener-policy) to `same-origin-allow-popups`, which is the most secure option that still allows the overlay to work.

This setting was [introduced in Django 4.0.x](https://docs.djangoproject.com/en/4.0/releases/4.0/#requests-and-responses) and by default, sets the [`Cross-Origin-Opener-Policy` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy) to `same-origin`, which prevents cross-origin popups from accessing their opener's browsing context. Prior to Django 4.0.x, the header was unset.

If you look through the Javascript of our enrollment overlay, you'll notice that it makes use of [`Window.postMessage()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) to communicate with the Benefits window and needs to be able to store some variables on that window. So, it makes sense that this header value breaks it, since with it,
> the [`window.opener`](https://developer.mozilla.org/en-US/docs/Web/API/Window/opener) property of the new window will be `null`

### Other notes
 - More explanation on `Cross-Origin-Opener-Policy`: https://web.dev/why-coop-coep/#coop
 - Interesting question on StackOverflow: https://stackoverflow.com/questions/71888175/why-is-a-cross-origin-opener-policy-unsafe-none-header-unsafe
 - To more easily read minified Javascript, it helps to enable the experimental Chrome debugger feature `Automatically pretty print in Sources Panel`: https://stackoverflow.com/a/61816945