### PR TITLE
Refactor: CSS Variables - Paragraph style and links

### DIFF
--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -16,9 +16,9 @@
 
     <link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet" type="text/css">
 
-    {% comment%}
-                CA State Template v6.0.7 comes with Bootstrap v5.1.3
-                See https://github.com/Office-of-Digital-Services/California-State-Web-Template/releases/tag/v6.0.7
+    {% comment %}
+      CA State Template v6.0.7 comes with Bootstrap v5.1.3
+      See https://github.com/Office-of-Digital-Services/California-State-Web-Template/releases/tag/v6.0.7
     {% endcomment %}
     <link href="https://california.azureedge.net/cdt/statetemplate/6.0.7/css/cagov.core.min.css" rel="stylesheet">
 
@@ -26,8 +26,8 @@
     <link href="{% static "img/favicon.ico" %}" rel="icon" type="image/x-icon" />
 
     {% comment %}
-        CA State Template v6.0.7 does not include jQuery
-        See https://github.com/Office-of-Digital-Services/California-State-Web-Template/releases/tag/v6.0.7
+      CA State Template v6.0.7 does not include jQuery
+      See https://github.com/Office-of-Digital-Services/California-State-Web-Template/releases/tag/v6.0.7
     {% endcomment %}
     <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
 
@@ -84,9 +84,9 @@
       </div>
     </footer>
 
-    {% comment%}
-                CA State Template v6.0.7 comes with Bootstrap v5.1.3
-                see https://github.com/Office-of-Digital-Services/California-State-Web-Template/releases/tag/v6.0.7
+    {% comment %}
+      CA State Template v6.0.7 comes with Bootstrap v5.1.3
+      see https://github.com/Office-of-Digital-Services/California-State-Web-Template/releases/tag/v6.0.7
     {% endcomment %}
     <script src="https://california.azureedge.net/cdt/statetemplate/6.0.7/js/cagov.core.min.js"></script>
 

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -17,8 +17,8 @@
     <link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet" type="text/css">
 
     {% comment%}
-        CA State Template v6.0.7 comes with Bootstrap v5.1.3
-        See https://github.com/Office-of-Digital-Services/California-State-Web-Template/releases/tag/v6.0.7
+                CA State Template v6.0.7 comes with Bootstrap v5.1.3
+                See https://github.com/Office-of-Digital-Services/California-State-Web-Template/releases/tag/v6.0.7
     {% endcomment %}
     <link href="https://california.azureedge.net/cdt/statetemplate/6.0.7/css/cagov.core.min.css" rel="stylesheet">
 
@@ -66,7 +66,7 @@
       </div>
     </header>
 
-    <main id="main-content" class="main-content" role="main">
+    <main id="main-content" role="main">
       {% block main_content %}
       {% endblock main_content %}
     </main>
@@ -85,8 +85,8 @@
     </footer>
 
     {% comment%}
-        CA State Template v6.0.7 comes with Bootstrap v5.1.3
-        see https://github.com/Office-of-Digital-Services/California-State-Web-Template/releases/tag/v6.0.7
+                CA State Template v6.0.7 comes with Bootstrap v5.1.3
+                see https://github.com/Office-of-Digital-Services/California-State-Web-Template/releases/tag/v6.0.7
     {% endcomment %}
     <script src="https://california.azureedge.net/cdt/statetemplate/6.0.7/js/cagov.core.min.js"></script>
 

--- a/benefits/core/templates/core/widgets/radio_select_option.html
+++ b/benefits/core/templates/core/widgets/radio_select_option.html
@@ -8,6 +8,6 @@
 {% if widget.wrap_label %}
   <label{% if widget.attrs.id %} for="{{ widget.attrs.id }}" class="radio-label"{% endif %}>
     {{ widget.label }}
-    {% if widget.description %}<span class="radio-label-description">{{ widget.description }}</span>{% endif %}
+    {% if widget.description %}<p class="radio-label-description">{{ widget.description }}</p>{% endif %}
   </label>
 {% endif %}

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -8,6 +8,7 @@
   --bs-body-color: var(--text-primary-color);
   --bs-body-text-align: left;
   --bs-body-font-weight: 400;
