### PR TITLE
One column everything

### DIFF
--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -57,10 +57,8 @@
     </header>
 
     <main id="main-content" class="main-content" role="main">
-      <div class="main-primary">
-        {% block main_content %}
-        {% endblock main_content %}
-      </div>
+      {% block main_content %}
+      {% endblock main_content %}
     </main>
 
     <footer id="footer" class="global-footer">

--- a/benefits/core/templates/core/page.html
+++ b/benefits/core/templates/core/page.html
@@ -19,51 +19,48 @@
         <div class="container">
         {% else %}
           {% load static %}
-          <div class="col-lg-6 image"></div>
-          <div class="col-md-8 offset-md-2 col-lg-6 offset-lg-0">
-          {% endif %}
-          <div class="container content">
-            {% block container_content %}
+        {% endif %}
+        <div class="container content">
+          {% block container_content %}
 
-              {% block icon_title %}
-                {% if page.content_title %}
-                  {% if page.icon %}
-                    {% include "core/includes/icon-title.html" with title=page.content_title icon=page.icon %}
-                  {% else %}
-                    <h1>{{ page.content_title }}</h1>
-                  {% endif %}
-                {% endif %}
-              {% endblock icon_title %}
-
-              {% block paragraph_content %}
-                {% for p in page.paragraphs %}<p>{{ p }}</p>{% endfor %}
-              {% endblock paragraph_content %}
-
-              {% block forms %}
-                {% if page.forms %}
-                  {% for f in page.forms %}
-                    {% include "core/includes/form.html" with form=f %}
-                  {% endfor %}
-                {% endif %}
-              {% endblock forms %}
-
-              {% block buttons %}
-                {% if page.buttons|length_is:"0" %}
+            {% block icon_title %}
+              {% if page.content_title %}
+                {% if page.icon %}
+                  {% include "core/includes/icon-title.html" with title=page.content_title icon=page.icon %}
                 {% else %}
-                  {% if "with-agency-links" in page.classes %}
-                    {% include "core/includes/agency-links.html" with buttons=page.buttons %}
-                  {% else %}
-                    <div class="buttons">
-                      {% for b in page.buttons %}
-                        {% include "core/includes/button.html" with button=b %}
-                      {% endfor %}
-                    </div>
-                  {% endif %}
+                  <h1>{{ page.content_title }}</h1>
                 {% endif %}
-              {% endblock buttons %}
+              {% endif %}
+            {% endblock icon_title %}
 
-            {% endblock container_content %}
-          </div>
+            {% block paragraph_content %}
+              {% for p in page.paragraphs %}<p>{{ p }}</p>{% endfor %}
+            {% endblock paragraph_content %}
+
+            {% block forms %}
+              {% if page.forms %}
+                {% for f in page.forms %}
+                  {% include "core/includes/form.html" with form=f %}
+                {% endfor %}
+              {% endif %}
+            {% endblock forms %}
+
+            {% block buttons %}
+              {% if page.buttons|length_is:"0" %}
+              {% else %}
+                {% if "with-agency-links" in page.classes %}
+                  {% include "core/includes/agency-links.html" with buttons=page.buttons %}
+                {% else %}
+                  <div class="buttons">
+                    {% for b in page.buttons %}
+                      {% include "core/includes/button.html" with button=b %}
+                    {% endfor %}
+                  </div>
+                {% endif %}
+              {% endif %}
+            {% endblock buttons %}
+
+          {% endblock container_content %}
         </div>
       </div>
     </div>

--- a/benefits/core/templates/core/page.html
+++ b/benefits/core/templates/core/page.html
@@ -15,7 +15,6 @@
 {% block main_content %}
   <div class="container-fluid">
     <div class="container row main-row">
-      {% load static %}
       <div class="container content">
         {% block container_content %}
 

--- a/benefits/core/templates/core/page.html
+++ b/benefits/core/templates/core/page.html
@@ -14,54 +14,50 @@
 
 {% block main_content %}
   <div class="container-fluid">
-    <div class="row main-row">
-      {% if page.noimage %}
-        <div class="container">
-        {% else %}
-          {% load static %}
-        {% endif %}
-        <div class="container content">
-          {% block container_content %}
+    <div class="container row main-row">
+      {% load static %}
+      <div class="container content">
+        {% block container_content %}
 
