### PR TITLE
Chore: only run CodeQL for javascript/python

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,11 @@ name: CodeQL
 
 on:
   push:
+    paths:
+      - "**.js"
+      - "**.py"
   pull_request:
-    branches: [ dev, test, prod ]
+    branches: [dev, test, prod]
   schedule:
     - cron: "24 9 * * 6"
 
@@ -20,20 +23,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ "javascript", "python" ]
+        language: ["javascript", "python"]
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
Avoids running this long-running job on _every commit_ for pure front-end HTML/CSS, language file updates, and other non-code scenarios