### PR TITLE
Refactor: Footer sizing and alignment

### DIFF
--- a/benefits/core/templates/core/agency_index.html
+++ b/benefits/core/templates/core/agency_index.html
@@ -7,7 +7,7 @@
 {% block container_content %}
   <h1>{{ page.headline }}</h1>
 
-  <h2>{% translate "core.pages.agency_index.h2" %}</h2>
+  <p>{% translate "core.pages.agency_index.h2" %}</p>
 
   {% block buttons %}
     {{ block.super }}

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -71,14 +71,14 @@
       {% endblock main_content %}
     </main>
 
-    <footer id="footer" class="global-footer">
+    <footer id="footer">
       <div class="container">
-        <ul class="footer-links">
+        <ul class="footer-links m-0 p-0 list-unstyled d-lg-flex gap-lg-4">
           <li>
-            <a href="{% url "core:help" %}">{% translate "core.buttons.help" %}</a>
+            <a class="m-0 ps-5 ps-lg-0" href="{% url "core:help" %}">{% translate "core.buttons.help" %}</a>
           </li>
           <li>
-            <a href="https://cdt.ca.gov/privacy-policy/" target="_blank" rel="noopener noreferrer">{% translate "core.buttons.privacy" %}</a>
+            <a class="m-0 ps-5 ps-lg-0" href="https://cdt.ca.gov/privacy-policy/" target="_blank" rel="noopener noreferrer">{% translate "core.buttons.privacy" %}</a>
           </li>
         </ul>
       </div>

--- a/benefits/core/templates/core/includes/form.html
+++ b/benefits/core/templates/core/includes/form.html
@@ -14,7 +14,7 @@
           {% endif %}
 
           {% if field.label %}
-            <label for="{{ field.id_for_label }}" class="form-control-label">
+            <label for="{{ field.id_for_label }}" class="form-control-label h2">
               {{ field.label }}
               {% if field.field.required %}<span class="required-label">*</span>{% endif %}
             </label>

--- a/benefits/core/templates/core/widgets/radio_select_option.html
+++ b/benefits/core/templates/core/widgets/radio_select_option.html
@@ -6,7 +6,7 @@
        {% include "django/forms/widgets/attrs.html" %}>
 
 {% if widget.wrap_label %}
-  <label{% if widget.attrs.id %} for="{{ widget.attrs.id }}" class="radio-label"{% endif %}>
+  <label{% if widget.attrs.id %} for="{{ widget.attrs.id }}" class="radio-label h3"{% endif %}>
     {{ widget.label }}
     {% if widget.description %}<p class="radio-label-description">{{ widget.description }}</p>{% endif %}
   </label>

--- a/benefits/eligibility/templates/eligibility/start.html
+++ b/benefits/eligibility/templates/eligibility/start.html
@@ -6,7 +6,7 @@
 
 {% block main_content %}
   <div class="container">
-    <h1 class="headline">{{ start_headline }}</h1>
+    <h1>{{ start_headline }}</h1>
 
     <h2 class="media-title">{{ start_sub_headline }}</h2>
 

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -74,7 +74,7 @@ msgstr ""
 "This option is for people who have a current Courtesy Card (includes MST "
 "RIDES Eligibility cardholders). This benefit is part of a demonstration tool "
 "and may need to be renewed in the future. Using this benefit means your new "
-"transit fare is half of the standard fare.the sample."
+"transit fare is half of the standard fare."
 
 msgid "eligibility.pages.start.mst_cc.headline"
 msgstr "You selected a Courtesy Card benefit."

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -50,6 +50,7 @@ h1,
 h2,
 .h2,
 h3,
+.h3,
 h4,
 h5,
 h6,
