### PR TITLE
Fix: Sign out row bug

### DIFF
--- a/benefits/core/templates/core/includes/previous-page-link.html
+++ b/benefits/core/templates/core/includes/previous-page-link.html
@@ -1,3 +1,3 @@
-<div class="row nav-button-row w-100 position-absolute">
+<div class="row nav-button-row position-absolute">
     <div class="d-flex align-items-center">{% include "core/includes/button.html" with button=previous_page_button %}</div>
 </div>

--- a/benefits/core/templates/core/includes/previous-page-link.html
+++ b/benefits/core/templates/core/includes/previous-page-link.html
@@ -1,3 +1,3 @@
-<div class="row previous-page-row">
+<div class="row nav-button-row w-100 position-absolute">
     <div class="d-flex align-items-center">{% include "core/includes/button.html" with button=previous_page_button %}</div>
 </div>

--- a/benefits/core/templates/core/includes/sign-out-link.html
+++ b/benefits/core/templates/core/includes/sign-out-link.html
@@ -3,7 +3,6 @@
 
 {% if authentication %}
   {% if authentication.required and authentication.logged_in %}
-    {% endcomment %}
     <div class="w-100 position-absolute">
       <div class="container">
         <div class="row nav-button-row">
@@ -14,4 +13,4 @@
       </div>
     </div>
   {% endif %}
-  {% endcomment %}
+{% endif %}

--- a/benefits/core/templates/core/includes/sign-out-link.html
+++ b/benefits/core/templates/core/includes/sign-out-link.html
@@ -1,19 +1,17 @@
 
 {% load i18n %}
 
-{% comment %} {% if authentication %}
-{% if authentication.required and authentication.logged_in %} {% endcomment %}
-  <div class="w-100 position-absolute">
-    <div class="container">
-      <div class="row" style="height: 70px;">
-        <div class="col-12 d-flex align-items-center justify-content-end">
-          <a class="signout-link" href="{{ authentication.sign_out_route }}">
-            {% comment %} {% translate authentication.sign_out_button_label %} {% endcomment %}
-            Sign out from Login.gov
-          </a>
+{% if authentication %}
+  {% if authentication.required and authentication.logged_in %}
+    {% endcomment %}
+    <div class="w-100 position-absolute">
+      <div class="container">
+        <div class="row nav-button-row">
+          <div class="col-12 d-flex align-items-center justify-content-end">
+            <a class="signout-link" href="{{ authentication.sign_out_route }}">{% translate authentication.sign_out_button_label %}</a>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-  {% comment %} {% endif %}
-  {% endif %} {% endcomment %}
+  {% endif %}
+  {% endcomment %}

--- a/benefits/core/templates/core/includes/sign-out-link.html
+++ b/benefits/core/templates/core/includes/sign-out-link.html
@@ -1,12 +1,19 @@
 
 {% load i18n %}
 
-{% if authentication %}
-  {% if authentication.required and authentication.logged_in %}
-    <div class="signout-row">
-      <div class="container">
-        <a class="signout-link" href="{{ authentication.sign_out_route }}">{% translate authentication.sign_out_button_label %}</a>
+{% comment %} {% if authentication %}
+{% if authentication.required and authentication.logged_in %} {% endcomment %}
+  <div class="w-100 position-absolute">
+    <div class="container">
+      <div class="row" style="height: 70px;">
+        <div class="col-12 d-flex align-items-center justify-content-end">
+          <a class="signout-link" href="{{ authentication.sign_out_route }}">
+            {% comment %} {% translate authentication.sign_out_button_label %} {% endcomment %}
+            Sign out from Login.gov
+          </a>
+        </div>
       </div>
     </div>