+  --bold-font-weight: 700;
   --bs-body-font-size: 18px;
   --bs-font-sans-serif: Roboto, system-ui, -apple-system, "Segoe UI", sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
@@ -21,6 +22,7 @@
   --footer-mobile-underline-color: var(--bs-white);
   --hover-color: #2f4c65;
   --error-color: #ea1010;
+  --selected-color: #562b97;
   --error-color-rgb: 234, 16, 16;
   --bs-danger: var(--error-color);
   --bs-danger-rgb: var(--error-color-rgb);
@@ -64,6 +66,24 @@ span,
   letter-spacing: var(--body-letter-spacing);
 }
 
+/* Links */
+/* Same sizes for all screen widths */
+a:not(.btn) {
+  color: var(--primary-color);
+  text-decoration: underline;
+  text-decoration-style: solid;
+  font-weight: var(--bold-font-weight);
+}
+
+a:hover:not(.btn) {
+  color: var(--hover-color);
+  text-decoration: underline;
+}
+
+a:visited:not(.btn) {
+  color: var(--selected-color);
+}
+
 h1,
 h2,
 h3,
@@ -81,12 +101,6 @@ h1 {
   font-weight: 700;
   font-size: 24px;
   line-height: 30px;
-  letter-spacing: 0.05em;
-}
-
-label {
-  font-size: 18px;
-  line-height: 26px;
   letter-spacing: 0.05em;
 }
 
@@ -128,8 +142,8 @@ footer {
 }
 
 footer.global-footer .footer-links a {
-  font-size: 18px;
   color: var(--footer-link-color);
+  font-weight: var(--bs-body-font-weight);
   text-decoration: underline;
 }
 
@@ -137,7 +151,6 @@ footer.global-footer .footer-links a:hover,
 footer.global-footer .footer-links a:focus,
 footer.global-footer .footer-links a:active {
   color: var(--footer-link-hover-color);
-  text-decoration: none;
 }
 
 /* class styles */

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -175,10 +175,6 @@ footer.global-footer .footer-links a:active {
   font-family: "Public Sans", Roboto, system-ui;
 }
 
-#login:hover {
-  background: var(--hover-color);
-}
-
 /* Sets the text `Login.gov` as transparent */
 /* With an Login.gov logo image over it */
 /* So screenreaders can read out `Login.gov` */
