### PR TITLE
Fix: Paragraph spacing across the app

### DIFF
--- a/benefits/core/templates/core/includes/media-list.html
+++ b/benefits/core/templates/core/includes/media-list.html
@@ -1,4 +1,4 @@
-<ul class="media-list mt-0 p-0 d-flex justify-content-center flex-column">
+<ul class="media-list mt-0 px-0 d-flex justify-content-center flex-column">
     {% for item in media %}
         <li class="media d-flex align-items-stretch w-auto">
             <div class="media-line">{% include "core/includes/icon.html" with icon=item.icon %}</div>

--- a/benefits/eligibility/templates/eligibility/start.html
+++ b/benefits/eligibility/templates/eligibility/start.html
@@ -17,7 +17,7 @@
         {% block media_list %}
           {% if media|length_is:"0" %}
           {% else %}
-            <ul class="media-list mt-0 p-0 d-flex justify-content-center flex-column">
+            <ul class="media-list mx-0 p-0 d-flex justify-content-center flex-column">
               {% for item in media %}
                 <li class="media d-flex align-items-stretch w-auto">
                   <div class="media-line">{% include "core/includes/icon.html" with icon=item.icon %}</div>

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -81,6 +81,19 @@ li {
   margin: 0;
 }
 
+/* First p immediately after an H1 */
+h1 + p:first-of-type,
+h1 + .media-list,
+/* Last p sibling to an H1 */
+.media-body--details p:not(:first-of-type) {
+  padding-top: 24px;
+}
+
+/* Last p siblings to an H1 */
+h1 ~ p:nth-last-of-type(1) {
+  padding-bottom: 24px;
+}
+
 @media (max-width: 992px) {
   /* Paragraph: Body Text, up to Small width */
   .p-sm {
@@ -552,10 +565,6 @@ footer .footer-links li a:visited {
 .container.content.help .button-back {
   margin-top: 5rem;
   margin-bottom: 5rem;
-}
-
-.container.content h1 ~ p:nth-last-of-type(1) {
-  margin-bottom: 2rem;
 }
 
 .container.content .btn-lg,


### PR DESCRIPTION
#1021 

Adds a few complex CSS declarations to address spacing between H1/Ps:

Gives padding-top to the following:
- `h1 + p:first-of-type` - First paragraph sibling after a H1. First paragraph sibling means that the first paragraph of an H1 inside another parent doesn't count. So a first paragraph after a H1 in a `media-body` doesn't count.
- `h1 + media-list` - First `media-list` after an H1. These are for pages with an H1 followed by a Media List, and no explanatory paragraph.
- `.media-body--details p:not(:first-of-type)`: Inside a `media-body--details`, all the `<p>`'s except for the first one. 

Padding bottom to the following:
- The last <p> after an H1.

```css
/* First p immediately after an H1 */
h1 + p:first-of-type,
h1 + .media-list,
/* Last p sibling to an H1 */
.media-body--details p:not(:first-of-type) {
  padding-top: 24px;
}

/* Last p siblings to an H1 */
h1 ~ p:nth-last-of-type(1) {
  padding-bottom: 24px;
}
```

The following should be fixed:
- On Enrollment Success, Enrollment pages, there is a Media Item that has 2 paragraphs. Currently, they don't have any spacing between them. That should be fixed.
- There should be padding between H1 and media items, and the first paragraph, on all pages:

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/194640128-70b7ba04-e9ee-42c5-8a3e-2a4ff7156564.png">
<img width="450" alt="image" src="https://user-images.githubusercontent.com/3673236/194640183-f1e5f385-4c37-4c3b-85cf-189d1c414406.png">

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/194640237-f4b47ecb-892e-4f3a-b1ad-a77bc83c2745.png">
<img width="451" alt="image" src="https://user-images.githubusercontent.com/3673236/194640254-f4bd19ac-7043-4400-8b1c-18e8353b9c92.png">


