### PR TITLE
Refactor: base grid

### DIFF
--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -70,7 +70,19 @@
       {% block main_content %}
         <div class="container main-row">
           <div class="row justify-content-between"></div>
-          <div class="row justify-content-center"></div>
+          <div class="row justify-content-center">
+            <div id="headline" class="col-lg-10 text-sm-start text-lg-center">
+              <h1>{{ page.headline }}</h1>
+            </div>
+            <div id="sub-headline" class="col-lg-10">
+              {% block sub-headline %}
+              {% endblock sub-headline %}
+            </div>
+            <div id="explanatory-text" class="col-lg-10">
+              {% block explanatory-text %}
+              {% endblock explanatory-text %}
+            </div>
+          </div>
           <div class="row justify-content-center"></div>
           <div class="row justify-content-end"></div>
         </div>

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -85,9 +85,9 @@
               {% endblock inner-content %}
             </div>
           </div>
-          <div class="row justify-content-end">
+          <div class="row d-flex flex-column-reverse justify-content-lg-end flex-lg-row">
             {% block call-to-action %}
-              <div class="col-lg-7 text-end">
+              <div class="col-lg-7 d-flex align-items-end flex-row-reverse">
                 {% block call-to-action-text %}
                 {% endblock call-to-action-text %}
               </div>

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -70,7 +70,8 @@
       {% block main_content %}
         <div class="container main-row">
           <div class="row justify-content-between">
-            {% block nav-buttons %}{% endblock nav-buttons %}
+            {% block nav-buttons %}
+            {% endblock nav-buttons %}
           </div>
           <div class="row justify-content-center">
             <div id="headline" class="col-lg-10 text-sm-start text-lg-center">
@@ -82,8 +83,8 @@
             </div>
           </div>
           <div class="row justify-content-center">
-              {% block inner-content %}
-              {% endblock inner-content %}
+            {% block inner-content %}
+            {% endblock inner-content %}
           </div>
           <div class="row d-flex flex-column-reverse justify-content-lg-end flex-lg-row">
             {% block call-to-action %}

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -74,16 +74,17 @@
             <div id="headline" class="col-lg-10 text-sm-start text-lg-center">
               <h1>{{ page.headline }}</h1>
             </div>
-            <div id="sub-headline" class="col-lg-10">
-              {% block sub-headline %}
-              {% endblock sub-headline %}
-            </div>
-            <div id="explanatory-text" class="col-lg-10">
+            <div class="col-lg-10">
               {% block explanatory-text %}
               {% endblock explanatory-text %}
             </div>
           </div>
-          <div class="row justify-content-center"></div>
+          <div class="row justify-content-center">
+            <div class="col-lg-6">
+              {% block inner-content %}
+              {% endblock inner-content %}
+            </div>
+          </div>
           <div class="row justify-content-end"></div>
         </div>
       {% endblock main_content %}

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -85,7 +85,18 @@
               {% endblock inner-content %}
             </div>
           </div>
-          <div class="row justify-content-end"></div>
+          <div class="row justify-content-end">
+            {% block call-to-action %}
+              <div class="col-lg-7 text-end">
+                {% block call-to-action-text %}
+                {% endblock call-to-action-text %}
+              </div>
+              <div class="col-lg-3">
+                {% block call-to-action-button %}
+                {% endblock call-to-action-button %}
+              </div>
+            {% endblock call-to-action %}
+          </div>
         </div>
       {% endblock main_content %}
     </main>

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -68,6 +68,12 @@
 
     <main id="main-content" role="main">
       {% block main_content %}
+        <div class="container main-row">
+          <div class="row justify-content-between"></div>
+          <div class="row justify-content-center"></div>
+          <div class="row justify-content-center"></div>
+          <div class="row justify-content-end"></div>
+        </div>
       {% endblock main_content %}
     </main>
 

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -74,7 +74,7 @@
             {% endblock nav-buttons %}
           </div>
           <div class="row justify-content-center">
-            <div id="headline" class="col-lg-10">
+            <div class="col-lg-10">
               <h1>{{ page.headline }}</h1>
             </div>
             <div class="col-lg-10">

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -74,7 +74,7 @@
             {% endblock nav-buttons %}
           </div>
           <div class="row justify-content-center">
-            <div id="headline" class="col-lg-10 text-sm-start text-lg-center">
+            <div id="headline" class="col-lg-10">
               <h1>{{ page.headline }}</h1>
             </div>
             <div class="col-lg-10">

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -69,7 +69,7 @@
     <main id="main-content" role="main">
       {% block main_content %}
         <div class="container main-row">
-          <div class="row justify-content-between">
+          <div class="row">
             {% block nav-buttons %}
             {% endblock nav-buttons %}
           </div>

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -132,17 +132,6 @@
                     $(".nocookies").addClass("d-none");
                 }
 