-            {% block icon_title %}
-              {% if page.content_title %}
-                {% if page.icon %}
-                  {% include "core/includes/icon-title.html" with title=page.content_title icon=page.icon %}
-                {% else %}
-                  <h1>{{ page.content_title }}</h1>
-                {% endif %}
-              {% endif %}
-            {% endblock icon_title %}
-
-            {% block paragraph_content %}
-              {% for p in page.paragraphs %}<p>{{ p }}</p>{% endfor %}
-            {% endblock paragraph_content %}
-
-            {% block forms %}
-              {% if page.forms %}
-                {% for f in page.forms %}
-                  {% include "core/includes/form.html" with form=f %}
-                {% endfor %}
-              {% endif %}
-            {% endblock forms %}
-
-            {% block buttons %}
-              {% if page.buttons|length_is:"0" %}
+          {% block icon_title %}
+            {% if page.content_title %}
+              {% if page.icon %}
+                {% include "core/includes/icon-title.html" with title=page.content_title icon=page.icon %}
               {% else %}
-                {% if "with-agency-links" in page.classes %}
-                  {% include "core/includes/agency-links.html" with buttons=page.buttons %}
-                {% else %}
-                  <div class="buttons">
-                    {% for b in page.buttons %}
-                      {% include "core/includes/button.html" with button=b %}
-                    {% endfor %}
-                  </div>
-                {% endif %}
+                <h1>{{ page.content_title }}</h1>
               {% endif %}
-            {% endblock buttons %}
+            {% endif %}
+          {% endblock icon_title %}
 
-          {% endblock container_content %}
-        </div>
+          {% block paragraph_content %}
+            {% for p in page.paragraphs %}<p>{{ p }}</p>{% endfor %}
+          {% endblock paragraph_content %}
+
+          {% block forms %}
+            {% if page.forms %}
+              {% for f in page.forms %}
+                {% include "core/includes/form.html" with form=f %}
+              {% endfor %}
+            {% endif %}
+          {% endblock forms %}
+
+          {% block buttons %}
+            {% if page.buttons|length_is:"0" %}
+            {% else %}
+              {% if "with-agency-links" in page.classes %}
+                {% include "core/includes/agency-links.html" with buttons=page.buttons %}
+              {% else %}
+                <div class="buttons">
+                  {% for b in page.buttons %}
+                    {% include "core/includes/button.html" with button=b %}
+                  {% endfor %}
+                </div>
+              {% endif %}
+            {% endif %}
+          {% endblock buttons %}
+
+        {% endblock container_content %}
       </div>
     </div>
-  {% endblock main_content %}
+  </div>
+{% endblock main_content %}

