### PR TITLE
Refactor: error page layout and wording

### DIFF
--- a/benefits/core/viewmodels.py
+++ b/benefits/core/viewmodels.py
@@ -168,6 +168,7 @@ class ErrorPage(Page):
             content_title=kwargs.get("content_title", _("core.pages.error.title")),
             paragraphs=kwargs.get("paragraphs", [_("core.pages.server_error.content_title")]),
             button=kwargs.get("button"),
+            noimage=True,
         )
 
     @staticmethod

--- a/benefits/core/viewmodels.py
+++ b/benefits/core/viewmodels.py
@@ -172,13 +172,23 @@ class ErrorPage(Page):
         )
 
     @staticmethod
-    def error(
+    def user_error(
+        title=_("core.pages.user_error.title"),
+        content_title=_("core.pages.user_error.content_title"),
+        paragraphs=[_("core.pages.user_error.p[0]")],
+        **kwargs,
+    ):
+        """Create a new core.viewmodels.ErrorPage instance with defaults for a user error."""
+        return ErrorPage(title=title, content_title=content_title, paragraphs=paragraphs, **kwargs)
+
+    @staticmethod
+    def server_error(
         title=_("core.pages.server_error.title"),
         content_title=_("core.pages.server_error.title"),
         paragraphs=[_("core.pages.server_error.p[0]"), _("core.pages.server_error.p[1]")],
         **kwargs,
     ):
-        """Create a new core.viewmodels.ErrorPage instance with defaults for a generic error."""
+        """Create a new core.viewmodels.ErrorPage instance with defaults for a generic server error."""
         return ErrorPage(title=title, content_title=content_title, paragraphs=paragraphs, **kwargs)
 
     @staticmethod

--- a/benefits/core/views.py
+++ b/benefits/core/views.py
@@ -107,7 +107,7 @@ def bad_request(request, exception, template_name="400.html"):
         session.update(request, origin=reverse(ROUTE_INDEX))
 
     home = viewmodels.Button.home(request)
-    page = viewmodels.ErrorPage.error(button=home)
+    page = viewmodels.ErrorPage.server_error(button=home)
     t = loader.get_template(template_name)
 
     return HttpResponseBadRequest(t.render(page.context_dict()))
@@ -154,7 +154,7 @@ def server_error(request, template_name="500.html"):
         session.update(request, origin=reverse(ROUTE_INDEX))
 
     home = viewmodels.Button.home(request)
-    page = viewmodels.ErrorPage.error(button=home)
+    page = viewmodels.ErrorPage.server_error(button=home)
     t = loader.get_template(template_name)
 
     return HttpResponseServerError(t.render(page.context_dict()))

--- a/benefits/core/views.py
+++ b/benefits/core/views.py
@@ -139,7 +139,8 @@ def page_not_found(request, exception, template_name="404.html"):
         session.update(request, origin=reverse(ROUTE_INDEX))
 
     home = viewmodels.Button.home(request)
-    page = viewmodels.ErrorPage.not_found(button=home, path=request.path)
+    # show a more user-friendly message instead of not_found
+    page = viewmodels.ErrorPage.user_error(button=home, path=request.path)
     t = loader.get_template(template_name)
 
     return HttpResponseNotFound(t.render(page.context_dict()))

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -453,7 +453,7 @@ msgstr "You may have reached this page on accident."
 #: benefits/core/viewmodels.py:178
 msgid "core.pages.user_error.p[0]"
 msgstr ""
-"To get started with Cal-ITP Benefits please click the button below and you "
+"To get started with Cal-ITP Benefits please click the button below, and you "
 "will be directed to the beginning of the enrollment process. "
 
 #: benefits/core/viewmodels.py:186 benefits/core/viewmodels.py:187

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -6,159 +6,159 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2022-08-04 01:13+0000\n"
+"POT-Creation-Date: 2022-09-20 19:06+0000\n"
 "Language: English\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: benefits/core/migrations/0002_sample_data.py:82
+#: benefits/core/migrations/0002_sample_data.py:86
 msgid "eligibility.buttons.signin"
 msgstr "Get started with"
 
-#: benefits/core/migrations/0002_sample_data.py:83
+#: benefits/core/migrations/0002_sample_data.py:87
 msgid "eligibility.buttons.signout"
 msgstr "Sign out of Login.gov"
 
-#: benefits/core/migrations/0002_sample_data.py:104
+#: benefits/core/migrations/0002_sample_data.py:108
 msgid "eligibility.pages.index.dmv.label"
 msgstr "Senior Discount Program"
 
-#: benefits/core/migrations/0002_sample_data.py:106
+#: benefits/core/migrations/0002_sample_data.py:110
 msgid "eligibility.pages.start.dmv.content_title"
 msgstr "You will need a few items to connect your discount:"
 
-#: benefits/core/migrations/0002_sample_data.py:107
+#: benefits/core/migrations/0002_sample_data.py:111
 msgid "eligibility.pages.start.dmv.items[0].title"
 msgstr "Provide your California ID number"
 
-#: benefits/core/migrations/0002_sample_data.py:108
+#: benefits/core/migrations/0002_sample_data.py:112
 msgid "eligibility.pages.start.dmv.items[0].text"
 msgstr "You will need to verify your age with a driver’s license or ID card."
 
-#: benefits/core/migrations/0002_sample_data.py:109
+#: benefits/core/migrations/0002_sample_data.py:113
 msgid "eligibility.pages.start.dmv.p[0]"
 msgstr ""
 "This program is currently open to those who are 65 or older. Not over 65? "
 "Get in touch with your transit provider to learn about other available "
 "discount programs."
 
-#: benefits/core/migrations/0002_sample_data.py:110
+#: benefits/core/migrations/0002_sample_data.py:114
 msgid "eligibility.pages.confirm.dmv.title"
 msgstr "Confirm Eligibility"
 
-#: benefits/core/migrations/0002_sample_data.py:111
+#: benefits/core/migrations/0002_sample_data.py:115
 msgid "eligibility.pages.confirm.dmv.content_title"
 msgstr "Let’s see if we can confirm your age with the DMV."
 
-#: benefits/core/migrations/0002_sample_data.py:112
+#: benefits/core/migrations/0002_sample_data.py:116
 msgid "eligibility.pages.confirm.dmv.p[0]"
 msgstr ""
 "Please enter your license/ID number and last name below. If you’re 65 or "
 "older, we can confirm that you are eligible for a senior discount when you "
 "ride transit. We do not save the information you enter here."
 
-#: benefits/core/migrations/0002_sample_data.py:113
+#: benefits/core/migrations/0002_sample_data.py:117
 msgid "eligibility.forms.confirm.dmv.fields.sub"
 msgstr "CA driver’s license or ID number"
 
-#: benefits/core/migrations/0002_sample_data.py:116
+#: benefits/core/migrations/0002_sample_data.py:120
 msgid "eligibility.forms.confirm.dmv.fields.name"
 msgstr "Last name (as it appears on ID)"
 
-#: benefits/core/migrations/0002_sample_data.py:119
+#: benefits/core/migrations/0002_sample_data.py:123
 msgid "eligibility.pages.unverified.dmv.title"
 msgstr "Eligibility Error"
 
-#: benefits/core/migrations/0002_sample_data.py:120
+#: benefits/core/migrations/0002_sample_data.py:124
 msgid "eligibility.pages.unverified.dmv.content_title"
 msgstr "Your eligibility could not be verified."
 
-#: benefits/core/migrations/0002_sample_data.py:121
+#: benefits/core/migrations/0002_sample_data.py:125
 msgid "eligibility.pages.unverified.dmv.p[0]"
 msgstr ""
 "You may still be eligible for a discount, but we can’t verify your age with "
 "the DMV."
 
-#: benefits/core/migrations/0002_sample_data.py:135
+#: benefits/core/migrations/0002_sample_data.py:139
 msgid "eligibility.pages.index.mst.label"
 msgstr "MST Courtesy Cardholder"
 
-#: benefits/core/migrations/0002_sample_data.py:136
+#: benefits/core/migrations/0002_sample_data.py:140
 msgid "eligibility.pages.index.mst.description"
 msgstr "(includes MST RIDES Paratransit Eligibility cardholders)"
 
-#: benefits/core/migrations/0002_sample_data.py:137
+#: benefits/core/migrations/0002_sample_data.py:141
 msgid "eligibility.pages.start.mst.content_title"
 msgstr ""
 "You’ll need to do two things to link your transit discount to your bank card."
 
-#: benefits/core/migrations/0002_sample_data.py:138
+#: benefits/core/migrations/0002_sample_data.py:142
 msgid "eligibility.pages.start.mst.items[0].title"
 msgstr "Your MST Courtesy Card"
 
-#: benefits/core/migrations/0002_sample_data.py:139
+#: benefits/core/migrations/0002_sample_data.py:143
 msgid "eligibility.pages.start.mst.items[0].text"
 msgstr "An active card that has not expired"
 
-#: benefits/core/migrations/0002_sample_data.py:140
+#: benefits/core/migrations/0002_sample_data.py:144
 msgid "eligibility.pages.start.mst.p[0]"
 msgstr ""
 "This program is currently open to all MST Courtesy Cardholders. Not a "
 "Courtesy Cardholder? Get in touch with your transit provider to learn about "
 "other available discount programs at"
 
-#: benefits/core/migrations/0002_sample_data.py:141
+#: benefits/core/migrations/0002_sample_data.py:145
 msgid "eligibility.pages.confirm.mst.title"
 msgstr "Confirm your Courtesy Card"
 
-#: benefits/core/migrations/0002_sample_data.py:142
+#: benefits/core/migrations/0002_sample_data.py:146
 msgid "eligibility.pages.confirm.mst.content_title"
 msgstr "Let’s see if we can find you in our system"
 
-#: benefits/core/migrations/0002_sample_data.py:143
+#: benefits/core/migrations/0002_sample_data.py:147
 msgid "eligibility.pages.confirm.mst.p[0]"
 msgstr ""
 "Please input your Courtesy Card number and last name below. If you’re a "
 "current MST Courtesy Cardholder, we can confirm that you are eligible for a "
 "discount. We do not save your information."
 
-#: benefits/core/migrations/0002_sample_data.py:144
+#: benefits/core/migrations/0002_sample_data.py:148
 msgid "eligibility.forms.confirm.mst.fields.sub"
 msgstr "MST Courtesy Card number"
 
-#: benefits/core/migrations/0002_sample_data.py:147
+#: benefits/core/migrations/0002_sample_data.py:151
 msgid "eligibility.forms.confirm.mst.fields.name"
 msgstr "Last name (as it appears on Courtesy Card)"
 
-#: benefits/core/migrations/0002_sample_data.py:150
+#: benefits/core/migrations/0002_sample_data.py:154
 msgid "eligibility.pages.unverified.mst.title"
 msgstr "Courtesy Card not located"
 
-#: benefits/core/migrations/0002_sample_data.py:151
+#: benefits/core/migrations/0002_sample_data.py:155
 msgid "eligibility.pages.unverified.mst.content_title"
 msgstr "We couldn’t locate you in our system"
 
-#: benefits/core/migrations/0002_sample_data.py:152
+#: benefits/core/migrations/0002_sample_data.py:156
 msgid "eligibility.pages.unverified.mst.p[0]"
 msgstr ""
 "That’s okay! You may still be eligible for our program. Please reach out to "
 "Monterey-Salinas Transit for assistance."
 
-#: benefits/core/migrations/0002_sample_data.py:159
+#: benefits/core/migrations/0002_sample_data.py:163
 msgid "eligibility.pages.index.oauth.label"
 msgstr "Senior Discount Program"
 
-#: benefits/core/migrations/0002_sample_data.py:161
+#: benefits/core/migrations/0002_sample_data.py:165
 msgid "eligibility.pages.start.oauth.content_title"
 msgstr "You will need a few items to connect your discount:"
 
-#: benefits/core/migrations/0002_sample_data.py:162
+#: benefits/core/migrations/0002_sample_data.py:166
 msgid "eligibility.pages.start.oauth.items[0].title"
 msgstr "A Login.gov account with identity verification"
 
-#: benefits/core/migrations/0002_sample_data.py:163
+#: benefits/core/migrations/0002_sample_data.py:167
 msgid "eligibility.pages.start.oauth.items[0].text"
 msgstr ""
 "Login.gov is a safe way to sign in to government services. Benefits uses "
@@ -166,19 +166,19 @@ msgstr ""
 "will be able to create one. You will also need to verify your identity, "
 "which will require these items:"
 
-#: benefits/core/migrations/0002_sample_data.py:164
+#: benefits/core/migrations/0002_sample_data.py:168
 msgid "eligibility.pages.start.oauth.p[0]"
 msgstr ""
 
-#: benefits/core/migrations/0002_sample_data.py:165
+#: benefits/core/migrations/0002_sample_data.py:169
 msgid "eligibility.pages.unverified.oauth.title"
 msgstr "Eligibility Error"
 
-#: benefits/core/migrations/0002_sample_data.py:166
+#: benefits/core/migrations/0002_sample_data.py:170
 msgid "eligibility.pages.unverified.oauth.content_title"
 msgstr "Your eligibility could not be verified."
 
-#: benefits/core/migrations/0002_sample_data.py:167
+#: benefits/core/migrations/0002_sample_data.py:171
 msgid "eligibility.pages.unverified.oauth.p[0]"
 msgstr ""
 "That’s okay! You may still be eligible for our program. Please reach out to "
@@ -227,8 +227,8 @@ msgctxt "image alt text"
 msgid "core.logos.large"
 msgstr "California Integrated Travel Project: Benefits logo (large)"
 
-#: benefits/core/templates/core/base.html:70 benefits/core/views.py:86
-#: benefits/core/views.py:87
+#: benefits/core/templates/core/base.html:70 benefits/core/views.py:92
+#: benefits/core/views.py:93
 msgid "core.buttons.help"
 msgstr "Help"
 
@@ -442,33 +442,47 @@ msgstr "Bus icon with flat tire"
 msgid "core.pages.server_error.content_title"
 msgstr "Sorry! Service for this site is down."
 
-#: benefits/core/viewmodels.py:175 benefits/core/viewmodels.py:176
+#: benefits/core/viewmodels.py:176
+msgid "core.pages.user_error.title"
+msgstr "Invalid state"
+
+#: benefits/core/viewmodels.py:177
+msgid "core.pages.user_error.content_title"
+msgstr "You may have reached this page on accident."
+
+#: benefits/core/viewmodels.py:178
+msgid "core.pages.user_error.p[0]"
+msgstr ""
+"To get started with Cal-ITP Benefits please click the button below and you "
+"will be directed to the beginning of the enrollment process. "
+
+#: benefits/core/viewmodels.py:186 benefits/core/viewmodels.py:187
 msgid "core.pages.server_error.title"
 msgstr "Service is down"
 
-#: benefits/core/viewmodels.py:177
+#: benefits/core/viewmodels.py:188
 msgid "core.pages.server_error.p[0]"
 msgstr "We should be back in operation soon."
 
-#: benefits/core/viewmodels.py:177
+#: benefits/core/viewmodels.py:188
 msgid "core.pages.server_error.p[1]"
 msgstr "Please refresh the page in a few minutes."
 
-#: benefits/core/viewmodels.py:185
+#: benefits/core/viewmodels.py:196
 msgid "core.pages.not_found.title"
 msgstr "Page not found"
 
-#: benefits/core/viewmodels.py:186
+#: benefits/core/viewmodels.py:197
 msgid "core.pages.not_found.content_title"
 msgstr "Sorry! We can’t find that page."
 
-#: benefits/core/viewmodels.py:187
+#: benefits/core/viewmodels.py:198
 msgid "core.pages.not_found.p[0]"
 msgstr ""
 "The page you are looking for might be somewhere else or may not exist "
 "anymore."
 
-#: benefits/core/viewmodels.py:210
+#: benefits/core/viewmodels.py:221
 msgid "core.buttons.wait"
 msgstr "Please wait..."
 
@@ -504,7 +518,7 @@ msgstr ""
 "Cal-ITP Benefits makes it easy to use your public transit discount every "
 "time you ride."
 
-#: benefits/core/views.py:83
+#: benefits/core/views.py:89
 msgid "core.buttons.back"
 msgstr "Go back"
 
@@ -534,6 +548,7 @@ msgstr ""
 "Connect your bank card to your public transit discount with Cal-ITP Benefits."
 
 #: benefits/eligibility/templates/eligibility/start.html:12
+#, python-format
 msgid "eligibility.pages.start.p[0]%(info_link)s"
 msgstr ""
 "You can tap your credit or debit card when you board, and your discount will "
@@ -555,7 +570,7 @@ msgstr "Select a discount option"
 msgid "eligibility.pages.index.content_title"
 msgstr "Select the discount option that best applies to you:"
 
-#: benefits/eligibility/views.py:80 benefits/enrollment/views.py:78
+#: benefits/eligibility/views.py:80 benefits/enrollment/views.py:80
 msgctxt "image alt text"
 msgid "core.icons.idcardcheck"
 msgstr "Identification card icon with checkmark"
@@ -576,7 +591,7 @@ msgstr "Your Social Security number"
 msgid "eligibility.pages.start.oauth.required_items[2]"
 msgstr "A phone number with a phone plan associated with your name"
 
-#: benefits/eligibility/views.py:108 benefits/enrollment/views.py:145
+#: benefits/eligibility/views.py:108 benefits/enrollment/views.py:150
 msgctxt "image alt text"
 msgid "core.icons.bankcardcheck"
 msgstr "Bank card icon with contactless symbol and checkmark"
@@ -598,7 +613,7 @@ msgstr "Don’t have a bank card or unsure if your card is contactless?"
 msgid "eligibility.pages.start.title"
 msgstr "Get Started"
 
-#: benefits/eligibility/views.py:234
+#: benefits/eligibility/views.py:236
 msgctxt "image alt text"
 msgid "core.icons.idcardquestion"
 msgstr "Identification card icon with question mark"
@@ -629,62 +644,62 @@ msgstr "If you are on a public or shared computer, please sign out of your"
 msgid "enrollment.pages.success.p4"
 msgstr "account."
 
-#: benefits/enrollment/views.py:76
+#: benefits/enrollment/views.py:78
 msgid "enrollment.pages.index.title"
 msgstr "Connect Card"
 
-#: benefits/enrollment/views.py:77
+#: benefits/enrollment/views.py:79
 msgid "enrollment.pages.index.content_title"
 msgstr "Let’s link your card to your discount."
 
-#: benefits/enrollment/views.py:79
+#: benefits/enrollment/views.py:81
 msgid "enrollment.pages.index.p[0]"
 msgstr ""
 "Now that you are logged in we can link your transit discount to your card "
 "through our payment partner, Littlepay."
 
-#: benefits/enrollment/views.py:79
+#: benefits/enrollment/views.py:81
 msgid "enrollment.pages.index.p[1]"
 msgstr ""
 "We don’t store your information, and you won’t be charged. When you use this "
 "card to pay for transit, you will always receive your discount."
 
-#: benefits/enrollment/views.py:79
+#: benefits/enrollment/views.py:81
 msgid "enrollment.pages.index.p[2]"
 msgstr ""
 "Please use a bank-issued contactless Visa or Mastercard credit or debit card."
 
-#: benefits/enrollment/views.py:84
+#: benefits/enrollment/views.py:86
 msgid "enrollment.buttons.payment_partner"
 msgstr "Connect Your Card"
 
-#: benefits/enrollment/views.py:124 benefits/enrollment/views.py:126
+#: benefits/enrollment/views.py:127 benefits/enrollment/views.py:129
 msgid "enrollment.pages.retry.title"
 msgstr "We couldn’t connect your bank card"
 
-#: benefits/enrollment/views.py:125
+#: benefits/enrollment/views.py:128
 msgctxt "image alt text"
 msgid "core.icons.bankcardquestion"
 msgstr "Bank card icon with contactless symbol and question mark"
 
-#: benefits/enrollment/views.py:127
+#: benefits/enrollment/views.py:130
 msgid "enrollment.pages.retry.p[0]"
 msgstr ""
 "You can try again or reach out to your transit provider for assistance."
 
-#: benefits/enrollment/views.py:130
+#: benefits/enrollment/views.py:133
 msgid "core.buttons.retry"
 msgstr "Try again"
 
-#: benefits/enrollment/views.py:148
+#: benefits/enrollment/views.py:153
 msgid "enrollment.pages.success.title"
 msgstr "Success"
 
-#: benefits/enrollment/views.py:149
+#: benefits/enrollment/views.py:154
 msgid "enrollment.pages.success.content_title"
 msgstr "Success! Your discount is now linked to your bank card."
 
-#: benefits/enrollment/views.py:159
+#: benefits/enrollment/views.py:164
 msgid "enrollment.pages.success.logout.title"
 msgstr ""
 "You have been successfully logged out. Thank you for using Cal-ITP Benefits!"

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -464,7 +464,7 @@ msgstr "TODO: You may have reached this page on accident."
 #: benefits/core/viewmodels.py:178
 msgid "core.pages.user_error.p[0]"
 msgstr ""
-"TODO: To get started with Cal-ITP Benefits please click the button below and "
+"TODO: To get started with Cal-ITP Benefits please click the button below, and "
 "you will be directed to the beginning of the enrollment process. "
 
 #: benefits/core/viewmodels.py:186 benefits/core/viewmodels.py:187

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -6,40 +6,40 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2022-08-04 01:13+0000\n"
+"POT-Creation-Date: 2022-09-20 19:06+0000\n"
 "Language: Español\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: benefits/core/migrations/0002_sample_data.py:82
+#: benefits/core/migrations/0002_sample_data.py:86
 msgid "eligibility.buttons.signin"
 msgstr "Comencemos con"
 
-#: benefits/core/migrations/0002_sample_data.py:83
+#: benefits/core/migrations/0002_sample_data.py:87
 msgid "eligibility.buttons.signout"
 msgstr "Cierre sesión de Login.gov"
 
-#: benefits/core/migrations/0002_sample_data.py:104
+#: benefits/core/migrations/0002_sample_data.py:108
 msgid "eligibility.pages.index.dmv.label"
 msgstr "TODO: Senior Discount Program"
 
-#: benefits/core/migrations/0002_sample_data.py:106
+#: benefits/core/migrations/0002_sample_data.py:110
 msgid "eligibility.pages.start.dmv.content_title"
 msgstr "Necesitará algunos artículos para conectar su descuento:"
 
-#: benefits/core/migrations/0002_sample_data.py:107
+#: benefits/core/migrations/0002_sample_data.py:111
 msgid "eligibility.pages.start.dmv.items[0].title"
 msgstr "Proporcione su número de identificación de California"
 
-#: benefits/core/migrations/0002_sample_data.py:108
+#: benefits/core/migrations/0002_sample_data.py:112
 msgid "eligibility.pages.start.dmv.items[0].text"
 msgstr ""
 "Deberá verificar su edad con una licencia de conducir o tarjeta de "
 "identificación."
 
-#: benefits/core/migrations/0002_sample_data.py:109
+#: benefits/core/migrations/0002_sample_data.py:113
 msgid "eligibility.pages.start.dmv.p[0]"
 msgstr ""
 "Este programa actualmente está disponible para personas de 65 años o más. "
@@ -47,15 +47,15 @@ msgstr ""
 "transporte público para obtener información sobre los programas de descuento "
 "disponibles."
 
-#: benefits/core/migrations/0002_sample_data.py:110
+#: benefits/core/migrations/0002_sample_data.py:114
 msgid "eligibility.pages.confirm.dmv.title"
 msgstr "Confirmar la elegibilidad"
 
-#: benefits/core/migrations/0002_sample_data.py:111
+#: benefits/core/migrations/0002_sample_data.py:115
 msgid "eligibility.pages.confirm.dmv.content_title"
 msgstr "Veamos si podemos confirmar su edad con el DMV."
 
-#: benefits/core/migrations/0002_sample_data.py:112
+#: benefits/core/migrations/0002_sample_data.py:116
 msgid "eligibility.pages.confirm.dmv.p[0]"
 msgstr ""
 "Por favor, ingrese su número de licencia/identificación y su apellido abajo. "
@@ -63,49 +63,49 @@ msgstr ""
 "para personas mayores cuando viaja en transporte público. No guardamos la "
 "información que ingresa aquí."
 
-#: benefits/core/migrations/0002_sample_data.py:113
+#: benefits/core/migrations/0002_sample_data.py:117
 msgid "eligibility.forms.confirm.dmv.fields.sub"
 msgstr "Licencia de conducir de California o número de identificación"
 
-#: benefits/core/migrations/0002_sample_data.py:116
+#: benefits/core/migrations/0002_sample_data.py:120
 msgid "eligibility.forms.confirm.dmv.fields.name"
 msgstr "Apellido (tal como aparece en la identificación)"
 
-#: benefits/core/migrations/0002_sample_data.py:119
+#: benefits/core/migrations/0002_sample_data.py:123
 msgid "eligibility.pages.unverified.dmv.title"
 msgstr "Error de elegibilidad"
 
-#: benefits/core/migrations/0002_sample_data.py:120
+#: benefits/core/migrations/0002_sample_data.py:124
 msgid "eligibility.pages.unverified.dmv.content_title"
 msgstr "No se pudo verificar su elegibilidad."
 
-#: benefits/core/migrations/0002_sample_data.py:121
+#: benefits/core/migrations/0002_sample_data.py:125
 msgid "eligibility.pages.unverified.dmv.p[0]"
 msgstr ""
 "Usted todavía puede ser elegible para un descuento, pero no podemos "
 "verificar su edad con el DMV."
 
-#: benefits/core/migrations/0002_sample_data.py:135
+#: benefits/core/migrations/0002_sample_data.py:139
 msgid "eligibility.pages.index.mst.label"
 msgstr "TODO: MST Courtesy Cardholder"
 
-#: benefits/core/migrations/0002_sample_data.py:136
+#: benefits/core/migrations/0002_sample_data.py:140
 msgid "eligibility.pages.index.mst.description"
 msgstr "TODO: (includes MST RIDES Paratransit Eligibility cardholders)"
 
-#: benefits/core/migrations/0002_sample_data.py:137
+#: benefits/core/migrations/0002_sample_data.py:141
 msgid "eligibility.pages.start.mst.content_title"
 msgstr "TODO: Genial, necesitarás dos cosas antes de empeza"
 
-#: benefits/core/migrations/0002_sample_data.py:138
+#: benefits/core/migrations/0002_sample_data.py:142
 msgid "eligibility.pages.start.mst.items[0].title"
 msgstr "Tu tarjeta de cortesía MST"
 
-#: benefits/core/migrations/0002_sample_data.py:139
+#: benefits/core/migrations/0002_sample_data.py:143
 msgid "eligibility.pages.start.mst.items[0].text"
 msgstr "Una tarjeta activa que no ha caducado"
 
-#: benefits/core/migrations/0002_sample_data.py:140
+#: benefits/core/migrations/0002_sample_data.py:144
 msgid "eligibility.pages.start.mst.p[0]"
 msgstr ""
 "Este programa está actualmente abierto a todas los titulares de tarjetas de "
@@ -113,56 +113,56 @@ msgstr ""
 "con su proveedor de transporte público para obtener información sobre los "
 "programas de descuento disponibles"
 
-#: benefits/core/migrations/0002_sample_data.py:141
+#: benefits/core/migrations/0002_sample_data.py:145
 msgid "eligibility.pages.confirm.mst.title"
 msgstr "Verificar su tarjeta de cortesía MST"
 
-#: benefits/core/migrations/0002_sample_data.py:142
+#: benefits/core/migrations/0002_sample_data.py:146
 msgid "eligibility.pages.confirm.mst.content_title"
 msgstr "Veamos si podemos encontrarle en nuestra sistema"
 
-#: benefits/core/migrations/0002_sample_data.py:143
+#: benefits/core/migrations/0002_sample_data.py:147
 msgid "eligibility.pages.confirm.mst.p[0]"
 msgstr ""
 "Por favor ingrese su número de tarjeta cortesía y apellido a continuación. "
 "Si eres titular de una tarjeta de cortesía MST, podemos confirmar que ere "
 "elegible para un descuento. Nosotros no guardamos su información."
 
-#: benefits/core/migrations/0002_sample_data.py:144
+#: benefits/core/migrations/0002_sample_data.py:148
 msgid "eligibility.forms.confirm.mst.fields.sub"
 msgstr "Número de tarjeta cortesía MST"
 
-#: benefits/core/migrations/0002_sample_data.py:147
+#: benefits/core/migrations/0002_sample_data.py:151
 msgid "eligibility.forms.confirm.mst.fields.name"
 msgstr "Apellido (como aparece en la identificación)"
 
-#: benefits/core/migrations/0002_sample_data.py:150
+#: benefits/core/migrations/0002_sample_data.py:154
 msgid "eligibility.pages.unverified.mst.title"
 msgstr "Tarjeta de cortesía MST no confirmada"
 
-#: benefits/core/migrations/0002_sample_data.py:151
+#: benefits/core/migrations/0002_sample_data.py:155
 msgid "eligibility.pages.unverified.mst.content_title"
 msgstr "No podemos confirmar su tarjeta de cortesía MST"
 
-#: benefits/core/migrations/0002_sample_data.py:152
+#: benefits/core/migrations/0002_sample_data.py:156
 msgid "eligibility.pages.unverified.mst.p[0]"
 msgstr ""
 "TODO: That’s okay! You may still be eligible for our program. Please reach "
 "out to Monterey-Salinas Transit for assistance."
 
-#: benefits/core/migrations/0002_sample_data.py:159
+#: benefits/core/migrations/0002_sample_data.py:163
 msgid "eligibility.pages.index.oauth.label"
 msgstr "TODO: Senior Discount Program"
 
-#: benefits/core/migrations/0002_sample_data.py:161
+#: benefits/core/migrations/0002_sample_data.py:165
 msgid "eligibility.pages.start.oauth.content_title"
 msgstr "Necesitará algunos artículos para conectar su descuento:"
 
-#: benefits/core/migrations/0002_sample_data.py:162
+#: benefits/core/migrations/0002_sample_data.py:166
 msgid "eligibility.pages.start.oauth.items[0].title"
 msgstr "Una cuenta de Login.gov con verificación de identidad"
 
-#: benefits/core/migrations/0002_sample_data.py:163
+#: benefits/core/migrations/0002_sample_data.py:167
 msgid "eligibility.pages.start.oauth.items[0].text"
 msgstr ""
 "Login.gov es una forma segura de iniciar sesión en servicios "
@@ -170,19 +170,19 @@ msgstr ""
 "no tiene una cuenta, podrá crear una. También deberá verificar su identidad, "
 "lo que requerirá estos artículos:"
 
-#: benefits/core/migrations/0002_sample_data.py:164
+#: benefits/core/migrations/0002_sample_data.py:168
 msgid "eligibility.pages.start.oauth.p[0]"
 msgstr ""
 
-#: benefits/core/migrations/0002_sample_data.py:165
+#: benefits/core/migrations/0002_sample_data.py:169
 msgid "eligibility.pages.unverified.oauth.title"
 msgstr "Error de elegibilidad"
 
-#: benefits/core/migrations/0002_sample_data.py:166
+#: benefits/core/migrations/0002_sample_data.py:170
 msgid "eligibility.pages.unverified.oauth.content_title"
 msgstr "No se pudo verificar su elegibilidad."
 
-#: benefits/core/migrations/0002_sample_data.py:167
+#: benefits/core/migrations/0002_sample_data.py:171
 msgid "eligibility.pages.unverified.oauth.p[0]"
 msgstr ""
 "¡Esta bien! Aún puede ser elegible para nuestro programa. Comuníquese con su "
@@ -234,8 +234,8 @@ msgid "core.logos.large"
 msgstr ""
 "Proyecto de viaje integrado de California: logotipo de beneficios (grande)"
 
-#: benefits/core/templates/core/base.html:70 benefits/core/views.py:86
-#: benefits/core/views.py:87
+#: benefits/core/templates/core/base.html:70 benefits/core/views.py:92
+#: benefits/core/views.py:93
 msgid "core.buttons.help"
 msgstr "Ayuda"
 
@@ -453,33 +453,47 @@ msgstr "Icono de autobus con llanta ponchada"
 msgid "core.pages.server_error.content_title"
 msgstr "¡Lo sentimos! El servicio para este sitio está caído."
 
-#: benefits/core/viewmodels.py:175 benefits/core/viewmodels.py:176
+#: benefits/core/viewmodels.py:176
+msgid "core.pages.user_error.title"
+msgstr "TODO: Invalid state"
+
+#: benefits/core/viewmodels.py:177
+msgid "core.pages.user_error.content_title"
+msgstr "TODO: You may have reached this page on accident."
+
+#: benefits/core/viewmodels.py:178
+msgid "core.pages.user_error.p[0]"
+msgstr ""
+"TODO: To get started with Cal-ITP Benefits please click the button below and "
+"you will be directed to the beginning of the enrollment process. "
+
+#: benefits/core/viewmodels.py:186 benefits/core/viewmodels.py:187
 msgid "core.pages.server_error.title"
 msgstr "El servicio no está funcionando"
 
-#: benefits/core/viewmodels.py:177
+#: benefits/core/viewmodels.py:188
 msgid "core.pages.server_error.p[0]"
 msgstr "Deberíamos volver a funcionar pronto."
 
-#: benefits/core/viewmodels.py:177
+#: benefits/core/viewmodels.py:188
 msgid "core.pages.server_error.p[1]"
 msgstr "Por favor, actualice la página en unos minutos."
 
-#: benefits/core/viewmodels.py:185
+#: benefits/core/viewmodels.py:196
 msgid "core.pages.not_found.title"
 msgstr "No podemos encontrar esa página"
 
-#: benefits/core/viewmodels.py:186
+#: benefits/core/viewmodels.py:197
 msgid "core.pages.not_found.content_title"
 msgstr "¡Lo sentimos! No podemos encontrar esa página."
 
-#: benefits/core/viewmodels.py:187
+#: benefits/core/viewmodels.py:198
 msgid "core.pages.not_found.p[0]"
 msgstr ""
 "La página que estás buscando puede estar en otro lugar o puede que ya no "
 "exista."
 
-#: benefits/core/viewmodels.py:210
+#: benefits/core/viewmodels.py:221
 msgid "core.buttons.wait"
 msgstr "Espere por favor..."
 
@@ -515,7 +529,7 @@ msgstr ""
 "Los beneficios de Cal-ITP facilita el uso de su descuento de transporte "
 "público cada vez que viaja"
 
-#: benefits/core/views.py:83
+#: benefits/core/views.py:89
 msgid "core.buttons.back"
 msgstr "Regresar a la página principal"
 
@@ -546,6 +560,7 @@ msgstr ""
 "Cal-ITP Benefits."
 
 #: benefits/eligibility/templates/eligibility/start.html:12
+#, python-format
 msgid "eligibility.pages.start.p[0]%(info_link)s"
 msgstr ""
 "Puede acercar su tarjeta de crédito o débito cuando aborde, y su descuento "
@@ -567,7 +582,7 @@ msgstr "TODO"
 msgid "eligibility.pages.index.content_title"
 msgstr "TODO"
 
-#: benefits/eligibility/views.py:80 benefits/enrollment/views.py:78
+#: benefits/eligibility/views.py:80 benefits/enrollment/views.py:80
 msgctxt "image alt text"
 msgid "core.icons.idcardcheck"
 msgstr "Icono de tarjeta de identificación con marca de verificación"
@@ -589,7 +604,7 @@ msgstr "Su número de Seguro Social"
 msgid "eligibility.pages.start.oauth.required_items[2]"
 msgstr "Un número de teléfono con un plan de teléfono asociado con su nombre"
 
-#: benefits/eligibility/views.py:108 benefits/enrollment/views.py:145
+#: benefits/eligibility/views.py:108 benefits/enrollment/views.py:150
 msgctxt "image alt text"
 msgid "core.icons.bankcardcheck"
 msgstr ""
@@ -615,7 +630,7 @@ msgstr ""
 msgid "eligibility.pages.start.title"
 msgstr "Comencemos"
 
-#: benefits/eligibility/views.py:234
+#: benefits/eligibility/views.py:236
 msgctxt "image alt text"
 msgid "core.icons.idcardquestion"
 msgstr "Icono de tarjeta de identificación con signo de interrogación"
@@ -647,65 +662,65 @@ msgstr ""
 msgid "enrollment.pages.success.p4"
 msgstr "."
 
-#: benefits/enrollment/views.py:76
+#: benefits/enrollment/views.py:78
 msgid "enrollment.pages.index.title"
 msgstr "Tarjeta de conexión"
 
-#: benefits/enrollment/views.py:77
+#: benefits/enrollment/views.py:79
 msgid "enrollment.pages.index.content_title"
 msgstr "Vamos a vincular su tarjeta con su descuento."
 
-#: benefits/enrollment/views.py:79
+#: benefits/enrollment/views.py:81
 msgid "enrollment.pages.index.p[0]"
 msgstr ""
 "Ahora que ha iniciado sesión, podemos vincular su descuento de tránsito a su "
 "tarjeta a través de nuestro socio de pagos, Littlepay."
 
-#: benefits/enrollment/views.py:79
+#: benefits/enrollment/views.py:81
 msgid "enrollment.pages.index.p[1]"
 msgstr ""
 "No almacenamos su información y no se le cobrará. Cuando utilice esta "
 "tarjeta para pagar el tránsito, siempre recibirá su descuento."
 
-#: benefits/enrollment/views.py:79
+#: benefits/enrollment/views.py:81
 msgid "enrollment.pages.index.p[2]"
 msgstr ""
 "Utilice una tarjeta de crédito o débito Visa o Mastercard sin contacto "
 "emitida por un banco."
 
-#: benefits/enrollment/views.py:84
+#: benefits/enrollment/views.py:86
 msgid "enrollment.buttons.payment_partner"
 msgstr "Conecta tu tarjeta"
 
-#: benefits/enrollment/views.py:124 benefits/enrollment/views.py:126
+#: benefits/enrollment/views.py:127 benefits/enrollment/views.py:129
 msgid "enrollment.pages.retry.title"
 msgstr "No pudimos conectar tú tarjeta bancaria"
 
-#: benefits/enrollment/views.py:125
+#: benefits/enrollment/views.py:128
 msgctxt "image alt text"
 msgid "core.icons.bankcardquestion"
 msgstr ""
 "Icono de tarjeta bancaria con símbolo sin contacto y signo de interrogación"
 
-#: benefits/enrollment/views.py:127
+#: benefits/enrollment/views.py:130
 msgid "enrollment.pages.retry.p[0]"
 msgstr ""
 "Puede intentarlo de nuevo o comunicarse con su proveedor de transporte local "
 "para obtener ayuda."
 
-#: benefits/enrollment/views.py:130
+#: benefits/enrollment/views.py:133
 msgid "core.buttons.retry"
 msgstr "Intentar otra vez"
 
-#: benefits/enrollment/views.py:148
+#: benefits/enrollment/views.py:153
 msgid "enrollment.pages.success.title"
 msgstr "Cierre sesión"
 
-#: benefits/enrollment/views.py:149
+#: benefits/enrollment/views.py:154
 msgid "enrollment.pages.success.content_title"
 msgstr "¡Éxito! Su descuento está ahora vinculado a su tarjeta bancaria."
 
-#: benefits/enrollment/views.py:159
+#: benefits/enrollment/views.py:164
 msgid "enrollment.pages.success.logout.title"
 msgstr ""
 "Ha cerrado la sesión correctamente. ¡Gracias por usar los beneficios de Cal-"

--- a/benefits/templates/200_user_error.html
+++ b/benefits/templates/200_user_error.html
@@ -1,0 +1,1 @@
+{% extends "core/page.html" %}

--- a/tests/pytest/core/test_viewmodels.py
+++ b/tests/pytest/core/test_viewmodels.py
@@ -1,16 +1,43 @@
 from django.utils import translation
 from django.utils.translation import gettext as _
+import pytest
 
 from benefits.core.viewmodels import ErrorPage
 
 
-def test_ErrorPage_server_error_translations():
+@pytest.mark.parametrize(
+    "error_page_function,title,content_title,paragraphs",
+    [
+        pytest.param(
+            ErrorPage.server_error,
+            "core.pages.server_error.title",
+            "core.pages.server_error.title",
+            ["core.pages.server_error.p[0]", "core.pages.server_error.p[1]"],
+            id="server_error",
+        ),
+        pytest.param(
+            ErrorPage.not_found,
+            "core.pages.not_found.title",
+            "core.pages.not_found.content_title",
+            ["core.pages.not_found.p[0]"],
+            id="not_found",
+        ),
+        pytest.param(
+            ErrorPage.user_error,
+            "core.pages.user_error.title",
+            "core.pages.user_error.content_title",
+            ["core.pages.user_error.p[0]"],
+            id="user_error",
+        ),
+    ],
+)
+def test_ErrorPage_translations(error_page_function, title, content_title, paragraphs):
     translation.activate("en")
 
-    error_page = ErrorPage.server_error()
-    english_title = f"{_('core.pages.index.prefix')}: {_('core.pages.server_error.title')}"
-    english_content_title = _("core.pages.server_error.title")
-    english_paragraphs = [_("core.pages.server_error.p[0]"), _("core.pages.server_error.p[1]")]
+    error_page = error_page_function()
+    english_title = f"{_('core.pages.index.prefix')}: {_(title)}"
+    english_content_title = _(content_title)
+    english_paragraphs = [_(paragraph) for paragraph in paragraphs]
 
     assert error_page.title == english_title
     assert error_page.content_title == english_content_title
@@ -18,38 +45,10 @@ def test_ErrorPage_server_error_translations():
 
     translation.activate("es")
 
-    error_page = ErrorPage.server_error()
-    spanish_title = f"{_('core.pages.index.prefix')}: {_('core.pages.server_error.title')}"
-    spanish_content_title = _("core.pages.server_error.title")
-    spanish_paragraphs = [_("core.pages.server_error.p[0]"), _("core.pages.server_error.p[1]")]
-
-    assert error_page.title != english_title
-    assert error_page.content_title != english_content_title
-    assert error_page.paragraphs != english_paragraphs
-
-    assert error_page.title == spanish_title
-    assert error_page.content_title == spanish_content_title
-    assert error_page.paragraphs == spanish_paragraphs
-
-
-def test_ErrorPage_not_found_translations():
-    translation.activate("en")
-
-    error_page = ErrorPage.not_found()
-    english_title = f"{_('core.pages.index.prefix')}: {_('core.pages.not_found.title')}"
-    english_content_title = _("core.pages.not_found.content_title")
-    english_paragraphs = [_("core.pages.not_found.p[0]")]
-
-    assert error_page.title == english_title
-    assert error_page.content_title == english_content_title
-    assert error_page.paragraphs == english_paragraphs
-
-    translation.activate("es")
-
-    error_page = ErrorPage.not_found()
-    spanish_title = f"{_('core.pages.index.prefix')}: {_('core.pages.not_found.title')}"
-    spanish_content_title = _("core.pages.not_found.content_title")
-    spanish_paragraphs = [_("core.pages.not_found.p[0]")]
+    error_page = error_page_function()
+    spanish_title = f"{_('core.pages.index.prefix')}: {_(title)}"
+    spanish_content_title = _(content_title)
+    spanish_paragraphs = [_(paragraph) for paragraph in paragraphs]
 
     assert error_page.title != english_title
     assert error_page.content_title != english_content_title

--- a/tests/pytest/core/test_viewmodels.py
+++ b/tests/pytest/core/test_viewmodels.py
@@ -4,10 +4,10 @@ from django.utils.translation import gettext as _
 from benefits.core.viewmodels import ErrorPage
 
 
-def test_ErrorPage_error_translations():
+def test_ErrorPage_server_error_translations():
     translation.activate("en")
 
-    error_page = ErrorPage.error()
+    error_page = ErrorPage.server_error()
     english_title = f"{_('core.pages.index.prefix')}: {_('core.pages.server_error.title')}"
     english_content_title = _("core.pages.server_error.title")
     english_paragraphs = [_("core.pages.server_error.p[0]"), _("core.pages.server_error.p[1]")]
@@ -18,7 +18,7 @@ def test_ErrorPage_error_translations():
 
     translation.activate("es")
 
-    error_page = ErrorPage.error()
+    error_page = ErrorPage.server_error()
     spanish_title = f"{_('core.pages.index.prefix')}: {_('core.pages.server_error.title')}"
     spanish_content_title = _("core.pages.server_error.title")
     spanish_paragraphs = [_("core.pages.server_error.p[0]"), _("core.pages.server_error.p[1]")]

--- a/tests/pytest/eligibility/test_views.py
+++ b/tests/pytest/eligibility/test_views.py
@@ -3,6 +3,7 @@ from django.urls import reverse
 import pytest
 
 
+from benefits.core.middleware import TEMPLATE_USER_ERROR
 from benefits.eligibility.forms import EligibilityVerifierSelectionForm
 from benefits.eligibility.views import (
     ROUTE_INDEX,
@@ -97,8 +98,11 @@ def test_index_get_agency_single_verifier(
 @pytest.mark.django_db
 def test_index_get_without_agency(client):
     path = reverse(ROUTE_INDEX)
-    with pytest.raises(AttributeError, match=r"agency"):
-        client.get(path)
+
+    response = client.get(path)
+
+    assert response.status_code == 200
+    assert response.template_name == TEMPLATE_USER_ERROR
 
 
 @pytest.mark.django_db
@@ -170,8 +174,10 @@ def test_start_verifier_auth_not_required(client):
 @pytest.mark.usefixtures("mocked_session_agency")
 def test_start_without_verifier(client):
     path = reverse(ROUTE_START)
-    with pytest.raises(AttributeError, match=r"verifier"):
-        client.get(path)
+
+    response = client.get(path)
+    assert response.status_code == 200
+    assert response.template_name == TEMPLATE_USER_ERROR
 
 
 @pytest.mark.django_db

--- a/tests/pytest/enrollment/test_views.py
+++ b/tests/pytest/enrollment/test_views.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 
 import pytest
 
+from benefits.core.middleware import TEMPLATE_USER_ERROR
 from benefits.enrollment.views import (
     ROUTE_INDEX,
     ROUTE_TOKEN,
@@ -35,8 +36,11 @@ def mocked_analytics_module(mocked_analytics_module):
 @pytest.mark.django_db
 def test_token_ineligible(client):
     path = reverse(ROUTE_TOKEN)
-    with pytest.raises(AttributeError, match=r"eligibility"):
-        client.get(path)
+
+    response = client.get(path)
+
+    assert response.status_code == 200
+    assert response.template_name == TEMPLATE_USER_ERROR
 
 
 @pytest.mark.django_db
@@ -132,15 +136,21 @@ def test_index_eligible_post_valid_form_success(
 @pytest.mark.django_db
 def test_index_ineligible(client):
     path = reverse(ROUTE_INDEX)
-    with pytest.raises(AttributeError, match=r"eligibility"):
-        client.get(path)
+
+    response = client.get(path)
+
+    assert response.status_code == 200
+    assert response.template_name == TEMPLATE_USER_ERROR
 
 
 @pytest.mark.django_db
 def test_retry_ineligible(client):
     path = reverse(ROUTE_RETRY)
-    with pytest.raises(AttributeError, match=r"eligibility"):
-        client.post(path)
+
+    response = client.post(path)
+
+    assert response.status_code == 200
+    assert response.template_name == TEMPLATE_USER_ERROR
 
 
 @pytest.mark.django_db
@@ -177,8 +187,11 @@ def test_retry_valid_form(mocker, client, mocked_analytics_module):
 @pytest.mark.django_db
 def test_success_no_verifier(client):
     path = reverse(ROUTE_SUCCESS)
-    with pytest.raises(AttributeError, match=r"verifier"):
-        client.get(path)
+
+    response = client.get(path)
+
+    assert response.status_code == 200
+    assert response.template_name == TEMPLATE_USER_ERROR
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Closes #914 (and closes #757 ?)

| Scenario | Before | After |
| --- | --- | --- |
| Navigate to a page earlier than you should | ![image](https://user-images.githubusercontent.com/25497886/191348910-a0bbd9ff-c50e-4658-a15f-a1af09af50b7.png) | ![image](https://user-images.githubusercontent.com/25497886/191349269-3989f90b-0078-4164-b07f-8831dac69ce2.png) |
| Page not found (404) | ![image](https://user-images.githubusercontent.com/25497886/191349025-973371e4-dd0b-4b38-9d04-30ea3c2ede3d.png) | ![image](https://user-images.githubusercontent.com/25497886/191349227-08b0a82e-d6ca-4f20-8305-c87db30fb30d.png) |

## Steps for Testing
### Scenario: Navigate to a page earlier than you should
1. Launch benefits via the VS Code debugger (choose config with `Debug=False`) <img src="https://user-images.githubusercontent.com/25497886/191577383-f555a995-a11d-4bb1-957f-b8646a19110e.png" width="400">
1. Start on the home page (e.g. `http://localhost:11369/`)
1. Using the URL bar, go to a page much later in the flow (e.g. `http://localhost:11369/enrollment`)

**Expected result**: one-column error page saying that the user may have reached this page on accident.

### Scenario: Page not found (404)
1. Launch benefits via the VS Code debugger (choose config with `Debug=False`)
1. Start on the home page (e.g. `http://localhost:11369`)
1. Using the URL bar, go to a nonexistent page

**Expected result**: one-column error page saying that the user may have reached this page on accident.