### PR TITLE
CSS Variables: Responsive headlines

### DIFF
--- a/benefits/core/templates/core/agency_index.html
+++ b/benefits/core/templates/core/agency_index.html
@@ -7,7 +7,7 @@
 {% block container_content %}
   <h1>{{ page.headline }}</h1>
 
-  <h2>{% translate "core.pages.agency_index.h2" %}</h2>
+  <p>{% translate "core.pages.agency_index.h2" %}</p>
 
   {% block buttons %}
     {{ block.super }}

--- a/benefits/core/templates/core/includes/form.html
+++ b/benefits/core/templates/core/includes/form.html
@@ -14,7 +14,7 @@
           {% endif %}
 
           {% if field.label %}
-            <label for="{{ field.id_for_label }}" class="form-control-label">
+            <label for="{{ field.id_for_label }}" class="form-control-label h2">
               {{ field.label }}
               {% if field.field.required %}<span class="required-label">*</span>{% endif %}
             </label>

--- a/benefits/core/templates/core/widgets/radio_select_option.html
+++ b/benefits/core/templates/core/widgets/radio_select_option.html
@@ -6,7 +6,7 @@
        {% include "django/forms/widgets/attrs.html" %}>
 
 {% if widget.wrap_label %}
-  <label{% if widget.attrs.id %} for="{{ widget.attrs.id }}" class="radio-label"{% endif %}>
+  <label{% if widget.attrs.id %} for="{{ widget.attrs.id }}" class="radio-label h3"{% endif %}>
     {{ widget.label }}
     {% if widget.description %}<p class="radio-label-description">{{ widget.description }}</p>{% endif %}
   </label>

--- a/benefits/eligibility/templates/eligibility/start.html
+++ b/benefits/eligibility/templates/eligibility/start.html
@@ -6,7 +6,7 @@
 
 {% block main_content %}
   <div class="container">
-    <h1 class="headline">{{ start_headline }}</h1>
+    <h1>{{ start_headline }}</h1>
 
     <h2 class="media-title">{{ start_sub_headline }}</h2>
 

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -74,7 +74,7 @@ msgstr ""
 "This option is for people who have a current Courtesy Card (includes MST "
 "RIDES Eligibility cardholders). This benefit is part of a demonstration tool "
 "and may need to be renewed in the future. Using this benefit means your new "
-"transit fare is half of the standard fare.the sample."
+"transit fare is half of the standard fare."
 
 msgid "eligibility.pages.start.mst_cc.headline"
 msgstr "You selected a Courtesy Card benefit."

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -50,6 +50,7 @@ h1,
 h2,
 .h2,
 h3,
+.h3,
 h4,
 h5,
 h6,
