### PR TITLE
Fix: Use rem calculation for 18px font

### DIFF
--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -10,7 +10,7 @@
   --bs-body-font-weight: 400;
   --medium-font-weight: 500;
   --bold-font-weight: 700;
-  --bs-body-font-size: 18px;
+  --bs-body-font-size: calc(18rem / 16);
   --bs-font-sans-serif: Roboto, system-ui, -apple-system, "Segoe UI", sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --bs-body-font-family: var(--bs-font-sans-serif);


### PR DESCRIPTION
related to #778

## How to test this PR
- Test the app in 200% on Chrome, Firefox, Safari on Desktop - Everything should be clickable/not blocked
- Test the app in 200% on mobile browsers - Everything should be clickable/not blocked
- @angela-tran What other kind of testing should we be doing for this check?

Reference: https://dev-benefits.calitp.org/help