### PR TITLE
Fixes: Buttons on Help, 200, 400, 404, 500, Unverified, Retry

### DIFF
--- a/benefits/core/templates/core/help.html
+++ b/benefits/core/templates/core/help.html
@@ -55,7 +55,17 @@
       </div>
     </div>
 
-    {% include "core/includes/agency-links.html" with buttons=page.buttons %}
+    <div class="row justify-content-center">
+      <div class="col-10">{% include "core/includes/agency-links.html" with buttons=page.buttons %}</div>
+    </div>
+
+    {% for back_button in page.buttons %}
+      {% if "btn-primary" in back_button.classes %}
+        <div class="row pt-8">
+          <div class="col-lg-3 offset-lg-8 col-8 offset-2">{% include "core/includes/button.html" with button=back_button %}</div>
+        </div>
+      {% endif %}
+    {% endfor %}
 
     <div class="row justify-content-center">
       <div class="col-8 col-lg-10 mt-4">

--- a/benefits/core/templates/core/help.html
+++ b/benefits/core/templates/core/help.html
@@ -48,10 +48,10 @@
 
         <h2 class="pt-8" id="questions">{% translate "core.pages.help.questions" %}</h2>
         <p class="pt-4">{% translate "core.pages.help.questions.p[0]" %}</p>
-
-        {% include "core/includes/agency-links.html" with buttons=page.buttons %}
       </div>
     </div>
+
+    {% include "core/includes/agency-links.html" with buttons=page.buttons %}
 
     <div class="row justify-content-center">
       <div class="col-lg-10 mt-4">

--- a/benefits/core/templates/core/help.html
+++ b/benefits/core/templates/core/help.html
@@ -1,19 +1,19 @@
-{% extends "core/page.html" %}
+{% extends "core/base.html" %}
 {% load i18n %}
 {% load static %}
 
 {% block main_content %}
-  <div class="container-fluid">
-    <div class="container content help">
-      {% block container_content %}
-        <h1>{{ page.headline }}</h1>
+  <div class="container">
+    <h1>{{ page.headline }}</h1>
 
-        <h2 id="what-is-cal-itp">{% translate "core.pages.help.about" %}</h2>
-        <p>{% translate "core.pages.help.about.p[0]" %}</p>
-        <p>{% translate "core.pages.help.about.p[1]" %}</p>
+    <div class="row justify-content-center">
+      <div class="col-10">
+        <h2 class="pt-8" id="what-is-cal-itp">{% translate "core.pages.help.about" %}</h2>
+        <p class="pt-4">{% translate "core.pages.help.about.p[0]" %}</p>
+        <p class="pt-4">{% translate "core.pages.help.about.p[1]" %}</p>
 
-        <h2 id="payment-options">{% translate "core.pages.help.payment_options" %}</h2>
-        <p>{% translate "core.pages.help.payment_options.p[0]" %}</p>
+        <h2 class="pt-8" id="payment-options">{% translate "core.pages.help.payment_options" %}</h2>
+        <p class="pt-4">{% translate "core.pages.help.payment_options.p[0]" %}</p>
 
         <p class="contactless-symbol">
           <img class="icon mx-auto d-block"
@@ -21,43 +21,45 @@
                alt="{% translate "core.icons.contactless" context "image alt text" %}"/>
         </p>
 
-        <p>{% translate "core.pages.help.payment_options.p[1]" %}</p>
-        <p>
+        <p class="pt-4">{% translate "core.pages.help.payment_options.p[1]" %}</p>
+        <p class="pt-4">
           {% blocktranslate with website="https://cash.app/help/us/en-us/14425-cal-transit" %}core.pages.help.payment_options.p[2][0]{{ website }}{% endblocktranslate %}
           {% blocktranslate with website="https://venmo.com/about/debitcard/" %}core.pages.help.payment_options.p[2][1]{{ website }}{% endblocktranslate %}
         </p>
-        <p>{% translate "core.pages.help.payment_options.p[3]" %}</p>
-        <p>{% translate "core.pages.help.payment_options.p[4]" %}</p>
+        <p class="pt-4">{% translate "core.pages.help.payment_options.p[3]" %}</p>
+        <p class="pt-4">{% translate "core.pages.help.payment_options.p[4]" %}</p>
 
