### PR TITLE
Fix: Radio button positioning, elements

### DIFF
--- a/benefits/core/templates/core/widgets/verifier_radio_select.html
+++ b/benefits/core/templates/core/widgets/verifier_radio_select.html
@@ -16,7 +16,7 @@
           {% endif %}
 
           {% for option in options %}
-            <div class="radio-input-group">{% include option.template_name with widget=option %}</div>
+            <div class="radio-input-group d-flex">{% include option.template_name with widget=option %}</div>
           {% endfor %}
 
           {% if group %}

--- a/benefits/core/templates/core/widgets/verifier_radio_select_option.html
+++ b/benefits/core/templates/core/widgets/verifier_radio_select_option.html
@@ -1,13 +1,13 @@
 
-<input class="radio-input rounded-circle"
+<input class="radio-input rounded-circle flex-grow-0 flex-shrink-0"
        type="{{ widget.type }}"
        name="{{ widget.name }}"
        {% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}
        {% include "django/forms/widgets/attrs.html" %}>
 
 {% if widget.wrap_label %}
-  <label{% if widget.attrs.id %} for="{{ widget.attrs.id }}" class="radio-label h3 d-inline"{% endif %}>
-    {{ widget.label }}
-    {% if widget.description %}<p class="radio-label-description">{{ widget.description }}</p>{% endif %}
+  <label{% if widget.attrs.id %} for="{{ widget.attrs.id }}" class="radio-label"{% endif %}>
+    <span class="d-block h3">{{ widget.label }}</span>
+    {% if widget.description %}<span class="d-block pt-1">{{ widget.description }}</span>{% endif %}
   </label>
 {% endif %}

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -442,22 +442,23 @@ footer .footer-links li a:visited {
 /* Forms: Radio Buttons */
 
 :root {
-  --var-radio-button-size: 24px;
+  --radio-button-size: 24px;
   --radio-input-color: var(--standout-color);
-  --radio-input-margin-right: 42px;
-  --radio-label-desc-margin-left: 70px;
+  --radio-input-gap: 40px;
 }
 
 @media (min-width: 992px) {
   :root {
-    --var-radio-button-size: 24px;
-    --radio-input-margin-right: 15px;
-    --radio-label-desc-margin-left: 42px;
+    --radio-input-gap: 15px;
   }
 }
 
 .radio-label {
   cursor: pointer;
+}
+
+.radio-input-group {
+  gap: var(--radio-input-gap);
 }
 
 .radio-input-group:not(:first-child) {
@@ -469,21 +470,15 @@ footer .footer-links li a:visited {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  width: var(--var-radio-button-size);
-  height: var(--var-radio-button-size);
+  width: var(--radio-button-size);
+  height: var(--radio-button-size);
   border: 2px solid var(--radio-input-color);
-  position: relative;
-  top: 7px;
-  margin-right: var(--radio-input-margin-right);
+  margin: 3px 0;
 }
 
 .radio-input:checked {
   background-color: var(--radio-input-color);
   box-shadow: inset 0 0 0 2px var(--bs-white);
-}
-
-.radio-label-description {
-  margin-left: var(--radio-label-desc-margin-left);
 }
 
 /* Media List */


### PR DESCRIPTION
fixes #1046 

## What this PR does

- Change the element make up of the radio button: The `label` now has two `span`s in it, (rather than one `paragraph`), to be HTML5 validator compliant.
<img width="498" alt="image" src="https://user-images.githubusercontent.com/3673236/195672992-7d465c1d-1c7a-4ec9-9305-06913e54f726.png">

- Change how the elements are positioned and aligned. Currently, the radio button is positioned with relative positioning. Now, it uses flexbox: The parent div that holds the Radio Button and the Label parent is now displayed with flex, with a `gap` of `var(--radio-input-gap)`, set as `40px` on Mobile and `15px` on Desktop.

<img width="1484" alt="image" src="https://user-images.githubusercontent.com/3673236/195673531-366ddaa3-59f9-4a99-b90b-4661e830c2a0.png">

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/195674191-c5f7591b-6729-4b6a-8f32-2695fb8d6ab2.png">

A margin of 3px top/bottom is given to the Radio Button (24px button + 6px total margin = 30px), so that it aligns with the first row of text on the Label (30px high when label is 1 one line):
<img width="431" alt="image" src="https://user-images.githubusercontent.com/3673236/195674404-2c8672a1-eee1-4061-89b3-ed593c813f2e.png">


```css
/* Forms: Radio Buttons */

:root {
  --radio-button-size: 24px;
  --radio-input-color: var(--standout-color);
  --radio-input-gap: 40px;
}

@media (min-width: 992px) {
  :root {
    --radio-input-gap: 15px;
  }
}

.radio-input-group {
  gap: var(--radio-input-gap);
}

.radio-input-group:not(:first-child) {
  padding-top: 24px;
}

.radio-input {
  cursor: pointer;
  -webkit-appearance: none;
  -moz-appearance: none;
  appearance: none;
  width: var(--radio-button-size);
  height: var(--radio-button-size);
  border: 2px solid var(--radio-input-color);
  margin: 3px 0;
}
```
