### PR TITLE
CSS Variables: Refactor footer sizing and alignment

### DIFF
--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -71,14 +71,14 @@
       {% endblock main_content %}
     </main>
 
-    <footer id="footer" class="global-footer">
+    <footer id="footer">
       <div class="container">
-        <ul class="footer-links">
+        <ul class="footer-links m-0 p-0 list-unstyled d-lg-flex gap-lg-4">
           <li>
-            <a href="{% url "core:help" %}">{% translate "core.buttons.help" %}</a>
+            <a class="m-0 ps-5 ps-lg-0" href="{% url "core:help" %}">{% translate "core.buttons.help" %}</a>
           </li>
           <li>
-            <a href="https://cdt.ca.gov/privacy-policy/" target="_blank" rel="noopener noreferrer">{% translate "core.buttons.privacy" %}</a>
+            <a class="m-0 ps-5 ps-lg-0" href="https://cdt.ca.gov/privacy-policy/" target="_blank" rel="noopener noreferrer">{% translate "core.buttons.privacy" %}</a>
           </li>
         </ul>
       </div>

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -153,6 +153,7 @@ main {
 /* Footer has same font styles on all screen widths */
 /* Mobile first: One link per row, each link is 50px height */
 /* Screen width above 992px - Footer is 50px height */
+/* Note: Not all Footer styles are written in mobile-first */
 
 :root {
   --footer-background-color: var(--dark-color);

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -207,13 +207,53 @@ footer.global-footer .footer-links li a:active {
   }
 }
 
-/* class styles */
+/* Header */
+
+.navbar.navbar-expand-sm.navbar-dark.bg-primary {
+  padding: 8.5px 1rem;
+}
+
+.navbar-brand {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.navbar-brand img.sm {
+  width: 120px;
+}
+
+.navbar-brand img.lg {
+  width: 271px;
+}
+
+/* Buttons */
 
 .btn-lg {
   border-width: 2px;
 }
 
-/* Log In */
+.btn-link {
+  color: var(--primary-color);
+}
+
+.btn-primary {
+  text-transform: capitalize;
+  letter-spacing: 0.05em;
+}
+
+.btn-outline-light {
+  width: 126px;
+  height: 38px;
+  padding: 0px !important;
+}
+
+.container.content .buttons label {
+  display: block;
+  margin-bottom: 2rem;
+  text-align: center;
+}
+
+/* Custom button: Log In */
 
 #login {
   cursor: pointer;
@@ -248,7 +288,7 @@ footer.global-footer .footer-links li a:active {
   line-height: 1;
 }
 
-/* Sign Out */
+/* Custom button: Sign Out */
 
 .signout-row {
   position: absolute;
@@ -270,20 +310,7 @@ footer.global-footer .footer-links li a:active {
   display: block;
 }
 
-.btn-link {
-  color: var(--primary-color);
-}
-
-.btn-primary {
-  text-transform: capitalize;
-  letter-spacing: 0.05em;
-}
-
-.btn-outline-light {
-  width: 126px;
-  height: 38px;
-  padding: 0px !important;
-}
+/* Forms: Inputs */
 
 .form-control {
   border-radius: 0.25rem;
@@ -326,7 +353,42 @@ footer.global-footer .footer-links li a:active {
   margin-bottom: 0;
 }
 
-/* Eligibility Start */
+/* Forms: Radio Buttons */
+
+.radio-label {
+  cursor: pointer;
+  display: inline;
+  margin-left: 15px;
+}
+
+.radio-input {
+  cursor: pointer;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+
+  border-radius: 50%;
+  width: 25px;
+  height: 25px;
+
+  border: 3px solid var(--radio-input-color);
+  margin-right: 5px;
+  margin-top: 20px;
+
+  position: relative;
+  top: 7px;
+}
+
+.radio-input:checked {
+  background-color: var(--radio-input-color);
+  box-shadow: inset 0 0 0 2px var(--bs-white);
+}
+
+.radio-label-description {
+  margin-left: 2rem;
+}
+
+/* Media List */
 
 .media-title {
   margin-bottom: 60px;
@@ -381,6 +443,8 @@ footer.global-footer .footer-links li a:active {
   list-style-type: disc;
 }
 
+/* Eligibility Start */
+
 .eligibility-start .buttons {
   display: flex;
   align-items: flex-end;
@@ -419,65 +483,7 @@ footer.global-footer .footer-links li a:active {
   width: 7rem;
 }
 
-.radio-label {
-  cursor: pointer;
-  display: inline;
-  margin-left: 15px;
-}
-
-.radio-input {
-  cursor: pointer;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-
-  border-radius: 50%;
-  width: 25px;
-  height: 25px;
-
-  border: 3px solid var(--radio-input-color);
-  margin-right: 5px;
-  margin-top: 20px;
-
-  position: relative;
-  top: 7px;
-}
-
-.radio-input:checked {
-  background-color: var(--radio-input-color);
-  box-shadow: inset 0 0 0 2px var(--bs-white);
-}
-
-.radio-label-description {
-  margin-left: 2rem;
-}
-
-/* context-specific overrides */
-
-/* Header */
-
-.navbar.navbar-expand-sm.navbar-dark.bg-primary {
-  padding: 8.5px 1rem;
-}
-
-.navbar-brand {
-  padding-top: 0;
-  padding-bottom: 0;
-}
-
-.navbar-brand img.sm {
-  width: 120px;
-}
-
-.navbar-brand img.lg {
-  width: 271px;
-}
-
-.container.content .buttons label {
-  display: block;
-  margin-bottom: 2rem;
-  text-align: center;
-}
+/* 404 Page */
 
 .container.content h1.icon-title {
   padding-bottom: 1.5rem;
@@ -492,6 +498,8 @@ footer.global-footer .footer-links li a:active {
   width: 150px;
   height: 150px;
 }
+
+/* Help */
 
 .container.content.help {
   margin: 4rem auto 2rem auto;

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -159,6 +159,7 @@ main {
   --footer-link-color: #73b3e7;
   --footer-link-width: 100%;
   --footer-link-hover-color: #9b74d7;
+  --footer-link-font-weight: 500;
   --footer-mobile-underline-color: var(--bs-white);
 }
 
@@ -178,7 +179,7 @@ footer .footer-links li {
 
 footer .footer-links li a {
   color: var(--footer-link-color);
-  font-weight: var(--bs-body-font-weight);
+  font-weight: var(--footer-link-font-weight);
   font-size: var(--bs-body-font-size);
   text-decoration: underline;
   letter-spacing: 0;

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -154,6 +154,8 @@ main {
 /* Mobile first: One link per row, each link is 50px height */
 /* Screen width above 992px - Footer is 50px height */
 /* Note: Not all Footer styles are written in mobile-first */
+/* to style the full-width line on mobile */
+/* and the desktop container-width sizing */
 
 :root {
   --footer-background-color: var(--dark-color);
@@ -194,6 +196,9 @@ footer .footer-links li a:visited {
   color: var(--footer-link-hover-color);
 }
 
+/* Custom non-mobile-first code to */
+/* allow the mobile footer to have a */
+/* full-width line beyond container-fluid width */
 @media (max-width: 992px) {
   footer .container {
     max-width: 100%;

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -16,10 +16,6 @@
   --bs-body-line-height: 1.5;
   --body-letter-spacing: 0.05em;
   --dark-color: #212121;
-  --footer-background-color: var(--dark-color);
-  --footer-link-color: #73b3e7;
-  --footer-link-hover-color: #9b74d7;
-  --footer-mobile-underline-color: var(--bs-white);
   --hover-color: #2f4c65;
   --error-color: #ea1010;
   --selected-color: #562b97;
@@ -40,11 +36,6 @@
   :root {
     --h1-font-size: calc(35rem / 16);
     --h1-text-align: center;
-  }
-}
-
-@media (min-width: 767px) {
-  :root {
     --main-content-min-height: calc(100vh - 130px);
     /* 130px = Header Height (80px) + Footer Height (50px) */
   }
@@ -161,18 +152,31 @@ main {
 /* Footer */
 /* Footer has same font styles on all screen widths */
 /* Mobile first: One link per row, each link is 50px height */
-/* Screen width above 767 - Footer is 50px height */
-footer.global-footer {
+/* Screen width above 992px - Footer is 50px height */
+
+:root {
+  --footer-background-color: var(--dark-color);
+  --footer-link-color: #73b3e7;
+  --footer-link-width: 100%;
+  --footer-link-hover-color: #9b74d7;
+  --footer-mobile-underline-color: var(--bs-white);
+}
+
+@media (min-width: 767px) {
+  :root {
+    --footer-link-width: auto;
+  }
+}
+
+footer {
   background: var(--footer-background-color);
-  padding: 0;
 }
 
-footer.global-footer .footer-links {
-  margin: 0 !important;
-  padding: 0;
+footer .footer-links li {
+  width: var(--footer-link-width);
 }
 
-footer.global-footer .footer-links li a {
+footer .footer-links li a {
   color: var(--footer-link-color);
   font-weight: var(--bs-body-font-weight);
   font-size: var(--bs-body-font-size);
@@ -181,28 +185,20 @@ footer.global-footer .footer-links li a {
   line-height: 50px;
 }
 
-footer.global-footer .footer-links li a:hover,
-footer.global-footer .footer-links li a:focus,
-footer.global-footer .footer-links li a:active {
+footer .footer-links li a:hover,
+footer .footer-links li a:focus,
+footer .footer-links li a:active,
+footer .footer-links li a:visited {
   color: var(--footer-link-hover-color);
 }
 
-@media (max-width: 757px) {
-  footer.global-footer .container {
+@media (max-width: 992px) {
+  footer .container {
     max-width: 100%;
     padding: 0;
   }
 
-  footer.global-footer .footer-links li {
-    width: 100%;
-  }
-
-  footer.global-footer .footer-links li a {
-    margin: 0;
-    padding-left: 30px;
-  }
-
-  footer.global-footer .footer-links li:not(:last-child) {
+  footer .footer-links li:not(:last-child) {
     border-bottom: 2px solid var(--footer-mobile-underline-color);
   }
 }

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -28,16 +28,12 @@
   --h1-text-align: left;
   --h2-font-size: calc(24rem / 16);
   --h3-font-size: calc(20rem / 16);
-  --main-content-min-height: calc(100vh - 182px);
-  /* 182px = Header Height (80px) + (Footer Link (50px) * Number of Links (2)) + Underline Height (2px) */
 }
 
 @media (min-width: 992px) {
   :root {
     --h1-font-size: calc(35rem / 16);
     --h1-text-align: center;
-    --main-content-min-height: calc(100vh - 130px);
-    /* 130px = Header Height (80px) + Footer Height (50px) */
   }
 }
 
@@ -153,6 +149,9 @@ main {
 /* Footer has same font styles on all screen widths */
 /* Mobile first: One link per row, each link is 50px height */
 /* Screen width above 992px - Footer is 50px height */
+/* Total footer height is 50px on Desktop */
+/* And 102 on Mobile */
+/* Footer breakpoint set to 992px */
 /* Note: Not all Footer styles are written in mobile-first */
 /* to style the full-width line on mobile */
 /* and the desktop container-width sizing */
@@ -164,11 +163,15 @@ main {
   --footer-link-hover-color: #9b74d7;
   --footer-link-font-weight: 500;
   --footer-mobile-underline-color: var(--bs-white);
+  --main-content-min-height: calc(100vh - 182px);
+  /* 182px = Header Height (80px) + (Footer Link (50px) * Number of Links (2)) + Underline Height (2px) */
 }
 
-@media (min-width: 767px) {
+@media (min-width: 992px) {
   :root {
     --footer-link-width: auto;
+    --main-content-min-height: calc(100vh - 130px);
+    /* 130px = Header Height (80px) + Footer Height (50px) */
   }
 }
 

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -32,12 +32,21 @@
   --h1-text-align: left;
   --h2-font-size: calc(24rem / 16);
   --h3-font-size: calc(20rem / 16);
+  --main-content-min-height: calc(100vh - 182px);
+  /* 182px = Header Height (80px) + (Footer Link (50px) * Number of Links (2)) + Underline Height (2px) */
 }
 
 @media (min-width: 992px) {
   :root {
     --h1-font-size: calc(35rem / 16);
     --h1-text-align: center;
+  }
+}
+
+@media (min-width: 767px) {
+  :root {
+    --main-content-min-height: calc(100vh - 130px);
+    /* 130px = Header Height (80px) + Footer Height (50px) */
   }
 }
 
@@ -143,52 +152,59 @@ h3,
   font-size: var(--h3-font-size);
 }
 
-/* making the sticky footer */
-html,
-body {
-  height: 100%;
-  overflow-y: unset;
-}
-
-body {
-  display: flex;
-  flex-direction: column;
-}
-
+/* Main */
+/* The minimum height is calculated by 100 viewport height minus Header and Footer height */
 main {
-  flex-shrink: 0 !important;
+  min-height: var(--main-content-min-height);
 }
 
-main#main-content.main-content {
-  position: relative;
+/* Footer */
+/* Footer has same font styles on all screen widths */
+/* Mobile first: One link per row, each link is 50px height */
+/* Screen width above 767 - Footer is 50px height */
+footer.global-footer {
+  background: var(--footer-background-color);
+  padding: 0;
 }
 
-/* All pages but the Start Page */
-main .main-row {
-  min-height: calc(100vh - 120px);
+footer.global-footer .footer-links {
+  margin: 0 !important;
+  padding: 0;
 }
 
-main .main-row .col-lg-6.image {
-  background: 48% 75% url("/static/img/ridertappingbankcard.png") no-repeat;
-  background-size: cover;
-}
-
-footer {
-  margin-top: auto;
-  padding-top: 1rem;
-  padding-bottom: 1rem;
-}
-
-footer.global-footer .footer-links a {
+footer.global-footer .footer-links li a {
   color: var(--footer-link-color);
   font-weight: var(--bs-body-font-weight);
+  font-size: var(--bs-body-font-size);
   text-decoration: underline;
+  letter-spacing: 0;
+  line-height: 50px;
 }
 
-footer.global-footer .footer-links a:hover,
-footer.global-footer .footer-links a:focus,
-footer.global-footer .footer-links a:active {
+footer.global-footer .footer-links li a:hover,
+footer.global-footer .footer-links li a:focus,
+footer.global-footer .footer-links li a:active {
   color: var(--footer-link-hover-color);
+}
+
+@media (max-width: 757px) {
+  footer.global-footer .container {
+    max-width: 100%;
+    padding: 0;
+  }
+
+  footer.global-footer .footer-links li {
+    width: 100%;
+  }
+
+  footer.global-footer .footer-links li a {
+    margin: 0;
+    padding-left: 30px;
+  }
+
+  footer.global-footer .footer-links li:not(:last-child) {
+    border-bottom: 2px solid var(--footer-mobile-underline-color);
+  }
 }
 
 /* class styles */
@@ -308,10 +324,6 @@ footer.global-footer .footer-links a:active {
 
 .form-group.with-errors .error-message p {
   margin-bottom: 0;
-}
-
-.global-footer {
-  background: var(--footer-background-color);
 }
 
 /* Eligibility Start */
@@ -554,36 +566,6 @@ footer.global-footer .footer-links a:active {
 }
 
 @media (max-width: 767px) {
-  /* xs and sm */
-  .global-footer {
-    padding: 0;
-  }
-
-  .global-footer .container {
-    padding: 0;
-    max-width: 100%;
-  }
-
-  .global-footer ul.footer-links {
-    margin: 0 !important;
-    padding: 0;
-  }
-
-  .global-footer ul.footer-links li {
-    width: 100%;
-    line-height: 50px;
-    margin-left: 0;
-  }
-
-  .global-footer ul.footer-links li:not(:last-child) {
-    border-bottom: 2px solid var(--footer-mobile-underline-color);
-  }
-
-  .global-footer ul.footer-links li a {
-    padding-left: 30px;
-    margin: 0;
-  }
-
   .radio-label {
     display: inline;
     margin-left: 5px;
@@ -602,12 +584,6 @@ footer.global-footer .footer-links a:active {
 
   .container.content .btn-lg {
     padding: 1.1875rem 0.813rem;
-  }
-
-  /* Mobile With Image */
-
-  .no-image-mobile .col-lg-6.image {
-    display: none !important;
   }
 
   .signout-row .container .signout-link {
@@ -709,12 +685,6 @@ footer.global-footer .footer-links a:active {
 }
 
 @media (min-width: 992px) {
-  footer {
-    margin-top: unset;
-    padding-top: 0.138rem;
-    padding-bottom: 0.138rem;
-  }
-
   .container.content input[type="submit"],
   .container.content .btn {
     width: fit-content;


### PR DESCRIPTION
closes #974 

## What this PR does
- Fixes: Fixes the current issue where on Desktop, the footer is not neatly at the bottom of the page on first load for pages that don't fill up the full viewport height.
- Redesigns: The footer height is now 50px on Desktop. The footer is slightly taller now on Desktop.
- Fixes: The type (leter-spacing, font-weight) for the footer was off. Now it's not.
- Deletes all old CSS code that tried to place the footer.
- Moves around CSS styles into categories and comments them.

## How to test
- Mobile: Footer should have no regressions
- Desktop: Go through short pages (agency index) - Footer should be at the bottom. 
- Desktop: Go through long pages (help, eligibility start) - Footer should have no regressions.
- Test the app in Private mode or a different browser to test the `visited` color logic.

## Nitty gritty details
- Removes `.global-footer` so this footer is now 100% free of custom CA Web Std Template styles. We were overriding most of them. Uses bootstrap classes instead to declare most styles. Uses CSS `gap` to separate the links on Desktop.
- Moves all footer-related CSS variables to right above the footer element CSS styles. We can undo this, but this helped me write/read this code.
- Logic for the viewport height, explained: This means, "Set the _minimum_ height of the center div to 100% of the viewport height, minus the height of the footer and the header". That means, if the natural height of the page is _more than_ 100vh from the start (which would apply to all pages on a smaller mobile device and some pages on a Desktop device), then the footer will flow naturally. **Edited to add:** The footer is sticky but not fixed. Fixed would mean the footer is always there even after you scroll.
```css
--main-content-min-height: calc(100vh - 182px);
  /* 182px = Header Height (80px) + (Footer Link (50px) * Number of Links (2)) + Underline Height (2px) */
--main-content-min-height: calc(100vh - 130px);
/* 130px = Header Height (80px) + Footer Height (50px) */
```

## Post merge actions:

After this PR is merged and deployed on Development, we should ask @srhhnry to test the footer out on her mobile and desktop devices.

## Screenshots

Short page - first load
<img width="1510" alt="image" src="https://user-images.githubusercontent.com/3673236/193887616-183883a5-8fc7-4a3c-9e99-34dde1125bd7.png">

Short page - visited links
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/193887563-af988254-1ed8-4686-a9e6-14a3ade0eb52.png">

Long page - first load
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/193887486-003ce60a-3492-41b4-a821-1c40bee2480b.png">

Mobile - 
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/193887444-9b5b826f-9f66-49ac-86cb-07bebe504f65.png">

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/193887410-0d35e5fc-b88a-486d-b588-d7f7e0bb9565.png">
