### PR TITLE
Refactor: Use CSS Variables for colors, font-family

### DIFF
--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -158,7 +158,6 @@ def confirm(request):
         content_title=_(verifier.form_content_title),
         paragraphs=[_(verifier.form_blurb)],
         form=forms.EligibilityVerificationForm(auto_id=True, label_suffix="", verifier=verifier),
-        classes="text-lg-center",
     )
 
     # GET from an unverified user, present the form

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -79,7 +79,6 @@ def index(request):
             content_title=_("enrollment.pages.index.content_title"),
             icon=viewmodels.Icon("idcardcheck", pgettext("image alt text", "core.icons.idcardcheck")),
             paragraphs=[_("enrollment.pages.index.p[0]"), _("enrollment.pages.index.p[1]"), _("enrollment.pages.index.p[2]")],
-            classes="text-lg-center no-image-mobile",
             forms=[tokenize_retry_form, tokenize_success_form],
             buttons=[
                 viewmodels.Button.primary(

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -9,6 +9,9 @@
   --bs-body-text-align: left;
   --bs-body-font-weight: 400;
   --bs-body-font-size: 16px;
+  --bs-font-sans-serif: Roboto, system-ui, -apple-system, "Segoe UI", sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --bs-body-font-family: var(--bs-font-sans-serif);
 }
 
 @font-face {
@@ -29,7 +32,7 @@ p,
 a,
 span,
 li {
-  font-family: "Roboto", sans-serif;
+  font-family: var(--bs-body-font-family);
 }
 
 h1,
@@ -124,9 +127,6 @@ footer.global-footer .footer-links a:active {
 /* Log In */
 
 #login {
-  background: var(--primary-color);
-  border: 0;
-  color: #ffffff;
   cursor: pointer;
   display: block;
   line-height: 1;

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -1,10 +1,17 @@
+:root {
+  --primary-color: #046b99;
+  --primary-color-rgb: 4, 107, 153;
+  --bs-blue: var(--primary-color);
+  --bs-primary-rgb: var(--primary-color-rgb);
+}
+
 /* HTML element overrides */
 
 body {
   font-weight: 400;
   font-size: 16px;
   line-height: 22px;
-  color: #000000;
+  color: var(--text-primary-color);
 }
 
 @font-face {
@@ -113,11 +120,6 @@ footer.global-footer .footer-links a:active {
 
 /* class styles */
 
-.bg-p2,
-.bg-primary {
-  background-color: #2b6597 !important;
-}
-
 .btn-lg {
   border-width: 2px;
 }
@@ -125,7 +127,7 @@ footer.global-footer .footer-links a:active {
 /* Log In */
 
 #login {
-  background: #046b99;
+  background: var(--primary-color);
   border: 0;
   color: #ffffff;
   cursor: pointer;
@@ -184,7 +186,7 @@ footer.global-footer .footer-links a:active {
 }
 
 .btn-link {
-  color: #046b99;
+  color: var(--primary-color);
 }
 
 .btn-primary {
@@ -431,7 +433,7 @@ footer.global-footer .footer-links a:active {
 }
 
 .radio-input:checked {
-  background-color: #046b99;
+  background-color: var(--primary-color);
   box-shadow: inset 0 0 0 2px white;
 }
 

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -12,6 +12,8 @@
   --bs-font-sans-serif: Roboto, system-ui, -apple-system, "Segoe UI", sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --bs-body-font-family: var(--bs-font-sans-serif);
+  --dark-color: #212121;
+  --footer-background-color: var(--dark-color);
 }
 
 @font-face {
@@ -199,13 +201,9 @@ footer.global-footer .footer-links a:active {
 
 .form-control {
   border-radius: 0.25rem;
-  border-color: #212121;
+  border-color: var(--primary-color);
   border-width: 2px;
-  color: #212121;
-}
-
-.form-control:focus-within {
-  color: #212121;
+  color: var(--text-primary-color);
 }
 
 .form-control-lg {
@@ -243,7 +241,7 @@ footer.global-footer .footer-links a:active {
 }
 
 .global-footer {
-  background: #212121;
+  background: var(--footer-background-color);
 }
 
 /* Eligibility Start */

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -634,11 +634,11 @@ footer.global-footer .footer-links a:active {
 
   .signout-row .container .signout-link {
     font-size: 18px;
-    color: #2b6597;
+    color: var(--primary-color);
     background: none;
     padding: 5px 10px;
     border-radius: 3px;
-    border: 2px solid #2b6597;
+    border: 2px solid var(--primary-color);
     margin-top: 20px;
     letter-spacing: 0.02em;
     font-weight: 500;

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -14,6 +14,15 @@
   --bs-body-font-family: var(--bs-font-sans-serif);
   --dark-color: #212121;
   --footer-background-color: var(--dark-color);
+  --footer-link-color: #73b3e7;
+  --footer-link-hover-color: #9b74d7;
+  --hover-color: #2f4c65;
+  --error-color: #ea1010;
+  --error-color-rgb: 234, 16, 16;
+  --bs-danger: var(--error-color);
+  --bs-danger-rgb: var(--error-color-rgb);
+  --standout-color: #323a45;
+  --radio-input-color: var(--standout-color);
 }
 
 @font-face {
@@ -109,14 +118,14 @@ footer {
 
 footer.global-footer .footer-links a {
   font-size: 18px;
-  color: #73b3e7;
+  color: var(--footer-link-color);
   text-decoration: underline;
 }
 
 footer.global-footer .footer-links a:hover,
 footer.global-footer .footer-links a:focus,
 footer.global-footer .footer-links a:active {
-  color: #9b74d7;
+  color: var(--footer-link-hover-color);
   text-decoration: none;
 }
 
@@ -143,7 +152,7 @@ footer.global-footer .footer-links a:active {
 }
 
 #login:hover {
-  background: #2f4c65;
+  background: var(--hover-color);
 }
 
 /* Sets the text `Login.gov` as transparent */
@@ -178,7 +187,7 @@ footer.global-footer .footer-links a:active {
 .signout-row .container .signout-link {
   font-size: 12px;
   text-decoration: underline;
-  color: #2b6597;
+  color: var(--primary-color);
   letter-spacing: 0.05rem;
   padding-top: 18px;
   display: block;
@@ -224,11 +233,11 @@ footer.global-footer .footer-links a:active {
 
 .form-group.with-errors label,
 .form-group.with-errors .required-label {
-  color: #de0c0c;
+  color: var(--error-color);
 }
 
 .form-group.with-errors .form-control {
-  border-color: #de0c0c;
+  border-color: var(--error-color);
 }
 
 .form-group.with-errors .error-message {
@@ -328,7 +337,7 @@ footer.global-footer .footer-links a:active {
 }
 
 .media-list .media .media-body .media-body--links .btn-lg:hover {
-  color: #2f4c65;
+  color: var(--hover-color);
 }
 
 .eligibility-start .main-container {
@@ -419,7 +428,7 @@ footer.global-footer .footer-links a:active {
   width: 25px;
   height: 25px;
 
-  border: 3px solid #000;
+  border: 3px solid var(--radio-input-color);
   margin-right: 5px;
   margin-top: 20px;
 
@@ -428,8 +437,8 @@ footer.global-footer .footer-links a:active {
 }
 
 .radio-input:checked {
-  background-color: var(--primary-color);
-  box-shadow: inset 0 0 0 2px white;
+  background-color: var(--radio-input-color);
+  box-shadow: inset 0 0 0 2px var(--bs-white);
 }
 
 .radio-label-description {

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -2,16 +2,13 @@
   --primary-color: #046b99;
   --primary-color-rgb: 4, 107, 153;
   --bs-blue: var(--primary-color);
+  --bs-primary: var(--primary-color);
   --bs-primary-rgb: var(--primary-color-rgb);
-}
-
-/* HTML element overrides */
-
-body {
-  font-weight: 400;
-  font-size: 16px;
-  line-height: 22px;
-  color: var(--text-primary-color);
+  --text-primary-color: #000000;
+  --bs-body-color: var(--text-primary-color);
+  --bs-body-text-align: left;
+  --bs-body-font-weight: 400;
+  --bs-body-font-size: 16px;
 }
 
 @font-face {
@@ -216,7 +213,7 @@ footer.global-footer .footer-links a:active {
 }
 
 .required-label {
-  color: #000;
+  color: var(--text-primary-color);
 }
 
 .form-group:not(.with-errors) {


### PR DESCRIPTION
#968 

- As much as possible, _override_ root Bootstrap CSS variables to match Figma style guide
- When a Bootstrap CSS variable is not available, create new CSS variables and use them throughout the code

The CSS file should no longer have any un-variable-ized colors and font-family declarations.

## How to read this code

- Read https://getbootstrap.com/docs/5.1/customize/css-variables/
- All variables that start with `--bs` are overriding Bootstrap CSS variables.

## How this change works

For example, when overriding `--bs-primary` with `#046b99`, like so:

```css
:root {
  --primary-color: #046b99;
  --primary-color-rgb: 4, 107, 153;
  --bs-blue: var(--primary-color);
  --bs-primary: var(--primary-color);
  --bs-primary-rgb: var(--primary-color-rgb);
}
```

all Bootstrap classes that rely on `--bs-primary` color will also be affected. Most notably, `btn-primary`, `bg-primary` will not all also use `#046b99`. With just these few CSS variable override lines, I was able to change *all* instances of the "primary" color to `#046b99` _throughout_ the CSS styles. Because of this, I was able to delete places in the style.css code where we were manually setting the Header background color or a Button background color to `#046b99`, because we are using classes of `bg-primary` or `btn-primary` instead.