-        <h2 id="login-gov">{% translate "core.pages.help.login_gov" %}</h2>
-        <p>{% translate "core.pages.help.login_gov.p[0]" %}</p>
-        <p>{% translate "core.pages.help.login_gov.p[1]" %}</p>
-        <p>{% translate "core.pages.help.login_gov.p[2]" %}</p>
+        <h2 class="pt-8" id="login-gov">{% translate "core.pages.help.login_gov" %}</h2>
+        <p class="pt-4">{% translate "core.pages.help.login_gov.p[0]" %}</p>
+        <p class="pt-4">{% translate "core.pages.help.login_gov.p[1]" %}</p>
+        <p class="pt-4">{% translate "core.pages.help.login_gov.p[2]" %}</p>
 
-        <h2 id="login-gov-verify">{% translate "core.pages.help.login_gov_verify" %}</h2>
-        <p>{% translate "core.pages.help.login_gov_verify.p[0]" %}</p>
-        <p>{% translate "core.pages.help.login_gov_verify.p[1]" %}</p>
-        <p>{% translate "core.pages.help.login_gov_verify.p[2]" %}</p>
-        <p>{% translate "core.pages.help.login_gov_verify.p[3]" %}</p>
+        <h2 class="pt-8" id="login-gov-verify">{% translate "core.pages.help.login_gov_verify" %}</h2>
+        <p class="pt-4">{% translate "core.pages.help.login_gov_verify.p[0]" %}</p>
+        <p class="pt-4">{% translate "core.pages.help.login_gov_verify.p[1]" %}</p>
+        <p class="pt-4">{% translate "core.pages.help.login_gov_verify.p[2]" %}</p>
+        <p class="pt-4">{% translate "core.pages.help.login_gov_verify.p[3]" %}</p>
 
-        <h2 id="littlepay">{% translate "core.pages.help.littlepay" %}</h2>
-        <p>{% translate "core.pages.help.littlepay.p[0]" %}</p>
-        <p>
+        <h2 class="pt-8" id="littlepay">{% translate "core.pages.help.littlepay" %}</h2>
+        <p class="pt-4">{% translate "core.pages.help.littlepay.p[0]" %}</p>
+        <p class="pt-4">
           {% blocktranslate with website="https://littlepay.com" %}core.pages.help.littlepay.p[1]{{ website }}{% endblocktranslate %}
         </p>
 
-        <h2 id="questions">{% translate "core.pages.help.questions" %}</h2>
-        <p>{% translate "core.pages.help.questions.p[0]" %}</p>
+        <h2 class="pt-8" id="questions">{% translate "core.pages.help.questions" %}</h2>
+        <p class="pt-4">{% translate "core.pages.help.questions.p[0]" %}</p>
 
-        {% block buttons %}
-          {% include "core/includes/agency-links.html" with buttons=page.buttons %}
-        {% endblock buttons %}
+        {% include "core/includes/agency-links.html" with buttons=page.buttons %}
+      </div>
+    </div>
 
-        <p class="mt-4">
+    <div class="row justify-content-center">
+      <div class="col-lg-10 mt-4">
+        <p class="pt-4">
           {% translate "core.pages.help.foss.text" %}
           <a href="https://www.github.com/cal-itp/benefits" target="_blank" rel="noopener noreferrer">{% translate "core.pages.help.foss.link" %}</a>.
         </p>
-      {% endblock container_content %}
+      </div>
     </div>
   </div>
 {% endblock main_content %}

--- a/benefits/core/templates/core/help.html
+++ b/benefits/core/templates/core/help.html
@@ -4,7 +4,11 @@
 
 {% block main_content %}
   <div class="container">
-    <h1>{{ page.headline }}</h1>
+    <div class="row justify-content-center">
+      <div class="col-10">
+        <h1>{{ page.headline }}</h1>
+      </div>
+    </div>
 
     <div class="row justify-content-center">
       <div class="col-10">
@@ -54,7 +58,7 @@
     {% include "core/includes/agency-links.html" with buttons=page.buttons %}
 
     <div class="row justify-content-center">
-      <div class="col-lg-10 mt-4">
+      <div class="col-8 col-lg-10 mt-4">
         <p class="pt-4">
           {% translate "core.pages.help.foss.text" %}
           <a href="https://www.github.com/cal-itp/benefits" target="_blank" rel="noopener noreferrer">{% translate "core.pages.help.foss.link" %}</a>.

