### PR TITLE
chore: output the subcommands used in the scripts

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eu
+set -eux
 
 docker compose build client
 

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eu
+set -eux
 
 # remove existing (old) database file
 # -f forces the delete (and avoids an error when the file doesn't exist)

--- a/bin/makemigrations.sh
+++ b/bin/makemigrations.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eu
+set -eux
 
 # remove existing migration file
 

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eu
+set -eux
 
 # initialize Django
 


### PR DESCRIPTION
Hopefully will help with troubleshooting failed container start.