### PR TITLE
Fixes: Media List spacing

### DIFF
--- a/benefits/core/templates/core/includes/media-list.html
+++ b/benefits/core/templates/core/includes/media-list.html
@@ -1,4 +1,4 @@
-<ul class="media-list mt-0 px-0 d-flex justify-content-center flex-column">
+<ul class="media-list m-0 px-0 d-flex justify-content-center flex-column">
     {% for item in media %}
         <li class="media d-flex align-items-stretch w-auto">
             <div class="media-line">{% include "core/includes/icon.html" with icon=item.icon %}</div>

--- a/benefits/core/templates/core/includes/media-list.html
+++ b/benefits/core/templates/core/includes/media-list.html
@@ -1,4 +1,4 @@
-<ul class="media-list mt-0 p-0 d-flex justify-content-center flex-column">
+<ul class="media-list mt-0 px-0 d-flex justify-content-center flex-column">
     {% for item in media %}
         <li class="media d-flex align-items-stretch w-auto">
             <div class="media-line">{% include "core/includes/icon.html" with icon=item.icon %}</div>

--- a/benefits/eligibility/templates/eligibility/start.html
+++ b/benefits/eligibility/templates/eligibility/start.html
@@ -17,7 +17,7 @@
         {% block media_list %}
           {% if media|length_is:"0" %}
           {% else %}
-            <ul class="media-list mt-0 p-0 d-flex justify-content-center flex-column">
+            <ul class="media-list mx-0 p-0 d-flex justify-content-center flex-column">
               {% for item in media %}
                 <li class="media d-flex align-items-stretch w-auto">
                   <div class="media-line">{% include "core/includes/icon.html" with icon=item.icon %}</div>

--- a/benefits/eligibility/templates/eligibility/start.html
+++ b/benefits/eligibility/templates/eligibility/start.html
@@ -17,7 +17,7 @@
         {% block media_list %}
           {% if media|length_is:"0" %}
           {% else %}
-            <ul class="media-list mx-0 p-0 d-flex justify-content-center flex-column">
+            <ul class="media-list m-0 px-0 d-flex justify-content-center flex-column">
               {% for item in media %}
                 <li class="media d-flex align-items-stretch w-auto">
                   <div class="media-line">{% include "core/includes/icon.html" with icon=item.icon %}</div>

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -150,16 +150,6 @@ h1 {
   padding-top: 70px;
 }
 
-/* First paragraph immediately after an H1 gets padding-top
-h1 + p:first-of-type {
-  padding-top: 24px;
-} */
-
-/* Last paragraph after an H1 gets padding bottom
-h1 ~ p:nth-last-of-type(1) {
-  padding-bottom: 24px;
-} */
-
 /* H2 */
 /* Same sizes for all screen widths: 24px (24rem/16 = 1.5rem) */
 /* Also has a class which can be applied to non-headline elements */

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -512,8 +512,9 @@ footer .footer-links li a:visited {
   }
 }
 
-h1 + .media-list,
+h1 + .media-list, /* A .media-list immediately following the h1: Enrollment, Enrollment Success, but not Eligibility Start */
 .media-body--details p:not(:first-of-type) {
+  /* All the p within .media-body--details, except for the first p - Any media item with more than one p */
   padding-top: 24px;
 }
 

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -150,6 +150,16 @@ h1 {
   padding-top: 70px;
 }
 
+/* First paragraph immediately after an H1 gets padding-top
+h1 + p:first-of-type {
+  padding-top: 24px;
+} */
+
+/* Last paragraph after an H1 gets padding bottom
+h1 ~ p:nth-last-of-type(1) {
+  padding-bottom: 24px;
+} */
+
 /* H2 */
 /* Same sizes for all screen widths: 24px (24rem/16 = 1.5rem) */
 /* Also has a class which can be applied to non-headline elements */
@@ -510,6 +520,11 @@ footer .footer-links li a:visited {
     --media-item-icon-margin: 32px;
     --media-title-margin-top: 64px;
   }
+}
+
+h1 + .media-list,
+.media-body--details p:not(:first-of-type) {
+  padding-top: 24px;
 }
 
 .media-title {


### PR DESCRIPTION
fixes #1021 

This time, this PR only adds padding logic to the Media List.

## What this PR does
- Fixes the lack of padding between paragraphs in a Media Item. There are several Media Items that now have more than one paragraph. Check Enrollment and Enrollment Success.
- Fixes the lack of padding between an H1 and a Media List. This applies to Media Lists that DO NOT have a Media Title. The Eligibility Start has its own special Media Title, whereas, Enrollment and Enrollment Success do not.
- Adds 1 CSS declaration/style
- Adds comments to explain how and where this is used

## CSS Documentation

- `+` Adjacent sibling combinator https://developer.mozilla.org/en-US/docs/Web/CSS/Adjacent_sibling_combinator
- `:not` https://developer.mozilla.org/en-US/docs/Web/CSS/:not
- `:first-of-type` https://developer.mozilla.org/en-US/docs/Web/CSS/:first-of-type

1. `h1 + .media-list`: Add padding between the `h1` and the whole `.media-list`. "Add padding-top to the `.media-list` _immediately following_ the `h1`: This happens on all pages with a Media List that does NOT have a Media Title.

So it happens on Enrollment Success:
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/195399121-8077a4ea-2153-4c17-876a-16c496af3613.png">

But it does NOT happen on Eligibility Start: Because Eligibility Start does not have a `.media-list` that is _immediately following_ the `h1`. There is another element between the `h1` and the `.media-list`:
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/195399524-0e37a838-ec15-4a55-9e19-a0d09a8f5066.png">


1. `.media-body--details p:not(:first-of-type)`: Add padding between paragraphs in Media List. "Add padding-top to all the `p` within `.media-body--details`, except for the first `p`

This is to target Media Items that have more than 1 paragraph. This happens on both Enrollment and Enrollment Success:
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/195398683-7c9da2e5-7df7-43ac-bbf0-41c8e78bb366.png">

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/195400877-1be9cb4b-5a4f-4e4b-b504-02ea663cdbad.png">

