### PR TITLE
Fix: Django template formatting

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get install -qq curl jq ssh
 USER $USER
 
 RUN python -m pip install --upgrade pip && \
-    pip install black flake8 pre-commit
+    pip install black djlint flake8 pre-commit
 
 COPY docs/requirements.txt docs/requirements.txt
 RUN pip install -r docs/requirements.txt

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,9 +21,10 @@
     "batisteo.vscode-django",
     "bpruitt-goddard.mermaid-markdown-syntax-highlighting",
     "eamodio.gitlens",
+    "esbenp.prettier-vscode",
     "mhutchie.git-graph",
+    "monosans.djlint",
     "ms-python.python",
-    "ms-python.vscode-pylance",
-    "esbenp.prettier-vscode"
+    "ms-python.vscode-pylance"
   ]
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
       - id: prettier
         types_or: [javascript, css]
 
-  - repo: https://github.com/rtts/djhtml
-    rev: 'v1.5.1'  # replace with the latest tag on GitHub
+  - repo: https://github.com/Riverside-Healthcare/djLint
+    rev: v1.7.0
     hooks:
-      - id: djhtml
+      - id: djlint-django

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,12 @@
 {
+  "djlint.guessProfile": false,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "[html]": {
-    "editor.formatOnSave": false
+    "editor.defaultFormatter": "monosans.djlint"
+  },
+  "[django-html]": {
+    "editor.defaultFormatter": "monosans.djlint"
   },
   "files.encoding": "utf8",
   "files.eol": "\n",

--- a/benefits/core/templates/core/agency_index.html
+++ b/benefits/core/templates/core/agency_index.html
@@ -1,16 +1,18 @@
-{% extends 'core/page.html' %}
+{% extends "core/page.html" %}
 {% load i18n %}
-{% block classes %}{{ block.super |add:" agency-index"}}{% endblock %}
+{% block classes %}
+  {{ block.super |add:" agency-index" }}
+{% endblock classes %}
 
 {% block container_content %}
-    <h1>{{ page.content_title }}</h1>
+  <h1>{{ page.content_title }}</h1>
 
-    <p>{% blocktranslate with info_link=info_link%}core.pages.agency_index.p[0]{{ info_link }}{% endblocktranslate %}</p>
-    <p>{% translate "core.pages.agency_index.p[1]" %}</p>
-    <p>{% translate "core.pages.agency_index.p[2]" %}</p>
+  <p>{% blocktranslate with info_link=info_link%}core.pages.agency_index.p[0]{{ info_link }}{% endblocktranslate %}</p>
+  <p>{% translate "core.pages.agency_index.p[1]" %}</p>
+  <p>{% translate "core.pages.agency_index.p[2]" %}</p>
 
-    {% block buttons%}
-        {{ block.super }}
-    {% endblock buttons %}
+  {% block buttons %}
+    {{ block.super }}
+  {% endblock buttons %}
 
 {% endblock container_content %}

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -1,79 +1,83 @@
+
 {% load i18n %}
 {% load static %}
 {% get_current_language as LANGUAGE_CODE %}
 <!doctype html>
-<html lang="{{ LANGUAGE_CODE }}" class="{% block classes %}{% endblock %}">
-    <head>
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <meta name="description" content="{% translate "core.pages.help.about.p[0]" %}">
-        <title>{% block page_title %}{% endblock  %}Cal-ITP</title>
+<html lang="{{ LANGUAGE_CODE }}" class="{% block classes %}{% endblock classes %}">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="description" content="{% translate "core.pages.help.about.p[0]" %}">
+    <title>
+      {% block page_title %}
+      {% endblock page_title %}
+      Cal-ITP
+    </title>
 
-        <link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet" type="text/css">
-        <link href="https://california.azureedge.net/cdt/statetemplate/6.0.2/css/cagov.core.min.css" rel="stylesheet">
-        <link href="{% static "css/styles.css" %}" rel="stylesheet">
-        <link href="{% static "img/favicon.ico" %}" rel="icon" type="image/x-icon" />
+    <link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet" type="text/css">
+    <link href="https://california.azureedge.net/cdt/statetemplate/6.0.2/css/cagov.core.min.css" rel="stylesheet">
+    <link href="{% static "css/styles.css" %}" rel="stylesheet">
+    <link href="{% static "img/favicon.ico" %}" rel="icon" type="image/x-icon" />
 
-        <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
 
-        {% include "core/includes/analytics.html" with api_key=analytics.api_key uid=analytics.uid did=analytics.did %}
-    </head>
-    <body>
-        {% if debug %}
-            {% include "core/includes/debug.html" %}
-        {% endif %}
-        <header role="banner" id="header" class="global-header">
-            <div id="skip-to-content">
-                <a href="#main-content">{% translate "core.buttons.skip" %}</a>
-            </div>
-            {% if messages %}
-                {% for message in messages %}
-                    {% include "core/includes/alert.html" with message=message %}
-                {% endfor %}
-            {% endif %}
+    {% include "core/includes/analytics.html" with api_key=analytics.api_key uid=analytics.uid did=analytics.did %}
+  </head>
+  <body>
+    {% if debug %}
+      {% include "core/includes/debug.html" %}
+    {% endif %}
+    <header role="banner" id="header" class="global-header">
+      <div id="skip-to-content">
+        <a href="#main-content">{% translate "core.buttons.skip" %}</a>
+      </div>
+      {% if messages %}
+        {% for message in messages %}
+          {% include "core/includes/alert.html" with message=message %}
+        {% endfor %}
+      {% endif %}
 
-            <div class="nocookies d-none" >
-                {% include "core/includes/nocookies.html" %}
-            </div>
+      <div class="nocookies d-none">{% include "core/includes/nocookies.html" %}</div>
 
-            <noscript>
-                {% include "core/includes/noscript.html" %}
-            </noscript>
+      <noscript>
+        {% include "core/includes/noscript.html" %}
+      </noscript>
 
-            <div class="navbar navbar-expand-sm navbar-dark bg-primary justify-content-between">
-                <div class="container">
-                    <span class="navbar-brand">
-                        <img class="sm d-lg-none" src="{% static "img/logo-sm.svg" %}" alt="{% translate "core.logos.small" context "image alt text" %}" />
-                        <img class="lg d-none d-lg-block" src="{% static "img/logo-lg.svg" %}"  alt="{% translate "core.logos.large" context "image alt text" %}" />
-                    </span>
-                    <span class="form-inline">
-                        {% include "core/includes/lang-selector.html" %}
-                    </span>
-                </div>
-            </div>
-        </header>
+      <div class="navbar navbar-expand-sm navbar-dark bg-primary justify-content-between">
+        <div class="container">
+          <span class="navbar-brand">
+            <img class="sm d-lg-none" src="{% static "img/logo-sm.svg" %}" alt="{% translate "core.logos.small" context "image alt text" %}"/>
+            <img class="lg d-none d-lg-block"
+                 src="{% static "img/logo-lg.svg" %}"
+                 alt="{% translate "core.logos.large" context "image alt text" %}"/>
+          </span>
+          <span class="form-inline">{% include "core/includes/lang-selector.html" %}</span>
+        </div>
+      </div>
+    </header>
 
-        <main id="main-content" class="main-content" role="main">
-            <div class="main-primary">
-                {% block main_content %}{% endblock %}
-            </div>
-        </main>
+    <main id="main-content" class="main-content" role="main">
+      <div class="main-primary">
+        {% block main_content %}
+        {% endblock main_content %}
+      </div>
+    </main>
 
-        <footer id="footer" class="global-footer">
-            <div class="container">
-                <ul class="footer-links">
-                    <li>
-                        <a href="{% url "core:help" %}">{% translate "core.buttons.help" %}</a>
-                    </li>
-                    <li>
-                        <a href="https://cdt.ca.gov/privacy-policy/" target="_blank" rel="noopener noreferrer">{% translate "core.buttons.privacy" %}</a>
-                    </li>
-                </ul>
-            </div>
-        </footer>
+    <footer id="footer" class="global-footer">
+      <div class="container">
+        <ul class="footer-links">
+          <li>
+            <a href="{% url "core:help" %}">{% translate "core.buttons.help" %}</a>
+          </li>
+          <li>
+            <a href="https://cdt.ca.gov/privacy-policy/" target="_blank" rel="noopener noreferrer">{% translate "core.buttons.privacy" %}</a>
+          </li>
+        </ul>
+      </div>
+    </footer>
 
-        <script src="https://california.azureedge.net/cdt/statetemplate/6.0.2/js/cagov.core.js"></script>
-        <script>
+    <script src="https://california.azureedge.net/cdt/statetemplate/6.0.2/js/cagov.core.js"></script>
+    <script>
             $(function() {
                 document.cookie = "testcookie"
                 if (document.cookie.indexOf("testcookie") < 0) {
@@ -99,6 +103,6 @@
                     amplitude.getInstance().logEvent('clicked link', {'href': e.target.href, 'path': window.location.pathname});
                 });
             });
