### PR TITLE
Feat: Add spinner to Check Status button

### DIFF
--- a/benefits/core/templates/core/includes/form.html
+++ b/benefits/core/templates/core/includes/form.html
@@ -36,14 +36,18 @@
         {% endif %}
         <div class="col-lg-3 offset-2 offset-sm-2 offset-lg-0 col-sm-8 col-8">
           {% if recaptcha.enabled %}
-            <button class="btn btn-lg btn-primary g-recaptcha"
+            <button class="btn btn-lg btn-primary spinner-hidden g-recaptcha"
                     data-sitekey="{{ recaptcha.site_key }}"
                     data-callback="onSubmit"
                     data-action="submit">
-              {{ form.submit_value }}
+              <span class="btn-text">{{ form.submit_value }}</span>
+              <span class="spinner-border spinner-border-sm" role="status"></span>
             </button>
           {% else %}
-            <button class="btn btn-lg btn-primary" data-action="submit">{{ form.submit_value }}</button>
+            <button class="btn btn-lg btn-primary spinner-hidden" data-action="submit">
+              <span class="btn-text">{{ form.submit_value }}</span>
+              <span class="spinner-border spinner-border-sm" role="status"></span>
+            </button>
           {% endif %}
         </div>
       </div>
@@ -63,9 +67,10 @@
                 $("form[action='{{form_action}}']").on("submit", function(e) {
                     if ("{{ form.submitting_value }}" !== "") {
                         $("button[data-action='submit']", this)
+                            .removeClass("spinner-hidden")
+                            .children().first().text("{{ form.submitting_value }}")
                             .attr("role", "status")
                             .attr("disabled", "true")
-                            .text("{{ form.submitting_value }}")
                             .addClass("disabled");
                     }
                 });

--- a/benefits/core/templates/core/includes/form.html
+++ b/benefits/core/templates/core/includes/form.html
@@ -36,17 +36,17 @@
         {% endif %}
         <div class="col-lg-3 offset-2 offset-sm-2 offset-lg-0 col-sm-8 col-8">
           {% if recaptcha.enabled %}
-            <button class="btn btn-lg btn-primary spinner-hidden g-recaptcha"
+            <button class="btn btn-lg btn-primary spinner-hidden d-flex justify-content-center align-items-center g-recaptcha"
                     data-sitekey="{{ recaptcha.site_key }}"
                     data-callback="onSubmit"
                     data-action="submit">
               <span class="btn-text">{{ form.submit_value }}</span>
-              <span class="spinner-border spinner-border-sm" role="status"></span>
+              <span class="spinner-border spinner-border-sm m-1" role="status"></span>
             </button>
           {% else %}
-            <button class="btn btn-lg btn-primary spinner-hidden" data-action="submit">
+            <button class="btn btn-lg btn-primary spinner-hidden d-flex justify-content-center align-items-center" data-action="submit">
               <span class="btn-text">{{ form.submit_value }}</span>
-              <span class="spinner-border spinner-border-sm" role="status"></span>
+              <span class="spinner-border spinner-border-sm m-1" role="status"></span>
             </button>
           {% endif %}
         </div>

--- a/benefits/core/templates/core/includes/form.html
+++ b/benefits/core/templates/core/includes/form.html
@@ -41,12 +41,12 @@
                     data-callback="onSubmit"
                     data-action="submit">
               <span class="btn-text">{{ form.submit_value }}</span>
-              <span class="spinner-border spinner-border-sm m-1" role="status"></span>
+              <span class="spinner-border spinner-border-sm" role="status"></span>
             </button>
           {% else %}
             <button class="btn btn-lg btn-primary spinner-hidden d-flex justify-content-center align-items-center" data-action="submit">
               <span class="btn-text">{{ form.submit_value }}</span>
-              <span class="spinner-border spinner-border-sm m-1" role="status"></span>
+              <span class="spinner-border spinner-border-sm" role="status"></span>
             </button>
           {% endif %}
         </div>

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -282,6 +282,12 @@ footer .footer-links li a:visited {
   padding: var(--primary-button-padding);
 }
 
+.btn-text {
+  letter-spacing: 0.02em;
+  font-weight: var(--medium-font-weight);
+  font-size: calc(20rem / 16);
+}
+
 /* A button that actually is a text link */
 /* TODO: Check if this is actually really used anymore */
 .btn-link {
@@ -293,6 +299,12 @@ footer .footer-links li a:visited {
 .btn-outline-dark,
 .btn-outline-light {
   border-width: 2px;
+}
+
+/* Custom button: Loading spinner */
+
+.spinner-hidden .spinner-border {
+  display: none;
 }
 
 /* Custom button: Login.gov Button with text and SVG */

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -307,6 +307,11 @@ footer .footer-links li a:visited {
   display: none;
 }
 
+.spinner-border {
+  border-width: 3px;
+  margin-left: 15px;
+}
+
 /* Custom button: Login.gov Button with text and SVG */
 /* Used on Eligibility Start */
 


### PR DESCRIPTION
closes #948 

## What this PR does
- Add Spinner to button  _if_ the button has a `form.submitting_value`. 
- The Eligibility Verification form has a `submitting_value` (`Checking`), so the spinner shows up there. No other place in the current app has a form with a `submitting_value`.

## Button with Spinner element

<img width="413" alt="image" src="https://user-images.githubusercontent.com/3673236/195678241-211e9885-e9c6-4d0f-91ea-20bc84cdefdf.png">

### Spinner:
- 3px border width
- 16x16 total size
- 15px margin left from the text
- `role="status"` for a11y
- Comes from Bootstrap: https://getbootstrap.com/docs/5.1/components/spinners/

<img width="937" alt="image" src="https://user-images.githubusercontent.com/3673236/195678277-d8f2ad0d-96eb-4332-8017-a4ce8ae74ff6.png">

### Button with Spinner:
- `<button>` with two `<span>`s
- One span for text, one span for spinner. (If these are in the _same_ span, then the whole text would also rotate).

## Testing
- Test all other buttons for height/size
- Test with keyboard
- A11y check: Does this new spinner affect a11y at all? If so how? How to mitigate?
- All other CTA buttons (besides Agency Index home page button) should have height 60px
<img width="699" alt="image" src="https://user-images.githubusercontent.com/3673236/195679275-51380701-af43-4bfd-a4b3-9548eee88067.png">
<img width="1081" alt="image" src="https://user-images.githubusercontent.com/3673236/195679777-61db30cf-1c6b-437c-8b96-574fdc1e532e.png">

