### PR TITLE
Fix: Allow margin-bottom for media-list

### DIFF
--- a/benefits/core/templates/core/includes/media-list.html
+++ b/benefits/core/templates/core/includes/media-list.html
@@ -1,4 +1,4 @@
-<ul class="media-list m-0 px-0 d-flex justify-content-center flex-column">
+<ul class="media-list mx-0 px-0 d-flex justify-content-center flex-column">
     {% for item in media %}
         <li class="media d-flex align-items-stretch w-auto">
             <div class="media-line">{% include "core/includes/icon.html" with icon=item.icon %}</div>


### PR DESCRIPTION
closes #1047

## What this PR does
- It uses `mx-0` instead of `m-0` so that the `margin-bottom: 64px;` on Media List still works. 
- The spacing between the bottom of the last Icon and the first Button should be 64px on both Desktop and Mobile

## Where to test

eligibility/start
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/195455246-2e3914dd-1f38-4a77-9746-f9f0a0559655.png">

enrollment
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/195455312-4361b70a-e7df-4106-ac7f-7bf20490ef3d.png">

enrollment/success (there is no button here, so there's no visual difference. ensure no regressions here)
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/195455447-b456c0c1-070c-4b10-b4a1-69ffb44e17f6.png">
