### PR TITLE
Improvements to Eligibility events

### DIFF
--- a/benefits/core/analytics.py
+++ b/benefits/core/analytics.py
@@ -12,6 +12,7 @@ from django.conf import settings
 import requests
 
 from benefits import VERSION
+from benefits.core.models import EligibilityType
 from . import session
 
 
@@ -45,8 +46,15 @@ class Event:
         agency_name = agency.long_name if agency else None
         verifier = session.verifier(request)
         verifier_name = verifier.name if verifier else None
+        eligibility_types = session.eligibility(request)
+        eligibility_types = EligibilityType.get_names(eligibility_types) if eligibility_types else None
 
-        self.update_event_properties(path=request.path, transit_agency=agency_name, eligibility_verifier=verifier_name)
+        self.update_event_properties(
+            path=request.path,
+            transit_agency=agency_name,
+            eligibility_types=eligibility_types,
+            eligibility_verifier=verifier_name,
+        )
 
         uagent = request.headers.get("user-agent")
 
@@ -59,6 +67,7 @@ class Event:
             referring_domain=refdom,
             user_agent=uagent,
             transit_agency=agency_name,
+            eligibility_types=eligibility_types,
             eligibility_verifier=verifier_name,
         )
 

--- a/benefits/core/models.py
+++ b/benefits/core/models.py
@@ -73,6 +73,18 @@ class EligibilityType(models.Model):
         logger.debug(f"Get {EligibilityType.__name__} list by ids: {ids}")
         return EligibilityType.objects.filter(id__in=ids)
 
+    @staticmethod
+    def get_names(eligibility_types):
+        """Convert a list of EligibilityType to a list of their names"""
+        if isinstance(eligibility_types, EligibilityType):
+            eligibility_types = [eligibility_types]
+        return [t.name for t in eligibility_types if isinstance(t, EligibilityType)]
+
+    @staticmethod
+    def get_names_to_verify(agency, verifier):
+        """Get the names of the eligibility types to check for the agency/verifier pair."""
+        return EligibilityType.get_names(agency.types_to_verify(verifier))
+
 
 class EligibilityVerifier(models.Model):
     """An entity that verifies eligibility."""

--- a/benefits/core/models.py
+++ b/benefits/core/models.py
@@ -80,11 +80,6 @@ class EligibilityType(models.Model):
             eligibility_types = [eligibility_types]
         return [t.name for t in eligibility_types if isinstance(t, EligibilityType)]
 
-    @staticmethod
-    def get_names_to_verify(agency, verifier):
-        """Get the names of the eligibility types to check for the agency/verifier pair."""
-        return EligibilityType.get_names(agency.types_to_verify(verifier))
-
 
 class EligibilityVerifier(models.Model):
     """An entity that verifies eligibility."""
@@ -233,6 +228,10 @@ class TransitAgency(models.Model):
         verifier_types = {eligibility_verifier.eligibility_type.id}
         supported_types = list(agency_types & verifier_types)
         return EligibilityType.get_many(supported_types)
+
+    def type_names_to_verify(self, verifier):
+        """List of names of the eligibility types to check for this agency."""
+        return EligibilityType.get_names(self.types_to_verify(verifier))
 
     @property
     def index_url(self):

--- a/benefits/eligibility/analytics.py
+++ b/benefits/eligibility/analytics.py
@@ -13,6 +13,14 @@ class EligibilityEvent(core.Event):
         self.update_event_properties(eligibility_types=eligibility_types)
 
 
+class SelectedVerifierEvent(EligibilityEvent):
+    """Analytics event representing the user selecting an eligibility verifier."""
+
+    def __init__(self, request, verifier, eligibility_types):
+        super().__init__(request, "selected eligibility verifier", eligibility_types)
+        self.update_event_properties(eligibility_verifier=verifier)
+
+
 class StartedEligibilityEvent(EligibilityEvent):
     """Analytics event representing the beginning of an eligibility verification check."""
 