-  {% endif %}
-{% endif %}
+  </div>
+  {% comment %} {% endif %}
+  {% endif %} {% endcomment %}

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -140,7 +140,6 @@ def retry(request):
         if form.is_valid():
             agency = session.agency(request)
             page = viewmodels.Page(
-                classes="no-image-mobile",
                 title=_("enrollment.pages.retry.title"),
                 icon=viewmodels.Icon("bankcardquestion", pgettext("image alt text", "core.icons.bankcardquestion")),
                 headline=_("enrollment.pages.retry.title"),

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -611,11 +611,3 @@ footer .footer-links li a:visited {
   margin-top: 5rem;
   margin-bottom: 5rem;
 }
-
-/* media queries */
-
-@media (max-width: 992px) {
-  .navbar.navbar-expand-sm.navbar-dark.bg-primary {
-    padding: 14.5px 0;
-  }
-}

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -347,34 +347,37 @@ footer .footer-links li a:visited {
 }
 
 /* Custom button: Sign Out */
+/* Nav Buttons: Previous Page, Sign Out */
 
-.signout-row {
-  position: absolute;
-  width: 100%;
-  z-index: 100;
+.nav-button-row {
+  height: 70px;
 }
 
-.signout-row .container {
-  display: flex;
-  justify-content: flex-end;
+/* Custom button: Sign Out */
+
+.signout-link,
+.signout-link:visited {
+  font-size: 18px;
+  color: var(--primary-color) !important;
+  padding: 2px 4px;
+  border-radius: 3px;
+  border: 2px solid var(--primary-color);
+  letter-spacing: 0.02em;
+  font-weight: 500 !important;
+  text-decoration: none !important;
 }
 
-.signout-row .container .signout-link {
-  font-size: 12px;
-  text-decoration: underline;
-  color: var(--primary-color);
-  letter-spacing: 0.05rem;
-  padding-top: 18px;
-  display: block;
+@media (min-width: 992px) {
+  .signout-link,
+  .signout-link:visited {
+    font-size: 12px;
+    text-decoration: underline !important;
+    letter-spacing: 0.05em;
+    border: none;
+  }
 }
 
 /* Custom button: Previous Page */
-
-.previous-page-row {
-  position: absolute;
-  z-index: 100;
-  height: 70px;
-}
 
 #previous-page-button {
   border-color: var(--text-primary-color);
@@ -612,27 +615,7 @@ footer .footer-links li a:visited {
 /* media queries */
 
 @media (max-width: 992px) {
-  .signout-row .container .signout-link {
-    font-size: 18px;
-    color: var(--primary-color);
-    background: none;
-    padding: 5px 10px;
-    border-radius: 3px;
-    border: 2px solid var(--primary-color);
-    margin-top: 20px;
-    letter-spacing: 0.02em;
-    font-weight: 500;
-  }
-
-  .signout-row .container .signout-link:hover {
-    background: none;
-  }
-
-  .signout-row {
-    top: 240px;
-  }
-
-  .no-image-mobile .signout-row {
-    top: 0;
+  .navbar.navbar-expand-sm.navbar-dark.bg-primary {
+    padding: 14.5px 0;
   }
 }

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -357,7 +357,7 @@ footer .footer-links li a:visited {
 
 .signout-link,
 .signout-link:visited {
-  font-size: 18px;
+  font-size: var(--bs-body-font-size);
   color: var(--primary-color) !important;
   padding: 2px 4px;
   border-radius: 3px;
@@ -372,7 +372,7 @@ footer .footer-links li a:visited {
   .signout-link:visited {
     font-size: 12px;
     text-decoration: underline !important;
-    letter-spacing: 0.05em;
+    letter-spacing: var(--body-letter-spacing);
     border: none;
   }
 }


### PR DESCRIPTION
closes #920 

## What this PR does
- Fixes the #920 mobile bug by setting the Sign Out button at a static height
- Creates a generic `nav-button-row` class with a height of `70px`, that both Previous Page and Sign Out button templates can use. This row is an absolutely-positioned div that starts at the bottom of the Header and does not affect H1 height/positioning.
- Positions the `Sign Out Button` using flex-box (vertically aligned, justified to the end), rather than setting a pixel padding top
- This PR also removes the padding left/right on the Header on mobile, so the Cal-ITP logo is closer to aligning with the buttons.
- This PR currently adds a few `!important` font declarations because the Sign Out button styles don't have underlines like the style guide's regular links do. Could use refactoring in the future.

## Notes
This PR should probably be merged after #1013 is merged to dev, so that the sign out row includes can be included in the new Enrollment Index page template.

We should also make sure to test the #920 scenario on desktop and mobile (test Login.gov with a non-senior).