@@ -193,6 +189,9 @@ footer.global-footer .footer-links a:active {
   padding-top: 1px;
   vertical-align: baseline;
   color: transparent;
+  font-size: 16px;
+  font-weight: var(--bold-font-weight);
+  line-height: 1;
 }
 
 /* Sign Out */

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -708,22 +708,12 @@ footer.global-footer .footer-links a:active {
   }
 
   .media-list .media .media-body--heading {
-    font-size: 20px;
     line-height: 30px;
   }
 
   .media-list .media .media-body--details p {
     padding-bottom: 25px;
     margin-left: 0;
-    font-size: 20px;
-    line-height: 30px;
-    letter-spacing: 0.05em;
-  }
-
-  .media-list .media .media-body--items li {
-    font-size: 20px;
-    line-height: 30px;
-    letter-spacing: 0.05em;
   }
 
   .media-list .media .media-body--links {

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -342,12 +342,6 @@ footer.global-footer .footer-links a:active {
   margin-bottom: 12px;
 }
 
-.media-list .media .media-body--items {
-  font-size: 18px;
-  letter-spacing: 0.05em;
-  line-height: 26.1px;
-}
-
 .media-list .media .media-body--items li {
   list-style-type: disc;
 }

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -454,9 +454,7 @@ footer.global-footer .footer-links a:active {
 
 .radio-label-description {
   display: block;
-  font-size: 0.75rem;
   margin-left: 2rem;
-  font-weight: normal;
 }
 
 /* context-specific overrides */

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -45,13 +45,19 @@ p,
 a,
 label,
 span,
+button,
+input,
+small,
 li {
   font-family: var(--bs-body-font-family);
 }
 
 /* Paragraph: Body Text */
 /* Same sizes for all screen widths */
-p {
+p,
+.p,
+span,
+.span {
   font-size: var(--bs-body-font-size);
   font-weight: var(--bs-body-font-weight);
   line-height: var(--bs-body-line-height);

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -8,10 +8,12 @@
   --bs-body-color: var(--text-primary-color);
   --bs-body-text-align: left;
   --bs-body-font-weight: 400;
-  --bs-body-font-size: 16px;
+  --bs-body-font-size: 18px;
   --bs-font-sans-serif: Roboto, system-ui, -apple-system, "Segoe UI", sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --bs-body-font-family: var(--bs-font-sans-serif);
+  --bs-body-line-height: 1.5;
+  --body-letter-spacing: 0.05em;
   --dark-color: #212121;
   --footer-background-color: var(--dark-color);
   --footer-link-color: #73b3e7;
@@ -33,7 +35,6 @@
   src: local("PublicSans"), url("../fonts/PublicSans-Bold.woff") format("woff");
 }
 
-body,
 h1,
 h2,
 h3,
@@ -42,9 +43,19 @@ h5,
 h6,
 p,
 a,
+label,
 span,
 li {
   font-family: var(--bs-body-font-family);
+}
+
+/* Paragraph: Body Text */
+/* Same sizes for all screen widths */
+p {
+  font-size: var(--bs-body-font-size);
+  font-weight: var(--bs-body-font-weight);
+  line-height: var(--bs-body-line-height);
+  letter-spacing: var(--body-letter-spacing);
 }
 
 h1,
@@ -64,13 +75,6 @@ h1 {
   font-weight: 700;
   font-size: 24px;
   line-height: 30px;
-  letter-spacing: 0.05em;
-}
-
-p {
-  margin-bottom: 1.5rem;
-  font-size: 18px;
-  line-height: 27px;
   letter-spacing: 0.05em;
 }
 

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -418,11 +418,6 @@ footer.global-footer .footer-links a:active {
   text-align: center;
 }
 
-.radio-container {
-  display: block;
-  margin-left: 15%;
-}
-
 .radio-label {
   cursor: pointer;
   display: inline;
@@ -453,7 +448,6 @@ footer.global-footer .footer-links a:active {
 }
 
 .radio-label-description {
-  display: block;
   margin-left: 2rem;
 }
 
@@ -615,11 +609,6 @@ footer.global-footer .footer-links a:active {
   .global-footer ul.footer-links li a {
     padding-left: 30px;
     margin: 0;
-  }
-
-  .radio-container {
-    display: block;
-    margin-left: 0%;
   }
 
   .radio-label {


### PR DESCRIPTION
part of #971

## What this PR does
- Set body `<p>` size to 18px for all browser widths/sizes
- Goes through the whole app and makes sure the `<p>` elements are set as such
- Does not yet add a set margin/padding-top/bottom to all `<p>` yet. To come in future PRs.
- Set standard colors, underlines for `<a>` links that are not `.btn`s

## Style guide

<img width="408" alt="image" src="https://user-images.githubusercontent.com/3673236/193163216-8be65c9e-b830-495f-ade2-d7703c8dc10b.png">
<img width="467" alt="image" src="https://user-images.githubusercontent.com/3673236/193163244-672f3e17-8341-460f-b3e2-f04464f4b893.png">


## Paragraphs

All of the un-bolded paragraphs in these screenshots are proper `<p>`s:
<img width="439" alt="image" src="https://user-images.githubusercontent.com/3673236/193163366-d6ea025d-b577-4b0a-8eb5-ee76d4e6ee6f.png">
<img width="1181" alt="image" src="https://user-images.githubusercontent.com/3673236/193163465-6cb90c07-2401-409c-917d-778bd20d90b5.png">
<img width="1228" alt="image" src="https://user-images.githubusercontent.com/3673236/193163470-f35415e3-84be-4737-8b2e-7e3be234c07d.png">

## Links
<img width="1320" alt="image" src="https://user-images.githubusercontent.com/3673236/193163287-dab747a2-299b-4ab3-aa4b-532fc027abec.png">
<img width="1409" alt="image" src="https://user-images.githubusercontent.com/3673236/193163440-f0ee5bf0-e101-48ad-836e-bc2f280c5d1a.png">