@@ -30,6 +38,11 @@ class ReturnedEligibilityEvent(EligibilityEvent):
             self.update_event_properties(status=status, error=error)
         if status == "success":
             self.update_user_properties(eligibility_types=eligibility_types)
+
+
+def selected_verifier(request, verifier, eligibility_types):
+    """Send the "selected eligibility verifier" analytics event."""
+    core.send_event(SelectedVerifierEvent(request, verifier, eligibility_types))
 
 
 def started_eligibility(request, eligibility_types):

--- a/benefits/eligibility/analytics.py
+++ b/benefits/eligibility/analytics.py
@@ -9,6 +9,7 @@ class EligibilityEvent(core.Event):
 
     def __init__(self, request, event_type, eligibility_types):
         super().__init__(request, event_type)
+        # overwrite core.Event eligibility_types
         self.update_event_properties(eligibility_types=eligibility_types)
 
 

--- a/benefits/eligibility/analytics.py
+++ b/benefits/eligibility/analytics.py
@@ -25,8 +25,11 @@ class ReturnedEligibilityEvent(EligibilityEvent):
 
     def __init__(self, request, eligibility_types, status, error=None):
         super().__init__(request, "returned eligibility", eligibility_types)
-        if str(status).lower() in ("error", "fail", "success"):
+        status = str(status).lower()
+        if status in ("error", "fail", "success"):
             self.update_event_properties(status=status, error=error)
+        if status == "success":
+            self.update_user_properties(eligibility_types=eligibility_types)
 
 
 def started_eligibility(request, eligibility_types):

--- a/benefits/eligibility/analytics.py
+++ b/benefits/eligibility/analytics.py
@@ -16,9 +16,8 @@ class EligibilityEvent(core.Event):
 class SelectedVerifierEvent(EligibilityEvent):
     """Analytics event representing the user selecting an eligibility verifier."""
 
-    def __init__(self, request, verifier, eligibility_types):
+    def __init__(self, request, eligibility_types):
         super().__init__(request, "selected eligibility verifier", eligibility_types)
-        self.update_event_properties(eligibility_verifier=verifier)
 
 
 class StartedEligibilityEvent(EligibilityEvent):
@@ -40,9 +39,9 @@ class ReturnedEligibilityEvent(EligibilityEvent):
             self.update_user_properties(eligibility_types=eligibility_types)
 
 
-def selected_verifier(request, verifier, eligibility_types):
+def selected_verifier(request, eligibility_types):
     """Send the "selected eligibility verifier" analytics event."""
-    core.send_event(SelectedVerifierEvent(request, verifier, eligibility_types))
+    core.send_event(SelectedVerifierEvent(request, eligibility_types))
 
 
 def started_eligibility(request, eligibility_types):

--- a/benefits/eligibility/verify.py
+++ b/benefits/eligibility/verify.py
@@ -2,10 +2,7 @@ from django.conf import settings
 
 from eligibility_api.client import Client
 
-
-def typenames_to_verify(agency, verifier):
-    """Get the names of the eligibility types to check for the agency/verifier pair."""
-    return [t.name for t in agency.types_to_verify(verifier)]
+from benefits.core.models import EligibilityType
 
 
 def eligibility_from_api(verifier, form, agency):
@@ -23,7 +20,7 @@ def eligibility_from_api(verifier, form, agency):
         server_public_key=verifier.public_key_data,
     )
 
-    response = client.verify(sub, name, typenames_to_verify(agency, verifier))
+    response = client.verify(sub, name, EligibilityType.get_names_to_verify(agency, verifier))
 
     if response.error and any(response.error):
         return None
@@ -35,6 +32,6 @@ def eligibility_from_api(verifier, form, agency):
 
 def eligibility_from_oauth(verifier, oauth_claim, agency):
     if verifier.uses_auth_verification and verifier.auth_provider.claim == oauth_claim:
-        return typenames_to_verify(agency, verifier)
+        return EligibilityType.get_names_to_verify(agency, verifier)
     else:
         return []