-        </script>
-    </body>
+    </script>
+  </body>
 </html>

--- a/benefits/core/templates/core/help.html
+++ b/benefits/core/templates/core/help.html
@@ -2,58 +2,62 @@
 {% load i18n %}
 {% load static %}
 
-{% block main_content%}
-    <div class="container-fluid">
-        <div class="container content help">
-            {% block container_content %}
-                <h1>{{ page.content_title }}</h1>
+{% block main_content %}
+  <div class="container-fluid">
+    <div class="container content help">
+      {% block container_content %}
+        <h1>{{ page.content_title }}</h1>
 
-                <h2 id="what-is-cal-itp">{% translate "core.pages.help.about" %}</h2>
-                <p>{% translate "core.pages.help.about.p[0]" %}</p>
-                <p>{% translate "core.pages.help.about.p[1]" %}</p>
+        <h2 id="what-is-cal-itp">{% translate "core.pages.help.about" %}</h2>
+        <p>{% translate "core.pages.help.about.p[0]" %}</p>
+        <p>{% translate "core.pages.help.about.p[1]" %}</p>
 
-                <h2 id="payment-options">{% translate "core.pages.help.payment_options" %}</h2>
-                <p>{% translate "core.pages.help.payment_options.p[0]" %}</p>
+        <h2 id="payment-options">{% translate "core.pages.help.payment_options" %}</h2>
+        <p>{% translate "core.pages.help.payment_options.p[0]" %}</p>
 
-                <p class="contactless-symbol">
-                    <img class="icon mx-auto d-block" src="{% static 'img/icon/contactless.svg' %}" alt="{% translate "core.icons.contactless" context "image alt text" %}" />
-                </p>
+        <p class="contactless-symbol">
+          <img class="icon mx-auto d-block"
+               src="{% static 'img/icon/contactless.svg' %}"
+               alt="{% translate "core.icons.contactless" context "image alt text" %}"/>
+        </p>
 
-                <p>{% translate "core.pages.help.payment_options.p[1]" %}</p>
-                <p>
-                    {% blocktranslate with website="https://cash.app/help/us/en-us/14425-cal-transit" %}core.pages.help.payment_options.p[2][0]{{ website }}{% endblocktranslate %}
-                    {% blocktranslate with website="https://venmo.com/about/debitcard/" %}core.pages.help.payment_options.p[2][1]{{ website }}{% endblocktranslate %}
-                </p>
-                <p>{% translate "core.pages.help.payment_options.p[3]" %}</p>
-                <p>{% translate "core.pages.help.payment_options.p[4]" %}</p>
+        <p>{% translate "core.pages.help.payment_options.p[1]" %}</p>
+        <p>
+          {% blocktranslate with website="https://cash.app/help/us/en-us/14425-cal-transit" %}core.pages.help.payment_options.p[2][0]{{ website }}{% endblocktranslate %}
+          {% blocktranslate with website="https://venmo.com/about/debitcard/" %}core.pages.help.payment_options.p[2][1]{{ website }}{% endblocktranslate %}
+        </p>
+        <p>{% translate "core.pages.help.payment_options.p[3]" %}</p>
+        <p>{% translate "core.pages.help.payment_options.p[4]" %}</p>
 
