### PR TITLE
Fix: auth scope check when userinfo is present, but claim is not

### DIFF
--- a/benefits/oauth/views.py
+++ b/benefits/oauth/views.py
@@ -70,7 +70,9 @@ def authorize(request):
         if userinfo:
             claim_value = userinfo.get(verifier_claim)
             # the claim comes back in userinfo like { "claim": "True" | "False" }
-            if claim_value is not None and claim_value.lower() == "true":
+            if claim_value is None:
+                logger.warning(f"userinfo did not contain: {verifier_claim}")
+            elif claim_value.lower() == "true":
                 # if userinfo contains our claim and the flag is true, store the *claim*
                 stored_claim = verifier_claim
 

--- a/benefits/oauth/views.py
+++ b/benefits/oauth/views.py
@@ -67,14 +67,11 @@ def authorize(request):
     if verifier_claim:
         userinfo = token.get("userinfo")
 
-        if userinfo:
+        if userinfo and userinfo.get(verifier_claim) is not None:
             # the claim comes back in userinfo like { "claim": "True" | "False" }
-            claim_flag = userinfo.get(verifier_claim).lower() == "true"
-        else:
-            claim_flag = False
-
-        # if userinfo contains our claim and the flag is true, store the *claim*
-        stored_claim = verifier_claim if claim_flag else None
+            if userinfo.get(verifier_claim).lower() == "true":
+                # if userinfo contains our claim and the flag is true, store the *claim*
+                stored_claim = verifier_claim
 
     session.update(request, oauth_token=id_token, oauth_claim=stored_claim)
 

--- a/benefits/oauth/views.py
+++ b/benefits/oauth/views.py
@@ -67,9 +67,10 @@ def authorize(request):
     if verifier_claim:
         userinfo = token.get("userinfo")
 
-        if userinfo and userinfo.get(verifier_claim) is not None:
+        if userinfo:
+            claim_value = userinfo.get(verifier_claim)
             # the claim comes back in userinfo like { "claim": "True" | "False" }
-            if userinfo.get(verifier_claim).lower() == "true":
+            if claim_value is not None and claim_value.lower() == "true":
                 # if userinfo contains our claim and the flag is true, store the *claim*
                 stored_claim = verifier_claim
 

--- a/benefits/oauth/views.py
+++ b/benefits/oauth/views.py
@@ -66,8 +66,13 @@ def authorize(request):
 
     if verifier_claim:
         userinfo = token.get("userinfo")
-        # the claim comes back in userinfo like { "claim": "True" | "False" }
-        claim_flag = (userinfo.get(verifier_claim) if userinfo else "false").lower() == "true"
+
+        if userinfo:
+            # the claim comes back in userinfo like { "claim": "True" | "False" }
+            claim_flag = userinfo.get(verifier_claim).lower() == "true"
+        else:
+            claim_flag = False
+
         # if userinfo contains our claim and the flag is true, store the *claim*
         stored_claim = verifier_claim if claim_flag else None
 

--- a/tests/pytest/oauth/test_views.py
+++ b/tests/pytest/oauth/test_views.py
@@ -121,11 +121,38 @@ def test_authorize_success_with_claim_false(
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_analytics_module")
-def test_authorize_success_without_claim(mocked_session_verifier_auth_required, mocked_oauth_create_client, app_request):
+def test_authorize_success_without_verifier_claim(
+    mocked_session_verifier_auth_required, mocked_oauth_create_client, app_request
+):
     verifier = mocked_session_verifier_auth_required.return_value
     verifier.auth_provider.claim = ""
     mocked_oauth_client = mocked_oauth_create_client.return_value
     mocked_oauth_client.authorize_access_token.return_value = {"id_token": "token", "userinfo": {"claim": "True"}}
+
+    result = authorize(app_request)
+
+    mocked_oauth_client.authorize_access_token.assert_called_with(app_request)
+    assert session.oauth_claim(app_request) is None
+    assert result.status_code == 302
+    assert result.url == reverse(ROUTE_CONFIRM)
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("mocked_analytics_module")
+@pytest.mark.parametrize(
+    "access_token_response",
+    [
+        {"id_token": "token"},  # no userinfo
+        {"id_token": "token", "userinfo": {"something_unexpected": "True"}},  # has userinfo, but not the expected claim
+    ],
+)
+def test_authorize_success_without_claim_in_response(
+    mocked_session_verifier_auth_required, mocked_oauth_create_client, app_request, access_token_response
+):
+    verifier = mocked_session_verifier_auth_required.return_value
+    verifier.auth_provider.claim = "claim"
+    mocked_oauth_client = mocked_oauth_create_client.return_value
+    mocked_oauth_client.authorize_access_token.return_value = access_token_response
 
     result = authorize(app_request)
 


### PR DESCRIPTION
Closes #863 