--- a/benefits/core/templates/core/includes/agency-links.html
+++ b/benefits/core/templates/core/includes/agency-links.html
@@ -1,23 +1,23 @@
-<div class="row buttons-agencies">
-  {% for agency_button in buttons %}
-    {% if "agency" in agency_button.classes %}
-      {% if agency_button.label %}<label class="mt-4 d-block fs-base ls-base">{{ agency_button.label }}</label>{% endif %}
-      <a class="d-table fs-base ls-base"
-         {% if agency_button.target %}target="{{ agency_button.target }}"{% endif %}
-         {% if agency_button.rel %}rel="{{ agency_button.rel }}"{% endif %}
-         href="{{ agency_button.url }}">
-        {{ agency_button.text }}
-      </a>
-    {% endif %}
-  {% endfor %}
+<div class="row justify-content-center">
+  <div class="col-10">
+    {% for agency_button in buttons %}
+      {% if "agency" in agency_button.classes %}
+        {% if agency_button.label %}<label class="mt-4 d-block fs-base ls-base">{{ agency_button.label }}</label>{% endif %}
+        <a class="d-table fs-base ls-base"
+           {% if agency_button.target %}target="{{ agency_button.target }}"{% endif %}
+           {% if agency_button.rel %}rel="{{ agency_button.rel }}"{% endif %}
+           href="{{ agency_button.url }}">
+          {{ agency_button.text }}
+        </a>
+      {% endif %}
+    {% endfor %}
+  </div>
 </div>
 
 {% for back_button in buttons %}
   {% if "btn-primary" in back_button.classes %}
-    <div class="row row d-flex justify-content-lg-end pt-8">
-      <div class="col-lg-3 offset-2 offset-sm-2 offset-lg-0 col-sm-8 col-8">
-        {% include "core/includes/button.html" with button=back_button %}
-      </div>
+    <div class="row pt-8">
+      <div class="col-lg-3 offset-lg-8 col-8 offset-2">{% include "core/includes/button.html" with button=back_button %}</div>
     </div>
   {% endif %}
 {% endfor %}

--- a/benefits/core/templates/core/includes/agency-links.html
+++ b/benefits/core/templates/core/includes/agency-links.html
@@ -1,23 +1,11 @@
-<div class="row justify-content-center">
-  <div class="col-10">
-    {% for agency_button in buttons %}
-      {% if "agency" in agency_button.classes %}
-        {% if agency_button.label %}<label class="mt-4 d-block fs-base ls-base">{{ agency_button.label }}</label>{% endif %}
-        <a class="d-table fs-base ls-base"
-           {% if agency_button.target %}target="{{ agency_button.target }}"{% endif %}
-           {% if agency_button.rel %}rel="{{ agency_button.rel }}"{% endif %}
-           href="{{ agency_button.url }}">
-          {{ agency_button.text }}
-        </a>
-      {% endif %}
-    {% endfor %}
-  </div>
-</div>
-
-{% for back_button in buttons %}
-  {% if "btn-primary" in back_button.classes %}
-    <div class="row pt-8">
-      <div class="col-lg-3 offset-lg-8 col-8 offset-2">{% include "core/includes/button.html" with button=back_button %}</div>
-    </div>
+{% for agency_button in buttons %}
+  {% if "agency" in agency_button.classes %}
+    {% if agency_button.label %}<label class="mt-4 d-block fs-base ls-base">{{ agency_button.label }}</label>{% endif %}
+    <a class="d-table fs-base ls-base"
+       {% if agency_button.target %}target="{{ agency_button.target }}"{% endif %}
+       {% if agency_button.rel %}rel="{{ agency_button.rel }}"{% endif %}
+       href="{{ agency_button.url }}">
+      {{ agency_button.text }}
+    </a>
   {% endif %}
 {% endfor %}

--- a/benefits/core/templates/core/includes/agency-links.html
+++ b/benefits/core/templates/core/includes/agency-links.html
@@ -1,9 +1,9 @@
-
-<div class="buttons-agencies">
+<div class="row buttons-agencies">
   {% for agency_button in buttons %}
     {% if "agency" in agency_button.classes %}
-      {% if agency_button.label %}<label>{{ agency_button.label }}</label>{% endif %}
-      <a {% if agency_button.target %}target="{{ agency_button.target }}"{% endif %}
+      {% if agency_button.label %}<label class="mt-4 d-block fs-base ls-base">{{ agency_button.label }}</label>{% endif %}
+      <a class="d-table fs-base ls-base"
+         {% if agency_button.target %}target="{{ agency_button.target }}"{% endif %}
          {% if agency_button.rel %}rel="{{ agency_button.rel }}"{% endif %}
          href="{{ agency_button.url }}">
         {{ agency_button.text }}
@@ -14,6 +14,10 @@
 
 {% for back_button in buttons %}
   {% if "btn-primary" in back_button.classes %}