@@ -69,7 +70,8 @@ li {
 p,
 .p,
 span,
-.span {
+.span,
+li {
   font-size: var(--bs-body-font-size);
   font-weight: var(--bs-body-font-weight);
   letter-spacing: var(--body-letter-spacing);
@@ -77,7 +79,7 @@ span,
 }
 
 /* Links */
-/* Same sizes for all screen widths */
+/* Same sizes for all screen widths: 18px */
 a:not(.btn) {
   color: var(--primary-color);
   text-decoration: underline;
@@ -100,6 +102,7 @@ h1,
 h2,
 .h2,
 h3,
+.h3,
 h4 {
   font-weight: var(--bold-font-weight);
   letter-spacing: var(--body-letter-spacing);
@@ -121,6 +124,13 @@ h1 {
 h2,
 .h2 {
   font-size: 24px;
+}
+
+/* H3 */
+/* Same sizes for all screen widths: 20px */
+h3,
+.h3 {
+  font-size: 20px;
 }
 
 /* making the sticky footer */
@@ -297,7 +307,6 @@ footer.global-footer .footer-links a:active {
 /* Eligibility Start */
 
 .media-title {
-  margin-top: 100px;
   margin-bottom: 60px;
 }
 
@@ -331,24 +340,15 @@ footer.global-footer .footer-links a:active {
 
 .media-list .media .media-body {
   padding: 0 60px;
-  line-height: 26.1px;
 }
 
 .media-list .media .media-body--heading {
-  font-size: 18px;
-  letter-spacing: 0.05em;
-  line-height: 26.1px;
-  font-weight: 700;
   padding-left: 0;
   margin-top: 0;
-  margin-bottom: 16px;
 }
 
 .media-list .media .media-body--details {
-  font-size: 18px;
-  letter-spacing: 0.05em;
   padding-bottom: 1rem;
-  line-height: 26.1px;
 }
 
 .media-list .media .media-body--details p {
@@ -357,26 +357,6 @@ footer.global-footer .footer-links a:active {
 
 .media-list .media .media-body--items li {
   list-style-type: disc;
-}
-
-.media-list .media .media-body .media-body--links .btn-lg {
-  font-size: 16px;
-  letter-spacing: 0.05em;
-  padding: 0 0 6px 0;
-  text-align: left;
-  width: fit-content;
-}
-
-.media-list .media .media-body .media-body--links .btn-lg:hover {
-  color: var(--hover-color);
-}
-
-.eligibility-start .main-container {
-  padding-top: 3rem;
-  padding-bottom: 2rem;
-  width: initial;
-  padding-left: 0;
-  padding-right: 0;
 }
 
 .eligibility-start .buttons {
@@ -398,7 +378,6 @@ footer.global-footer .footer-links a:active {
 
 .eligibility-start h1.headline {
   margin-bottom: 50px;
-  margin-top: 64px;
 }
 
 /* Enrollment Success */
@@ -696,10 +675,6 @@ footer.global-footer .footer-links a:active {
     padding: 0;
   }
 
-  .media-list .media .media-body--heading {
-    line-height: 30px;
-  }
-
   .media-list .media .media-body--details p {
     padding-bottom: 25px;
     margin-left: 0;
@@ -710,20 +685,7 @@ footer.global-footer .footer-links a:active {
     float: right;
   }
 
-  .eligibility-start .main-content .container strong .info-link {
-    display: none;
-  }
-
-  .media-list .media .media-body .media-body--links .btn-lg {
-    font-size: 18px;
-    line-height: 27px;
-    font-weight: 700;
-    letter-spacing: 0.05em;
-    display: block;
-  }
-
   .media-title {
-    text-align: left !important;
     margin-top: 42px;
     margin-bottom: 46px;
   }

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -30,12 +30,13 @@
   --radio-input-color: var(--standout-color);
   --h1-font-size: 1.5em;
   --h1-text-align: left;
+  --h2-font-size: 1.3333333em;
+  --h3-font-size: 1.1111111em;
 }
 
 @media (min-width: 992px) {
   :root {
-    --h1-font-size: 2.1875em;
-    /* 2.1875em = 35px */
+    --h1-font-size: 1.944444em;
     --h1-text-align: center;
   }
 }
@@ -48,7 +49,8 @@
 }
 
 body {
-  font-size: 100%;
+  font-size: 1.125em;
+  /* 18px/16px = 1.125em */
 }
 
 h1,
@@ -117,8 +119,8 @@ h4 {
 }
 
 /* H1 */
-/* Mobile first: Screen width up to 992px - 24px and left-aligned */
-/* Screen width above 992px - 35px and centered */
+/* Mobile first: Screen width up to 992px - 24px (24px/18 = 1.333em) and left */
+/* Screen width above 992px - 35px (35px/18 = 1.9444) and centered */
 /* Does not have a class. Do not apply to non-headline elements. */
 h1 {
   font-size: var(--h1-font-size);
@@ -127,21 +129,19 @@ h1 {
 }
 
 /* H2 */
-/* Same sizes for all screen widths: 24px; */
+/* Same sizes for all screen widths: 24px (24px/18px = 1.333em) */
 /* Also has a class which can be applied to non-headline elements */
 h2,
 .h2 {
-  font-size: 1.5em;
-  /* 1.25em = 24px */
+  font-size: var(--h2-font-size);
 }
 
 /* H3 */
-/* Same sizes for all screen widths: 20px */
+/* Same sizes for all screen widths: 20px (20px/18px = 1.111em) */
 /* Also has a class which can be applied to non-headline elements */
 h3,
 .h3 {
-  font-size: 1.25em;
-  /* 1.25em = 20px */
+  font-size: var(--h3-font-size);
 }
 
 /* making the sticky footer */

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -207,13 +207,53 @@ footer.global-footer .footer-links li a:active {
   }
 }
 
-/* class styles */
+/* Header */
+
+.navbar.navbar-expand-sm.navbar-dark.bg-primary {
+  padding: 8.5px 1rem;
+}
+
+.navbar-brand {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.navbar-brand img.sm {
+  width: 120px;
+}
+
+.navbar-brand img.lg {
+  width: 271px;
+}
+
+/* Buttons */
 
 .btn-lg {
   border-width: 2px;
 }
 
-/* Log In */
+.btn-link {
+  color: var(--primary-color);
+}
+
+.btn-primary {
+  text-transform: capitalize;
+  letter-spacing: 0.05em;
+}
+
+.btn-outline-light {
+  width: 126px;
+  height: 38px;
+  padding: 0px !important;
+}
+
+.container.content .buttons label {
+  display: block;
+  margin-bottom: 2rem;
+  text-align: center;
+}
+
+/* Custom button: Log In */
 
 #login {
   cursor: pointer;
@@ -248,7 +288,7 @@ footer.global-footer .footer-links li a:active {
   line-height: 1;
 }
 
-/* Sign Out */
+/* Custom button: Sign Out */
 
 .signout-row {
   position: absolute;
@@ -270,20 +310,7 @@ footer.global-footer .footer-links li a:active {
   display: block;
 }
 
-.btn-link {
-  color: var(--primary-color);
-}
-
-.btn-primary {
-  text-transform: capitalize;
-  letter-spacing: 0.05em;
-}
-
-.btn-outline-light {
-  width: 126px;
-  height: 38px;
-  padding: 0px !important;
-}
+/* Forms: Inputs */
 
 .form-control {
   border-radius: 0.25rem;
@@ -326,7 +353,42 @@ footer.global-footer .footer-links li a:active {
   margin-bottom: 0;
 }
 
-/* Eligibility Start */
+/* Forms: Radio Buttons */
+
+.radio-label {
+  cursor: pointer;
+  display: inline;
+  margin-left: 15px;
+}
+
+.radio-input {
+  cursor: pointer;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+
+  border-radius: 50%;
+  width: 25px;
+  height: 25px;
+
+  border: 3px solid var(--radio-input-color);
+  margin-right: 5px;
+  margin-top: 20px;
+
+  position: relative;
+  top: 7px;
+}
+
+.radio-input:checked {
+  background-color: var(--radio-input-color);
+  box-shadow: inset 0 0 0 2px var(--bs-white);
+}
+
+.radio-label-description {
+  margin-left: 2rem;
+}
+
+/* Media List */
 
 .media-title {
   margin-bottom: 60px;
@@ -381,6 +443,8 @@ footer.global-footer .footer-links li a:active {
   list-style-type: disc;
 }
 
+/* Eligibility Start */
+
 .eligibility-start .buttons {
   display: flex;
   align-items: flex-end;
@@ -431,65 +495,7 @@ footer.global-footer .footer-links li a:active {
   padding-top: 20vh;
 }
 
-.radio-label {
-  cursor: pointer;
-  display: inline;
-  margin-left: 15px;
-}
-
-.radio-input {
-  cursor: pointer;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-
-  border-radius: 50%;
-  width: 25px;
-  height: 25px;
-
-  border: 3px solid var(--radio-input-color);
-  margin-right: 5px;
-  margin-top: 20px;
-
-  position: relative;
-  top: 7px;
-}
-
-.radio-input:checked {
-  background-color: var(--radio-input-color);
-  box-shadow: inset 0 0 0 2px var(--bs-white);
-}
-
-.radio-label-description {
-  margin-left: 2rem;
-}
-
-/* context-specific overrides */
-
-/* Header */
-
-.navbar.navbar-expand-sm.navbar-dark.bg-primary {
-  padding: 8.5px 1rem;
-}
-
-.navbar-brand {
-  padding-top: 0;
-  padding-bottom: 0;
-}
-
-.navbar-brand img.sm {
-  width: 120px;
-}
-
-.navbar-brand img.lg {
-  width: 271px;
-}
-
-.container.content .buttons label {
-  display: block;
-  margin-bottom: 2rem;
-  text-align: center;
-}
+/* 404 Page */
 
 .container.content h1.icon-title {
   padding-bottom: 1.5rem;
@@ -504,6 +510,8 @@ footer.global-footer .footer-links li a:active {
   width: 150px;
   height: 150px;
 }
+
+/* Help */
 
 .container.content.help {
   margin: 4rem auto 2rem auto;

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -97,7 +97,8 @@ a:visited:not(.btn) {
 }
 
 /* Headlines */
-
+/* All headlines */
+/* All headlines share font-weight, letter-spacing, line-height and margin */
 h1,
 h2,
 .h2,
@@ -113,6 +114,7 @@ h4 {
 /* H1 */
 /* Mobile first: Screen width up to 992px - 24px and left-aligned */
 /* Screen width above 992px - 35px and centered */
+/* Does not have a class. Do not apply to non-headline elements. */
 h1 {
   font-size: var(--h1-font-size);
   text-align: var(--h1-text-align);
@@ -121,6 +123,7 @@ h1 {
 
 /* H2 */
 /* Same sizes for all screen widths: 24px; */
+/* Also has a class which can be applied to non-headline elements */
 h2,
 .h2 {
   font-size: 24px;
@@ -128,6 +131,7 @@ h2,
 
 /* H3 */
 /* Same sizes for all screen widths: 20px */
+/* Also has a class which can be applied to non-headline elements */
 h3,
 .h3 {
   font-size: 20px;

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -478,7 +478,6 @@ footer.global-footer .footer-links a:active {
 }
 
 .container.content h1.icon-title span.icon {
-  text-align: center;
   display: block;
   padding-bottom: 3rem;
 }
@@ -493,7 +492,6 @@ footer.global-footer .footer-links a:active {
 }
 
 .container.content.help h1 {
-  margin-top: 5.5rem;
   margin-bottom: 4rem;
 }
 

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -32,12 +32,21 @@
   --h1-text-align: left;
   --h2-font-size: calc(24rem / 16);
   --h3-font-size: calc(20rem / 16);
+  --main-content-min-height: calc(100vh - 182px);
+  /* 182px = Header Height (80px) + (Footer Link (50px) * Number of Links (2)) + Underline Height (2px) */
 }
 
 @media (min-width: 992px) {
   :root {
     --h1-font-size: calc(35rem / 16);
     --h1-text-align: center;
+  }
+}
+
+@media (min-width: 767px) {
+  :root {
+    --main-content-min-height: calc(100vh - 130px);
+    /* 130px = Header Height (80px) + Footer Height (50px) */
   }
 }
 
@@ -143,52 +152,59 @@ h3,
   font-size: var(--h3-font-size);
 }
 
-/* making the sticky footer */
-html,
-body {
-  height: 100%;
-  overflow-y: unset;
-}
-
-body {
-  display: flex;
-  flex-direction: column;
-}
-
+/* Main */
+/* The minimum height is calculated by 100 viewport height minus Header and Footer height */
 main {
-  flex-shrink: 0 !important;
+  min-height: var(--main-content-min-height);
 }
 
-main#main-content.main-content {
-  position: relative;
+/* Footer */
+/* Footer has same font styles on all screen widths */
+/* Mobile first: One link per row, each link is 50px height */
+/* Screen width above 767 - Footer is 50px height */
+footer.global-footer {
+  background: var(--footer-background-color);
+  padding: 0;
 }
 
-/* All pages but the Start Page */
-main .main-row {
-  min-height: calc(100vh - 120px);
+footer.global-footer .footer-links {
+  margin: 0 !important;
+  padding: 0;
 }
 
-main .main-row .col-lg-6.image {
-  background: 48% 75% url("/static/img/ridertappingbankcard.png") no-repeat;
-  background-size: cover;
-}
-
-footer {
-  margin-top: auto;
-  padding-top: 1rem;
-  padding-bottom: 1rem;
-}
-
-footer.global-footer .footer-links a {
+footer.global-footer .footer-links li a {
   color: var(--footer-link-color);
   font-weight: var(--bs-body-font-weight);
+  font-size: var(--bs-body-font-size);
   text-decoration: underline;
+  letter-spacing: 0;
+  line-height: 50px;
 }
 
-footer.global-footer .footer-links a:hover,
-footer.global-footer .footer-links a:focus,
-footer.global-footer .footer-links a:active {
+footer.global-footer .footer-links li a:hover,
+footer.global-footer .footer-links li a:focus,
+footer.global-footer .footer-links li a:active {
   color: var(--footer-link-hover-color);
+}
+
+@media (max-width: 757px) {
+  footer.global-footer .container {
+    max-width: 100%;
+    padding: 0;
+  }
+
+  footer.global-footer .footer-links li {
+    width: 100%;
+  }
+
+  footer.global-footer .footer-links li a {
+    margin: 0;
+    padding-left: 30px;
+  }
+
+  footer.global-footer .footer-links li:not(:last-child) {
+    border-bottom: 2px solid var(--footer-mobile-underline-color);
+  }
 }
 
 /* class styles */
@@ -308,10 +324,6 @@ footer.global-footer .footer-links a:active {
 
 .form-group.with-errors .error-message p {
   margin-bottom: 0;
-}
-
-.global-footer {
-  background: var(--footer-background-color);
 }
 
 /* Eligibility Start */
@@ -566,36 +578,6 @@ footer.global-footer .footer-links a:active {
 }
 
 @media (max-width: 767px) {
-  /* xs and sm */
-  .global-footer {
-    padding: 0;
-  }
-
-  .global-footer .container {
-    padding: 0;
-    max-width: 100%;
-  }
-
-  .global-footer ul.footer-links {
-    margin: 0 !important;
-    padding: 0;
-  }
-
-  .global-footer ul.footer-links li {
-    width: 100%;
-    line-height: 50px;
-    margin-left: 0;
-  }
-
-  .global-footer ul.footer-links li:not(:last-child) {
-    border-bottom: 2px solid var(--footer-mobile-underline-color);
-  }
-
-  .global-footer ul.footer-links li a {
-    padding-left: 30px;
-    margin: 0;
-  }
-
   .radio-label {
     display: inline;
     margin-left: 5px;
@@ -614,12 +596,6 @@ footer.global-footer .footer-links a:active {
 
   .container.content .btn-lg {
     padding: 1.1875rem 0.813rem;
-  }
-
-  /* Mobile With Image */
-
-  .no-image-mobile .col-lg-6.image {
-    display: none !important;
   }
 
   .signout-row .container .signout-link {
@@ -725,12 +701,6 @@ footer.global-footer .footer-links a:active {
 }
 
 @media (min-width: 992px) {
-  footer {
-    margin-top: unset;
-    padding-top: 0.138rem;
-    padding-bottom: 0.138rem;
-  }
-
   .container.content input[type="submit"],
   .container.content .btn {
     width: fit-content;

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -159,6 +159,7 @@ main {
   --footer-link-color: #73b3e7;
   --footer-link-width: 100%;
   --footer-link-hover-color: #9b74d7;
+  --footer-link-font-weight: 500;
   --footer-mobile-underline-color: var(--bs-white);
 }
 
@@ -178,7 +179,7 @@ footer .footer-links li {
 
 footer .footer-links li a {
   color: var(--footer-link-color);
-  font-weight: var(--bs-body-font-weight);
+  font-weight: var(--footer-link-font-weight);
   font-size: var(--bs-body-font-size);
   text-decoration: underline;
   letter-spacing: 0;

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -380,8 +380,8 @@ footer.global-footer .footer-links a:active {
   line-height: 1;
 }
 
-.eligibility-start h1.headline {
-  margin-bottom: 50px;
+.eligibility-start h1 {
+  padding-bottom: 64px;
 }
 
 /* Enrollment Success */
@@ -642,9 +642,8 @@ footer.global-footer .footer-links a:active {
 
   /* Eligibility Start */
 
-  .eligibility-start h1.headline {
-    margin-top: 24px;
-    margin-bottom: 16px;
+  .eligibility-start h1 {
+    padding-bottom: 24px;
   }
 
   .eligibility-start .main-content {
@@ -688,7 +687,6 @@ footer.global-footer .footer-links a:active {
   }
 
   .media-title {
-    margin-top: 42px;
     margin-bottom: 46px;
   }
 

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -16,10 +16,6 @@
   --bs-body-line-height: 1.5;
   --body-letter-spacing: 0.05em;
   --dark-color: #212121;
-  --footer-background-color: var(--dark-color);
-  --footer-link-color: #73b3e7;
-  --footer-link-hover-color: #9b74d7;
-  --footer-mobile-underline-color: var(--bs-white);
   --hover-color: #2f4c65;
   --error-color: #ea1010;
   --selected-color: #562b97;
@@ -40,11 +36,6 @@
   :root {
     --h1-font-size: calc(35rem / 16);
     --h1-text-align: center;
-  }
-}
-
-@media (min-width: 767px) {
-  :root {
     --main-content-min-height: calc(100vh - 130px);
     /* 130px = Header Height (80px) + Footer Height (50px) */
   }
@@ -161,18 +152,31 @@ main {
 /* Footer */
 /* Footer has same font styles on all screen widths */
 /* Mobile first: One link per row, each link is 50px height */
-/* Screen width above 767 - Footer is 50px height */
-footer.global-footer {
+/* Screen width above 992px - Footer is 50px height */
+
+:root {
+  --footer-background-color: var(--dark-color);
+  --footer-link-color: #73b3e7;
+  --footer-link-width: 100%;
+  --footer-link-hover-color: #9b74d7;
+  --footer-mobile-underline-color: var(--bs-white);
+}
+
+@media (min-width: 767px) {
+  :root {
+    --footer-link-width: auto;
+  }
+}
+
+footer {
   background: var(--footer-background-color);
-  padding: 0;
 }
 
-footer.global-footer .footer-links {
-  margin: 0 !important;
-  padding: 0;
+footer .footer-links li {
+  width: var(--footer-link-width);
 }
 
-footer.global-footer .footer-links li a {
+footer .footer-links li a {
   color: var(--footer-link-color);
   font-weight: var(--bs-body-font-weight);
   font-size: var(--bs-body-font-size);
@@ -181,28 +185,20 @@ footer.global-footer .footer-links li a {
   line-height: 50px;
 }
 
-footer.global-footer .footer-links li a:hover,
-footer.global-footer .footer-links li a:focus,
-footer.global-footer .footer-links li a:active {
+footer .footer-links li a:hover,
+footer .footer-links li a:focus,
+footer .footer-links li a:active,
+footer .footer-links li a:visited {
   color: var(--footer-link-hover-color);
 }
 
-@media (max-width: 757px) {
-  footer.global-footer .container {
+@media (max-width: 992px) {
+  footer .container {
     max-width: 100%;
     padding: 0;
   }
 
-  footer.global-footer .footer-links li {
-    width: 100%;
-  }
-
-  footer.global-footer .footer-links li a {
-    margin: 0;
-    padding-left: 30px;
-  }
-
-  footer.global-footer .footer-links li:not(:last-child) {
+  footer .footer-links li:not(:last-child) {
     border-bottom: 2px solid var(--footer-mobile-underline-color);
   }
 }

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -28,6 +28,15 @@
   --bs-danger-rgb: var(--error-color-rgb);
   --standout-color: #323a45;
   --radio-input-color: var(--standout-color);
+  --h1-font-size: 24px;
+  --h1-text-align: left;
+}
+
+@media (min-width: 992px) {
+  :root {
+    --h1-font-size: 35px;
+    --h1-text-align: center;
+  }
 }
 
 @font-face {
@@ -93,13 +102,22 @@ h2,
 h3,
 h4 {
   font-weight: var(--bold-font-weight);
-  line-height: var(--bs-body-line-height);
   letter-spacing: var(--body-letter-spacing);
   line-height: var(--bs-body-line-height);
+  margin: 0;
+}
+
+/* H1 */
+/* Mobile first: Screen width up to 992px - 24px and left-aligned */
+/* Screen width above 992px - 35px and centered */
+h1 {
+  font-size: var(--h1-font-size);
+  text-align: var(--h1-text-align);
+  padding-top: 70px;
 }
 
 /* H2 */
-/* Same sizes for all screen widths */
+/* Same sizes for all screen widths: 24px; */
 h2,
 .h2 {
   font-size: 24px;
@@ -379,10 +397,6 @@ footer.global-footer .footer-links a:active {
 }
 
 .eligibility-start h1.headline {
-  font-size: 35px;
-  line-height: 52.5px;
-  letter-spacing: 0.05em;
-  text-align: center;
   margin-bottom: 50px;
   margin-top: 64px;
 }
@@ -414,10 +428,6 @@ footer.global-footer .footer-links a:active {
 
 .logged-out.enrollment-success .container.content {
   padding-top: 20vh;
-}
-
-.logged-out.enrollment-success .container.content h1 {
-  text-align: center;
 }
 
 .radio-label {
@@ -474,11 +484,6 @@ footer.global-footer .footer-links a:active {
   width: 271px;
 }
 
-.container.content {
-  margin-top: 2rem;
-  margin-bottom: 2rem;
-}
-
 .container.content .buttons label {
   display: block;
   margin-bottom: 2rem;
@@ -487,8 +492,6 @@ footer.global-footer .footer-links a:active {
 
 .container.content h1.icon-title {
   padding-bottom: 1.5rem;
-  line-height: 36px;
-  text-align: center;
 }
 
 .container.content h1.icon-title span.icon {
@@ -507,10 +510,6 @@ footer.global-footer .footer-links a:active {
 }
 
 .container.content.help h1 {
-  letter-spacing: 0.05em;
-  font-weight: 700;
-  font-size: 2.25rem;
-  text-align: center;
   margin-top: 5.5rem;
   margin-bottom: 4rem;
 }
@@ -663,9 +662,6 @@ footer.global-footer .footer-links a:active {
   /* Eligibility Start */
 
   .eligibility-start h1.headline {
-    text-align: left;
-    font-size: 24px;
-    line-height: 36px;
     margin-top: 24px;
     margin-bottom: 16px;
   }
@@ -767,14 +763,6 @@ footer.global-footer .footer-links a:active {
     padding-bottom: 0.138rem;
   }
 
-  .container.content {
-    padding-left: 3.5rem;
-    padding-right: 3.5rem;
-    padding-top: 2rem;
-    padding-bottom: 2rem;
-    margin: 0;
-  }
-
   .container.content input[type="submit"],
   .container.content .btn {
     width: fit-content;
@@ -797,15 +785,6 @@ footer.global-footer .footer-links a:active {
 }
 
 @media (min-width: 1200px) {
-  /* xl+ */
-  .container.content {
-    padding-left: 5rem;
-    padding-right: 5rem;
-    padding-top: 4.5rem;
-    padding-bottom: 2rem;
-    margin: 0;
-  }
-
   /* Override for only the Agency Index page */
   .agency-index .container.content h1 ~ p:nth-last-of-type(1) {
     margin-bottom: 5rem;

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -28,15 +28,15 @@
   --bs-danger-rgb: var(--error-color-rgb);
   --standout-color: #323a45;
   --radio-input-color: var(--standout-color);
-  --h1-font-size: 1.5em;
+  --h1-font-size: calc(24rem / 16);
   --h1-text-align: left;
-  --h2-font-size: 1.3333333em;
-  --h3-font-size: 1.1111111em;
+  --h2-font-size: calc(24rem / 16);
+  --h3-font-size: calc(20rem / 16);
 }
 
 @media (min-width: 992px) {
   :root {
-    --h1-font-size: 1.944444em;
+    --h1-font-size: calc(35rem / 16);
     --h1-text-align: center;
   }
 }
@@ -49,8 +49,7 @@
 }
 
 body {
-  font-size: 1.125em;
-  /* 18px/16px = 1.125em */
+  font-size: 100%;
 }
 
 h1,
@@ -119,8 +118,8 @@ h4 {
 }
 
 /* H1 */
-/* Mobile first: Screen width up to 992px - 24px (24px/18 = 1.333em) and left */
-/* Screen width above 992px - 35px (35px/18 = 1.9444) and centered */
+/* Mobile first: Screen width up to 992px - 24px (24rem/16 = 1.5rem) and left */
+/* Screen width above 992px - 35px (35rem/16 = 2.1875rem) and centered */
 /* Does not have a class. Do not apply to non-headline elements. */
 h1 {
   font-size: var(--h1-font-size);
@@ -129,7 +128,7 @@ h1 {
 }
 
 /* H2 */
-/* Same sizes for all screen widths: 24px (24px/18px = 1.333em) */
+/* Same sizes for all screen widths: 24px (24rem/16 = 1.5rem) */
 /* Also has a class which can be applied to non-headline elements */
 h2,
 .h2 {
@@ -137,7 +136,7 @@ h2,
 }
 
 /* H3 */
-/* Same sizes for all screen widths: 20px (20px/18px = 1.111em) */
+/* Same sizes for all screen widths: 20px (20rem/16 = 1.25rem) */
 /* Also has a class which can be applied to non-headline elements */
 h3,
 .h3 {

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -28,13 +28,14 @@
   --bs-danger-rgb: var(--error-color-rgb);
   --standout-color: #323a45;
   --radio-input-color: var(--standout-color);
-  --h1-font-size: 24px;
+  --h1-font-size: 1.5em;
   --h1-text-align: left;
 }
 
 @media (min-width: 992px) {
   :root {
-    --h1-font-size: 35px;
+    --h1-font-size: 2.1875em;
+    /* 2.1875em = 35px */
     --h1-text-align: center;
   }
 }
@@ -44,6 +45,10 @@
   font-weight: 700;
   font-style: normal;
   src: local("PublicSans"), url("../fonts/PublicSans-Bold.woff") format("woff");
+}
+
+body {
+  font-size: 100%;
 }
 
 h1,
@@ -126,7 +131,8 @@ h1 {
 /* Also has a class which can be applied to non-headline elements */
 h2,
 .h2 {
-  font-size: 24px;
+  font-size: 1.5em;
+  /* 1.25em = 24px */
 }
 
 /* H3 */
@@ -134,7 +140,8 @@ h2,
 /* Also has a class which can be applied to non-headline elements */
 h3,
 .h3 {
-  font-size: 20px;
+  font-size: 1.25em;
+  /* 1.25em = 20px */
 }
 
 /* making the sticky footer */

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -39,6 +39,7 @@
 
 h1,
 h2,
+.h2,
 h3,
 h4,
 h5,
@@ -62,8 +63,8 @@ span,
 .span {
   font-size: var(--bs-body-font-size);
   font-weight: var(--bs-body-font-weight);
-  line-height: var(--bs-body-line-height);
   letter-spacing: var(--body-letter-spacing);
+  line-height: var(--bs-body-line-height);
 }
 
 /* Links */
@@ -84,28 +85,27 @@ a:visited:not(.btn) {
   color: var(--selected-color);
 }
 
+/* Headlines */
+
 h1,
 h2,
+.h2,
 h3,
-h4,
-h5,
-h6 {
-  font-weight: 500;
-  font-size: 24px;
-  line-height: 30px;
-  margin-top: 30px;
-  margin-bottom: 20px;
+h4 {
+  font-weight: var(--bold-font-weight);
+  line-height: var(--bs-body-line-height);
+  letter-spacing: var(--body-letter-spacing);
+  line-height: var(--bs-body-line-height);
 }
 
-h1 {
-  font-weight: 700;
+/* H2 */
+/* Same sizes for all screen widths */
+h2,
+.h2 {
   font-size: 24px;
-  line-height: 30px;
-  letter-spacing: 0.05em;
 }
 
 /* making the sticky footer */
-
 html,
 body {
   height: 100%;
@@ -281,10 +281,6 @@ footer.global-footer .footer-links a:active {
 .media-title {
   margin-top: 100px;
   margin-bottom: 60px;
-  font-size: 24px;
-  line-height: 36px;
-  letter-spacing: 0.05em;
-  font-weight: 700;
 }
 
 .media-list {
@@ -520,9 +516,6 @@ footer.global-footer .footer-links a:active {
 }
 
 .container.content.help h2 {
-  letter-spacing: 0.05em;
-  font-weight: 700;
-  font-size: 1.5rem;
   margin-bottom: 3rem;
   margin-top: 3rem;
 }


### PR DESCRIPTION
closes #974 

**⚠️ This PR relies on #991 to be merged first.**

## What this PR does
- Fixes: Fixes the current issue where on Desktop, the footer is not neatly at the bottom of the page on first load for pages that don't fill up the full viewport height.
- Redesigns: The footer height is now 50px on Desktop. The footer is slightly taller now on Desktop.
- Fixes: The type (leter-spacing, font-weight) for the footer was off. Now it's not.
- Deletes all old CSS code that tried to place the footer.
- Moves around CSS styles into categories and comments them.

## How to test
- Mobile: Footer should have no regressions
- Desktop: Go through short pages (agency index) - Footer should be at the bottom. 
- Desktop: Go through long pages (help, eligibility start) - Footer should have no regressions.
- Test the app in Private mode or a different browser to test the `visited` color logic.

## Nitty gritty details
- Removes `.global-footer` so this footer is now 100% free of custom CA Web Std Template styles. We were overriding most of them. Uses bootstrap classes instead to declare most styles. Uses CSS `gap` to separate the links on Desktop.
- Moves all footer-related CSS variables to right above the footer element CSS styles. We can undo this, but this helped me write/read this code.
- Logic for the viewport height, explained: This means, "Set the _minimum_ height of the center div to 100% of the viewport height, minus the height of the footer and the header". That means, if the natural height of the page is _more than_ 100vh from the start (which would apply to all pages on a smaller mobile device and some pages on a Desktop device), then the footer will flow naturally. The footer is not sticky. Sticky would mean the footer is always there even after you scroll.
```css
--main-content-min-height: calc(100vh - 182px);
  /* 182px = Header Height (80px) + (Footer Link (50px) * Number of Links (2)) + Underline Height (2px) */
--main-content-min-height: calc(100vh - 130px);
/* 130px = Header Height (80px) + Footer Height (50px) */
```

## Screenshots

Short page - first load
<img width="1510" alt="image" src="https://user-images.githubusercontent.com/3673236/193887616-183883a5-8fc7-4a3c-9e99-34dde1125bd7.png">

Short page - visited links
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/193887563-af988254-1ed8-4686-a9e6-14a3ade0eb52.png">

Long page - first load
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/193887486-003ce60a-3492-41b4-a821-1c40bee2480b.png">

Mobile - 
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/193887444-9b5b826f-9f66-49ac-86cb-07bebe504f65.png">

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/193887410-0d35e5fc-b88a-486d-b588-d7f7e0bb9565.png">
