### PR TITLE
Terraform: add container registry/image to slots

### DIFF
--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -88,6 +88,10 @@ resource "azurerm_linux_web_app_slot" "dev" {
   site_config {
     ftps_state             = "Disabled"
     vnet_route_all_enabled = true
+    application_stack {
+      docker_image     = "ghcr.io/cal-itp/benefits"
+      docker_image_tag = "dev"
+    }
   }
 
   identity {
@@ -126,6 +130,10 @@ resource "azurerm_linux_web_app_slot" "test" {
   site_config {
     ftps_state             = "Disabled"
     vnet_route_all_enabled = true
+    application_stack {
+      docker_image     = "ghcr.io/cal-itp/benefits"
+      docker_image_tag = "test"
+    }
   }
 
   identity {


### PR DESCRIPTION
These settings tell the slot which `registry/image:tag` to pull from.