-                <h2 id="login-gov">{% translate "core.pages.help.login_gov" %}</h2>
-                <p>{% translate "core.pages.help.login_gov.p[0]" %}</p>
-                <p>{% translate "core.pages.help.login_gov.p[1]" %}</p>
-                <p>{% translate "core.pages.help.login_gov.p[2]" %}</p>
+        <h2 id="login-gov">{% translate "core.pages.help.login_gov" %}</h2>
+        <p>{% translate "core.pages.help.login_gov.p[0]" %}</p>
+        <p>{% translate "core.pages.help.login_gov.p[1]" %}</p>
+        <p>{% translate "core.pages.help.login_gov.p[2]" %}</p>
 
-                <h2 id="login-gov-verify">{% translate "core.pages.help.login_gov_verify" %}</h2>
-                <p>{% translate "core.pages.help.login_gov_verify.p[0]" %}</p>
-                <p>{% translate "core.pages.help.login_gov_verify.p[1]" %}</p>
-                <p>{% translate "core.pages.help.login_gov_verify.p[2]" %}</p>
-                <p>{% translate "core.pages.help.login_gov_verify.p[3]" %}</p>
+        <h2 id="login-gov-verify">{% translate "core.pages.help.login_gov_verify" %}</h2>
+        <p>{% translate "core.pages.help.login_gov_verify.p[0]" %}</p>
+        <p>{% translate "core.pages.help.login_gov_verify.p[1]" %}</p>
+        <p>{% translate "core.pages.help.login_gov_verify.p[2]" %}</p>
+        <p>{% translate "core.pages.help.login_gov_verify.p[3]" %}</p>
 
-                <h2 id="littlepay">{% translate "core.pages.help.littlepay" %}</h2>
-                <p>{% translate "core.pages.help.littlepay.p[0]" %}</p>
-                <p>{% blocktranslate with website="https://littlepay.com" %}core.pages.help.littlepay.p[1]{{ website }}{% endblocktranslate %}</p>
+        <h2 id="littlepay">{% translate "core.pages.help.littlepay" %}</h2>
+        <p>{% translate "core.pages.help.littlepay.p[0]" %}</p>
+        <p>
+          {% blocktranslate with website="https://littlepay.com" %}core.pages.help.littlepay.p[1]{{ website }}{% endblocktranslate %}
+        </p>
 
-                <h2 id="questions">{% translate "core.pages.help.questions" %}</h2>
-                <p>{% translate "core.pages.help.questions.p[0]" %}</p>
+        <h2 id="questions">{% translate "core.pages.help.questions" %}</h2>
+        <p>{% translate "core.pages.help.questions.p[0]" %}</p>
 
-                {% block buttons %}
-                    {% include "core/includes/agency-links.html" with buttons=page.buttons %}
-                {% endblock buttons %}
+        {% block buttons %}
+          {% include "core/includes/agency-links.html" with buttons=page.buttons %}
+        {% endblock buttons %}
 
-                <p class="mt-4">
-                    {% translate "core.pages.help.foss.text" %}
-                    <a href="https://www.github.com/cal-itp/benefits" target="_blank" rel="noopener noreferrer">{% translate "core.pages.help.foss.link" %}</a>.
-                </p>
-            {% endblock %}
-        </div>
+        <p class="mt-4">
+          {% translate "core.pages.help.foss.text" %}
+          <a href="https://www.github.com/cal-itp/benefits" target="_blank" rel="noopener noreferrer">{% translate "core.pages.help.foss.link" %}</a>.
+        </p>
+      {% endblock container_content %}
     </div>
-{% endblock %}
+  </div>
+{% endblock main_content %}

--- a/benefits/core/templates/core/includes/agency-links.html
+++ b/benefits/core/templates/core/includes/agency-links.html
@@ -1,21 +1,19 @@
+
 <div class="buttons-agencies">
-    {% for agency_button in buttons %}
-        {% if "agency" in agency_button.classes %}
-            {% if agency_button.label %}
-                <label>{{ agency_button.label }}</label>
-            {% endif %}
-            <a {% if agency_button.target %}target="{{ agency_button.target }}"{% endif %}
-                {% if agency_button.rel %}rel="{{ agency_button.rel }}"{% endif %}
-                href="{{ agency_button.url }}">
-                {{ agency_button.text }}
-            </a>
-        {% endif %}
-    {% endfor %}
-</div>
-{% for back_button in buttons %}
-    {% if "btn-primary" in back_button.classes %}
-        <div class="button-back">
-            {% include "core/includes/button.html" with button=back_button %}
-        </div>
+  {% for agency_button in buttons %}
+    {% if "agency" in agency_button.classes %}
+      {% if agency_button.label %}<label>{{ agency_button.label }}</label>{% endif %}
+      <a {% if agency_button.target %}target="{{ agency_button.target }}"{% endif %}
+         {% if agency_button.rel %}rel="{{ agency_button.rel }}"{% endif %}
+         href="{{ agency_button.url }}">
+        {{ agency_button.text }}
+      </a>
     {% endif %}
+  {% endfor %}
+</div>
+
+{% for back_button in buttons %}
+  {% if "btn-primary" in back_button.classes %}
+    <div class="button-back">{% include "core/includes/button.html" with button=back_button %}</div>
+  {% endif %}
 {% endfor %}

--- a/benefits/core/templates/core/includes/alert-bar.html
+++ b/benefits/core/templates/core/includes/alert-bar.html
@@ -1,6 +1,7 @@
+
 <div class="navbar navbar-expand-sm navbar-dark bg-danger">
-    <div class="container">
-        {% block content %}
-        {% endblock %}
-    </div>
+  <div class="container">
+    {% block content %}
+    {% endblock content %}
+  </div>
 </div>

--- a/benefits/core/templates/core/includes/alert.html
+++ b/benefits/core/templates/core/includes/alert.html
@@ -1,27 +1,15 @@
-<div class="alert
 
-    {% if message.level_tag == "error" %}
-        alert-danger
-    {% elif message.level_tag == "warning" %}
-        alert-warning
-    {% elif message.level_tag == "success" %}
-        alert-success
-    {% elif message.level_tag == "info" %}
-        alert-info
-    {% elif message.level_tag == "debug" %}
-        alert-severe
-    {% endif %}
+<div class="alert {% if message.level_tag == "error" %} alert-danger {% elif message.level_tag == "warning" %} alert-warning {% elif message.level_tag == "success" %} alert-success {% elif message.level_tag == "info" %} alert-info {% elif message.level_tag == "debug" %} alert-severe {% endif %} alert-dismissible alert-banner"
+     role="alert">
 