--- a/benefits/core/viewmodels.py
+++ b/benefits/core/viewmodels.py
@@ -104,7 +104,6 @@ class Page:
     """
     Represents a page of content:
     * title: str
-    * noimage: bool
     * icon: core.viewmodels.Icon
     * content_title: str
     * paragraphs: str[]
@@ -122,7 +121,6 @@ class Page:
         else:
             self.title = f"{_('core.pages.index.prefix')}: {self.title}"
 
-        self.noimage = kwargs.get("noimage", False)
         self.icon = kwargs.get("icon")
         self.content_title = kwargs.get("content_title")
         self.paragraphs = kwargs.get("paragraphs", [])
@@ -143,8 +141,6 @@ class Page:
         self.classes = kwargs.get("classes", [])
         if not isinstance(self.classes, list):
             self.classes = self.classes.split(" ")
-        if not self.noimage:
-            self.classes.append("with-image")
 
     def context_dict(self):
         """Return a context dict for a Page."""
@@ -168,7 +164,6 @@ class ErrorPage(Page):
             content_title=kwargs.get("content_title", _("core.pages.error.title")),
             paragraphs=kwargs.get("paragraphs", [_("core.pages.server_error.content_title")]),
             button=kwargs.get("button"),
-            noimage=True,
         )
 
     @staticmethod

--- a/benefits/core/views.py
+++ b/benefits/core/views.py
@@ -41,7 +41,6 @@ def index(request):
         content_title=_("core.pages.index.content_title"),
         buttons=buttons,
         classes="home",
-        noimage=True,
     )
 
     return TemplateResponse(request, TEMPLATE_PAGE, page.context_dict())
@@ -64,7 +63,6 @@ def agency_index(request, agency):
         content_title=_("core.pages.agency_index.content_title"),
         button=button,
         classes="home",
-        noimage=True,
     )
 
     help_page = reverse(ROUTE_HELP)
@@ -94,7 +92,6 @@ def help(request):
         title=_("core.buttons.help"),
         content_title=_("core.buttons.help"),
         buttons=buttons,
-        noimage=True,
     )
 
     return TemplateResponse(request, TEMPLATE_HELP, page.context_dict())

--- a/benefits/core/views.py
+++ b/benefits/core/views.py
@@ -41,6 +41,7 @@ def index(request):
         content_title=_("core.pages.index.content_title"),
         buttons=buttons,
         classes="home",
+        noimage=True,
     )
 
     return TemplateResponse(request, TEMPLATE_PAGE, page.context_dict())
@@ -63,6 +64,7 @@ def agency_index(request, agency):
         content_title=_("core.pages.agency_index.content_title"),
         button=button,
         classes="home",
+        noimage=True,
     )
 
     help_page = reverse(ROUTE_HELP)

--- a/benefits/eligibility/templates/eligibility/start.html
+++ b/benefits/eligibility/templates/eligibility/start.html
@@ -5,8 +5,6 @@
 {% endblock classes %}
 
 {% block main_content %}
-  <div class="one-column-image"></div>
-
   <div class="container">
     <h1 class="headline">{% translate "eligibility.pages.start.content_title" %}</h1>
     <p>{% blocktranslate with info_link=info_link%}eligibility.pages.start.p[0]{{ info_link }}{% endblocktranslate %}</p>

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -39,6 +39,7 @@ def index(request):
         title=_("eligibility.pages.index.title"),
         content_title=_("eligibility.pages.index.content_title"),
         forms=forms.EligibilityVerifierSelectionForm(agency=agency),
+        noimage=True,
     )
 
     if request.method == "POST":
@@ -167,6 +168,7 @@ def confirm(request):
         paragraphs=[_(verifier.form_blurb)],
         form=forms.EligibilityVerificationForm(auto_id=True, label_suffix="", verifier=verifier),
         classes="text-lg-center",
+        noimage=True,
     )
 
     # GET from an unverified user, present the form

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -39,7 +39,6 @@ def index(request):
         title=_("eligibility.pages.index.title"),
         content_title=_("eligibility.pages.index.content_title"),
         forms=forms.EligibilityVerifierSelectionForm(agency=agency),
-        noimage=True,
     )
 
     if request.method == "POST":
@@ -122,7 +121,6 @@ def start(request):
 
     page = viewmodels.Page(
         title=_("eligibility.pages.start.title"),
-        noimage=True,
         paragraphs=[_(verifier.start_blurb)],
         button=button,
     )
@@ -168,7 +166,6 @@ def confirm(request):
         paragraphs=[_(verifier.form_blurb)],
         form=forms.EligibilityVerificationForm(auto_id=True, label_suffix="", verifier=verifier),
         classes="text-lg-center",
-        noimage=True,
     )
 
     # GET from an unverified user, present the form
@@ -231,7 +228,6 @@ def unverified(request):
     buttons.append(viewmodels.Button.home(request))
 
     page = viewmodels.Page(
-        noimage=True,
         title=_(verifier.unverified_title),
         classes="with-agency-links",
         content_title=_(verifier.unverified_content_title),

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -86,6 +86,7 @@ def index(request):
                     text=_("enrollment.buttons.payment_partner"), id=tokenize_button, url=f"#{tokenize_button}"
                 ),
             ],
+            noimage=True,
         )
         context = {}
         context.update(page.context_dict())
@@ -129,6 +130,7 @@ def retry(request):
                 content_title=_("enrollment.pages.retry.title"),
                 paragraphs=[_("enrollment.pages.retry.p[0]")],
                 buttons=viewmodels.Button.agency_contact_links(agency),
+                noimage=True,
             )
             page.buttons.append(viewmodels.Button.primary(text=_("core.buttons.retry"), url=session.origin(request)))
             return TemplateResponse(request, TEMPLATE_RETRY, page.context_dict())
@@ -152,6 +154,7 @@ def success(request):
         classes="no-image-mobile",
         title=_("enrollment.pages.success.title"),
         content_title=_("enrollment.pages.success.content_title"),
+        noimage=True,
     )
 
     if verifier.is_auth_required:

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -86,7 +86,6 @@ def index(request):
                     text=_("enrollment.buttons.payment_partner"), id=tokenize_button, url=f"#{tokenize_button}"
                 ),
             ],
-            noimage=True,
         )
         context = {}
         context.update(page.context_dict())
@@ -130,7 +129,6 @@ def retry(request):
                 content_title=_("enrollment.pages.retry.title"),
                 paragraphs=[_("enrollment.pages.retry.p[0]")],
                 buttons=viewmodels.Button.agency_contact_links(agency),
-                noimage=True,
             )
             page.buttons.append(viewmodels.Button.primary(text=_("core.buttons.retry"), url=session.origin(request)))
             return TemplateResponse(request, TEMPLATE_RETRY, page.context_dict())
@@ -154,7 +152,6 @@ def success(request):
         classes="no-image-mobile",
         title=_("enrollment.pages.success.title"),
         content_title=_("enrollment.pages.success.content_title"),
-        noimage=True,
     )
 
     if verifier.is_auth_required:
@@ -165,7 +162,6 @@ def success(request):
         else:
             page.classes = ["no-image-mobile", "logged-out"]
             page.content_title = _("enrollment.pages.success.logout.title")
-            page.noimage = True
     else:
         page.icon = icon
 

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -61,10 +61,6 @@ label {
   letter-spacing: 0.05em;
 }
 
-.main-content .main-primary a:not(.btn) {
-  background: none;
-}
-
 /* making the sticky footer */
 
 html,
@@ -675,10 +671,6 @@ footer.global-footer .footer-links a:active {
 
   .no-image-mobile .signout-row {
     top: 0;
-  }
-
-  .no-image-mobile .main-primary .container-fluid {
-    margin-top: 72px;
   }
 
   /* Eligibility Start */

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -491,15 +491,6 @@ footer.global-footer .footer-links a:active {
   height: 150px;
 }
 
-.with-image .container.content h1.icon-title img.icon {
-  width: 92px;
-  height: 92px;
-}
-
-.with-image .container.content h1.icon-title {
-  text-align: left;
-}
-
 .container.content.help {
   margin: 4rem auto 2rem auto;
 }
@@ -642,13 +633,6 @@ footer.global-footer .footer-links a:active {
     display: none !important;
   }
 
-  .with-image main .main-row .col-lg-6.image {
-    background-position: center bottom;
-    height: 240px;
-    background-size: cover;
-    margin-bottom: 60px;
-  }
-
   .signout-row .container .signout-link {
     font-size: 18px;
     color: #2b6597;
@@ -784,14 +768,6 @@ footer.global-footer .footer-links a:active {
 }
 
 @media (min-width: 992px) {
-  /* undoing the sticky footer for pages with header image
-       the backup plan is to color the body the same as the footer
-       to avoid the floating footer look
-    */
-  .with-image main {
-    flex-shrink: unset;
-  }
-
   footer {
     margin-top: unset;
     padding-top: 0.138rem;

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -96,14 +96,6 @@ main .main-row .col-lg-6.image {
   background-size: cover;
 }
 
-.one-column-image {
-  background: url("/static/img/rider-tapping-bank-card-horizontal.png");
-  background-size: cover;
-  background-repeat: no-repeat;
-  background-position: center center;
-  height: 292px;
-}
-
 footer {
   margin-top: auto;
   padding-top: 1rem;
@@ -640,10 +632,6 @@ footer.global-footer .footer-links a:active {
 }
 
 @media (max-width: 992px) {
-  .one-column-image {
-    height: 131px;
-  }
-
   .navbar.navbar-expand-sm.navbar-dark.bg-primary {
     padding: 14.5px 1rem;
   }


### PR DESCRIPTION
closes #933 

## What this PR does
- Make all views with the Page view model use the one-column layout by setting `noimage` to `True`.
- Deletes CSS style code for `eligibility/start` page design (shortened image on top)

## Deleted code
- `main-primary` class and css
- `one-column-image` class and css
- `with-image` (and `col-lg-6.image` class and css and jquery
- `noimage` from Page class and container template

## To test
- Test in Debug=False mode: Go through the whole flow in English/Spanish on Desktop and Mobile
- Ensure no regressions on /help
- Ensure no regressions on error pages: 404, 500
- http://localhost:11369/
- http://localhost:11369/eligibility/start
- http://localhost:11369/eligibility/
- http://localhost:11369/eligibility/confirm
- http://localhost:11369/enrollment/
- http://localhost:11369/enrollment/success