### PR TITLE
Refactor & Redesign: Eligibility Index, Eligibility Confirm form pages

### DIFF
--- a/benefits/core/templates/core/includes/form.html
+++ b/benefits/core/templates/core/includes/form.html
@@ -6,33 +6,45 @@
   <form action="{{ form_action }}" method="{{ form.method | default:"post" | upper }}" role="form">
     {% csrf_token %}
 
-    {% for field in form %}
-      <div class="form-group">
-        {% if field.label %}
-          <label for="{{ field.id_for_label }}" class="form-control-label h2">
-            {{ field.label }}
-            {% if field.field.required %}<span class="required-label">*</span>{% endif %}
-          </label>
-        {% endif %}
+    <div class="row">
+      {% comment %} <div class="offset-lg-3 col-lg-6"> {% endcomment %}
+      <div class="offset-lg-1 col-lg-9">
+        {% for field in form %}
+          <div class="row">
+            <div class="col-12">
+              {% if field.label %}
+                <label for="{{ field.id_for_label }}" class="form-control-label h2">
+                  {{ field.label }}
+                  {% if field.field.required %}<span class="required-label">*</span>{% endif %}
+                </label>
+              {% endif %}
 
-        {{ field }}
+              {{ field }}
 
-        {% if field.help_text %}<small class="form-text text-muted">{{ field.help_text }}</small>{% endif %}
+              {% if field.help_text %}<small class="form-text text-muted">{{ field.help_text }}</small>{% endif %}
+            </div>
+          </div>
+        {% endfor %}
       </div>
-    {% endfor %}
+    </div>
 
     {% if form.submit_value %}
-      <div class="form-group">
-        {% if recaptcha.enabled %}
-          <button class="btn btn-lg btn-primary g-recaptcha"
-                  data-sitekey="{{ recaptcha.site_key }}"
-                  data-callback="onSubmit"
-                  data-action="submit">
-            {{ form.submit_value }}
-          </button>
-        {% else %}
-          <button class="btn btn-lg btn-primary">{{ form.submit_value }}</button>
-        {% endif %}
+      <div class="row d-flex flex-column-reverse justify-content-lg-end flex-lg-row">
+        <div class="col-lg-7 d-flex align-items-end flex-row-reverse">
+          <p>Not sure which option is right for you? Please visit our Help Page.</p>
+        </div>
+        <div class="col-lg-3">
+          {% if recaptcha.enabled %}
+            <button class="btn btn-lg btn-primary w-100 g-recaptcha"
+                    data-sitekey="{{ recaptcha.site_key }}"
+                    data-callback="onSubmit"
+                    data-action="submit">
+              {{ form.submit_value }}
+            </button>
+          {% else %}
+            <button class="btn btn-lg btn-primary w-100">{{ form.submit_value }}</button>
+          {% endif %}
+        </div>
       </div>
     {% endif %}
 
@@ -44,6 +56,7 @@
                 }
       </script>
     {% endif %}
