### PR TITLE
Chore: remove fixtures volume mount

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -10,8 +10,6 @@ services:
     env_file: .env
     ports:
       - "${DJANGO_LOCAL_PORT:-8000}:8000"
-    volumes:
-      - ./fixtures:/home/calitp/app/fixtures:ro
 
   dev:
     build:


### PR DESCRIPTION
Minor `compose.yml` update to remove the fixtures volume mount from the `client` service - since we're no longer using fixtures.