### PR TITLE
Devcontainer: debug in non-debug mode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,18 @@
       "env": {
         "DJANGO_DEBUG": "true"
       }
+    },
+    {
+      "name": "Django: Benefits Client, Debug=False",
+      "type": "python",
+      "request": "launch",
+      "program": "${workspaceFolder}/manage.py",
+      "args": ["runserver", "--insecure", "0.0.0.0:8000"],
+      "django": true,
+      "env": {
+        "DJANGO_DEBUG": "false",
+        "DJANGO_STATICFILES_STORAGE": "django.contrib.staticfiles.storage.StaticFilesStorage"
+      }
     }
   ]
 }

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -218,7 +218,10 @@ USE_TZ = True
 
 STATIC_URL = "/static/"
 STATICFILES_DIRS = [os.path.join(BASE_DIR, "benefits", "static")]
-STATICFILES_STORAGE = "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
+# use Manifest Static Files Storage by default
+STATICFILES_STORAGE = os.environ.get(
+    "DJANGO_STATICFILES_STORAGE", "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
+)
 STATIC_ROOT = os.path.join(BASE_DIR, "static")
 
 # Logging configuration


### PR DESCRIPTION
Yes, really!

This PR adds a new VS Code *Run and Debug* configuration that:

* Launches the app with `DJANGO_DEBUG=False`
* Supports hitting breakpoints in the code

This is accomplished with a small override on the static files setting, which is only used for this debug config.

Useful for seeing and debugging error pages etc. more like how users see them.