### PR TITLE
Feat: track verifier in all analytic events

### DIFF
--- a/benefits/core/analytics.py
+++ b/benefits/core/analytics.py
@@ -43,8 +43,10 @@ class Event:
 
         agency = session.agency(request)
         agency_name = agency.long_name if agency else None
+        verifier = session.verifier(request)
+        verifier_name = verifier.name if verifier else None
 
-        self.update_event_properties(path=request.path, transit_agency=agency_name)
+        self.update_event_properties(path=request.path, transit_agency=agency_name, eligibility_verifier=verifier_name)
 
         uagent = request.headers.get("user-agent")
 
@@ -52,7 +54,13 @@ class Event:
         match = Event._domain_re.match(ref) if ref else None
         refdom = match.group(1) if match else None
 
-        self.update_user_properties(referrer=ref, referring_domain=refdom, user_agent=uagent, transit_agency=agency_name)
+        self.update_user_properties(
+            referrer=ref,
+            referring_domain=refdom,
+            user_agent=uagent,
+            transit_agency=agency_name,
+            eligibility_verifier=verifier_name,
+        )
 
         # event is initialized, consume next counter
         self.event_id = next(Event._counter)

--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -222,6 +222,7 @@ def mocked_session_verifier_oauth(mocker, model_EligibilityVerifier_AuthProvider
 @pytest.fixture
 def mocked_session_verifier_auth_required(mocker, model_EligibilityVerifier, mocked_session_verifier):
     mock_verifier = mocker.Mock(spec=model_EligibilityVerifier)
+    mock_verifier.name = model_EligibilityVerifier.name
     mock_verifier.is_auth_required = True
     mocked_session_verifier.return_value = mock_verifier
     return mocked_session_verifier


### PR DESCRIPTION
Closes #875

I noticed that `transit_agency` is also being sent as a user property, so I did the same with `eligibility_verifier`.