### PR TITLE
Refactor: eligibility start view msgids

### DIFF
--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -95,8 +95,8 @@ def start(request):
             0,
             dict(
                 icon=viewmodels.Icon("idcardcheck", pgettext("image alt text", "core.icons.idcardcheck")),
-                heading=_("eligibility.pages.start.oauth.heading"),
-                details=_("eligibility.pages.start.oauth.details"),
+                heading=_(verifier.start_item_name),
+                details=_(verifier.start_item_description),
                 links=[
                     viewmodels.Button.link(
                         classes="btn-text btn-link",

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -83,18 +83,19 @@ def start(request):
     )
 
     if verifier.is_auth_required:
-        identity_item["links"] = [
-            viewmodels.Button.link(
-                classes="btn-text btn-link",
-                text=_("eligibility.pages.start.oauth.link_text"),
-                url=f"{reverse(ROUTE_HELP)}#login-gov",
-            ),
-        ]
-        identity_item["bullets"] = [
-            _("eligibility.pages.start.oauth.required_items[0]"),
-            _("eligibility.pages.start.oauth.required_items[1]"),
-            _("eligibility.pages.start.oauth.required_items[2]"),
-        ]
+        if verifier.uses_auth_verification:
+            identity_item["links"] = [
+                viewmodels.Button.link(
+                    classes="btn-text btn-link",
+                    text=_("eligibility.pages.start.oauth.link_text"),
+                    url=f"{reverse(ROUTE_HELP)}#login-gov",
+                ),
+            ]
+            identity_item["bullets"] = [
+                _("eligibility.pages.start.oauth.required_items[0]"),
+                _("eligibility.pages.start.oauth.required_items[1]"),
+                _("eligibility.pages.start.oauth.required_items[2]"),
+            ]
 
         if not session.logged_in(request):
             button = viewmodels.Button.login(

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -75,42 +75,26 @@ def start(request):
 
     button = viewmodels.Button.primary(text=_("eligibility.buttons.continue"), url=reverse(ROUTE_CONFIRM))
 
-    media = [
-        dict(
-            icon=viewmodels.Icon("bankcardcheck", pgettext("image alt text", "core.icons.bankcardcheck")),
-            heading=_("eligibility.pages.start.bankcard.title"),
-            details=_("eligibility.pages.start.bankcard.text"),
-            links=[
-                viewmodels.Button.link(
-                    classes="btn-text btn-link",
-                    text=_("eligibility.pages.start.bankcard.button[0].link"),
-                    url=f"{reverse(ROUTE_HELP)}#payment-options",
-                ),
-            ],
-        ),
-    ]
+    # define the verifier-specific required item
+    identity_item = dict(
+        icon=viewmodels.Icon("idcardcheck", pgettext("image alt text", "core.icons.idcardcheck")),
+        heading=_(verifier.start_item_name),
+        details=_(verifier.start_item_description),
+    )
 
     if verifier.is_auth_required:
-        media.insert(
-            0,
-            dict(
-                icon=viewmodels.Icon("idcardcheck", pgettext("image alt text", "core.icons.idcardcheck")),
-                heading=_(verifier.start_item_name),
-                details=_(verifier.start_item_description),
-                links=[
-                    viewmodels.Button.link(
-                        classes="btn-text btn-link",
-                        text=_("eligibility.pages.start.oauth.link_text"),
-                        url=f"{reverse(ROUTE_HELP)}#login-gov",
-                    ),
-                ],
-                bullets=[
-                    _("eligibility.pages.start.oauth.required_items[0]"),
-                    _("eligibility.pages.start.oauth.required_items[1]"),
-                    _("eligibility.pages.start.oauth.required_items[2]"),
-                ],
+        identity_item["links"] = [
+            viewmodels.Button.link(
+                classes="btn-text btn-link",
+                text=_("eligibility.pages.start.oauth.link_text"),
+                url=f"{reverse(ROUTE_HELP)}#login-gov",
             ),
-        )
+        ]
+        identity_item["bullets"] = [
+            _("eligibility.pages.start.oauth.required_items[0]"),
+            _("eligibility.pages.start.oauth.required_items[1]"),
+            _("eligibility.pages.start.oauth.required_items[2]"),
+        ]
 
         if not session.logged_in(request):
             button = viewmodels.Button.login(
@@ -118,15 +102,21 @@ def start(request):
                 url=reverse(ROUTE_LOGIN),
             )
 
-    else:
-        media.insert(
-            0,
-            dict(
-                icon=viewmodels.Icon("idcardcheck", pgettext("image alt text", "core.icons.idcardcheck")),
-                heading=_(verifier.start_item_name),
-                details=_(verifier.start_item_description),
+    # define the bank card item
+    bank_card_item = dict(
+        icon=viewmodels.Icon("bankcardcheck", pgettext("image alt text", "core.icons.bankcardcheck")),
+        heading=_("eligibility.pages.start.bankcard.title"),
+        details=_("eligibility.pages.start.bankcard.text"),
+        links=[
+            viewmodels.Button.link(
+                classes="btn-text btn-link",
+                text=_("eligibility.pages.start.bankcard.button[0].link"),
+                url=f"{reverse(ROUTE_HELP)}#payment-options",
             ),
-        )
+        ],
+    )
+
+    media = [identity_item, bank_card_item]
 
     page = viewmodels.Page(
         title=_("eligibility.pages.start.title"),

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2022-08-03 23:18+0000\n"
+"POT-Creation-Date: 2022-08-04 01:13+0000\n"
 "Language: English\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -548,45 +548,45 @@ msgctxt "image alt text"
 msgid "core.icons.idcardcheck"
 msgstr "Identification card icon with checkmark"
 
-#: benefits/eligibility/views.py:89
+#: benefits/eligibility/views.py:90
 msgid "eligibility.pages.start.oauth.link_text"
 msgstr "Learn more about Login.gov and providing proof of identity"
 
-#: benefits/eligibility/views.py:94
+#: benefits/eligibility/views.py:95
 msgid "eligibility.pages.start.oauth.required_items[0]"
 msgstr "Your state-issued ID card"
 
-#: benefits/eligibility/views.py:95
+#: benefits/eligibility/views.py:96
 msgid "eligibility.pages.start.oauth.required_items[1]"
 msgstr "Your Social Security number"
 
-#: benefits/eligibility/views.py:96
+#: benefits/eligibility/views.py:97
 msgid "eligibility.pages.start.oauth.required_items[2]"
 msgstr "A phone number with a phone plan associated with your name"
 
-#: benefits/eligibility/views.py:107 benefits/enrollment/views.py:145
+#: benefits/eligibility/views.py:108 benefits/enrollment/views.py:145
 msgctxt "image alt text"
 msgid "core.icons.bankcardcheck"
 msgstr "Bank card icon with contactless symbol and checkmark"
 
-#: benefits/eligibility/views.py:108
+#: benefits/eligibility/views.py:109
 msgid "eligibility.pages.start.bankcard.title"
 msgstr "Your bank card details"
 
-#: benefits/eligibility/views.py:109
+#: benefits/eligibility/views.py:110
 msgid "eligibility.pages.start.bankcard.text"
 msgstr ""
 "Your card must be a contactless debit or credit card by Visa or Mastercard."
 
-#: benefits/eligibility/views.py:113
+#: benefits/eligibility/views.py:114
 msgid "eligibility.pages.start.bankcard.button[0].link"
 msgstr "Don’t have a bank card or unsure if your card is contactless?"
 
-#: benefits/eligibility/views.py:122
+#: benefits/eligibility/views.py:123
 msgid "eligibility.pages.start.title"
 msgstr "Get Started"
 
-#: benefits/eligibility/views.py:233
+#: benefits/eligibility/views.py:234
 msgctxt "image alt text"
 msgid "core.icons.idcardquestion"
 msgstr "Identification card icon with question mark"

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2022-07-25 22:59+0000\n"
+"POT-Creation-Date: 2022-08-03 23:18+0000\n"
 "Language: English\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -543,51 +543,50 @@ msgstr "Select a discount option"
 msgid "eligibility.pages.index.content_title"
 msgstr "Select the discount option that best applies to you:"
 
-#: benefits/eligibility/views.py:80 benefits/enrollment/views.py:145
-msgctxt "image alt text"
-msgid "core.icons.bankcardcheck"
-msgstr "Bank card icon with contactless symbol and checkmark"
-
-#: benefits/eligibility/views.py:81
-msgid "eligibility.pages.start.bankcard.title"
-msgstr "Your bank card details"
-
-#: benefits/eligibility/views.py:82
-msgid "eligibility.pages.start.bankcard.text"
-msgstr ""
-"Your card must be a contactless debit or credit card by Visa or Mastercard."
-
-#: benefits/eligibility/views.py:86
-msgid "eligibility.pages.start.bankcard.button[0].link"
-msgstr "Don’t have a bank card or unsure if your card is contactless?"
-
-#: benefits/eligibility/views.py:97 benefits/eligibility/views.py:125
-#: benefits/enrollment/views.py:78
+#: benefits/eligibility/views.py:80 benefits/enrollment/views.py:78
 msgctxt "image alt text"
 msgid "core.icons.idcardcheck"
 msgstr "Identification card icon with checkmark"
 
-#: benefits/eligibility/views.py:103
+#: benefits/eligibility/views.py:89
 msgid "eligibility.pages.start.oauth.link_text"
 msgstr "Learn more about Login.gov and providing proof of identity"
 
-#: benefits/eligibility/views.py:108
+#: benefits/eligibility/views.py:94
 msgid "eligibility.pages.start.oauth.required_items[0]"
 msgstr "Your state-issued ID card"
 
-#: benefits/eligibility/views.py:109
+#: benefits/eligibility/views.py:95
 msgid "eligibility.pages.start.oauth.required_items[1]"
 msgstr "Your Social Security number"
 
-#: benefits/eligibility/views.py:110
+#: benefits/eligibility/views.py:96
 msgid "eligibility.pages.start.oauth.required_items[2]"
 msgstr "A phone number with a phone plan associated with your name"
 
-#: benefits/eligibility/views.py:132
+#: benefits/eligibility/views.py:107 benefits/enrollment/views.py:145
+msgctxt "image alt text"
+msgid "core.icons.bankcardcheck"
+msgstr "Bank card icon with contactless symbol and checkmark"
+
+#: benefits/eligibility/views.py:108
+msgid "eligibility.pages.start.bankcard.title"
+msgstr "Your bank card details"
+
+#: benefits/eligibility/views.py:109
+msgid "eligibility.pages.start.bankcard.text"
+msgstr ""
+"Your card must be a contactless debit or credit card by Visa or Mastercard."
+
+#: benefits/eligibility/views.py:113
+msgid "eligibility.pages.start.bankcard.button[0].link"
+msgstr "Don’t have a bank card or unsure if your card is contactless?"
+
+#: benefits/eligibility/views.py:122
 msgid "eligibility.pages.start.title"
 msgstr "Get Started"
 
-#: benefits/eligibility/views.py:243
+#: benefits/eligibility/views.py:233
 msgctxt "image alt text"
 msgid "core.icons.idcardquestion"
 msgstr "Identification card icon with question mark"

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -567,18 +567,6 @@ msgctxt "image alt text"
 msgid "core.icons.idcardcheck"
 msgstr "Identification card icon with checkmark"
 
-#: benefits/eligibility/views.py:98
-msgid "eligibility.pages.start.oauth.heading"
-msgstr "A Login.gov account with identity verification"
-
-#: benefits/eligibility/views.py:99
-msgid "eligibility.pages.start.oauth.details"
-msgstr ""
-"Login.gov is a safe way to sign in to government services. Benefits uses "
-"Login.gov to verify your age. If you do not have an account already, you "
-"will be able to create one. You will also need to verify your identity, "
-"which will require these items:"
-
 #: benefits/eligibility/views.py:103
 msgid "eligibility.pages.start.oauth.link_text"
 msgstr "Learn more about Login.gov and providing proof of identity"

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2022-08-03 23:18+0000\n"
+"POT-Creation-Date: 2022-08-04 01:13+0000\n"
 "Language: Español\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -560,50 +560,50 @@ msgctxt "image alt text"
 msgid "core.icons.idcardcheck"
 msgstr "Icono de tarjeta de identificación con marca de verificación"
 
-#: benefits/eligibility/views.py:89
+#: benefits/eligibility/views.py:90
 msgid "eligibility.pages.start.oauth.link_text"
 msgstr ""
 "Conozca más sobre Login.gov y cómo proporcionar una prueba de identidad."
 
-#: benefits/eligibility/views.py:94
+#: benefits/eligibility/views.py:95
 msgid "eligibility.pages.start.oauth.required_items[0]"
 msgstr "Su tarjeta de identificación emitida por el estado"
 
-#: benefits/eligibility/views.py:95
+#: benefits/eligibility/views.py:96
 msgid "eligibility.pages.start.oauth.required_items[1]"
 msgstr "Su número de Seguro Social"
 
-#: benefits/eligibility/views.py:96
+#: benefits/eligibility/views.py:97
 msgid "eligibility.pages.start.oauth.required_items[2]"
 msgstr "Un número de teléfono con un plan de teléfono asociado con su nombre"
 
-#: benefits/eligibility/views.py:107 benefits/enrollment/views.py:145
+#: benefits/eligibility/views.py:108 benefits/enrollment/views.py:145
 msgctxt "image alt text"
 msgid "core.icons.bankcardcheck"
 msgstr ""
 "Icono de tarjeta bancaria con símbolo sin contacto y marca de verificación"
 
-#: benefits/eligibility/views.py:108
+#: benefits/eligibility/views.py:109
 msgid "eligibility.pages.start.bankcard.title"
 msgstr "Los datos de su tarjeta bancaria"
 
-#: benefits/eligibility/views.py:109
+#: benefits/eligibility/views.py:110
 msgid "eligibility.pages.start.bankcard.text"
 msgstr ""
 "Su tarjeta debe ser una tarjeta de débito o crédito sin contacto de Visa o "
 "Mastercard."
 
-#: benefits/eligibility/views.py:113
+#: benefits/eligibility/views.py:114
 msgid "eligibility.pages.start.bankcard.button[0].link"
 msgstr ""
 "¿No tienes tarjeta bancaria o no está seguro si tiene una tarjeta sin "
 "contacto?"
 
-#: benefits/eligibility/views.py:122
+#: benefits/eligibility/views.py:123
 msgid "eligibility.pages.start.title"
 msgstr "Comencemos"
 
-#: benefits/eligibility/views.py:233
+#: benefits/eligibility/views.py:234
 msgctxt "image alt text"
 msgid "core.icons.idcardquestion"
 msgstr "Icono de tarjeta de identificación con signo de interrogación"

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -583,18 +583,6 @@ msgctxt "image alt text"
 msgid "core.icons.idcardcheck"
 msgstr "Icono de tarjeta de identificación con marca de verificación"
 
-#: benefits/eligibility/views.py:98
-msgid "eligibility.pages.start.oauth.heading"
-msgstr "Una cuenta de Login.gov con verificación de identidad"
-
-#: benefits/eligibility/views.py:99
-msgid "eligibility.pages.start.oauth.details"
-msgstr ""
-"Login.gov es una forma segura de iniciar sesión en servicios "
-"gubernamentales. Benefits utiliza Login.gov para verificar su edad. Si aún "
-"no tiene una cuenta, podrá crear una. También deberá verificar su identidad, "
-"lo que requerirá estos artículos:"
-
 #: benefits/eligibility/views.py:103
 msgid "eligibility.pages.start.oauth.link_text"
 msgstr ""

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2022-07-25 22:59+0000\n"
+"POT-Creation-Date: 2022-08-03 23:18+0000\n"
 "Language: Español\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -555,56 +555,55 @@ msgstr "TODO"
 msgid "eligibility.pages.index.content_title"
 msgstr "TODO"
 
-#: benefits/eligibility/views.py:80 benefits/enrollment/views.py:145
+#: benefits/eligibility/views.py:80 benefits/enrollment/views.py:78
+msgctxt "image alt text"
+msgid "core.icons.idcardcheck"
+msgstr "Icono de tarjeta de identificación con marca de verificación"
+
+#: benefits/eligibility/views.py:89
+msgid "eligibility.pages.start.oauth.link_text"
+msgstr ""
+"Conozca más sobre Login.gov y cómo proporcionar una prueba de identidad."
+
+#: benefits/eligibility/views.py:94
+msgid "eligibility.pages.start.oauth.required_items[0]"
+msgstr "Su tarjeta de identificación emitida por el estado"
+
+#: benefits/eligibility/views.py:95
+msgid "eligibility.pages.start.oauth.required_items[1]"
+msgstr "Su número de Seguro Social"
+
+#: benefits/eligibility/views.py:96
+msgid "eligibility.pages.start.oauth.required_items[2]"
+msgstr "Un número de teléfono con un plan de teléfono asociado con su nombre"
+
+#: benefits/eligibility/views.py:107 benefits/enrollment/views.py:145
 msgctxt "image alt text"
 msgid "core.icons.bankcardcheck"
 msgstr ""
 "Icono de tarjeta bancaria con símbolo sin contacto y marca de verificación"
 
-#: benefits/eligibility/views.py:81
+#: benefits/eligibility/views.py:108
 msgid "eligibility.pages.start.bankcard.title"
 msgstr "Los datos de su tarjeta bancaria"
 
-#: benefits/eligibility/views.py:82
+#: benefits/eligibility/views.py:109
 msgid "eligibility.pages.start.bankcard.text"
 msgstr ""
 "Su tarjeta debe ser una tarjeta de débito o crédito sin contacto de Visa o "
 "Mastercard."
 
-#: benefits/eligibility/views.py:86
+#: benefits/eligibility/views.py:113
 msgid "eligibility.pages.start.bankcard.button[0].link"
 msgstr ""
 "¿No tienes tarjeta bancaria o no está seguro si tiene una tarjeta sin "
 "contacto?"
 
-#: benefits/eligibility/views.py:97 benefits/eligibility/views.py:125
-#: benefits/enrollment/views.py:78
-msgctxt "image alt text"
-msgid "core.icons.idcardcheck"
-msgstr "Icono de tarjeta de identificación con marca de verificación"
-
-#: benefits/eligibility/views.py:103
-msgid "eligibility.pages.start.oauth.link_text"
-msgstr ""
-"Conozca más sobre Login.gov y cómo proporcionar una prueba de identidad."
-
-#: benefits/eligibility/views.py:108
-msgid "eligibility.pages.start.oauth.required_items[0]"
-msgstr "Su tarjeta de identificación emitida por el estado"
-
-#: benefits/eligibility/views.py:109
-msgid "eligibility.pages.start.oauth.required_items[1]"
-msgstr "Su número de Seguro Social"
-
-#: benefits/eligibility/views.py:110
-msgid "eligibility.pages.start.oauth.required_items[2]"
-msgstr "Un número de teléfono con un plan de teléfono asociado con su nombre"
-
-#: benefits/eligibility/views.py:132
+#: benefits/eligibility/views.py:122
 msgid "eligibility.pages.start.title"
 msgstr "Comencemos"
 
-#: benefits/eligibility/views.py:243
+#: benefits/eligibility/views.py:233
 msgctxt "image alt text"
 msgid "core.icons.idcardquestion"
 msgstr "Icono de tarjeta de identificación con signo de interrogación"


### PR DESCRIPTION
A part of #776 

This PR cleans up how the `eligibility` `start` view function uses msgids. 

The view was hard-coding some oauth msgids when really those should be coming from the `EligibilityVerifier` model.    
The view also hard-codes some msgids for the links and bullet points, but because those are not configurable, we can at least add some logic to only show them if the verifier uses authentication as eligibility verification since that's what the links and bullet points are about.