-    alert-dismissible alert-banner" role="alert">
-
-    <div class="container">
-        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-            <span class="ca-gov-icon-close-mark" aria-hidden="true"></span>
-        </button>
-        <span class="alert-level">
-            <span class="ca-gov-icon-important" aria-hidden="true"></span>
-            {{ message.level_tag | upper}}
-        </span>
-        <span class="alert-text">{{ message }}</span>
-    </div>
+  <div class="container">
+    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+      <span class="ca-gov-icon-close-mark" aria-hidden="true"></span>
+    </button>
+    <span class="alert-level">
+      <span class="ca-gov-icon-important" aria-hidden="true"></span>
+      {{ message.level_tag | upper }}
+    </span>
+    <span class="alert-text">{{ message }}</span>
+  </div>
 </div>

--- a/benefits/core/templates/core/includes/button.html
+++ b/benefits/core/templates/core/includes/button.html
@@ -1,16 +1,13 @@
+
 {% if button.url %}
-    {% if button.label %}
-        <label>{{ button.label }}</label>
-    {% endif %}
-    <a {% if button.id %}id="{{ button.id }}"{% endif %}
-        {% if button.target %}target="{{ button.target }}"{% endif %}
-        {% if button.rel %}rel="{{ button.rel }}"{% endif %}
-        class="{{ button.classes | join:" " }}"
-        href="{{ button.url }}"
-        role="button">
-        {{ button.text }}
-        {% if button.fallback_text %}
-            <span class="fallback-text">{{ button.fallback_text }}</span>
-        {% endif %}
-    </a>
+  {% if button.label %}<label>{{ button.label }}</label>{% endif %}
+  <a {% if button.id %}id="{{ button.id }}"{% endif %}
+     {% if button.target %}target="{{ button.target }}"{% endif %}
+     {% if button.rel %}rel="{{ button.rel }}"{% endif %}
+     class="{{ button.classes | join:" " }}"
+     href="{{ button.url }}"
+     role="button">
+    {{ button.text }}
+    {% if button.fallback_text %}<span class="fallback-text">{{ button.fallback_text }}</span>{% endif %}
+  </a>
 {% endif %}

--- a/benefits/core/templates/core/includes/debug.html
+++ b/benefits/core/templates/core/includes/debug.html
@@ -1,10 +1,15 @@
 {% extends "core/includes/alert-bar.html" %}
 
 {% block content %}
-    <span class="navbar-brand">DEBUG MODE</span>
-    {% if debug %}
-        <code class="navbar-text text-white text-break">
-            { {% for key, value in debug.items %}"{{ key }}": "{{ value }}"{% if not forloop.last %}, {% endif %}{% endfor %} }
-        </code>
-    {% endif %}
-{% endblock %}
+  <span class="navbar-brand">DEBUG MODE</span>
+  {% if debug %}
+    <code class="navbar-text text-white text-break">
+      {
+      {% for key, value in debug.items %}
+        "{{ key }}": "{{ value }}"
+        {% if not forloop.last %},{% endif %}
+      {% endfor %}
+      }
+    </code>
+  {% endif %}
+{% endblock content %}

--- a/benefits/core/templates/core/includes/form.html
+++ b/benefits/core/templates/core/includes/form.html
@@ -1,64 +1,61 @@
+
 {% if form.action_url %}
 
-    {% url form.action_url as form_action %}
+  {% url form.action_url as form_action %}
 
-    <form action="{{ form_action }}" method="{{ form.method | default:"post" | upper }}" role="form">
-        {% csrf_token %}
+  <form action="{{ form_action }}" method="{{ form.method | default:"post" | upper }}" role="form">
+    {% csrf_token %}
 
-        {% for field in form %}
-            {% if field.errors %}
-                <div class="form-group with-errors">
-            {% else %}
-                <div class="form-group">
-            {% endif %}
+    {% for field in form %}
+      {% if field.errors %}
+        <div class="form-group with-errors">
+        {% else %}
+          <div class="form-group">
+          {% endif %}
 
-            {% if field.label %}
-                <label for="{{ field.id_for_label }}" class="form-control-label">
-                    {{ field.label }}
-                    {% if field.field.required %}<span class="required-label">*</span>{% endif %}
-                </label>
-            {% endif %}
+          {% if field.label %}
+            <label for="{{ field.id_for_label }}" class="form-control-label">
+              {{ field.label }}
+              {% if field.field.required %}<span class="required-label">*</span>{% endif %}
+            </label>
+          {% endif %}
 
-            {{ field }}
+          {{ field }}
 
-            {% if field.help_text %}
-                <small class="form-text text-muted">
-                    {{ field.help_text }}
-                </small>
-            {% endif %}
+          {% if field.help_text %}<small class="form-text text-muted">{{ field.help_text }}</small>{% endif %}
 
-            {% if field.errors %}
-                <div class="error-message">
-                    {% for error in field.errors %}
-                        <p>{{ error }}</p>
-                    {% endfor %}
-                </div>
-            {% endif %}
+          {% if field.errors %}
+            <div class="error-message">
+              {% for error in field.errors %}<p>{{ error }}</p>{% endfor %}
             </div>
-        {% endfor %}
+          {% endif %}
+        </div>
+      {% endfor %}
 
-        {% if form.submit_value %}
-            <div class="form-group">
-                {% if recaptcha.enabled %}
-                    <button class="btn btn-lg btn-primary g-recaptcha"
-                        data-sitekey="{{ recaptcha.site_key }}"
-                        data-callback="onSubmit"
-                        data-action="submit">{{ form.submit_value }}</button>
-                {% else %}
-                    <button class="btn btn-lg btn-primary">{{ form.submit_value }}</button>
-                {% endif %}
-            </div>
-        {% endif %}
+      {% if form.submit_value %}
+        <div class="form-group">
+          {% if recaptcha.enabled %}
+            <button class="btn btn-lg btn-primary g-recaptcha"
+                    data-sitekey="{{ recaptcha.site_key }}"
+                    data-callback="onSubmit"
+                    data-action="submit">
+              {{ form.submit_value }}
+            </button>
+          {% else %}
+            <button class="btn btn-lg btn-primary">{{ form.submit_value }}</button>
+          {% endif %}
+        </div>
+      {% endif %}
 