-    <div class="button-back">{% include "core/includes/button.html" with button=back_button %}</div>
+    <div class="row row d-flex justify-content-lg-end pt-8">
+      <div class="col-lg-3 offset-2 offset-sm-2 offset-lg-0 col-sm-8 col-8">
+        {% include "core/includes/button.html" with button=back_button %}
+      </div>
+    </div>
   {% endif %}
 {% endfor %}

--- a/benefits/core/templates/core/includes/icon-title.html
+++ b/benefits/core/templates/core/includes/icon-title.html
@@ -1,5 +1,5 @@
 
 <h1 class="icon-title">
-  <span class="icon">{% include "core/includes/icon.html" with icon=icon alt=alt %}</span>
+  <span class="icon d-block pb-lg-8 pb-4">{% include "core/includes/icon.html" with icon=icon alt=alt %}</span>
   {{ title }}
 </h1>

--- a/benefits/core/templates/core/includes/icon-title.html
+++ b/benefits/core/templates/core/includes/icon-title.html
@@ -1,5 +1,5 @@
 
-<h1 class="icon-title">
+<h1 class="icon-title h2 text-center">
   <span class="icon d-block pb-5">{% include "core/includes/icon.html" with icon=icon alt=alt %}</span>
   {{ title }}
 </h1>

--- a/benefits/core/templates/core/includes/icon-title.html
+++ b/benefits/core/templates/core/includes/icon-title.html
@@ -1,5 +1,5 @@
 
 <h1 class="icon-title">
-  <span class="icon d-block pb-lg-8 pb-4">{% include "core/includes/icon.html" with icon=icon alt=alt %}</span>
+  <span class="icon d-block pb-5">{% include "core/includes/icon.html" with icon=icon alt=alt %}</span>
   {{ title }}
 </h1>

--- a/benefits/core/templates/core/page.html
+++ b/benefits/core/templates/core/page.html
@@ -49,15 +49,11 @@
           {% block buttons %}
             {% if page.buttons|length_is:"0" %}
             {% else %}
-              {% if "with-agency-links" in page.classes %}
-                {% include "core/includes/agency-links.html" with buttons=page.buttons %}
-              {% else %}
-                <div class="buttons">
-                  {% for b in page.buttons %}
-                    {% include "core/includes/button.html" with button=b %}
-                  {% endfor %}
-                </div>
-              {% endif %}
+              <div class="buttons">
+                {% for b in page.buttons %}
+                  {% include "core/includes/button.html" with button=b %}
+                {% endfor %}
+              </div>
             {% endif %}
           {% endblock buttons %}
 

--- a/benefits/eligibility/templates/eligibility/unverified.html
+++ b/benefits/eligibility/templates/eligibility/unverified.html
@@ -7,7 +7,7 @@
     {% include "core/includes/icon-title.html" with title=page.headline icon=page.icon %}
 
     <div class="row justify-content-center">
-      <div class="col-lg-10">
+      <div class="col-lg-8 pt-4">
         {% for p in page.paragraphs %}<p>{{ p }}</p>{% endfor %}
       </div>
     </div>

--- a/benefits/eligibility/templates/eligibility/unverified.html
+++ b/benefits/eligibility/templates/eligibility/unverified.html
@@ -1,9 +1,9 @@
 {% extends "core/base.html" %}
 
 {% block main_content %}
-  <div class="container">
-    {% include "core/includes/sign-out-link.html" %}
+  {% include "core/includes/sign-out-link.html" %}
 
+  <div class="container">
     {% include "core/includes/icon-title.html" with title=page.headline icon=page.icon %}
 
     <div class="row justify-content-center">

--- a/benefits/eligibility/templates/eligibility/unverified.html
+++ b/benefits/eligibility/templates/eligibility/unverified.html
@@ -1,6 +1,17 @@
-{% extends "core/page.html" %}
+{% extends "core/base.html" %}
 
 {% block main_content %}
-  {% include "core/includes/sign-out-link.html" %}
-  {{ block.super }}
+  <div class="container">
+    {% include "core/includes/sign-out-link.html" %}
+
+    {% include "core/includes/icon-title.html" with title=page.headline icon=page.icon %}
+
+    <div class="row justify-content-center">
+      <div class="col-lg-10">
+        {% for p in page.paragraphs %}<p>{{ p }}</p>{% endfor %}
+      </div>
+    </div>
+
+    {% include "core/includes/agency-links.html" with buttons=page.buttons %}
+  </div>
 {% endblock main_content %}

