### PR TITLE
Chore: move coverage config to pyproject.toml

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,0 @@
-[run]
-omit = benefits/core/migrations/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,7 @@ repos:
       - id: mixed-line-ending
       - id: end-of-file-fixer
       - id: requirements-txt-fixer
+      - id: check-toml
       - id: check-yaml
         args: ["--unsafe"]
       - id: check-added-large-files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,11 @@ use_gitignore = true
 
 # Configuration for pytest
 
+[tool.coverage.run]
+omit = [
+    "benefits/core/migrations/*"
+]
+
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "benefits.settings"
 markers = [


### PR DESCRIPTION
`pytest-cov` installs `coverage[toml]`, so can load from this file by default.

This reduces the number of config files we need in the repo, and consolidates config information for python tooling.