@@ -69,7 +70,8 @@ li {
 p,
 .p,
 span,
-.span {
+.span,
+li {
   font-size: var(--bs-body-font-size);
   font-weight: var(--bs-body-font-weight);
   letter-spacing: var(--body-letter-spacing);
@@ -77,7 +79,7 @@ span,
 }
 
 /* Links */
-/* Same sizes for all screen widths */
+/* Same sizes for all screen widths: 18px */
 a:not(.btn) {
   color: var(--primary-color);
   text-decoration: underline;
@@ -100,6 +102,7 @@ h1,
 h2,
 .h2,
 h3,
+.h3,
 h4 {
   font-weight: var(--bold-font-weight);
   letter-spacing: var(--body-letter-spacing);
@@ -121,6 +124,13 @@ h1 {
 h2,
 .h2 {
   font-size: 24px;
+}
+
+/* H3 */
+/* Same sizes for all screen widths: 20px */
+h3,
+.h3 {
+  font-size: 20px;
 }
 
 /* making the sticky footer */
@@ -297,7 +307,6 @@ footer.global-footer .footer-links a:active {
 /* Eligibility Start */
 
 .media-title {
-  margin-top: 100px;
   margin-bottom: 60px;
 }
 
@@ -331,24 +340,15 @@ footer.global-footer .footer-links a:active {
 
 .media-list .media .media-body {
   padding: 0 60px;
-  line-height: 26.1px;
 }
 
 .media-list .media .media-body--heading {
-  font-size: 18px;
-  letter-spacing: 0.05em;
-  line-height: 26.1px;
-  font-weight: 700;
   padding-left: 0;
   margin-top: 0;
-  margin-bottom: 16px;
 }
 
 .media-list .media .media-body--details {
-  font-size: 18px;
-  letter-spacing: 0.05em;
   padding-bottom: 1rem;
-  line-height: 26.1px;
 }
 
 .media-list .media .media-body--details p {
@@ -357,26 +357,6 @@ footer.global-footer .footer-links a:active {
 
 .media-list .media .media-body--items li {
   list-style-type: disc;
-}
-
-.media-list .media .media-body .media-body--links .btn-lg {
-  font-size: 16px;
-  letter-spacing: 0.05em;
-  padding: 0 0 6px 0;
-  text-align: left;
-  width: fit-content;
-}
-
-.media-list .media .media-body .media-body--links .btn-lg:hover {
-  color: var(--hover-color);
-}
-
-.eligibility-start .main-container {
-  padding-top: 3rem;
-  padding-bottom: 2rem;
-  width: initial;
-  padding-left: 0;
-  padding-right: 0;
 }
 
 .eligibility-start .buttons {
@@ -398,7 +378,6 @@ footer.global-footer .footer-links a:active {
 
 .eligibility-start h1.headline {
   margin-bottom: 50px;
-  margin-top: 64px;
 }
 
 /* Enrollment Success */
@@ -696,10 +675,6 @@ footer.global-footer .footer-links a:active {
     padding: 0;
   }
 
-  .media-list .media .media-body--heading {
-    line-height: 30px;
-  }
-
   .media-list .media .media-body--details p {
     padding-bottom: 25px;
     margin-left: 0;
@@ -710,20 +685,7 @@ footer.global-footer .footer-links a:active {
     float: right;
   }
 
-  .eligibility-start .main-content .container strong .info-link {
-    display: none;
-  }
-
-  .media-list .media .media-body .media-body--links .btn-lg {
-    font-size: 18px;
-    line-height: 27px;
-    font-weight: 700;
-    letter-spacing: 0.05em;
-    display: block;
-  }
-
   .media-title {
-    text-align: left !important;
     margin-top: 42px;
     margin-bottom: 46px;
   }

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -30,12 +30,13 @@
   --radio-input-color: var(--standout-color);
   --h1-font-size: 1.5em;
   --h1-text-align: left;
+  --h2-font-size: 1.3333333em;
+  --h3-font-size: 1.1111111em;
 }
 
 @media (min-width: 992px) {
   :root {
-    --h1-font-size: 2.1875em;
-    /* 2.1875em = 35px */
+    --h1-font-size: 1.944444em;
     --h1-text-align: center;
   }
 }
@@ -48,7 +49,8 @@
 }
 
 body {
-  font-size: 100%;
+  font-size: 1.125em;
+  /* 18px/16px = 1.125em */
 }
 
 h1,
@@ -117,8 +119,8 @@ h4 {
 }
 
 /* H1 */
-/* Mobile first: Screen width up to 992px - 24px and left-aligned */
-/* Screen width above 992px - 35px and centered */
+/* Mobile first: Screen width up to 992px - 24px (24px/18 = 1.333em) and left */
+/* Screen width above 992px - 35px (35px/18 = 1.9444) and centered */
 /* Does not have a class. Do not apply to non-headline elements. */
 h1 {
   font-size: var(--h1-font-size);
@@ -127,21 +129,19 @@ h1 {
 }
 
 /* H2 */
-/* Same sizes for all screen widths: 24px; */
+/* Same sizes for all screen widths: 24px (24px/18px = 1.333em) */
 /* Also has a class which can be applied to non-headline elements */
 h2,
 .h2 {
-  font-size: 1.5em;
-  /* 1.25em = 24px */
+  font-size: var(--h2-font-size);
 }
 
 /* H3 */
-/* Same sizes for all screen widths: 20px */
+/* Same sizes for all screen widths: 20px (20px/18px = 1.111em) */
 /* Also has a class which can be applied to non-headline elements */
 h3,
 .h3 {
-  font-size: 1.25em;
-  /* 1.25em = 20px */
+  font-size: var(--h3-font-size);
 }
 
 /* making the sticky footer */

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -97,7 +97,8 @@ a:visited:not(.btn) {
 }
 
 /* Headlines */
-
+/* All headlines */
+/* All headlines share font-weight, letter-spacing, line-height and margin */
 h1,
 h2,
 .h2,
@@ -113,6 +114,7 @@ h4 {
 /* H1 */
 /* Mobile first: Screen width up to 992px - 24px and left-aligned */
 /* Screen width above 992px - 35px and centered */
+/* Does not have a class. Do not apply to non-headline elements. */
 h1 {
   font-size: var(--h1-font-size);
   text-align: var(--h1-text-align);
@@ -121,6 +123,7 @@ h1 {
 
 /* H2 */
 /* Same sizes for all screen widths: 24px; */
+/* Also has a class which can be applied to non-headline elements */
 h2,
 .h2 {
   font-size: 24px;
@@ -128,6 +131,7 @@ h2,
 
 /* H3 */
 /* Same sizes for all screen widths: 20px */
+/* Also has a class which can be applied to non-headline elements */
 h3,
 .h3 {
   font-size: 20px;

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -478,7 +478,6 @@ footer.global-footer .footer-links a:active {
 }
 
 .container.content h1.icon-title span.icon {
-  text-align: center;
   display: block;
   padding-bottom: 3rem;
 }
@@ -493,7 +492,6 @@ footer.global-footer .footer-links a:active {
 }
 
 .container.content.help h1 {
-  margin-top: 5.5rem;
   margin-bottom: 4rem;
 }
 

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -380,8 +380,8 @@ footer.global-footer .footer-links a:active {
   line-height: 1;
 }
 
-.eligibility-start h1.headline {
-  margin-bottom: 50px;
+.eligibility-start h1 {
+  padding-bottom: 64px;
 }
 
 /* Enrollment Success */
@@ -642,9 +642,8 @@ footer.global-footer .footer-links a:active {
 
   /* Eligibility Start */
 
-  .eligibility-start h1.headline {
-    margin-top: 24px;
-    margin-bottom: 16px;
+  .eligibility-start h1 {
+    padding-bottom: 24px;
   }
 
   .eligibility-start .main-content {
@@ -688,7 +687,6 @@ footer.global-footer .footer-links a:active {
   }
 
   .media-title {
-    margin-top: 42px;
     margin-bottom: 46px;
   }
 

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -28,6 +28,15 @@
   --bs-danger-rgb: var(--error-color-rgb);
   --standout-color: #323a45;
   --radio-input-color: var(--standout-color);
+  --h1-font-size: 24px;
+  --h1-text-align: left;
+}
+
+@media (min-width: 992px) {
+  :root {
+    --h1-font-size: 35px;
+    --h1-text-align: center;
+  }
 }
 
 @font-face {
@@ -93,13 +102,22 @@ h2,
 h3,
 h4 {
   font-weight: var(--bold-font-weight);
-  line-height: var(--bs-body-line-height);
   letter-spacing: var(--body-letter-spacing);
   line-height: var(--bs-body-line-height);
+  margin: 0;
+}
+
+/* H1 */
+/* Mobile first: Screen width up to 992px - 24px and left-aligned */
+/* Screen width above 992px - 35px and centered */
+h1 {
+  font-size: var(--h1-font-size);
+  text-align: var(--h1-text-align);
+  padding-top: 70px;
 }
 
 /* H2 */
-/* Same sizes for all screen widths */
+/* Same sizes for all screen widths: 24px; */
 h2,
 .h2 {
   font-size: 24px;
@@ -379,10 +397,6 @@ footer.global-footer .footer-links a:active {
 }
 
 .eligibility-start h1.headline {
-  font-size: 35px;
-  line-height: 52.5px;
-  letter-spacing: 0.05em;
-  text-align: center;
   margin-bottom: 50px;
   margin-top: 64px;
 }
@@ -414,10 +428,6 @@ footer.global-footer .footer-links a:active {
 
 .logged-out.enrollment-success .container.content {
   padding-top: 20vh;
-}
-
-.logged-out.enrollment-success .container.content h1 {
-  text-align: center;
 }
 
 .radio-label {
@@ -474,11 +484,6 @@ footer.global-footer .footer-links a:active {
   width: 271px;
 }
 
-.container.content {
-  margin-top: 2rem;
-  margin-bottom: 2rem;
-}
-
 .container.content .buttons label {
   display: block;
   margin-bottom: 2rem;
@@ -487,8 +492,6 @@ footer.global-footer .footer-links a:active {
 
 .container.content h1.icon-title {
   padding-bottom: 1.5rem;
-  line-height: 36px;
-  text-align: center;
 }
 
 .container.content h1.icon-title span.icon {
@@ -507,10 +510,6 @@ footer.global-footer .footer-links a:active {
 }
 
 .container.content.help h1 {
-  letter-spacing: 0.05em;
-  font-weight: 700;
-  font-size: 2.25rem;
-  text-align: center;
   margin-top: 5.5rem;
   margin-bottom: 4rem;
 }
@@ -663,9 +662,6 @@ footer.global-footer .footer-links a:active {
   /* Eligibility Start */
 
   .eligibility-start h1.headline {
-    text-align: left;
-    font-size: 24px;
-    line-height: 36px;
     margin-top: 24px;
     margin-bottom: 16px;
   }
@@ -767,14 +763,6 @@ footer.global-footer .footer-links a:active {
     padding-bottom: 0.138rem;
   }
 
-  .container.content {
-    padding-left: 3.5rem;
-    padding-right: 3.5rem;
-    padding-top: 2rem;
-    padding-bottom: 2rem;
-    margin: 0;
-  }
-
   .container.content input[type="submit"],
   .container.content .btn {
     width: fit-content;
@@ -797,15 +785,6 @@ footer.global-footer .footer-links a:active {
 }
 
 @media (min-width: 1200px) {
-  /* xl+ */
-  .container.content {
-    padding-left: 5rem;
-    padding-right: 5rem;
-    padding-top: 4.5rem;
-    padding-bottom: 2rem;
-    margin: 0;
-  }
-
   /* Override for only the Agency Index page */
   .agency-index .container.content h1 ~ p:nth-last-of-type(1) {
     margin-bottom: 5rem;

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -28,15 +28,15 @@
   --bs-danger-rgb: var(--error-color-rgb);
   --standout-color: #323a45;
   --radio-input-color: var(--standout-color);
-  --h1-font-size: 1.5em;
+  --h1-font-size: calc(24rem / 16);
   --h1-text-align: left;
-  --h2-font-size: 1.3333333em;
-  --h3-font-size: 1.1111111em;
+  --h2-font-size: calc(24rem / 16);
+  --h3-font-size: calc(20rem / 16);
 }
 
 @media (min-width: 992px) {
   :root {
-    --h1-font-size: 1.944444em;
+    --h1-font-size: calc(35rem / 16);
     --h1-text-align: center;
   }
 }
@@ -49,8 +49,7 @@
 }
 
 body {
-  font-size: 1.125em;
-  /* 18px/16px = 1.125em */
+  font-size: 100%;
 }
 
 h1,
@@ -119,8 +118,8 @@ h4 {
 }
 
 /* H1 */
-/* Mobile first: Screen width up to 992px - 24px (24px/18 = 1.333em) and left */
-/* Screen width above 992px - 35px (35px/18 = 1.9444) and centered */
+/* Mobile first: Screen width up to 992px - 24px (24rem/16 = 1.5rem) and left */
+/* Screen width above 992px - 35px (35rem/16 = 2.1875rem) and centered */
 /* Does not have a class. Do not apply to non-headline elements. */
 h1 {
   font-size: var(--h1-font-size);
@@ -129,7 +128,7 @@ h1 {
 }
 
 /* H2 */
-/* Same sizes for all screen widths: 24px (24px/18px = 1.333em) */
+/* Same sizes for all screen widths: 24px (24rem/16 = 1.5rem) */
 /* Also has a class which can be applied to non-headline elements */
 h2,
 .h2 {
@@ -137,7 +136,7 @@ h2,
 }
 
 /* H3 */
-/* Same sizes for all screen widths: 20px (20px/18px = 1.111em) */
+/* Same sizes for all screen widths: 20px (20rem/16 = 1.25rem) */
 /* Also has a class which can be applied to non-headline elements */
 h3,
 .h3 {

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -28,13 +28,14 @@
   --bs-danger-rgb: var(--error-color-rgb);
   --standout-color: #323a45;
   --radio-input-color: var(--standout-color);
-  --h1-font-size: 24px;
+  --h1-font-size: 1.5em;
   --h1-text-align: left;
 }
 
 @media (min-width: 992px) {
   :root {
-    --h1-font-size: 35px;
+    --h1-font-size: 2.1875em;
+    /* 2.1875em = 35px */
     --h1-text-align: center;
   }
 }
@@ -44,6 +45,10 @@
   font-weight: 700;
   font-style: normal;
   src: local("PublicSans"), url("../fonts/PublicSans-Bold.woff") format("woff");
+}
+
+body {
+  font-size: 100%;
 }
 
 h1,
@@ -126,7 +131,8 @@ h1 {
 /* Also has a class which can be applied to non-headline elements */
 h2,
 .h2 {
-  font-size: 24px;
+  font-size: 1.5em;
+  /* 1.25em = 24px */
 }
 
 /* H3 */
@@ -134,7 +140,8 @@ h2,
 /* Also has a class which can be applied to non-headline elements */
 h3,
 .h3 {
-  font-size: 20px;
+  font-size: 1.25em;
+  /* 1.25em = 20px */
 }
 
 /* making the sticky footer */

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -39,6 +39,7 @@
 
 h1,
 h2,
+.h2,
 h3,
 h4,
 h5,
@@ -62,8 +63,8 @@ span,
 .span {
   font-size: var(--bs-body-font-size);
   font-weight: var(--bs-body-font-weight);
-  line-height: var(--bs-body-line-height);
   letter-spacing: var(--body-letter-spacing);
+  line-height: var(--bs-body-line-height);
 }
 
 /* Links */
@@ -84,28 +85,27 @@ a:visited:not(.btn) {
   color: var(--selected-color);
 }
 
+/* Headlines */
+
 h1,
 h2,
+.h2,
 h3,
-h4,
-h5,
-h6 {
-  font-weight: 500;
-  font-size: 24px;
-  line-height: 30px;
-  margin-top: 30px;
-  margin-bottom: 20px;
+h4 {
+  font-weight: var(--bold-font-weight);
+  line-height: var(--bs-body-line-height);
+  letter-spacing: var(--body-letter-spacing);
+  line-height: var(--bs-body-line-height);
 }
 
-h1 {
-  font-weight: 700;
+/* H2 */
+/* Same sizes for all screen widths */
+h2,
+.h2 {
   font-size: 24px;
-  line-height: 30px;
-  letter-spacing: 0.05em;
 }
 
 /* making the sticky footer */
-
 html,
 body {
   height: 100%;
@@ -281,10 +281,6 @@ footer.global-footer .footer-links a:active {
 .media-title {
   margin-top: 100px;
   margin-bottom: 60px;
-  font-size: 24px;
-  line-height: 36px;
-  letter-spacing: 0.05em;
-  font-weight: 700;
 }
 
 .media-list {
@@ -520,9 +516,6 @@ footer.global-footer .footer-links a:active {
 }
 
 .container.content.help h2 {
-  letter-spacing: 0.05em;
-  font-weight: 700;
-  font-size: 1.5rem;
   margin-bottom: 3rem;
   margin-top: 3rem;
 }


### PR DESCRIPTION
closes #971 

## What this PR does

### Font sizes
- Add styles for all `h1`, `h2`, `h3` and back-up CSS classes for `h2`, `h3`
- Set up responsive CSS variables for `h1`: `h1` changes font-size when the screen width gets wider
- Write the font styles in mobile-first mode: Meaning, create media queries for the wider screen widths and set the default to the mobile width
- Delete CSS styles that were declaring font sizes that are now taken care of with the proper h1, h2, h3 declaration

### Font spacing: Margins and padding
- Delete all margins/padding from `container.content`. Set all margin/padding on `container.content` to 0.
- Adds `padding-top` of 70px to H1

### Font size units
- I set `body` to 18px, which is 1.125em. That's calculated with: 18/16=1.125.
- I used the same formula to get the em sizes for the h1, h2 and h3. 

## Styles and variables:

- Margin is set to zero for all headlines

### H1

- `<h1>`: Font size is 24px and left-aligned on mobile. At screen widths of 992px and up, the font size increases to 35px and is centered. On all screen widths, h1s have a padding-top of 70px.

### H2

- `<h2>` and `h2` class
- Font size 24px for all screen widths

### H3

- `<h3>` and `h3` class
- Font size 20px for all screen widths


## Testing and 2 expected regressions

This PR does not add any padding to any other elements (like paragraphs or forms). So spacing differences around paragraphs, forms, anything else are expected.


1. There is one expected regression that will be taken care of in a future ticket https://github.com/cal-itp/benefits/issues/947 

This PR added a class, `h2`, to the Form includes' `label` element: https://github.com/cal-itp/benefits/pull/991/files#diff-e80e374594a3ed9b08de85983db18bdb5fb593fcab674d7a45c57513a0a10088R17

This template is used in two different places, which both have `label` elements. The two different `label` elements, however, have different font sizes. I will be taking care of this style override when I rewrite the CSS for the input page.

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/193706736-6f8531fd-d995-4eac-aa64-0817d4e3dc4e.png">
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/193706759-65284c50-0146-46d6-b6fa-c993a88ce195.png">

2. Regression on Mobile for Eligibility Start
<img width="1103" alt="image" src="https://user-images.githubusercontent.com/3673236/193707743-0c738a59-064f-4166-b1cf-e8f012a900e5.png">

Although the spacing is correct for the H1 and H2 on Elig Start., Elig Start Mobile has a particular style override for the H2. On mobile, the H2 becomes a Paragraph style. This will also be taken care of in this PR #934 