--- a/benefits/eligibility/templates/eligibility/unverified.html
+++ b/benefits/eligibility/templates/eligibility/unverified.html
@@ -12,6 +12,17 @@
       </div>
     </div>
 
-    {% include "core/includes/agency-links.html" with buttons=page.buttons %}
+    <div class="row justify-content-center">
+      <div class="col-lg-8">{% include "core/includes/agency-links.html" with buttons=page.buttons %}</div>
+    </div>
+
+    {% for back_button in page.buttons %}
+      {% if "btn-primary" in back_button.classes %}
+        <div class="row pt-8 justify-content-center">
+          <div class="col-lg-3 col-8">{% include "core/includes/button.html" with button=back_button %}</div>
+        </div>
+      {% endif %}
+    {% endfor %}
+
   </div>
 {% endblock main_content %}

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -235,7 +235,6 @@ def unverified(request):
 
     page = viewmodels.Page(
         title=_(verifier.unverified_title),
-        classes="with-agency-links",
         headline=_(verifier.unverified_headline),
         icon=viewmodels.Icon("idcardquestion", pgettext("image alt text", "core.icons.idcardquestion")),
         paragraphs=[_(verifier.unverified_blurb)],

--- a/benefits/enrollment/templates/enrollment/retry.html
+++ b/benefits/enrollment/templates/enrollment/retry.html
@@ -1,6 +1,28 @@
-{% extends "core/page.html" %}
+{% extends "core/base.html" %}
 
 {% block main_content %}
   {% include "core/includes/sign-out-link.html" %}
-  {{ block.super }}
+
+  <div class="container">
+    {% include "core/includes/icon-title.html" with title=page.headline icon=page.icon %}
+
+    <div class="row justify-content-center">
+      <div class="col-lg-8 pt-4">
+        {% for p in page.paragraphs %}<p>{{ p }}</p>{% endfor %}
+      </div>
+    </div>
+
+    <div class="row justify-content-center">
+      <div class="col-lg-8">{% include "core/includes/agency-links.html" with buttons=page.buttons %}</div>
+    </div>
+
+    {% for back_button in page.buttons %}
+      {% if "btn-primary" in back_button.classes %}
+        <div class="row pt-8 justify-content-center">
+          <div class="col-lg-3 col-8">{% include "core/includes/button.html" with button=back_button %}</div>
+        </div>
+      {% endif %}
+    {% endfor %}
+
+  </div>
 {% endblock main_content %}

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -107,6 +107,14 @@ li {
   padding-top: 64px;
 }
 
+.fs-base {
+  font-size: var(--bs-body-font-size);
+}
+
+.ls-base {
+  letter-spacing: var(--body-letter-spacing);
+}
+
 /* Links */
 /* Same sizes for all screen widths: 18px */
 a:not(.btn) {
@@ -566,59 +574,18 @@ h1 + .media-list, /* A .media-list immediately following the h1: Enrollment Succ
 
 /* 404 Page */
 
-.container.content h1.icon-title {
+h1.icon-title {
   padding-bottom: 1.5rem;
 }
 
-.container.content h1.icon-title span.icon {
+h1.icon-title span.icon {
   display: block;
   padding-bottom: 3rem;
 }
 
-.container.content h1.icon-title img.icon {
+h1.icon-title img.icon {
   width: 150px;
   height: 150px;
-}
-
-/* Help */
-
-.container.content.help {
-  margin: 4rem auto 2rem auto;
-}
-
-.container.content.help h1 {
-  margin-bottom: 4rem;
-}
-
-.container.content.help h2 {
-  margin-bottom: 3rem;
-  margin-top: 3rem;
-}
-
-.container.content.help p {
-  margin-bottom: 2rem;
-}
-
-.container.content .buttons-agencies {
-  font-size: 18px;
-  letter-spacing: 0.05rem;
-  margin-bottom: 3rem;
-}
-
-.container.content .buttons-agencies a {
-  display: table;
-  margin-bottom: 0.2rem;
-}
-
-.container.content .buttons-agencies label {
-  display: block;
-  margin-top: 2rem;
-  font-size: 18px;
-}
-
-.container.content.help .button-back {
-  margin-top: 5rem;
-  margin-bottom: 5rem;
 }
 
 /* Agency Index */

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -572,22 +572,6 @@ h1 + .media-list, /* A .media-list immediately following the h1: Enrollment Succ
   margin-left: var(--logout-paragraph-margin-left);
 }
 
-/* 404 Page */
-
-h1.icon-title {
-  padding-bottom: 1.5rem;
-}
-
-h1.icon-title span.icon {
-  display: block;
-  padding-bottom: 3rem;
-}
-
-h1.icon-title img.icon {
-  width: 150px;
-  height: 150px;
-}
-
 /* Agency Index */
 /* This page has a full-width and full-height background image, creating the need to re-set the Footer margin top to 0 */
 

--- a/benefits/templates/200_user_error.html
+++ b/benefits/templates/200_user_error.html
@@ -1,19 +1,19 @@
 {% extends "core/base.html" %}
 
 {% block main_content %}
-    <div class="container">
-        {% include "core/includes/icon-title.html" with title=page.headline icon=page.icon %}
+  <div class="container">
+    {% include "core/includes/icon-title.html" with title=page.headline icon=page.icon %}
 
-        <div class="row justify-content-center">
-            <div class="col-lg-8 pt-4">
-                {% for p in page.paragraphs %}<p>{{ p }}</p>{% endfor %}
-            </div>
-        </div>
-
-        <div class="row pt-8 justify-content-center">
-            {% for b in page.buttons %}
-                <div class="col-lg-3 col-8">{% include "core/includes/button.html" with button=b %}</div>
-            {% endfor %}
-        </div>
+    <div class="row justify-content-center">
+      <div class="col-lg-8 pt-4">
+        {% for p in page.paragraphs %}<p>{{ p }}</p>{% endfor %}
+      </div>
     </div>
+
+    <div class="row pt-8 justify-content-center">
+      {% for b in page.buttons %}
+        <div class="col-lg-3 col-8">{% include "core/includes/button.html" with button=b %}</div>
+      {% endfor %}
+    </div>
+  </div>
 {% endblock main_content %}

--- a/benefits/templates/200_user_error.html
+++ b/benefits/templates/200_user_error.html
@@ -1,1 +1,19 @@
-{% extends "core/page.html" %}
+{% extends "core/base.html" %}
+
+{% block main_content %}
+    <div class="container">
+        {% include "core/includes/icon-title.html" with title=page.headline icon=page.icon %}
+
+        <div class="row justify-content-center">
+            <div class="col-lg-8 pt-4">
+                {% for p in page.paragraphs %}<p>{{ p }}</p>{% endfor %}
+            </div>
+        </div>
+
+        <div class="row pt-8 justify-content-center">
+            {% for b in page.buttons %}
+                <div class="col-lg-3 col-8">{% include "core/includes/button.html" with button=b %}</div>
+            {% endfor %}
+        </div>
+    </div>
+{% endblock main_content %}

--- a/benefits/templates/400.html
+++ b/benefits/templates/400.html
@@ -5,7 +5,7 @@
     {% include "core/includes/icon-title.html" with title=page.headline icon=page.icon %}
 
     <div class="row justify-content-center">
-      <div class="col-lg-10 pt-4">
+      <div class="col-lg-8 pt-4">
         {% for p in page.paragraphs %}<p>{{ p }}</p>{% endfor %}
       </div>
     </div>

--- a/benefits/templates/400.html
+++ b/benefits/templates/400.html
@@ -10,9 +10,9 @@
       </div>
     </div>
 
-    <div class="row pt-8">
+    <div class="row pt-8 justify-content-center">
       {% for b in page.buttons %}
-        <div class="col-lg-3 offset-lg-8 col-8 offset-2">{% include "core/includes/button.html" with button=b %}</div>
+        <div class="col-lg-3 col-8">{% include "core/includes/button.html" with button=b %}</div>
       {% endfor %}
     </div>
   </div>

--- a/benefits/templates/400.html
+++ b/benefits/templates/400.html
@@ -1,1 +1,19 @@
-{% extends "core/page.html" %}
+{% extends "core/base.html" %}
+
+{% block main_content %}
+    <div class="container">
+        {% include "core/includes/icon-title.html" with title=page.headline icon=page.icon %}
+
+        <div class="row justify-content-center">
+            <div class="col-lg-10">
+                {% for p in page.paragraphs %}<p>{{ p }}</p>{% endfor %}
+            </div>
+        </div>
+
+        <div class="row pt-8">
+            {% for b in page.buttons %}
+                <div class="col-lg-3 offset-lg-8 col-8 offset-2">{% include "core/includes/button.html" with button=b %}</div>
+            {% endfor %}
+        </div>
+    </div>
+{% endblock main_content %}

--- a/benefits/templates/400.html
+++ b/benefits/templates/400.html
@@ -1,19 +1,19 @@
 {% extends "core/base.html" %}
 
 {% block main_content %}
-    <div class="container">
-        {% include "core/includes/icon-title.html" with title=page.headline icon=page.icon %}
+  <div class="container">
+    {% include "core/includes/icon-title.html" with title=page.headline icon=page.icon %}
 
-        <div class="row justify-content-center">
-            <div class="col-lg-10">
-                {% for p in page.paragraphs %}<p>{{ p }}</p>{% endfor %}
-            </div>
-        </div>
-
-        <div class="row pt-8">
-            {% for b in page.buttons %}
-                <div class="col-lg-3 offset-lg-8 col-8 offset-2">{% include "core/includes/button.html" with button=b %}</div>
-            {% endfor %}
-        </div>
+    <div class="row justify-content-center">
+      <div class="col-lg-10 pt-4">
+        {% for p in page.paragraphs %}<p>{{ p }}</p>{% endfor %}
+      </div>
     </div>
+
+    <div class="row pt-8">
+      {% for b in page.buttons %}
+        <div class="col-lg-3 offset-lg-8 col-8 offset-2">{% include "core/includes/button.html" with button=b %}</div>
+      {% endfor %}
+    </div>
+  </div>
 {% endblock main_content %}

--- a/benefits/templates/404.html
+++ b/benefits/templates/404.html
@@ -5,7 +5,7 @@
     {% include "core/includes/icon-title.html" with title=page.headline icon=page.icon %}
 
     <div class="row justify-content-center">
-      <div class="col-lg-10 pt-4">
+      <div class="col-lg-8 pt-4">
         {% for p in page.paragraphs %}<p>{{ p }}</p>{% endfor %}
       </div>
     </div>

--- a/benefits/templates/404.html
+++ b/benefits/templates/404.html
@@ -5,7 +5,7 @@
     {% include "core/includes/icon-title.html" with title=page.headline icon=page.icon %}
 
     <div class="row justify-content-center">
-      <div class="col-lg-10">
+      <div class="col-lg-10 pt-4">
         {% for p in page.paragraphs %}<p>{{ p }}</p>{% endfor %}
       </div>
     </div>

--- a/benefits/templates/404.html
+++ b/benefits/templates/404.html
@@ -10,9 +10,9 @@
       </div>
     </div>
 
-    <div class="row pt-8">
+    <div class="row pt-8 justify-content-center">
       {% for b in page.buttons %}
-        <div class="col-lg-3 offset-lg-8 col-8 offset-2">{% include "core/includes/button.html" with button=b %}</div>
+        <div class="col-lg-3 col-8">{% include "core/includes/button.html" with button=b %}</div>
       {% endfor %}
     </div>
   </div>

--- a/benefits/templates/404.html
+++ b/benefits/templates/404.html
@@ -1,1 +1,19 @@
-{% extends "core/page.html" %}
+{% extends "core/base.html" %}
+
+{% block main_content %}
+  <div class="container">
+    {% include "core/includes/icon-title.html" with title=page.headline icon=page.icon %}
+
+    <div class="row justify-content-center">
+      <div class="col-lg-10">
+        {% for p in page.paragraphs %}<p>{{ p }}</p>{% endfor %}
+      </div>
+    </div>
+
+    <div class="row pt-8">
+      {% for b in page.buttons %}
+        <div class="col-lg-3 offset-lg-8 col-8 offset-2">{% include "core/includes/button.html" with button=b %}</div>
+      {% endfor %}
+    </div>
+  </div>
+{% endblock main_content %}

--- a/benefits/templates/500.html
+++ b/benefits/templates/500.html
@@ -5,7 +5,7 @@
     {% include "core/includes/icon-title.html" with title=page.headline icon=page.icon %}
 
     <div class="row justify-content-center">
-      <div class="col-lg-10 pt-4">
+      <div class="col-lg-8 pt-4">
         {% for p in page.paragraphs %}<p>{{ p }}</p>{% endfor %}
       </div>
     </div>

--- a/benefits/templates/500.html
+++ b/benefits/templates/500.html
@@ -5,7 +5,7 @@
     {% include "core/includes/icon-title.html" with title=page.headline icon=page.icon %}
 
     <div class="row justify-content-center">
-      <div class="col-lg-10">
+      <div class="col-lg-10 pt-4">
         {% for p in page.paragraphs %}<p>{{ p }}</p>{% endfor %}
       </div>
     </div>

--- a/benefits/templates/500.html
+++ b/benefits/templates/500.html
@@ -10,9 +10,9 @@
       </div>
     </div>
 
-    <div class="row pt-8">
+    <div class="row pt-8 justify-content-center">
       {% for b in page.buttons %}
-        <div class="col-lg-3 offset-lg-8 col-8 offset-2">{% include "core/includes/button.html" with button=b %}</div>
+        <div class="col-lg-3 col-8">{% include "core/includes/button.html" with button=b %}</div>
       {% endfor %}
     </div>
   </div>

--- a/benefits/templates/500.html
+++ b/benefits/templates/500.html
@@ -1,1 +1,19 @@
-{% extends "core/page.html" %}
+{% extends "core/base.html" %}
+
+{% block main_content %}
+  <div class="container">
+    {% include "core/includes/icon-title.html" with title=page.headline icon=page.icon %}
+
+    <div class="row justify-content-center">
+      <div class="col-lg-10">
+        {% for p in page.paragraphs %}<p>{{ p }}</p>{% endfor %}
+      </div>
+    </div>
+
+    <div class="row pt-8">
+      {% for b in page.buttons %}
+        <div class="col-lg-3 offset-lg-8 col-8 offset-2">{% include "core/includes/button.html" with button=b %}</div>
+      {% endfor %}
+    </div>
+  </div>
+{% endblock main_content %}


### PR DESCRIPTION
fixes #972 
fixes #512 

## What this PR does
- Use `base.html` for Help, 200, 400, 404, 500, Unverified (eligibility/unverified), Retry (enrollment/retry)
- Agency Links include: Removes the Back button from this includes
- Removes Agency Links include from Page
- Removes `with-agency-links` CSS logic
- For Agency Links, it does do everything in this ticket #512 - but further changes / future ticket is necessary to remove these lines: https://github.com/cal-itp/benefits/pull/1042/files#diff-1a4430de237c046c679071ef0d2a5b267007651b8fa1c42e755f0a1cea4d469cR2 https://github.com/cal-itp/benefits/pull/1042/files#diff-32d0e53bd73778cc6c0437f522dd3269a366d343d321f0d9eee21d3ec3d4d166R20 (Probably needs a ticket to refactor the Page view model to make it easier to pass in the agency links differently from a Back button, or something like that)

## What this PR does not do
- Make any changes to the Button viewmodel
- Make any changes to the way we currently use 3 classes `btn.btn-primary.btn-lg` to achieve the look of 1 button (We don't really use these classes in any other combination or in isolation). 
- This PR does not remove the existence of `btn-link` class or `Button.link()` because, this, too, is also (only) used in Agency Links and so it cannot be removed.


## CSS Documentation: New utility classes

Use these classes to quickly set something to have the base (16px) font size, base (0.05em) letter spacing.

```css
.fs-base {
  font-size: var(--bs-body-font-size);
}

.ls-base {
  letter-spacing: var(--body-letter-spacing);
}
```

### Help

- Put Help on a `col-10` width and `justify-content-center`
- Put the Back button on a `col-8 col-lg-3` width, and right-aligned on Desktop and centered on Mobile
- Use `pt-4` for paragraph padding
- Agency Links includes: Remove the back button from this include.
- Because this page has the Free and Open Source text _after_ the Call To Action, I had to override the whole `main_content`

![Screenshot 2022-10-12 at 09-51-16 Transit Benefits Help Cal-ITP](https://user-images.githubusercontent.com/3673236/195402292-1aa90851-e81a-448c-bc87-c007b0ccac65.png)
<img width="341" alt="image" src="https://user-images.githubusercontent.com/3673236/195402403-6e2b5f92-b1b1-4bc7-b147-fef29c4732d8.png">
<img width="450" alt="image" src="https://user-images.githubusercontent.com/3673236/195402968-b1afa99f-5d1b-4623-81d1-fc0b98b9c7f5.png">

### 200, 400, 404, 500

- Centers the button.
- Uses `icon-title`, `buttons` includes

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/195404130-7d3b0274-0267-4551-9e7c-6daec50937fc.png">




### Unverified: Unverified Login.gov, Unverified CC

- This page also uses the Agency Links includes, which no longer has the Back button in it.
- Uses `icon-title`, `agency-links`, `buttons` includes inside the `container`. Uses `sign-out-link` *outside* of the container.
- Centers the button.

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/195403115-523e911e-d681-43af-9ff3-32ecfd29ef7e.png">
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/195403215-aee7ac7d-d26a-4b88-ada7-3d07ce0b0b6a.png">


### Retry

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/195425212-4b69a0da-9430-4e1a-93b9-ecc6e773f90c.png">
I had to fake some code to get this layout to load
