### PR TITLE
Fix: Enrollment Index - Add H1 padding

### DIFF
--- a/benefits/enrollment/templates/enrollment/index.html
+++ b/benefits/enrollment/templates/enrollment/index.html
@@ -5,15 +5,13 @@
 {% endblock nav-buttons %}
 
 {% block headline %}
-<div class="col-lg-5">
-  <h1>{{ page.headline }}</h1>
-</div>
+  <div class="col-lg-5">
+    <h1 class="pb-lg-8 pb-4">{{ page.headline }}</h1>
+  </div>
 {% endblock headline %}
 
 {% block inner-content %}
-  <div class="col-12 col-sm-12 col-lg-10">
-    {% include "core/includes/media-list.html" with media=media %}
-  </div>
+  <div class="col-12 col-sm-12 col-lg-10">{% include "core/includes/media-list.html" with media=media %}</div>
 
   {% comment %} This Javascript code must be before the forms. {% endcomment %}
   {% if payment_processor %}

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -504,7 +504,7 @@ footer .footer-links li a:visited {
   }
 }
 
-h1 + .media-list, /* A .media-list immediately following the h1: Enrollment, Enrollment Success, but not Eligibility Start */
+h1 + .media-list, /* A .media-list immediately following the h1: Enrollment Success, but not Eligibility Start */
 .media-body--details p:not(:first-of-type) {
   /* All the p within .media-body--details, except for the first p - Any media item with more than one p */
   padding-top: 24px;


### PR DESCRIPTION
fixes #1049 

## What this PR does
- Use `pb-lg-8 pb-4` to add 24px padding on Mobile, 64px padding on Desktop between the H1 and the Media List on Enrollment Index

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/195460944-601c7d91-ca03-4348-8e02-69001ef6b4e9.png">
<img width="724" alt="image" src="https://user-images.githubusercontent.com/3673236/195460955-f164a26f-bf89-4254-981c-9163c7c3b468.png">
