### PR TITLE
Analytics: rename transit agency property

### DIFF
--- a/benefits/core/analytics.py
+++ b/benefits/core/analytics.py
@@ -42,9 +42,9 @@ class Event:
         self.__dict__.update(kwargs)
 
         agency = session.agency(request)
-        name = agency.long_name if agency else None
+        agency_name = agency.long_name if agency else None
 
-        self.update_event_properties(path=request.path, provider_name=name)
+        self.update_event_properties(path=request.path, transit_agency=agency_name)
 
         uagent = request.headers.get("user-agent")
 
@@ -52,7 +52,7 @@ class Event:
         match = Event._domain_re.match(ref) if ref else None
         refdom = match.group(1) if match else None
 
-        self.update_user_properties(referrer=ref, referring_domain=refdom, user_agent=uagent, provider_name=name)
+        self.update_user_properties(referrer=ref, referring_domain=refdom, user_agent=uagent, transit_agency=agency_name)
 
         # event is initialized, consume next counter
         self.event_id = next(Event._counter)


### PR DESCRIPTION
Part of #871, updates the event property in the app code.

Once in QA, we can update the tracking plan in Amplitude.