### PR TITLE
Feat: send eligibility type with eligibility events

### DIFF
--- a/benefits/eligibility/analytics.py
+++ b/benefits/eligibility/analytics.py
@@ -19,11 +19,11 @@ class StartedEligibilityEvent(EligibilityEvent):
         super().__init__(request, "started eligibility", eligibility_types)
 
 
-class ReturnedEligibilityEvent(core.Event):
+class ReturnedEligibilityEvent(EligibilityEvent):
     """Analytics event representing the end of an eligibility verification check."""
 
-    def __init__(self, request, status, error=None):
-        super().__init__(request, "returned eligibility")
+    def __init__(self, request, eligibility_types, status, error=None):
+        super().__init__(request, "returned eligibility", eligibility_types)
         if str(status).lower() in ("error", "fail", "success"):
             self.update_event_properties(status=status, error=error)
 
@@ -33,16 +33,16 @@ def started_eligibility(request, eligibility_types):
     core.send_event(StartedEligibilityEvent(request, eligibility_types))
 
 
-def returned_error(request, error):
+def returned_error(request, eligibility_types, error):
     """Send the "returned eligibility" analytics event with an error status."""
-    core.send_event(ReturnedEligibilityEvent(request, status="error", error=error))
+    core.send_event(ReturnedEligibilityEvent(request, eligibility_types, status="error", error=error))
 
 
-def returned_fail(request):
+def returned_fail(request, eligibility_types):
     """Send the "returned eligibility" analytics event with a fail status."""
-    core.send_event(ReturnedEligibilityEvent(request, status="fail"))
+    core.send_event(ReturnedEligibilityEvent(request, eligibility_types, status="fail"))
 
 
-def returned_success(request):
+def returned_success(request, eligibility_types):
     """Send the "returned eligibility" analytics event with a success status."""
-    core.send_event(ReturnedEligibilityEvent(request, status="success"))
+    core.send_event(ReturnedEligibilityEvent(request, eligibility_types, status="success"))

--- a/benefits/eligibility/analytics.py
+++ b/benefits/eligibility/analytics.py
@@ -12,11 +12,11 @@ class EligibilityEvent(core.Event):
         self.update_event_properties(eligibility_types=eligibility_types)
 
 
-class StartedEligibilityEvent(core.Event):
+class StartedEligibilityEvent(EligibilityEvent):
     """Analytics event representing the beginning of an eligibility verification check."""
 
-    def __init__(self, request):
-        super().__init__(request, "started eligibility")
+    def __init__(self, request, eligibility_types):
+        super().__init__(request, "started eligibility", eligibility_types)
 
 
 class ReturnedEligibilityEvent(core.Event):
@@ -28,9 +28,9 @@ class ReturnedEligibilityEvent(core.Event):
             self.update_event_properties(status=status, error=error)
 
 
-def started_eligibility(request):
+def started_eligibility(request, eligibility_types):
     """Send the "started eligibility" analytics event."""
-    core.send_event(StartedEligibilityEvent(request))
+    core.send_event(StartedEligibilityEvent(request, eligibility_types))
 
 
 def returned_error(request, error):

--- a/benefits/eligibility/analytics.py
+++ b/benefits/eligibility/analytics.py
@@ -4,6 +4,14 @@ The eligibility application: analytics implementation.
 from benefits.core import analytics as core
 
 
+class EligibilityEvent(core.Event):
+    """Base analytics event for eligibility verification."""
+
+    def __init__(self, request, event_type, eligibility_types):
+        super().__init__(request, event_type)
+        self.update_event_properties(eligibility_types=eligibility_types)
+
+
 class StartedEligibilityEvent(core.Event):
     """Analytics event representing the beginning of an eligibility verification check."""
 

--- a/benefits/eligibility/verify.py
+++ b/benefits/eligibility/verify.py
@@ -3,6 +3,11 @@ from django.conf import settings
 from eligibility_api.client import Client
 
 
+def typenames_to_verify(agency, verifier):
+    """Get the names of the eligibility types to check for the agency/verifier pair."""
+    return [t.name for t in agency.types_to_verify(verifier)]
+
+
 def eligibility_from_api(verifier, form, agency):
     sub, name = form.cleaned_data.get("sub"), form.cleaned_data.get("name")
 
@@ -18,10 +23,7 @@ def eligibility_from_api(verifier, form, agency):
         server_public_key=verifier.public_key_data,
     )
 
-    # get the eligibility type names to check
-    types = list(map(lambda t: t.name, agency.types_to_verify(verifier)))
-
-    response = client.verify(sub, name, types)
+    response = client.verify(sub, name, typenames_to_verify(agency, verifier))
 
     if response.error and any(response.error):
         form.add_api_errors(response.error)
@@ -34,6 +36,6 @@ def eligibility_from_api(verifier, form, agency):
 
 def eligibility_from_oauth(verifier, oauth_claim, agency):
     if verifier.uses_auth_verification and verifier.auth_provider.claim == oauth_claim:
-        return list(map(lambda t: t.name, agency.types_to_verify(verifier)))
+        return typenames_to_verify(agency, verifier)
     else:
         return []

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -190,7 +190,7 @@ def confirm(request):
 
         # form was not valid, allow for correction/resubmission
         if verified_types is None:
-            analytics.returned_error(request, form.errors)
+            analytics.returned_error(request, types_to_verify, form.errors)
             page.forms = [form]
             return TemplateResponse(request, TEMPLATE_CONFIRM, page.context_dict())
         # no types were verified
@@ -206,7 +206,7 @@ def confirm(request):
 def verified(request, verified_types):
     """View handler for the verified eligibility page."""
 
-    analytics.returned_success(request)
+    analytics.returned_success(request, verified_types)
 
     session.update(request, eligibility_types=verified_types)
 
@@ -218,14 +218,15 @@ def verified(request, verified_types):
 def unverified(request):
     """View handler for the unverified eligibility page."""
 
-    analytics.returned_fail(request)
+    agency = session.agency(request)
+    verifier = session.verifier(request)
+    types_to_verify = verify.typenames_to_verify(agency, verifier)
+
+    analytics.returned_fail(request, types_to_verify)
 
     # tel: link to agency phone number
-    agency = session.agency(request)
     buttons = viewmodels.Button.agency_contact_links(agency)
     buttons.append(viewmodels.Button.home(request))
-
-    verifier = session.verifier(request)
 
     page = viewmodels.Page(
         noimage=True,

--- a/tests/pytest/eligibility/test_verify.py
+++ b/tests/pytest/eligibility/test_verify.py
@@ -1,7 +1,7 @@
 import pytest
 
 from benefits.eligibility.forms import EligibilityVerificationForm
-from benefits.eligibility.verify import eligibility_from_api, eligibility_from_oauth
+from benefits.eligibility.verify import typenames_to_verify, eligibility_from_api, eligibility_from_oauth
 
 
 @pytest.fixture
@@ -12,6 +12,15 @@ def form(mocker):
 @pytest.fixture
 def mock_api_client_verify(mocker):
     return mocker.patch("benefits.eligibility.verify.Client.verify")
+
+
+@pytest.mark.django_db
+def test_typenames_to_verify(model_TransitAgency, model_EligibilityVerifier):
+    expected = [t.name for t in model_TransitAgency.types_to_verify(model_EligibilityVerifier)]
+
+    result = typenames_to_verify(model_TransitAgency, model_EligibilityVerifier)
+
+    assert result == expected
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Closes #874 

* On `eligibility:start`, send the requested types
* On `eligibility:success`, send the verified types
* On `eligibility:error` or `eligibility:fail`, send the requested types