### PR TITLE
Fix: local docs site build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,3 @@
-fontawesome_markdown
 mkdocs
 mkdocs-awesome-pages-plugin
 mkdocs-macros-plugin

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,7 +59,7 @@ markdown_extensions:
       custom_fences:
         - name: mermaid
           class: mermaid
-          format: !!python/name:pymdownx.superfences.fence_div_format
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.smartsymbols
   - meta
   - toc:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,8 +45,12 @@ extra_css:
 
 markdown_extensions:
   - admonition
+  - attr_list
   - codehilite:
       linenums: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_generator: !!python/name:materialx.emoji.to_svg
   - pymdownx.inlinehilite
   - pymdownx.tasklist:
       custom_checkbox: true
@@ -62,4 +66,3 @@ markdown_extensions:
       # insert a blank space before the character
       permalink: " ¶"
   - smarty
-  - fontawesome_markdown


### PR DESCRIPTION
Closes #798.
Closes #801.

The unused `fontawesome_mkdown` extension was causing a local site build issue on some machines.

`mkdocs-material` comes with built-in support for emojis/icons, see https://squidfunk.github.io/mkdocs-material/reference/icons-emojis/#configuration

This PR removes the unused extension and configures the site to enable the built-in feature.

Snuck in a small fix for Mermaid diagrams as well.