### PR TITLE
Docs: update links to Django documentation from 3.2 to 4.0

### DIFF
--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -122,7 +122,7 @@ SECURE_CROSS_ORIGIN_OPENER_POLICY = "same-origin-allow-popups"
 # SSL terminates before getting to Django, and NGINX adds this header to indicate
 # if the original request was secure or not
 #
-# See https://docs.djangoproject.com/en/3.2/ref/settings/#secure-proxy-ssl-header
+# See https://docs.djangoproject.com/en/4.0/ref/settings/#secure-proxy-ssl-header
 if not DEBUG:
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 

--- a/benefits/urls.py
+++ b/benefits/urls.py
@@ -2,7 +2,7 @@
 benefits URL Configuration
 
 The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/3.2/topics/http/urls/
+    https://docs.djangoproject.com/en/4.0/topics/http/urls/
 """
 import logging
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ The application is accessible to the public at [benefits.calitp.org](https://ben
 
 ## Technical details
 
-`benefits` is a [Django 3][django] web application. The application talks to one or more [Eligibility Verification APIs](https://docs.calitp.org/eligibility-api/specification) or authentication providers. These APIs and the application are
+`benefits` is a [Django 4][django] web application. The application talks to one or more [Eligibility Verification APIs](https://docs.calitp.org/eligibility-api/specification) or authentication providers. These APIs and the application are
 designed for privacy and security of user information:
 
 - The API communicates with signed and encrypted JSON Web Tokens containing only the most necessary of user data for the purpose of eligibility verification
@@ -64,4 +64,4 @@ sequenceDiagram
 [interconnections]: deployment/infrastructure/#system-interconnections
 [hosting]: deployment/
 [littlepay]: https://littlepay.com/
-[i18n]: https://docs.djangoproject.com/en/3.2/topics/i18n/
+[i18n]: https://docs.djangoproject.com/en/4.0/topics/i18n/

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -5,8 +5,8 @@ run the app locally. But further configuration is required before many of the in
 
 There are two primary components of the application configuration include:
 
-* Overall app settings in [environment variables][env-vars]
-* Content and more specific configurations in [fixtures][fixtures]
+- Overall app settings in [environment variables][env-vars]
+- Content and more specific configurations in [fixtures][fixtures]
 
 The majority (but not all) of the environment variables are read into [Django settings](#django-settings) during application
 startup.
@@ -75,9 +75,9 @@ else:
 [benefits-manage]: https://github.com/cal-itp/benefits/blob/dev/manage.py
 [benefits-settings]: https://github.com/cal-itp/benefits/blob/dev/benefits/settings.py
 [benefits-wsgi]: https://github.com/cal-itp/benefits/blob/dev/benefits/wsgi.py
-[django-model]: https://docs.djangoproject.com/en/3.2/topics/db/models/
-[django-settings]: https://docs.djangoproject.com/en/3.2/topics/settings/
-[django-using-settings]: https://docs.djangoproject.com/en/3.2/topics/settings/#using-settings-in-python-code
+[django-model]: https://docs.djangoproject.com/en/4.0/topics/db/models/
+[django-settings]: https://docs.djangoproject.com/en/4.0/topics/settings/
+[django-using-settings]: https://docs.djangoproject.com/en/4.0/topics/settings/#using-settings-in-python-code
 [env-vars]: environment-variables.md
 [fixtures]: fixtures.md
 [getting-started]: ../getting-started/README.md

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -42,8 +42,8 @@ If blank or an invalid key, analytics events aren't captured (though may still b
 
 Boolean:
 
-* `True`: activates Django's built-in admin interface for content authoring.
-* `False` (default): skips this activation.
+- `True`: activates Django's built-in admin interface for content authoring.
+- `False` (default): skips this activation.
 
 ### `DJANGO_ALLOWED_HOSTS`
 
@@ -53,7 +53,7 @@ Boolean:
 
 !!! tldr "Django docs"
 
-    [Settings: `ALLOWS_HOSTS`](https://docs.djangoproject.com/en/3.2/ref/settings/#allowed-hosts)
+    [Settings: `ALLOWS_HOSTS`](https://docs.djangoproject.com/en/4.0/ref/settings/#allowed-hosts)
 
 A list of strings representing the host/domain names that this Django site can serve.
 
@@ -65,13 +65,13 @@ A list of strings representing the host/domain names that this Django site can s
 
 !!! tldr "Django docs"
 
-    [Settings: `DEBUG`](https://docs.djangoproject.com/en/3.2/ref/settings/#debug)
+    [Settings: `DEBUG`](https://docs.djangoproject.com/en/4.0/ref/settings/#debug)
 
 Boolean:
 
-* `True`: the application is launched with debug mode turned on, allows pausing on breakpoints in the code, changes how static
-          files are served
-* `False` (default): the application is launched with debug mode turned off, similar to how it runs in production
+- `True`: the application is launched with debug mode turned on, allows pausing on breakpoints in the code, changes how static
+  files are served
+- `False` (default): the application is launched with debug mode turned off, similar to how it runs in production
 
 ### `DJANGO_INIT_PATH`
 
@@ -104,7 +104,7 @@ From inside the container, the app is always listening on port `8000`.
 
 !!! tldr "Django docs"
 
-    [Settings: `LOGGING_CONFIG`](https://docs.djangoproject.com/en/3.2/ref/settings/#logging-config)
+    [Settings: `LOGGING_CONFIG`](https://docs.djangoproject.com/en/4.0/ref/settings/#logging-config)
 
 The log level used in the application's logging configuration.
 
@@ -118,7 +118,7 @@ By default the application sends logs to `stdout`.
 
 !!! tldr "Django docs"
 
-    [Settings: `SECRET_KEY`](https://docs.djangoproject.com/en/3.2/ref/settings/#secret-key)
+    [Settings: `SECRET_KEY`](https://docs.djangoproject.com/en/4.0/ref/settings/#secret-key)
 
 Django's primary secret, keep this safe!
 
@@ -130,7 +130,7 @@ Django's primary secret, keep this safe!
 
 !!! tldr "Django docs"
 
-    [Settings: `CSRF_TRUSTED_ORIGINS`](https://docs.djangoproject.com/en/3.2/ref/settings/#csrf-trusted-origins)
+    [Settings: `CSRF_TRUSTED_ORIGINS`](https://docs.djangoproject.com/en/4.0/ref/settings/#csrf-trusted-origins)
 
 Comma-separated list of hosts which are trusted origins for unsafe requests (e.g. POST)
 

--- a/docs/configuration/fixtures.md
+++ b/docs/configuration/fixtures.md
@@ -24,31 +24,31 @@ environment's configuration database.
 
 The sample data included in the repository fixtures is enough to bootstrap the application with basic functionality:
 
-* Multiple transit agency configurations
-* Multiple eligibility verification pathways
-* With and without authentication required before eligibility verification
-* In concert with the [sample eligibility server][eligibility-server], verification with test user data
+- Multiple transit agency configurations
+- Multiple eligibility verification pathways
+- With and without authentication required before eligibility verification
+- In concert with the [sample eligibility server][eligibility-server], verification with test user data
 
 ### Not included
 
 Some configuration data is not available with the samples in the repository:
 
-* OAuth configuration to enable authentication (read more about [OAuth configuration](oauth.md))
-* Rate Limiting configuration for eligibility
-* reCAPTCHA configuration for user-submitted forms
-* Payment processor configuration for the enrollment phase
-* Amplitude configuration for capturing analytics events
+- OAuth configuration to enable authentication (read more about [OAuth configuration](oauth.md))
+- Rate Limiting configuration for eligibility
+- reCAPTCHA configuration for user-submitted forms
+- Payment processor configuration for the enrollment phase
+- Amplitude configuration for capturing analytics events
 
 ### Sample transit agency: `ABC`
 
-* Presents the user a choice between two different eligibility pathways
-* One eligibility verifier requires authentication
-* One eligibility verifier does not require authentication
+- Presents the user a choice between two different eligibility pathways
+- One eligibility verifier requires authentication
+- One eligibility verifier does not require authentication
 
 ### Sample transit agency: `DefTL`
 
-* Single eligibility pathway, no choice presented to the user
-* Eligibility verifier does not require authentication
+- Single eligibility pathway, no choice presented to the user
+- Eligibility verifier does not require authentication
 
 ## Building the configuration database
 
@@ -73,7 +73,7 @@ more information.
 
 [core-models]: https://github.com/cal-itp/benefits/blob/dev/benefits/core/models.py
 [cypress-fixtures]: https://github.com/cal-itp/benefits/tree/dev/tests/cypress/fixtures
-[django-data-fixtures]: https://docs.djangoproject.com/en/3.2/howto/initial-data/#providing-data-with-fixtures
+[django-data-fixtures]: https://docs.djangoproject.com/en/4.0/howto/initial-data/#providing-data-with-fixtures
 [eligibility-server]: https://docs.calitp.org/eligibility-server
 [env-django-init]: environment-variables.md#djangoinitpath
 [fixtures-sample]: https://github.com/cal-itp/benefits/tree/dev/fixtures

--- a/docs/configuration/rate-limit.md
+++ b/docs/configuration/rate-limit.md
@@ -44,4 +44,4 @@ Comma-separated list of HTTP Methods for which requests are rate limited.
 Number of seconds before additional requests are denied.
 
 [benefits-middleware]: https://github.com/cal-itp/benefits/blob/dev/benefits/core/middleware.py
-[django-middleware]: https://docs.djangoproject.com/en/3.2/ref/settings/#std:setting-MIDDLEWARE
+[django-middleware]: https://docs.djangoproject.com/en/4.0/ref/settings/#std:setting-MIDDLEWARE


### PR DESCRIPTION
Forgot about docs in #793 

Updates links to Django documentation from 3.2 to 4.0. Some minor formatting changes also were applied.