### PR TITLE
Feat: issue template for managing a release

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.yml
+++ b/.github/ISSUE_TEMPLATE/release.yml
@@ -1,0 +1,65 @@
+name: New Release
+description: Publish a new release of the Benefits app
+title: Make a Release
+labels:
+  - release
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Prepare a new release
+
+        Use the form below to prepare a new release of the Benefits app.
+
+        Each release is coordinated by a **Release Manager**. The release manager may assign sub-tasks or ask for help
+        as-needed, but is otherwise responsible for all aspects of the release.
+
+        After this issue is created, use the checklist to manage the steps
+        of the release process, marking items as completed. [Read more about the
+        release process](https://docs.calitp.org/benefits/deployment/release/).
+
+        Close this issue when the checklist is complete.
+  - type: input
+    id: manager
+    attributes:
+      label: Release manager
+      description: GitHub handle of who is responsible for this release; assign this issue to this user
+      placeholder: "@cal-itp-bot"
+  - type: input
+    id: version
+    attributes:
+      label: Release version
+      description: Calver-formatted version for this release
+      placeholder: YYYY.0M.R
+  - type: markdown
+    attributes:
+      value: |
+        ## Release type
+
+        Reference the diagram and discussion on [the release process docs](https://docs.calitp.org/benefits/deployment/release/).
+
+        * `Regular` release: propogates from `dev` to `test`, and then `test` to `prod`. Only possible if `dev` is ready to deploy.
+        * `Hotfix` release: propogates from `test` to `prod`, skipping `dev`.
+  - type: dropdown
+    id: type
+    attributes:
+      label: What type of release is this?
+      options:
+        - "Regular"
+        - "Hotfix"
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Release checklist
+      description: Complete these items in sequence as the release progresses
+      options:
+        - Create a branch called release/version from the source branch
+        - Bump the application version
+        - Open a PR for the release branch into the staging target, merge
+        - "(If applicable): open another PR from dev to test"
+        - QA the app in test
+        - Open a PR to for the test branch into prod, merge
+        - QA the app in prod
+        - Tag the release on the prod branch, push the tag to GitHub
+        - Create a release in GitHub for the tag, generating release notes
+        - Edit release notes with additional context, images, animations, etc. as-needed

--- a/docs/deployment/release.md
+++ b/docs/deployment/release.md
@@ -10,6 +10,8 @@ can be found under [Workflows](./workflows.md).
 The list of releases can be found on the [repository Releases page](https://github.com/cal-itp/benefits/tags)
 on GitHub.
 
+[Start a new Release on Github](https://github.com/cal-itp/benefits/issues/new?labels=release&template=release.yml&title=Make+a+Release){ .md-button }
+
 ## 0. Decide on the new version number
 
 A new release implies a new version.


### PR DESCRIPTION
This PR introduces a new Issue Template using GitHub's [Issue forms syntax](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms).

We want to be able to track the manual steps, and give more context into the folks responsible for the release. The form asks for a few items up front, including the `Release manager` and `version`.

The form also encodes the steps found on the docs page: https://docs.calitp.org/benefits/deployment/release/ into a checklist that can be used to guide the release process. The release is complete when the checklist is finished, and the tracking issue can then be closed.