-        {% if recaptcha.enabled %}
-            <script src="{{ recaptcha.api_url }}"></script>
-            <script>
+      {% if recaptcha.enabled %}
+        <script src="{{ recaptcha.api_url }}"></script>
+        <script>
                 function onSubmit(token) {
                     $("form[action='{{form_action}}']").submit();
                 }
-            </script>
-        {% endif %}
-        <script>
+        </script>
+      {% endif %}
+      <script>
             $(function(){
                 $("form[action='{{form_action}}']").on("submit", function(e) {
                     $(".form-group", this).removeClass("with-errors");
@@ -73,7 +70,7 @@
                     }
                 });
             });
-        </script>
+      </script>
     </form>
 
-{% endif %}
+  {% endif %}

--- a/benefits/core/templates/core/includes/icon-title.html
+++ b/benefits/core/templates/core/includes/icon-title.html
@@ -1,6 +1,5 @@
+
 <h1 class="icon-title">
-    <span class="icon">
-        {% include "core/includes/icon.html" with icon=icon alt=alt %}
-    </span>
-    {{ title }}
+  <span class="icon">{% include "core/includes/icon.html" with icon=icon alt=alt %}</span>
+  {{ title }}
 </h1>

--- a/benefits/core/templates/core/includes/icon.html
+++ b/benefits/core/templates/core/includes/icon.html
@@ -1,8 +1,13 @@
+
 {% if not icon.src %}
-    <p class="bg-grey-lightest color-standout">Missing <strong><code>icon.src</code></strong> argument</p>
+  <p class="bg-grey-lightest color-standout">
+    Missing <strong><code>icon.src</code></strong> argument
+  </p>
 {% elif not icon.alt %}
-    <p class="bg-grey-lightest color-standout">Missing <strong><code>icon.alt</code></strong> argument</p>
+  <p class="bg-grey-lightest color-standout">
+    Missing <strong><code>icon.alt</code></strong> argument
+  </p>
 {% else %}
-    {% load static %}
-    <img class="icon" src="{% static icon.src %}" alt="{{ icon.alt }}" />
+  {% load static %}
+  <img class="icon" src="{% static icon.src %}" alt="{{ icon.alt }}" />
 {% endif %}

--- a/benefits/core/templates/core/includes/lang-selector.html
+++ b/benefits/core/templates/core/includes/lang-selector.html
@@ -1,3 +1,4 @@
+
 {% load i18n %}
 {% get_current_language as LANGUAGE_CODE %}
 {% get_available_languages as LANGUAGES %}
@@ -9,12 +10,12 @@ If more language support is added, the hidden input can be replaced by a select
 {% endcomment %}
 
 {% for code, lang in LANGUAGES %}
-    {% if code != LANGUAGE_CODE %}
-        <form method="POST" action="{% url "set_language" %}">
-            {% csrf_token %}
-            {% get_language_info for code as langinfo %}
-            <input name="language" type="hidden" value="{{ code }}" />
-            <button class="btn btn-lg btn-outline-light" type="submit">{{ langinfo.name_local | capfirst }}</button>
-        </form>
-    {% endif %}
+  {% if code != LANGUAGE_CODE %}
+    <form method="post" action="{% url "set_language" %}">
+      {% csrf_token %}
+      {% get_language_info for code as langinfo %}
+      <input name="language" type="hidden" value="{{ code }}" />
+      <button class="btn btn-lg btn-outline-light" type="submit">{{ langinfo.name_local | capfirst }}</button>
+    </form>
+  {% endif %}
 {% endfor %}

--- a/benefits/core/templates/core/includes/nocookies.html
+++ b/benefits/core/templates/core/includes/nocookies.html
@@ -2,10 +2,10 @@
 {% load i18n %}
 
 {% block content %}
-    <div class="text-left">
-        <span class="navbar-brand">{% translate "core.includes.nocookies.brand" %}</span>
-        <span class="navbar-text">
-            {% translate "core.includes.nocookies.text" %} <a href="/">{% translate "core.buttons.return_home" %}</a>.
-        </span>
-    </div>
-{% endblock %}
+  <div class="text-left">
+    <span class="navbar-brand">{% translate "core.includes.nocookies.brand" %}</span>
+    <span class="navbar-text">
+      {% translate "core.includes.nocookies.text" %} <a href="{% url "core:index" %}">{% translate "core.buttons.return_home" %}</a>.
+    </span>
+  </div>
+{% endblock content %}

--- a/benefits/core/templates/core/includes/noscript.html
+++ b/benefits/core/templates/core/includes/noscript.html
@@ -2,10 +2,10 @@
 {% load i18n %}
 
 {% block content %}
-    <div class="text-left">
-        <span class="navbar-brand">{% translate "core.includes.noscript.brand" %}</span>
-        <span class="navbar-text">
-            {% translate "core.includes.noscript.text" %} <a href="/">{% translate "core.buttons.return_home" %}</a>.
-        </span>
-    </div>
-{% endblock %}
+  <div class="text-left">
+    <span class="navbar-brand">{% translate "core.includes.noscript.brand" %}</span>
+    <span class="navbar-text">
+      {% translate "core.includes.noscript.text" %} <a href="{% url "core:index" %}">{% translate "core.buttons.return_home" %}</a>.
+    </span>
+  </div>
+{% endblock content %}

--- a/benefits/core/templates/core/includes/sign-out-link.html
+++ b/benefits/core/templates/core/includes/sign-out-link.html
@@ -1,11 +1,12 @@
+
 {% load i18n %}
 
 {% if authentication %}
