### PR TITLE
Devcontainer: add terraform extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,6 +22,7 @@
     "bpruitt-goddard.mermaid-markdown-syntax-highlighting",
     "eamodio.gitlens",
     "esbenp.prettier-vscode",
+    "hashicorp.terraform",
     "mhutchie.git-graph",
     "monosans.djlint",
     "ms-python.python",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,5 +22,8 @@
   "python.linting.flake8Enabled": true,
   "python.testing.pytestArgs": ["tests/pytest", "--import-mode=importlib"],
   "python.testing.pytestEnabled": true,
-  "python.testing.unittestEnabled": false
+  "python.testing.unittestEnabled": false,
+  "[terraform]": {
+    "editor.defaultFormatter": "hashicorp.terraform"
+  }
 }


### PR DESCRIPTION
At least provides syntax highlighting within the devcontainer.

With a local (host) terraform install, provides format-on-save and additional VS Code commands.