### PR TITLE
feat(analytics): return Group ID with Returned Success

### DIFF
--- a/benefits/enrollment/analytics.py
+++ b/benefits/enrollment/analytics.py
@@ -7,10 +7,12 @@ from benefits.core import analytics as core
 class ReturnedEnrollmentEvent(core.Event):
     """Analytics event representing the end of payment processor enrollment request."""
 
-    def __init__(self, request, status, error=None):
+    def __init__(self, request, status, error=None, payment_group=None):
         super().__init__(request, "returned enrollment")
         if str(status).lower() in ("error", "retry", "success"):
             self.update_event_properties(status=status, error=error)
+        if payment_group is not None:
+            self.update_event_properties(payment_group=payment_group)
 
 
 def returned_error(request, error):

--- a/benefits/enrollment/analytics.py
+++ b/benefits/enrollment/analytics.py
@@ -23,6 +23,6 @@ def returned_retry(request):
     core.send_event(ReturnedEnrollmentEvent(request, status="retry"))
 
 
-def returned_success(request):
+def returned_success(request, payment_group):
     """Send the "returned enrollment" analytics event with a success status."""
-    core.send_event(ReturnedEnrollmentEvent(request, status="success"))
+    core.send_event(ReturnedEnrollmentEvent(request, status="success", payment_group=payment_group))

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -62,7 +62,7 @@ def index(request):
 
         response = api.Client(agency).enroll(card_token, eligibility.group_id)
         if response.success:
-            analytics.returned_success(request)
+            analytics.returned_success(request, eligibility.group_id)
             return success(request)
         else:
             analytics.returned_error(request, response.message)

--- a/tests/pytest/enrollment/test_views.py
+++ b/tests/pytest/enrollment/test_views.py
@@ -113,7 +113,12 @@ def test_index_eligible_post_valid_form_failure(mocker, client, card_tokenize_fo
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_session_agency", "mocked_session_verifier", "mocked_session_eligibility")
-def test_index_eligible_post_valid_form_success(mocker, client, card_tokenize_form_data, mocked_analytics_module):
+def test_index_eligible_post_valid_form_success(
+    mocker,
+    client,
+    card_tokenize_form_data,
+    mocked_analytics_module,
+):
     mock_response = mocker.Mock()
     mock_response.success = True
     mocker.patch("benefits.enrollment.views.api.Client.enroll", return_value=mock_response)
@@ -121,10 +126,9 @@ def test_index_eligible_post_valid_form_success(mocker, client, card_tokenize_fo
     path = reverse(ROUTE_INDEX)
     response = client.post(path, card_tokenize_form_data)
 
-    mocked_analytics_module.returned_success.assert_called_once()
+    mocked_analytics_module.returned_success
     assert response.status_code == 200
     assert response.template_name == TEMPLATE_SUCCESS
-    mocked_analytics_module.returned_success.assert_called_once()
 
 
 @pytest.mark.django_db

--- a/tests/pytest/enrollment/test_views.py
+++ b/tests/pytest/enrollment/test_views.py
@@ -126,7 +126,7 @@ def test_index_eligible_post_valid_form_success(
     path = reverse(ROUTE_INDEX)
     response = client.post(path, card_tokenize_form_data)
 
-    mocked_analytics_module.returned_success
+    mocked_analytics_module.returned_success.assert_called_once()
     assert response.status_code == 200
     assert response.template_name == TEMPLATE_SUCCESS
     mocked_analytics_module.returned_success.assert_called_once()

--- a/tests/pytest/enrollment/test_views.py
+++ b/tests/pytest/enrollment/test_views.py
@@ -114,10 +114,7 @@ def test_index_eligible_post_valid_form_failure(mocker, client, card_tokenize_fo
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_session_agency", "mocked_session_verifier", "mocked_session_eligibility")
 def test_index_eligible_post_valid_form_success(
-    mocker,
-    client,
-    card_tokenize_form_data,
-    mocked_analytics_module,
+    mocker, client, card_tokenize_form_data, mocked_analytics_module, model_EligibilityType
 ):
     mock_response = mocker.Mock()
     mock_response.success = True
@@ -126,10 +123,10 @@ def test_index_eligible_post_valid_form_success(
     path = reverse(ROUTE_INDEX)
     response = client.post(path, card_tokenize_form_data)
 
-    mocked_analytics_module.returned_success.assert_called_once()
     assert response.status_code == 200
     assert response.template_name == TEMPLATE_SUCCESS
-    mocked_analytics_module.returned_success.assert_called_once()
+    mocked_analytics_module.returned_success.assert_called_once
+    assert model_EligibilityType.group_id in mocked_analytics_module.returned_success.call_args.args
 
 
 @pytest.mark.django_db

--- a/tests/pytest/enrollment/test_views.py
+++ b/tests/pytest/enrollment/test_views.py
@@ -129,6 +129,7 @@ def test_index_eligible_post_valid_form_success(
     mocked_analytics_module.returned_success
     assert response.status_code == 200
     assert response.template_name == TEMPLATE_SUCCESS
+    mocked_analytics_module.returned_success.assert_called_once()
 
 
 @pytest.mark.django_db

--- a/tests/pytest/enrollment/test_views.py
+++ b/tests/pytest/enrollment/test_views.py
@@ -125,7 +125,7 @@ def test_index_eligible_post_valid_form_success(
 
     assert response.status_code == 200
     assert response.template_name == TEMPLATE_SUCCESS
-    mocked_analytics_module.returned_success.assert_called_once
+    mocked_analytics_module.returned_success.assert_called_once()
     assert model_EligibilityType.group_id in mocked_analytics_module.returned_success.call_args.args
 
 


### PR DESCRIPTION
closes #890 

Passes `eligibility.group_id` as `payment_group` into Amplitude for successful enrollment event