### PR TITLE
Chore: only run CodeQL for .js/.py on pull_request

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,9 @@ on:
       - "**.py"
   pull_request:
     branches: [dev, test, prod]
+    paths:
+      - "**.js"
+      - "**.py"
   schedule:
     - cron: "24 9 * * 6"
 


### PR DESCRIPTION
Following up from #1018, adding filters to the `on.pull_request` event.