-    {% if authentication.required and authentication.logged_in %}
-        <div class="signout-row">
-            <div class="container">
-                <a class="signout-link" href="{{ authentication.sign_out_route }}">{% translate authentication.sign_out_button_label %}</a>
-            </div>
-        </div>
-    {% endif %}
+  {% if authentication.required and authentication.logged_in %}
+    <div class="signout-row">
+      <div class="container">
+        <a class="signout-link" href="{{ authentication.sign_out_route }}">{% translate authentication.sign_out_button_label %}</a>
+      </div>
+    </div>
+  {% endif %}
 {% endif %}

--- a/benefits/core/templates/core/page.html
+++ b/benefits/core/templates/core/page.html
@@ -1,68 +1,70 @@
 {% extends "core/base.html" %}
 
 {% if page.title %}
-    {% block classes %}{{ page.classes|join:" " }}{% endblock %}
+  {% block classes %}
+    {{ page.classes|join:" " }}
+  {% endblock classes %}
 {% endif %}
 
 {% if page.title %}
-    {% block page_title %}{{ page.title }} | {% endblock page_title %}
+  {% block page_title %}
+    {{ page.title }} |
+  {% endblock page_title %}
 {% endif %}
 
 {% block main_content %}
-    <div class="container-fluid">
-        <div class="row main-row">
-            {% if page.noimage %}
-                <div class="container">
-            {% else %}
-                {% load static %}
-                <div class="col-lg-6 image">
-                </div>
-                <div class="col-md-8 offset-md-2 col-lg-6 offset-lg-0">
-            {% endif %}
-            <div class="container content">
-                {% block container_content %}
+  <div class="container-fluid">
+    <div class="row main-row">
+      {% if page.noimage %}
+        <div class="container">
+        {% else %}
+          {% load static %}
+          <div class="col-lg-6 image"></div>
+          <div class="col-md-8 offset-md-2 col-lg-6 offset-lg-0">
+          {% endif %}
+          <div class="container content">
+            {% block container_content %}
 
-                    {% block icon_title %}
-                        {% if page.content_title %}
-                            {% if page.icon %}
-                                {% include "core/includes/icon-title.html" with title=page.content_title icon=page.icon %}
-                            {% else %}
-                                <h1>{{ page.content_title }}</h1>
-                            {% endif %}
-                        {% endif %}
-                    {% endblock icon_title %}
+              {% block icon_title %}
+                {% if page.content_title %}
+                  {% if page.icon %}
+                    {% include "core/includes/icon-title.html" with title=page.content_title icon=page.icon %}
+                  {% else %}
+                    <h1>{{ page.content_title }}</h1>
+                  {% endif %}
+                {% endif %}
+              {% endblock icon_title %}
 
-                    {% block paragraph_content %}
-                        {% for p in page.paragraphs %}
-                            <p>{{ p }}</p>
-                        {% endfor %}
-                    {% endblock paragraph_content %}
+              {% block paragraph_content %}
+                {% for p in page.paragraphs %}<p>{{ p }}</p>{% endfor %}
+              {% endblock paragraph_content %}
 
-                    {% block forms %}
-                        {% if page.forms %}
-                            {% for f in page.forms %}
-                                {% include "core/includes/form.html" with form=f %}
-                            {% endfor %}
-                        {% endif %}
-                    {% endblock forms %}
+              {% block forms %}
+                {% if page.forms %}
+                  {% for f in page.forms %}
+                    {% include "core/includes/form.html" with form=f %}
+                  {% endfor %}
+                {% endif %}
+              {% endblock forms %}
 
-                    {% block buttons %}
-                        {% if page.buttons|length_is:"0" %}{% else %}
-                            {% if "with-agency-links" in page.classes %}
-                                {% include "core/includes/agency-links.html" with buttons=page.buttons %}
-                            {% else %}
-                                <div class="buttons">
-                                    {% for b in page.buttons %}
-                                        {% include "core/includes/button.html" with button=b %}
-                                    {% endfor %}
-                                </div>
-                            {% endif %}
-                        {% endif %}
-                    {% endblock buttons %}
+              {% block buttons %}
+                {% if page.buttons|length_is:"0" %}
+                {% else %}
+                  {% if "with-agency-links" in page.classes %}
+                    {% include "core/includes/agency-links.html" with buttons=page.buttons %}
+                  {% else %}
+                    <div class="buttons">
+                      {% for b in page.buttons %}
+                        {% include "core/includes/button.html" with button=b %}
+                      {% endfor %}
+                    </div>
+                  {% endif %}
+                {% endif %}
+              {% endblock buttons %}
 
-                {% endblock container_content %}
-            </div>
+            {% endblock container_content %}
+          </div>
         </div>
+      </div>
     </div>
-    </div>
-{% endblock main_content %}
+  {% endblock main_content %}

--- a/benefits/core/templates/core/widgets/radio_select.html
+++ b/benefits/core/templates/core/widgets/radio_select.html
@@ -1,19 +1,21 @@
+
 {% with id=widget.attrs.id %}
-    <div{% if id %} id="{{ id }}"{% endif %} class="radio-container">
-        {% for group, options, index in widget.optgroups %}
-            {% if group %}
-                <div>{{ group }}
-                    <div{% if id %} id="{{ id }}_{{ index }}"{% endif %}>
-            {% endif %}
+  <div{% if id %} id="{{ id }}"{% endif %} class="radio-container">
+    {% for group, options, index in widget.optgroups %}
+      {% if group %}
+        <div>
+          {{ group }}
+          <div{% if id %} id="{{ id }}_{{ index }}"{% endif %}>
+          {% endif %}
 
-            {% for option in options %}
-                <div>{% include option.template_name with widget=option %}</div>
-            {% endfor %}
+          {% for option in options %}
+            <div>{% include option.template_name with widget=option %}</div>
+          {% endfor %}
 
-            {% if group %}
-                </div>
-                </div>
-            {% endif %}
-        {% endfor %}
-    </div>
+          {% if group %}
+          </div>
+        </div>
+      {% endif %}
+    {% endfor %}
+  </div>
 {% endwith %}

--- a/benefits/core/templates/core/widgets/radio_select_option.html
+++ b/benefits/core/templates/core/widgets/radio_select_option.html
@@ -1,14 +1,13 @@
-<input class="radio-input" type="{{ widget.type }}" name="{{ widget.name }}"
-    {% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}
-    {% include "django/forms/widgets/attrs.html" %}>
+
+<input class="radio-input"
+       type="{{ widget.type }}"
+       name="{{ widget.name }}"
+       {% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}
+       {% include "django/forms/widgets/attrs.html" %}>
 
 {% if widget.wrap_label %}
