### PR TITLE
Chore: update State Template

### DIFF
--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -15,7 +15,7 @@
     </title>
 
     <link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet" type="text/css">
-    <link href="https://california.azureedge.net/cdt/statetemplate/6.0.2/css/cagov.core.min.css" rel="stylesheet">
+    <link href="https://california.azureedge.net/cdt/statetemplate/6.0.7/css/cagov.core.min.css" rel="stylesheet">
     <link href="{% static "css/styles.css" %}" rel="stylesheet">
     <link href="{% static "img/favicon.ico" %}" rel="icon" type="image/x-icon" />
 
@@ -76,7 +76,7 @@
       </div>
     </footer>
 
-    <script src="https://california.azureedge.net/cdt/statetemplate/6.0.2/js/cagov.core.js"></script>
+    <script src="https://california.azureedge.net/cdt/statetemplate/6.0.7/js/cagov.core.min.js"></script>
     <script>
             $(function() {
                 document.cookie = "testcookie"

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -15,10 +15,20 @@
     </title>
 
     <link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet" type="text/css">
+
+    {% comment%}
+        CA State Template v6.0.7 comes with Bootstrap v5.1.3
+        See https://github.com/Office-of-Digital-Services/California-State-Web-Template/releases/tag/v6.0.7
+    {% endcomment %}
     <link href="https://california.azureedge.net/cdt/statetemplate/6.0.7/css/cagov.core.min.css" rel="stylesheet">
+
     <link href="{% static "css/styles.css" %}" rel="stylesheet">
     <link href="{% static "img/favicon.ico" %}" rel="icon" type="image/x-icon" />
 
+    {% comment %}
+        CA State Template v6.0.7 does not include jQuery
+        See https://github.com/Office-of-Digital-Services/California-State-Web-Template/releases/tag/v6.0.7
+    {% endcomment %}
     <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
 
     {% include "core/includes/analytics.html" with api_key=analytics.api_key uid=analytics.uid did=analytics.did %}
@@ -76,7 +86,12 @@
       </div>
     </footer>
 
+    {% comment%}
+        CA State Template v6.0.7 comes with Bootstrap v5.1.3
+        see https://github.com/Office-of-Digital-Services/California-State-Web-Template/releases/tag/v6.0.7
+    {% endcomment %}
     <script src="https://california.azureedge.net/cdt/statetemplate/6.0.7/js/cagov.core.min.js"></script>
+
     <script>
             $(function() {
                 document.cookie = "testcookie"

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -266,7 +266,7 @@ CSP_CONNECT_SRC = ["'self'", "https://api.amplitude.com/"]
 env_connect_src = _filter_empty(os.environ.get("DJANGO_CSP_CONNECT_SRC", "").split(","))
 CSP_CONNECT_SRC.extend(env_connect_src)
 
-CSP_FONT_SRC = ["'self'", "https://california.azureedge.net/cdt/statetemplate/", "https://fonts.gstatic.com/"]
+CSP_FONT_SRC = ["'self'", "https://california.azureedge.net/", "https://fonts.gstatic.com/"]
 env_font_src = _filter_empty(os.environ.get("DJANGO_CSP_FONT_SRC", "").split(","))
 CSP_FONT_SRC.extend(env_font_src)
 
@@ -281,7 +281,7 @@ if RECAPTCHA_ENABLED:
 
 CSP_SCRIPT_SRC = [
     "'unsafe-inline'",
-    "https://california.azureedge.net/cdt/statetemplate/",
+    "https://california.azureedge.net/",
     "https://cdn.amplitude.com/libs/",
     "https://code.jquery.com/",
     "*.littlepay.com",
@@ -294,7 +294,7 @@ if RECAPTCHA_ENABLED:
 CSP_STYLE_SRC = [
     "'self'",
     "'unsafe-inline'",
-    "https://california.azureedge.net/cdt/statetemplate/",
+    "https://california.azureedge.net/",
     "https://fonts.googleapis.com/css",
 ]
 env_style_src = _filter_empty(os.environ.get("DJANGO_CSP_STYLE_SRC", "").split(","))


### PR DESCRIPTION
Closes #777

## Key page detail

| Page | Before (mobile) | After (mobile) | Before (desktop) | After (desktop) | Notes |
| ----- | ------- | ------ | ----- | ---- | --- |
| `/eligibility/start` | ![image](https://user-images.githubusercontent.com/1783439/191872392-3a3464b9-2d68-426f-9426-8657eee30d64.png) | ![image](https://user-images.githubusercontent.com/1783439/191872443-4c34e589-0030-4305-a70f-6c66395675a9.png) | ![image](https://user-images.githubusercontent.com/1783439/191872631-fcac9f32-ca2c-4041-9d49-b59f401c9217.png) | ![image](https://user-images.githubusercontent.com/1783439/191872662-3d166908-370c-44f4-a69a-1bcf8256e6a2.png) | Increased gutter around icon/navbar on mobile |
| `/enrollment` | ![image](https://user-images.githubusercontent.com/1783439/191873184-19fa86ec-fc12-44a6-a78b-45a1ced7ebdd.png) | ![image](https://user-images.githubusercontent.com/1783439/191873062-88472ade-7743-48df-b565-51ad55096944.png) | ![image](https://user-images.githubusercontent.com/1783439/191872839-1940a9d3-6aef-4241-b6eb-cf9a94229dfc.png) | ![image](https://user-images.githubusercontent.com/1783439/191872861-2cef462c-a234-41fc-ba2e-1e4fb0205bed.png) | Smaller primary button text, underlined secondary on mobile; justified text in desktop?? |
| all pages | ![image](https://user-images.githubusercontent.com/1783439/192346846-da1992d9-89c1-4522-a530-b984f6b9621c.png) | ![image](https://user-images.githubusercontent.com/1783439/192346945-92946b90-58c3-4f52-ae18-badbdadc44d3.png) | ![image](https://user-images.githubusercontent.com/1783439/192347058-f5f12889-28fd-43bd-8b43-1107f5de9378.png) | ![image](https://user-images.githubusercontent.com/1783439/192347562-8c3b6e3b-0e0e-42c2-b9ec-bb4b32b081c9.png) | Hard to see - but on desktop at a certain height, the `body` background color is showing through under the footer (white line at the very bottom) |

@angela-tran @machikoyasuda thoughts on addressing these issues here vs. as part of some of the other template cleanup work?