--- a/benefits/eligibility/verify.py
+++ b/benefits/eligibility/verify.py
@@ -2,8 +2,6 @@ from django.conf import settings
 
 from eligibility_api.client import Client
 
-from benefits.core.models import EligibilityType
-
 
 def eligibility_from_api(verifier, form, agency):
     sub, name = form.cleaned_data.get("sub"), form.cleaned_data.get("name")
@@ -20,7 +18,7 @@ def eligibility_from_api(verifier, form, agency):
         server_public_key=verifier.public_key_data,
     )
 
-    response = client.verify(sub, name, EligibilityType.get_names_to_verify(agency, verifier))
+    response = client.verify(sub, name, agency.type_names_to_verify(verifier))
 
     if response.error and any(response.error):
         return None
@@ -32,6 +30,6 @@ def eligibility_from_api(verifier, form, agency):
 
 def eligibility_from_oauth(verifier, oauth_claim, agency):
     if verifier.uses_auth_verification and verifier.auth_provider.claim == oauth_claim:
-        return EligibilityType.get_names_to_verify(agency, verifier)
+        return agency.type_names_to_verify(verifier)
     else:
         return []

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -64,6 +64,9 @@ def index(request):
             verifier = EligibilityVerifier.objects.get(id=verifier_id)
             session.update(request, verifier=verifier)
 
+            types_to_verify = EligibilityType.get_names_to_verify(agency, verifier)
+            analytics.selected_verifier(request, verifier.name, types_to_verify)
+
             response = redirect(eligibility_start)
         else:
             # form was not valid, allow for correction/resubmission

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -11,7 +11,7 @@ from django.utils.translation import pgettext, gettext as _
 
 from benefits.core import recaptcha, session, viewmodels
 from benefits.core.middleware import AgencySessionRequired, LoginRequired, RateLimit, RecaptchaEnabled, VerifierSessionRequired
-from benefits.core.models import EligibilityVerifier
+from benefits.core.models import EligibilityType, EligibilityVerifier
 from benefits.core.views import ROUTE_HELP
 from . import analytics, forms, verify
 
@@ -156,7 +156,7 @@ def confirm(request):
 
     agency = session.agency(request)
     verifier = session.verifier(request)
-    types_to_verify = verify.typenames_to_verify(agency, verifier)
+    types_to_verify = EligibilityType.get_names_to_verify(agency, verifier)
 
     # GET for OAuth verification
     if request.method == "GET" and verifier.uses_auth_verification:
@@ -232,7 +232,7 @@ def unverified(request):
 
     agency = session.agency(request)
     verifier = session.verifier(request)
-    types_to_verify = verify.typenames_to_verify(agency, verifier)
+    types_to_verify = EligibilityType.get_names_to_verify(agency, verifier)
 
     analytics.returned_fail(request, types_to_verify)
 

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -11,7 +11,7 @@ from django.utils.translation import pgettext, gettext as _
 
 from benefits.core import recaptcha, session, viewmodels
 from benefits.core.middleware import AgencySessionRequired, LoginRequired, RateLimit, RecaptchaEnabled, VerifierSessionRequired
-from benefits.core.models import EligibilityType, EligibilityVerifier
+from benefits.core.models import EligibilityVerifier
 from benefits.core.views import ROUTE_HELP
 from . import analytics, forms, verify
 
@@ -64,7 +64,7 @@ def index(request):
             verifier = EligibilityVerifier.objects.get(id=verifier_id)
             session.update(request, verifier=verifier)
 
-            types_to_verify = EligibilityType.get_names_to_verify(agency, verifier)
+            types_to_verify = agency.type_names_to_verify(verifier)
             analytics.selected_verifier(request, verifier.name, types_to_verify)
 
             response = redirect(eligibility_start)
@@ -159,7 +159,7 @@ def confirm(request):
 
     agency = session.agency(request)
     verifier = session.verifier(request)
-    types_to_verify = EligibilityType.get_names_to_verify(agency, verifier)
+    types_to_verify = agency.type_names_to_verify(verifier)
 
     # GET for OAuth verification
     if request.method == "GET" and verifier.uses_auth_verification:
@@ -235,7 +235,7 @@ def unverified(request):
 
     agency = session.agency(request)
     verifier = session.verifier(request)
-    types_to_verify = EligibilityType.get_names_to_verify(agency, verifier)
+    types_to_verify = agency.type_names_to_verify(verifier)
 
     analytics.returned_fail(request, types_to_verify)
 

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -65,7 +65,7 @@ def index(request):
             session.update(request, verifier=verifier)
 
             types_to_verify = agency.type_names_to_verify(verifier)
-            analytics.selected_verifier(request, verifier.name, types_to_verify)
+            analytics.selected_verifier(request, types_to_verify)
 
             response = redirect(eligibility_start)
         else:

--- a/tests/pytest/core/test_analytics.py
+++ b/tests/pytest/core/test_analytics.py
@@ -1,0 +1,82 @@
+import pytest
+
+import benefits.core.analytics
+from benefits.core.analytics import Event
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("event_type", ["EVENT_TYPE", "eVeNt TyPe", "event-type"])
+def test_Event_event_type_lowercase(app_request, event_type):
+    expected = str(event_type).lower()
+    event = Event(app_request, event_type)
+
+    assert event.event_type == expected
+
+
+@pytest.mark.django_db
+def test_Event_reads_session(app_request, mocker):
+    session_spy = mocker.spy(benefits.core.analytics, "session")
+
+    Event(app_request, "event_type")
+
+    session_spy.agency.assert_called_once_with(app_request)
+    session_spy.did.assert_called_once_with(app_request)
+    session_spy.eligibility.assert_called_once_with(app_request)
+    session_spy.language.assert_called_once_with(app_request)
+    session_spy.start.assert_called_once_with(app_request)
+    session_spy.uid.assert_called_once_with(app_request)
+    session_spy.verifier.assert_called_once_with(app_request)
+
+
+@pytest.mark.django_db
+def test_Event_sets_default_event_properties(app_request, mocker):
+    update_spy = mocker.spy(benefits.core.analytics.Event, "update_event_properties")
+
+    Event(app_request, "event_type")
+
+    assert "path" in update_spy.call_args.kwargs
+    assert "transit_agency" in update_spy.call_args.kwargs
+    assert "eligibility_types" in update_spy.call_args.kwargs
+    assert "eligibility_verifier" in update_spy.call_args.kwargs
+
+
+@pytest.mark.django_db
+def test_Event_sets_default_user_properties(app_request, mocker):
+    update_spy = mocker.spy(benefits.core.analytics.Event, "update_user_properties")
+
+    Event(app_request, "event_type")
+
+    assert "referrer" in update_spy.call_args.kwargs
+    assert "referring_domain" in update_spy.call_args.kwargs
+    assert "user_agent" in update_spy.call_args.kwargs
+    assert "transit_agency" in update_spy.call_args.kwargs
+    assert "eligibility_types" in update_spy.call_args.kwargs
+    assert "eligibility_verifier" in update_spy.call_args.kwargs
+
+
+@pytest.mark.django_db
+def test_Event_update_event_properties(app_request):
+    key, value = "key", "value"
+    event = Event(app_request, "event_type")
+
+    assert len(event.event_properties) > 0
+    assert key not in event.event_properties
+
+    event.update_event_properties(**{key: value})
+
+    assert key in event.event_properties
+    assert event.event_properties[key] == value
+
+
+@pytest.mark.django_db
+def test_Event_update_user_properties(app_request):
+    key, value = "key", "value"
+    event = Event(app_request, "event_type")
+
+    assert len(event.user_properties) > 0
+    assert key not in event.user_properties
+
+    event.update_user_properties(**{key: value})
+
+    assert key in event.user_properties
+    assert event.user_properties[key] == value

--- a/tests/pytest/core/test_models.py
+++ b/tests/pytest/core/test_models.py
@@ -79,6 +79,24 @@ def test_EligibilityType_get_many_somematching(model_EligibilityType):
 
 
 @pytest.mark.django_db