-                var doc = document.documentElement;
-                if ($(doc).hasClass("with-image")) {
-                    var top = localStorage.getItem("scroll");
-                    if (top !== null) {
-                        doc.scrollTop = parseInt(top, 10);
-                    }
-                    window.addEventListener("visibilitychange", () => {
-                        localStorage.setItem("scroll", doc.scrollTop);
-                    });
-                }
-
                 $("a[href^='https'], a[href^='tel'], [href*='#']").on("click", function(e) {
                     amplitude.getInstance().logEvent('clicked link', {'href': e.target.href, 'path': window.location.pathname});
                 });

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -82,10 +82,8 @@
             </div>
           </div>
           <div class="row justify-content-center">
-            <div class="col-lg-6">
               {% block inner-content %}
               {% endblock inner-content %}
-            </div>
           </div>
           <div class="row d-flex flex-column-reverse justify-content-lg-end flex-lg-row">
             {% block call-to-action %}

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -69,7 +69,9 @@
     <main id="main-content" role="main">
       {% block main_content %}
         <div class="container main-row">
-          <div class="row justify-content-between"></div>
+          <div class="row justify-content-between">
+            {% block nav-buttons %}{% endblock nav-buttons %}
+          </div>
           <div class="row justify-content-center">
             <div id="headline" class="col-lg-10 text-sm-start text-lg-center">
               <h1>{{ page.headline }}</h1>


### PR DESCRIPTION
Closes #961 

This PR defines a grid on `base.html` with blocks that other templates can "fill in". If a page wants to completely ignore the grid, it can do so by overriding the `main_content` block, but it should only do this if it truly is completely different from all other pages.

### What this PR does not cover and follow-up PRs need to cover

- #1009
- Port over templates that contain forms which need to render their own button
- Implement CSS for spacing between sections according to 8px-based design system
- Add support for error pages and port over
- See if Help page can use the grid
- Implement CSS for making buttons have `width: 100%`

### Screenshots
<details>

**Agency Index**
![Screenshot 2022-10-04 at 20-13-35 Transit Benefits Introduction Cal-ITP](https://user-images.githubusercontent.com/25497886/193959717-e6182cb3-05fc-4ee9-a2a7-0c1bb49c09ee.png)

**Verifier Selection**
![Screenshot 2022-10-04 at 20-13-47 Transit Benefits Select a benefit option Cal-ITP](https://user-images.githubusercontent.com/25497886/193959806-ae233873-e8a7-40c6-9e6c-4927c928499f.png)

**CC Eligibility Start**
![Screenshot 2022-10-04 at 20-13-55 Transit Benefits Get Started Cal-ITP](https://user-images.githubusercontent.com/25497886/193959830-134a3618-0b0e-4a46-86b4-7fc1cd1afc0d.png)

**Login.gov Eligibility Start**
![Screenshot 2022-10-04 at 20-22-11 Transit Benefits Get Started Cal-ITP](https://user-images.githubusercontent.com/25497886/193959890-9eb1d8ec-6123-4463-8a42-fe07553622c1.png)

**CC Eligibility Confirm**
![Screenshot 2022-10-04 at 20-16-22 Transit Benefits Confirm your Courtesy Card Cal-ITP](https://user-images.githubusercontent.com/25497886/193959928-c4b158d5-7320-4c65-80fd-f8cc796134e0.png)

**CC Enrollment Connect Card**
![Screenshot 2022-10-04 at 20-19-04 Transit Benefits Connect your card Cal-ITP](https://user-images.githubusercontent.com/25497886/193959959-95a73dee-79a6-4075-bf46-12ccbfba3009.png)

**CC Eligibility Unverified**
![Screenshot 2022-10-04 at 20-16-47 Transit Benefits Courtesy Card not located Cal-ITP](https://user-images.githubusercontent.com/25497886/193959984-90e54d25-4672-4529-af92-b012678ea640.png)

**Login.gov Enrollment Connect Card**
![Screenshot 2022-10-04 at 20-23-23 Transit Benefits Connect your card Cal-ITP](https://user-images.githubusercontent.com/25497886/193960027-b31440d2-698f-46b7-abac-22639de094d7.png)

_Note: these Enrollment Success screenshots will be out of date as soon as #946 is merged in_
**CC Enrollment Success**
![Screenshot 2022-10-04 at 20-21-15 Transit Benefits Success Cal-ITP](https://user-images.githubusercontent.com/25497886/193960064-28a9776c-03eb-41c3-b7e0-3f44651ce24f.png)

**Login.gov Enrollment Success**
![Screenshot 2022-10-04 at 20-23-48 Transit Benefits Success Cal-ITP](https://user-images.githubusercontent.com/25497886/193960081-11ffeb3e-d14f-4d6d-81e1-635dca5ca9c6.png)

**Login.gov Logged Out**
![Screenshot 2022-10-04 at 20-23-57 Transit Benefits Success Cal-ITP](https://user-images.githubusercontent.com/25497886/193960143-39228cc6-3b8f-4c2b-b4e3-2647368df2c2.png)

</details>