-    <label{% if widget.attrs.id %} for="{{ widget.attrs.id }}" class="radio-label"{% endif %}>
-        {{ widget.label }}
-        {% if widget.description %}
-            <span class="radio-label-description">
-                {{ widget.description }}
-            </span>
-        {% endif %}
-    </label>
+  <label{% if widget.attrs.id %} for="{{ widget.attrs.id }}" class="radio-label"{% endif %}>
+    {{ widget.label }}
+    {% if widget.description %}<span class="radio-label-description">{{ widget.description }}</span>{% endif %}
+  </label>
 {% endif %}

--- a/benefits/eligibility/templates/eligibility/confirm.html
+++ b/benefits/eligibility/templates/eligibility/confirm.html
@@ -1,6 +1,6 @@
 {% extends "core/page.html" %}
 
 {% block main_content %}
-    {% include "core/includes/sign-out-link.html" %}
-    {{ block.super }}
-{% endblock %}
+  {% include "core/includes/sign-out-link.html" %}
+  {{ block.super }}
+{% endblock main_content %}

--- a/benefits/eligibility/templates/eligibility/start.html
+++ b/benefits/eligibility/templates/eligibility/start.html
@@ -1,54 +1,51 @@
 {% extends "core/page.html" %}
 {% load i18n %}
 {% block classes %}
-    {{ block.super |add:" eligibility-start"}}
-{% endblock %}
+  {{ block.super |add:" eligibility-start" }}
+{% endblock classes %}
 
 {% block main_content %}
-    <div class="one-column-image"></div>
+  <div class="one-column-image"></div>
 
-    <div class="container">
-        <h1 class="headline">{% translate "core.pages.agency_index.p[3]" %}</h1>
-        <p>{% blocktranslate with info_link=info_link%}core.pages.agency_index.p[0]{{ info_link }}{% endblocktranslate %}</p>
-        <p>{% translate "core.pages.agency_index.p[2]" %}</p>
+  <div class="container">
+    <h1 class="headline">{% translate "core.pages.agency_index.p[3]" %}</h1>
+    <p>{% blocktranslate with info_link=info_link%}core.pages.agency_index.p[0]{{ info_link }}{% endblocktranslate %}</p>
+    <p>{% translate "core.pages.agency_index.p[2]" %}</p>
 
-        <h2 class="media-title">{{title}}</h2>
+    <h2 class="media-title">{{ title }}</h2>
 
-        {% block media_list %}
-            {% if media|length_is:"0" %}{% else %}
-                <ul class="media-list">
-                    {% for item in media %}
-                        <li class="media">
-                            <div class="media-line">
-                                {% include "core/includes/icon.html" with icon=item.icon %}
-                            </div>
-                            <div class="media-body">
-                                <h3 class="media-body--heading">{{ item.heading }}</h3>
-                                <div class="media-body--details">
-                                    <p>{{ item.details }}</p>
-                                    <div class="media-body--items">
-                                        <ul>
-                                            {% for l in item.bullets %}
-                                                <li>{{ l }}</li>
-                                            {% endfor %}
-                                        </ul>
-                                    </div>
-                                </div>
-                                <div class="media-body--links">
-                                    {% for l in item.links %}
-                                        {% include "core/includes/button.html" with button=l %}
-                                    {% endfor %}
-                                </div>
-                            </div>
-                        </li>
-                    {% endfor %}
-                </ul>
-            {% endif %}
-        {% endblock %}
+    {% block media_list %}
+      {% if media|length_is:"0" %}
+      {% else %}
+        <ul class="media-list">
+          {% for item in media %}
+            <li class="media">
+              <div class="media-line">{% include "core/includes/icon.html" with icon=item.icon %}</div>
+              <div class="media-body">
+                <h3 class="media-body--heading">{{ item.heading }}</h3>
+                <div class="media-body--details">
+                  <p>{{ item.details }}</p>
+                  <div class="media-body--items">
+                    <ul>
+                      {% for l in item.bullets %}<li>{{ l }}</li>{% endfor %}
+                    </ul>
+                  </div>
+                </div>
+                <div class="media-body--links">
+                  {% for l in item.links %}
+                    {% include "core/includes/button.html" with button=l %}
+                  {% endfor %}
+                </div>
+              </div>
+            </li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+    {% endblock media_list %}
 
-        {% block buttons %}
-            {{ block.super }}
-        {% endblock %}
-    </div>
+    {% block buttons %}
+      {{ block.super }}
+    {% endblock buttons %}
+  </div>
 
-{% endblock %}
+{% endblock main_content %}

--- a/benefits/eligibility/templates/eligibility/unverified.html
+++ b/benefits/eligibility/templates/eligibility/unverified.html
@@ -1,6 +1,6 @@
 {% extends "core/page.html" %}
 
 {% block main_content %}
-    {% include "core/includes/sign-out-link.html" %}
-    {{ block.super }}
-{% endblock %}
+  {% include "core/includes/sign-out-link.html" %}
+  {{ block.super }}
+{% endblock main_content %}

--- a/benefits/enrollment/templates/enrollment/index.html
+++ b/benefits/enrollment/templates/enrollment/index.html
@@ -1,21 +1,21 @@
 {% extends "core/page.html" %}
 
 {% block main_content %}
-    {% include "core/includes/sign-out-link.html" %}
-    {{ block.super }}
-{% endblock %}
+  {% include "core/includes/sign-out-link.html" %}
+  {{ block.super }}
+{% endblock main_content %}
 
 {% block icon_title %}
-    {{ block.super }}
-{% endblock%}
+  {{ block.super }}
+{% endblock icon_title %}
 
 {% block paragraph_content %}
-    {{ block.super }}
-    {% if payment_processor %}
-        <button type="button" class="btn btn-primary btn-lg loading" role="status" disabled>
-            {{ payment_processor.loading_text }}
-        </button>
-        <script>
+  {{ block.super }}
+  {% if payment_processor %}
+    <button type="button" class="btn btn-primary btn-lg loading" role="status" disabled>
+      {{ payment_processor.loading_text }}
+    </button>
+    <script>
             var startedEvent = "started payment connection", closedEvent = "closed payment connection";
 
             $.getScript("{{ payment_processor.card_tokenize_url }}")