+def test_EligibilityType_get_names(model_EligibilityType):
+    expected = [model_EligibilityType.name]
+
+    result = EligibilityType.get_names([model_EligibilityType])
+
+    assert result == expected
+
+
+@pytest.mark.django_db
+def test_EligibilityType_get_names_to_verify(model_TransitAgency, model_EligibilityVerifier):
+    expected = [t.name for t in model_TransitAgency.types_to_verify(model_EligibilityVerifier)]
+
+    result = EligibilityType.get_names_to_verify(model_TransitAgency, model_EligibilityVerifier)
+
+    assert result == expected
+
+
+@pytest.mark.django_db
 def test_EligibilityVerifier_str(model_EligibilityVerifier):
     assert str(model_EligibilityVerifier) == model_EligibilityVerifier.name
 

--- a/tests/pytest/core/test_models.py
+++ b/tests/pytest/core/test_models.py
@@ -88,15 +88,6 @@ def test_EligibilityType_get_names(model_EligibilityType):
 
 
 @pytest.mark.django_db
-def test_EligibilityType_get_names_to_verify(model_TransitAgency, model_EligibilityVerifier):
-    expected = [t.name for t in model_TransitAgency.types_to_verify(model_EligibilityVerifier)]
-
-    result = EligibilityType.get_names_to_verify(model_TransitAgency, model_EligibilityVerifier)
-
-    assert result == expected
-
-
-@pytest.mark.django_db
 def test_EligibilityVerifier_str(model_EligibilityVerifier):
     assert str(model_EligibilityVerifier) == model_EligibilityVerifier.name
 
@@ -220,6 +211,15 @@ def test_TransitAgency_types_to_verify(model_TransitAgency):
     result = model_TransitAgency.types_to_verify(verifier)
     assert len(result) == 1
     assert eligibility in result
+
+
+@pytest.mark.django_db
+def test_TransitAgency_type_names_to_verify(model_TransitAgency, model_EligibilityVerifier):
+    expected = [t.name for t in model_TransitAgency.types_to_verify(model_EligibilityVerifier)]
+
+    result = model_TransitAgency.type_names_to_verify(model_EligibilityVerifier)
+
+    assert result == expected
 
 
 @pytest.mark.django_db

--- a/tests/pytest/eligibility/test_analytics.py
+++ b/tests/pytest/eligibility/test_analytics.py
@@ -1,0 +1,16 @@
+import pytest
+
+from benefits.eligibility.analytics import EligibilityEvent
+
+
+@pytest.mark.django_db
+def test_EligibilityEvent_overwrites_session_eligibility_types(app_request, mocker):
+    type1, type2 = "type1", "type2"
+    mocker.patch("benefits.core.analytics.session.eligibility", return_value=[type1])
+    mocker.patch("benefits.core.analytics.EligibilityType.get_names", return_value=[type1])
+
+    event = EligibilityEvent(app_request, "event_type", [type2])
+
+    assert "eligibility_types" in event.event_properties
+    assert type2 in event.event_properties["eligibility_types"]
+    assert type1 not in event.event_properties["eligibility_types"]

--- a/tests/pytest/eligibility/test_analytics.py
+++ b/tests/pytest/eligibility/test_analytics.py
@@ -1,16 +1,36 @@
 import pytest
 
-from benefits.eligibility.analytics import EligibilityEvent
+from benefits.eligibility.analytics import EligibilityEvent, ReturnedEligibilityEvent
 
 
 @pytest.mark.django_db
-def test_EligibilityEvent_overwrites_session_eligibility_types(app_request, mocker):
-    type1, type2 = "type1", "type2"
+def test_EligibilityEvent_overwrites_event_eligibility_types(app_request, mocker):
+    key, type1, type2 = "eligibility_types", "type1", "type2"
     mocker.patch("benefits.core.analytics.session.eligibility", return_value=[type1])
     mocker.patch("benefits.core.analytics.EligibilityType.get_names", return_value=[type1])
 
     event = EligibilityEvent(app_request, "event_type", [type2])
 
