### PR TITLE
Improve local image build process

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/vscode-remote/devcontainer.json
 {
   "name": "cal-itp/benefits",
-  "dockerComposeFile": ["compose.yml"],
+  "dockerComposeFile": ["../compose.yml"],
   "service": "dev",
   "runServices": ["dev", "docs", "server"],
   "workspaceFolder": "/home/calitp/app",

--- a/.github/workflows/labeler-docker.yml
+++ b/.github/workflows/labeler-docker.yml
@@ -4,9 +4,10 @@ on:
   pull_request:
     types: [opened]
     paths:
-      - '.devcontainer/**'
-      - '.dockerignore'
-      - 'Dockerfile'
+      - ".devcontainer/**"
+      - ".dockerignore"
+      - "compose.yml"
+      - "Dockerfile"
 
 jobs:
   label-actions:

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -eu
+
+cd .devcontainer/
+
+docker compose build client
+
+docker compose build dev

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -eu
 
-cd .devcontainer/
-
 docker compose build client
 
 docker compose build dev

--- a/compose.yml
+++ b/compose.yml
@@ -3,17 +3,17 @@ version: "3.8"
 
 services:
   client:
-    build: ..
+    build: .
     image: benefits_client:latest
     env_file: .env
     ports:
       - "${DJANGO_LOCAL_PORT:-8000}:8000"
     volumes:
-      - ../fixtures:/home/calitp/app/fixtures:ro
+      - ./fixtures:/home/calitp/app/fixtures:ro
 
   dev:
     build:
-      context: ..
+      context: .
       dockerfile: .devcontainer/Dockerfile
     image: benefits_client:dev
     env_file: .env
@@ -24,7 +24,7 @@ services:
     ports:
       - "${DJANGO_LOCAL_PORT:-8000}:8000"
     volumes:
-      - ../:/home/calitp/app
+      - ./:/home/calitp/app
 
   docs:
     image: benefits_client:dev
@@ -33,7 +33,7 @@ services:
     ports:
       - "8001"
     volumes:
-      - ../:/home/calitp/app
+      - ./:/home/calitp/app
 
   server:
     image: ghcr.io/cal-itp/eligibility-server@sha256:337d5b2beb1e458980be49a778efd4a47f8daa8decc5e8329c0d528596e2f196

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -45,6 +45,6 @@ To close out of the container and re-open the directory locally in Visual Studio
 1. Type `Remote-Containers` to filter the commands
 1. Select `Reopen Locally`
 
-[config-file]: https://github.com/cal-itp/benefits/blob/dev/.devcontainer.json
+[config-file]: https://github.com/cal-itp/benefits/blob/dev/.devcontainer/devcontainer.json
 [vscode]: https://code.visualstudio.com/
 [vscode-containers]: https://code.visualstudio.com/docs/remote/containers

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -27,7 +27,8 @@ If you do not receive a prompt, or when you feel like starting from a fresh envi
 
 1. `Ctrl/Cmd+Shift+P` to bring up the command palette in Visual Studio Code
 1. Type `Remote-Containers` to filter the commands
-1. Select `Rebuild and Reopen in Container`
+1. Select `Rebuild and Reopen in Container` to completely rebuild the devcontainer
+1. Select `Reopen in Container` to reopen the most recent devcontainer build
 
 ## Attach a debugger
 

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -10,14 +10,6 @@ The following commands should be run in a terminal program like `bash`.
 git clone https://github.com/cal-itp/benefits
 ```
 
-## Change into the .devcontainer dir
-
-This is where configuration for running locally is stored.
-
-```bash
-cd benefits/.devcontainer
-```
-
 ## Create an environment file
 
 The application is configured with defaults to run locally, but an `.env` file is required to run with Docker Compose. This file can be empty, or environment overrides can be added as needed:
@@ -34,10 +26,12 @@ DJANGO_LOCAL_PORT=9000
 
 See [Configuration](../configuration) for more details on supported environment variables and their settings.
 
-## Build image using Docker Compose
+## Run the build script
+
+This builds the runtime and devcontainer images:
 
 ```bash
-docker compose build client
+bin/build.sh
 ```
 
 If you need all layers to rebuild, use:
@@ -67,9 +61,9 @@ you setup as part of initialization.
 
 By default, [sample data][sample-data] is used to initialize Django. Alternatively you may:
 
-* Modify the sample data file(s); or
-* Override the `DJANGO_INIT_PATH` environment variable with different data file(s); or
-* (If `DJANGO_ADMIN=true`) use the backend administrative interface CRUD
+- Modify the sample data file(s); or
+- Override the `DJANGO_INIT_PATH` environment variable with different data file(s); or
+- (If `DJANGO_ADMIN=true`) use the backend administrative interface CRUD
 
 Stop the running services with:
 


### PR DESCRIPTION
This PR does a few things:

1. New helper script `bin/build.sh` builds both the `client` and `dev` images
2. Move `compose.yml` up from the `.devcontainer/` directory to the root (❗also, `.env` has to move to the root❗)
3. Update docs with simplified Getting Started

The main goal here was to remove the `devcontainer/` directory from any setup flow and make building and rebuilding the images locally (e.g. for PR review) easier. 

`docker compose` commands can now be run directly from the root.