@@ -83,17 +83,13 @@
                 $(".loading").remove();
                 console.log(exception);
             });
-        </script>
-    {% else %}
-        <h2>Error!</h2>
-        <p>No access token configured</p>
-    {% endif %}
-{% endblock %}
+    </script>
+  {% else %}
+    <h2>Error!</h2>
+    <p>No access token configured</p>
+  {% endif %}
+{% endblock paragraph_content %}
 
 {% block buttons %}
-    {% if payment_processor %}
-        <div class="invisible">
-            {{ block.super }}
-        </div>
-    {% endif %}
-{% endblock %}
+  {% if payment_processor %}<div class="invisible">{{ block.super }}</div>{% endif %}
+{% endblock buttons %}

--- a/benefits/enrollment/templates/enrollment/retry.html
+++ b/benefits/enrollment/templates/enrollment/retry.html
@@ -1,6 +1,6 @@
 {% extends "core/page.html" %}
 
 {% block main_content %}
-    {% include "core/includes/sign-out-link.html" %}
-    {{ block.super }}
-{% endblock %}
+  {% include "core/includes/sign-out-link.html" %}
+  {{ block.super }}
+{% endblock main_content %}

--- a/benefits/enrollment/templates/enrollment/success.html
+++ b/benefits/enrollment/templates/enrollment/success.html
@@ -4,33 +4,29 @@
 {% load static %}
 
 {% block classes %}
-    {{ block.super |add:" enrollment-success"}}
-{% endblock %}
+  {{ block.super |add:" enrollment-success" }}
+{% endblock classes %}
 
 {% block paragraph_content %}
-    {% if "logged-out" in page.classes %}
-        <img class="success-image" src="/static/img/icon/happybus.svg">
-    {% else %}
-        <p>{% translate "enrollment.pages.success.p1" %}</p>
-        <p>{% translate "enrollment.pages.success.p2" %}</p>
-        <p>{% blocktranslate with help_link=help_link%}enrollment.pages.success.p3{{ help_link }}{% endblocktranslate %}</p>
-    {% endif %}
-{% endblock %}
+  {% if "logged-out" in page.classes %}
+    <img class="success-image" src="{% static "img/icon/happybus.svg" %}" alt="Bus icon with smiley face">
+  {% else %}
+    <p>{% translate "enrollment.pages.success.p1" %}</p>
+    <p>{% translate "enrollment.pages.success.p2" %}</p>
+    <p>{% blocktranslate with help_link=help_link%}enrollment.pages.success.p3{{ help_link }}{% endblocktranslate %}</p>
+  {% endif %}
+{% endblock paragraph_content %}
 
 {% block buttons %}
-    {% if page.buttons|length_is:"1" %}
-        <p>
-            <span>{% translate "enrollment.pages.success.p3" %}</span>
-            {% for b in page.buttons %}
-                <a id="{{ b.id }}"
-                    class="{{ b.classes | join:" " }}"
-                    style="display: inline-block;"
-                    href="{{ b.url }}"
-                    role="b">
-                    <span class="fallback-text">{{ b.fallback_text }}</span>
-                </a>
-            {% endfor %}
-            <span>{% translate "enrollment.pages.success.p4" %}</span>
-        </p>
-    {% endif %}
+  {% if page.buttons|length_is:"1" %}
+    <p>
+      <span>{% translate "enrollment.pages.success.p3" %}</span>
+      {% for b in page.buttons %}
+        <a id="{{ b.id }}" class="{{ b.classes | join:" " }}" style="display: inline-block;" href="{{ b.url }}" role="b">
+          <span class="fallback-text">{{ b.fallback_text }}</span>
+        </a>
+      {% endfor %}
+      <span>{% translate "enrollment.pages.success.p4" %}</span>
+    </p>
+  {% endif %}
 {% endblock buttons %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,27 @@
-# Configuration for Black.
-
 # NOTE: you have to use single-quoted strings in TOML for regular expressions.
 # It's the equivalent of r-strings in Python.  Multiline strings are treated as
 # verbose regular expressions by Black.  Use [ ] to denote a significant space
 # character.
 
+# Configuration for black
+
 [tool.black]
 line-length = 127
 target-version = ['py38']
 include = '\.pyi?$'
+
+# Configuration for djlint
+
+[tool.djlint]
+ignore = "H006,H017,H021,H025,H031"
+indent = 2
+max_attribute_length = 127
+max_line_length = 127
+profile = "django"
+preserve_blank_lines = true
+use_gitignore = true
+
+# Configuration for pytest
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "benefits.settings"


### PR DESCRIPTION
Closes #815.

## What this PR does

* Swap `djhtml` for [`djlint`](https://github.com/Riverside-Healthcare/djlint) in `pre-commit` for HTML files
  * `prettier` handles CSS files
* [Integrate `djlint` with devcontainer](https://djlint.com/docs/integrations/#visual-studio-code) for linting and formatting
* Lint/format all our HTML files
  * Fix spacing (settings below)
  * Apply names to all `{% endblock %}` tags e.g. `{% endblock buttons %}`
  * Collapse inline tags e.g. `{% if %}...{% endif %}` inside an HTML `class` attribute
  * Expand block-level tags
  * Use `{% url %}` tag instead of hardcoding app URLs
  * Use `{% static %}` tag to load static files (images) instead of hardcoding paths

## `djlint` settings

To match our `prettier` config:

* Indent size 2
* Max line length 127
* Keep blank lines
* Use `.gitignore` (so e.g. local `coverage/` reports aren't processed)
* Ignore [rules](https://djlint.com/docs/linter/#rules):
  * `H006`: *`img` tag should have `height` and `width` attributes*
  * `H017`: *Tag should be self closing*
  * `H021`: *Inline styles should be avoided* (maybe fix with front-end cleanups)
  * `H025`: *Tag seems to be an orphan* (#775 may fix this)
  * `H031`: *Consider adding meta keywords* (we can look at doing this too)