-    assert "eligibility_types" in event.event_properties
-    assert type2 in event.event_properties["eligibility_types"]
-    assert type1 not in event.event_properties["eligibility_types"]
+    # event_properties should have been overwritten
+    assert key in event.event_properties
+    assert type2 in event.event_properties[key]
+    assert type1 not in event.event_properties[key]
+
+    # user_properties should not have been overwritten
+    assert key in event.user_properties
+    assert type1 in event.user_properties[key]
+    assert type2 not in event.user_properties[key]
+
+
+@pytest.mark.django_db
+def test_ReturnedEligibilityEvent_success_overwrites_user_eligibility_types(app_request, mocker):
+    key, type1, type2 = "eligibility_types", "type1", "type2"
+    mocker.patch("benefits.core.analytics.session.eligibility", return_value=[type1])
+    mocker.patch("benefits.core.analytics.EligibilityType.get_names", return_value=[type1])
+
+    event = ReturnedEligibilityEvent(app_request, eligibility_types=[type2], status="success")
+
+    # user_properties should have been overwritten
+    assert key in event.user_properties
+    assert type1 not in event.user_properties[key]
+    assert type2 in event.user_properties[key]

--- a/tests/pytest/eligibility/test_verify.py
+++ b/tests/pytest/eligibility/test_verify.py
@@ -1,7 +1,7 @@
 import pytest
 
 from benefits.eligibility.forms import EligibilityVerificationForm
-from benefits.eligibility.verify import typenames_to_verify, eligibility_from_api, eligibility_from_oauth
+from benefits.eligibility.verify import eligibility_from_api, eligibility_from_oauth
 
 
 @pytest.fixture
@@ -12,15 +12,6 @@ def form(mocker):
 @pytest.fixture
 def mock_api_client_verify(mocker):
     return mocker.patch("benefits.eligibility.verify.Client.verify")
-
-
-@pytest.mark.django_db
-def test_typenames_to_verify(model_TransitAgency, model_EligibilityVerifier):
-    expected = [t.name for t in model_TransitAgency.types_to_verify(model_EligibilityVerifier)]
-
-    result = typenames_to_verify(model_TransitAgency, model_EligibilityVerifier)
-
-    assert result == expected
 
 
 @pytest.mark.django_db

--- a/tests/pytest/eligibility/test_views.py
+++ b/tests/pytest/eligibility/test_views.py
@@ -119,7 +119,7 @@ def test_index_post_invalid_form(client):
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_session_agency")
-def test_index_post_valid_form(client, model_EligibilityVerifier, mocked_session_update):
+def test_index_post_valid_form(client, model_EligibilityVerifier, mocked_session_update, mocked_analytics_module):
     path = reverse(ROUTE_INDEX)
 
     response = client.post(path, {"verifier": model_EligibilityVerifier.id})
@@ -127,6 +127,7 @@ def test_index_post_valid_form(client, model_EligibilityVerifier, mocked_session
     assert response.status_code == 302
     assert response.url == reverse(ROUTE_START)
     assert mocked_session_update.call_args.kwargs["verifier"] == model_EligibilityVerifier
+    mocked_analytics_module.selected_verifier.assert_called_once()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Closes #342 
Closes #926

## What this PR does

### New event for `selected eligibility verifier`

This event is sent when the user submits the form on `/eligibility/index` page (the "benefit selection" form). It includes an event property `eligibility_verifier` identifying which was selected.

**Note** the event is _not sent_ when there is only a single `EligibilityVerifier` configured in the app. In this case, the user is never presented with the selection form. This is an unlikely scenario given that we are launching the new events with the Courtesy Card feature and alongside the existing Older Adults pathway.

### `eligibility_types` on all events

This PR adds the `eligibility_types` event property (a list of zero or more type names) for _all analytics events_ by adding it to the base `core.analytics.Event` class. The value is initially pulled from the user's session.

Events using the `eligibility.analytics.EligibilityEvent` as a base class override the default session values (based on the work in #874).



