### PR TITLE
Fix: sticky footer

### DIFF
--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -1,3 +1,28 @@
+/* making the sticky footer */
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+}
+
+main {
+  flex: 1 0 auto;
+}
+
+footer {
+  flex-shrink: 0;
+}
+
 /* HTML element overrides */
 
 body {
@@ -59,23 +84,6 @@ label {
   font-size: 18px;
   line-height: 26px;
   letter-spacing: 0.05em;
-}
-
-/* making the sticky footer */
-
-html,
-body {
-  height: 100%;
-  overflow-y: unset;
-}
-
-body {
-  display: flex;
-  flex-direction: column;
-}
-
-main {
-  flex-shrink: 0 !important;
 }
 
 main#main-content.main-content {


### PR DESCRIPTION
Related to #961 

This PR achieves a sticky footer, following an approach detailed by [CSS-tricks](https://css-tricks.com/couple-takes-sticky-footer/#aa-there-is-flexbox). This method is simple and effective at ensuring the footer actually sticks to the bottom.

(We also use it on Compiler's website.) 

### Additional context

This was needed because it appears that [a recent change](https://github.com/cal-itp/benefits/pull/932/files#diff-744df555aee38173a0b0868baa7befa720e6a28f80747523e74e724c126cd381L807-L814) caused a regression: a small amount of whitespace appeared under the footer. This only occurred for Desktop screen size.

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/25497886/192639295-55c8679b-fcf8-45f2-9a23-0ab8bb4b779e.png) | ![after](https://user-images.githubusercontent.com/25497886/192639999-4fc31dc8-9106-45a7-96ab-e133fb110829.png) |

The inline comment that was removed and the commit message from https://github.com/cal-itp/benefits/pull/4/commits/f446bf6d8e1acffd78dc2c6b08b237fd467cbc52 are supporting evidence that the sticky footer implementation was relying on  `flex-shrink: unset;` to fix unexpected whitespace.