### PR TITLE
Fix: Eligibility Start - Mobile: Add padding top between help text and button

### DIFF
--- a/benefits/eligibility/templates/eligibility/start.html
+++ b/benefits/eligibility/templates/eligibility/start.html
@@ -16,7 +16,9 @@
 {% endblock inner-content %}
 
 {% block call-to-action-text %}
-  <p>{% blocktranslate with help_link=help_link%}eligibility.pages.start.help_text{{ help_link }}{% endblocktranslate %}</p>
+  <p class="pt-4 pt-lg-0">
+    {% blocktranslate with help_link=help_link%}eligibility.pages.start.help_text{{ help_link }}{% endblocktranslate %}
+  </p>
 {% endblock call-to-action-text %}
 
 {% block call-to-action-button %}


### PR DESCRIPTION
fixes #1050 

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/195458760-2ee89348-7466-45f4-9f6b-df2361f31804.png">

On mobile, two left screens should now have the same padding between the button and the help text, just like Eligibility Index.