+
     <script>
             $(function(){
                 $("form[action='{{form_action}}']").on("submit", function(e) {

--- a/benefits/eligibility/templates/eligibility/confirm.html
+++ b/benefits/eligibility/templates/eligibility/confirm.html
@@ -1,6 +1,27 @@
 {% extends "core/page.html" %}
 
 {% block main_content %}
-  {% include "core/includes/sign-out-link.html" %}
-  {{ block.super }}
+  <div class="container">
+    {% include "core/includes/sign-out-link.html" %}
+
+    <div class="row justify-content-center">
+      <div class="col-lg-10">
+        {% block icon_title %}
+          <h1>{{ page.headline }}</h1>
+        {% endblock icon_title %}
+
+        {% block paragraph_content %}
+          {% for p in page.paragraphs %}<p>{{ p }}</p>{% endfor %}
+        {% endblock paragraph_content %}
+      </div>
+    </div>
+
+    <div class="row">
+      {% block forms %}
+        {% for f in page.forms %}
+          {% include "core/includes/form.html" with classes="TODO: variable" form=f %}
+        {% endfor %}
+      {% endblock forms %}
+    </div>
+  </div>
 {% endblock main_content %}

--- a/benefits/eligibility/templates/eligibility/index.html
+++ b/benefits/eligibility/templates/eligibility/index.html
@@ -1,0 +1,25 @@
+{% extends "core/page.html" %}
+
+{% block main_content %}
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-lg-10">
+                {% block icon_title %}
+                    <h1>{{ page.headline }}</h1>
+                {% endblock icon_title %}
+
+                {% block paragraph_content %}
+                    {% for p in page.paragraphs %}<p>{{ p }}</p>{% endfor %}
+                {% endblock paragraph_content %}
+            </div>
+        </div>
+
+        <div class="row">
+            {% block forms %}
+                {% for f in page.forms %}
+                    {% include "core/includes/form.html" with classes="TODO: variable" form=f %}
+                {% endfor %}
+            {% endblock forms %}
+        </div>
+    </div>
+{% endblock main_content %}

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -12,7 +12,7 @@ from django.utils.translation import pgettext, gettext as _
 from benefits.core import recaptcha, session, viewmodels
 from benefits.core.middleware import AgencySessionRequired, LoginRequired, RateLimit, VerifierSessionRequired
 from benefits.core.models import EligibilityVerifier
-from benefits.core.views import ROUTE_HELP, TEMPLATE_PAGE
+from benefits.core.views import ROUTE_HELP
 from . import analytics, forms, verify
 
 
@@ -22,6 +22,7 @@ ROUTE_LOGIN = "oauth:login"
 ROUTE_CONFIRM = "eligibility:confirm"
 ROUTE_ENROLLMENT = "enrollment:index"
 
+TEMPLATE_INDEX = "eligibility/index.html"
 TEMPLATE_START = "eligibility/start.html"
 TEMPLATE_CONFIRM = "eligibility/confirm.html"
 TEMPLATE_UNVERIFIED = "eligibility/unverified.html"
@@ -59,14 +60,14 @@ def index(request):
         else:
             # form was not valid, allow for correction/resubmission
             page.forms = [form]
-            response = TemplateResponse(request, TEMPLATE_PAGE, page.context_dict())
+            response = TemplateResponse(request, TEMPLATE_INDEX, page.context_dict())
     else:
         if agency.eligibility_verifiers.count() == 1:
             verifier = agency.eligibility_verifiers.first()
             session.update(request, verifier=verifier)
             response = redirect(eligibility_start)
         else:
-            response = TemplateResponse(request, TEMPLATE_PAGE, page.context_dict())
+            response = TemplateResponse(request, TEMPLATE_INDEX, page.context_dict())
 
     return response
 

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -265,12 +265,6 @@ footer .footer-links li a:visited {
   padding: 0px !important;
 }
 
-.container.content .buttons label {
-  display: block;
-  margin-bottom: 2rem;
-  text-align: center;
-}
-
 /* Custom button: Log In */
 
 #login {
@@ -433,14 +427,14 @@ footer .footer-links li a:visited {
 
 /* Eligibility Start */
 
-.eligibility-start .buttons .btn {
+/* .eligibility-start .buttons .btn {
   width: 100%;
-}
+} */
 
-.eligibility-start .main-container .buttons label {
+/* .eligibility-start .main-container .buttons label {
   margin: 0 0.8rem 0 0;
   line-height: 1;
-}
+} */
 
 /* Enrollment Success */
 
@@ -519,23 +513,23 @@ footer .footer-links li a:visited {
   margin-bottom: 5rem;
 }
 
-.container.content h1 ~ p:nth-last-of-type(1) {
+/* .container.content h1 ~ p:nth-last-of-type(1) {
   margin-bottom: 2rem;
-}
+} */
 
-.container.content .btn-lg,
-.eligibility-start .btn-link {
-  font-weight: 500;
+/* .container.content .btn-lg,
+.eligibility-start .btn-link { */
+/* font-weight: 500;
   margin-bottom: 1rem;
-  padding: 0.8125rem;
-  /* btn-lg height is 60px */
-  width: 100%;
-}
+  padding: 0.8125rem; */
+/* btn-lg height is 60px */
+/* width: 100%; */
+/* } */
 
-.container.content .btn-link,
+/* .container.content .btn-link,
 .eligibility-start .btn-link {
   text-decoration: underline;
-}
+} */
 
 /* media queries */
 
@@ -557,9 +551,9 @@ footer .footer-links li a:visited {
     padding: 14.5px 1rem;
   }
 
-  .container.content .btn-lg {
+  /* .container.content .btn-lg {
     padding: 1.1875rem 0.813rem;
-  }
+  } */
 
   .signout-row .container .signout-link {
     font-size: 18px;
@@ -605,15 +599,4 @@ footer .footer-links li a:visited {
   .agency-index .container.content h1 ~ p:nth-last-of-type(1) {
     margin-bottom: 2rem;
   } */
-}
-
-@media (min-width: 992px) {
-  .container.content input[type="submit"],
-  .container.content .btn {
-    width: fit-content;
-    min-width: 250px;
-    display: block;
-    margin-left: auto;
-    margin-right: auto;
-  }
 }


### PR DESCRIPTION
closes #947 

## What this PR does

This PR shows how the two pages, Eligibility Index and Eligibility Confirm, can be created with a one-off html file that inherit from `page` or `base` and overrides `main_content`, while also allowing the form input area to be properly aligned for its own unique page design.

This PR also will refactor the Radio Button and Text Input CSS with variables and Bootstrap classes.

### Eligibility Index / Radio Buttons
- [x] Creates custom template, `eligibility/index.html` that inherits from `page` (but in the future can easily inherit from `base` from #1003)
- [ ] Set and send `offset-lg-1 col-lg-9` to the form includes to set the form as 9-col wide and aligned with the headline and explanatory text
- [ ] Radio Button label: Needs to be a different headline size
- [ ] Radio Button spacing: Variable-ize and correct it

### Eligibility Confirm / Text Inputs
- [x] Build off of the already-built `eligibility/confirm.html` and add on headline, explanatory-text and form
- [ ] Set and send `offset-lg-3 col-lg-6` to the form includes, to set the form as 6-col wide and centered
- [ ] Text input spacing and colors: Correct it
- [ ] Text input helper text: Correct it

### Form submit buttons
- Add divs and classes to set the form input button to be 3-col wide on Desktop and right-aligned, and centered on mobile
- [ ] Simplify form submit button classes, may possibly fix #948 regression
- [ ] Simplify form submit CSS code with variables

### Other
- Update view tests