### PR TITLE
Feat: terraform production configuration

### DIFF
--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -84,6 +84,12 @@ resource "azurerm_linux_web_app" "main" {
   }
 }
 
+resource "azurerm_app_service_custom_hostname_binding" "main" {
+  hostname            = "benefits.calitp.org"
+  app_service_name    = azurerm_linux_web_app.main.name
+  resource_group_name = data.azurerm_resource_group.prod.name
+}
+
 resource "azurerm_linux_web_app_slot" "dev" {
   name                      = "dev"
   https_only                = true

--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -51,7 +51,9 @@ resource "azurerm_linux_web_app" "main" {
       # custom config
       "ANALYTICS_KEY",
       "DJANGO_ALLOWED_HOSTS",
+      "DJANGO_LOAD_SAMPLE_DATA",
       "DJANGO_LOG_LEVEL",
+      "DJANGO_MIGRATIONS_DIR",
       "DJANGO_TRUSTED_ORIGINS",
 
       # populated through auto-instrumentation

--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -24,6 +24,10 @@ resource "azurerm_linux_web_app" "main" {
   site_config {
     ftps_state             = "Disabled"
     vnet_route_all_enabled = true
+    application_stack {
+      docker_image     = "ghcr.io/cal-itp/benefits"
+      docker_image_tag = "prod"
+    }
   }
 
   identity {


### PR DESCRIPTION
## Custom hostname binding

I'm not sure if this is right / will work.

We have an [`azurerm_linux_web_app`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_web_app) which I think is considered an "App Service".

[`app_service_custom_hostname_binding`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service_custom_hostname_binding) expects an App Service name.

## `prod` Docker image reference

So deploys will work with CI (already configured in Azure)

## Sticky settings

Adding our new `DJANGO_LOAD_SAMPLE_DATA` and `DJANGO_MIGRATIONS_DIR` settings (for data migrations).