### PR TITLE
Refactor: remove agency index pass-thru

### DIFF
--- a/benefits/core/views.py
+++ b/benefits/core/views.py
@@ -52,9 +52,6 @@ def agency_index(request, agency):
     session.reset(request)
     session.update(request, agency=agency, origin=agency.index_url)
 
-    if len(agency.eligibility_verifiers.all()) == 1:
-        return redirect(reverse(ROUTE_ELIGIBILITY))
-
     button = viewmodels.Button.primary(text=_("core.pages.index.continue"), url=reverse(ROUTE_ELIGIBILITY))
 
     page = viewmodels.Page(

--- a/tests/pytest/core/test_views.py
+++ b/tests/pytest/core/test_views.py
@@ -4,7 +4,7 @@ import pytest
 
 from benefits.core.models import EligibilityVerifier, TransitAgency
 import benefits.core.session
-from benefits.core.views import ROUTE_ELIGIBILITY, ROUTE_INDEX, ROUTE_HELP, TEMPLATE_AGENCY, bad_request, csrf_failure
+from benefits.core.views import ROUTE_INDEX, ROUTE_HELP, TEMPLATE_AGENCY, bad_request, csrf_failure
 
 
 ROUTE_AGENCY = "core:agency_index"
@@ -60,8 +60,8 @@ def test_agency_index_single_verifier(mocker, model_TransitAgency, client, sessi
     session_reset_spy.assert_called_once()
     mocked_session_update.assert_called_once()
 
-    assert response.status_code == 302
-    assert response.url == reverse(ROUTE_ELIGIBILITY)
+    assert response.status_code == 200
+    assert response.template_name == TEMPLATE_AGENCY
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Closes #976... Although I realized in doing this that, it doesn't actually matter? We'll have a single agency with multiple verifiers, so this check would have failed anyway.

Oh well, it's dead code, so fine to remove.