### PR TITLE
Fix: local eligibility server

### DIFF
--- a/.devcontainer/server/.env.server
+++ b/.devcontainer/server/.env.server
@@ -1,1 +1,2 @@
-IMPORT_FILE_PATH=/.devcontainer/server/data.csv
+ELIGIBILITY_SERVER_SETTINGS=/.devcontainer/server/settings.py
+FLASK_APP=eligibility_server/app.py

--- a/.devcontainer/server/settings.py
+++ b/.devcontainer/server/settings.py
@@ -1,0 +1,22 @@
+# App settings
+
+LOG_LEVEL = "DEBUG"
+
+# Eligibility Verification settings
+
+CLIENT_KEY_PATH = "https://raw.githubusercontent.com/cal-itp/eligibility-server/main/keys/client.pub"
+SERVER_PRIVATE_KEY_PATH = "https://raw.githubusercontent.com/cal-itp/eligibility-server/main/keys/server.key"
+SERVER_PUBLIC_KEY_PATH = "https://raw.githubusercontent.com/cal-itp/eligibility-server/main/keys/server.pub"
+SUB_FORMAT_REGEX = r".+"
+
+# Data settings
+
+IMPORT_FILE_PATH = "/.devcontainer/server/data.csv"
+INPUT_HASH_ALGO = ""
+
+# CSV-specific settings
+
+CSV_DELIMITER = ";"
+CSV_NEWLINE = ""
+CSV_QUOTING = 3
+CSV_QUOTECHAR = ""

--- a/benefits/core/migrations/0002_sample_data.py
+++ b/benefits/core/migrations/0002_sample_data.py
@@ -92,7 +92,7 @@ PEM DATA
 
     verifier1 = EligibilityVerifier.objects.create(
         name="Test Eligibility Verifier 1",
-        api_url="http://server:5000/verify",
+        api_url="http://server:8000/verify",
         api_auth_header="X-Server-API-Key",
         api_auth_key="server-auth-token",
         eligibility_type=type1,
@@ -123,7 +123,7 @@ PEM DATA
 
     verifier2 = EligibilityVerifier.objects.create(
         name="Test Eligibility Verifier 2",
-        api_url="http://server:5000/verify",
+        api_url="http://server:8000/verify",
         api_auth_header="X-Server-API-Key",
         api_auth_key="server-auth-token",
         eligibility_type=type2,
@@ -171,11 +171,11 @@ PEM DATA
 
     payment_processor = PaymentProcessor.objects.create(
         name="Test Payment Processor",
-        api_base_url="http://server:5000",
+        api_base_url="http://server:8000",
         api_access_token_endpoint="access-token",
         api_access_token_request_key="request_access",
         api_access_token_request_val="REQUEST_ACCESS",
-        card_tokenize_url="http://localhost:5000/static/tokenize.js",
+        card_tokenize_url="http://server:8000/static/tokenize.js",
         card_tokenize_func="tokenize",
         card_tokenize_env="test",
         client_cert=dummy_cert,

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -4,3 +4,5 @@ set -eux
 docker compose build client
 
 docker compose build dev
+
+docker compose pull server

--- a/compose.yml
+++ b/compose.yml
@@ -39,6 +39,6 @@ services:
     image: ghcr.io/cal-itp/eligibility-server:main
     env_file: .devcontainer/server/.env.server
     ports:
-      - "5000"
+      - "8000"
     volumes:
       - ./.devcontainer:/.devcontainer


### PR DESCRIPTION
Closes #880.

Update to use the new settings format. 

The local eligibility server now works within the devcontainer and locally with:

```bash
docker compose up server
```

Added a line to the `bin/build.sh` helper script to pull the latest `server` image from GHCR.

## Testing

The following should give a verification success:

1. Set `DJANGO_LOAD_SAMPLE_DATA=true`, remove any custom sample data migrations
2. Open the devcontainer with this branch
3. F5 to run the Benefits app
4. Configuration: `ABC` with `Courtesy Cards`
5. User: `B2345678, Hernandez`

Notice output in the `server` Docker logs:

```console
+ bin/init.sh
+ python setup.py
+ nginx
+ python -m gunicorn -c /home/calitp/run/gunicorn.conf.py eligibility_server.app:app
[2022-09-01 23:56:09 +0000] [11] [INFO] Starting gunicorn 20.1.0
[2022-09-01 23:56:09 +0000] [11] [INFO] Listening at: unix:/home/calitp/run/gunicorn.sock (11)
[2022-09-01 23:56:09 +0000] [11] [INFO] Using worker: sync
[2022-09-01 23:56:09 +0000] [14] [INFO] Booting worker with pid: 14
[2022-09-01 23:56:09 +0000] [15] [INFO] Booting worker with pid: 15
[2022-09-01 23:56:09 +0000] [16] [INFO] Booting worker with pid: 16
[2022-09-01 23:56:09 +0000] [17] [INFO] Booting worker with pid: 17
[2022-09-01 23:56:09 +0000] [18] [INFO] Booting worker with pid: 18
[01/Sep/2022:23:58:27 +0000] "GET /verify HTTP/1.1" 200 1210 "-" "python-requests/2.28.1" "-"
 - - [01/Sep/2022:23:58:27 +0000] "GET /verify HTTP/1.0" 200 1210 "-" "python-requests/2.28.1"
```