### PR TITLE
Fix: Google Lighthouse/HTML5 Validator fix for images

### DIFF
--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -59,13 +59,13 @@
           <span class="navbar-brand p-0">
             <img class="sm d-lg-none"
                  src="{% static "img/logo-sm.svg" %}"
-                 width="90px"
-                 height="51.3px"
+                 width="90"
+                 height="51.3"
                  alt="{% translate "core.logos.small" context "image alt text" %}"/>
             <img class="lg d-none d-lg-block"
                  src="{% static "img/logo-lg.svg" %}"
-                 width="220px"
-                 height="50px"
+                 width="220"
+                 height="50"
                  alt="{% translate "core.logos.large" context "image alt text" %}"/>
           </span>
           <span class="form-inline">{% include "core/includes/lang-selector.html" %}</span>

--- a/benefits/core/templates/core/help.html
+++ b/benefits/core/templates/core/help.html
@@ -17,6 +17,8 @@
 
         <p class="contactless-symbol">
           <img class="icon mx-auto d-block"
+               width="40px"
+               height="50px"
                src="{% static 'img/icon/contactless.svg' %}"
                alt="{% translate "core.icons.contactless" context "image alt text" %}"/>
         </p>

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -10,7 +10,7 @@
   --bs-body-font-weight: 400;
   --medium-font-weight: 500;
   --bold-font-weight: 700;
-  --bs-body-font-size: 18px;
+  --bs-body-font-size: calc(18rem / 16);
   --bs-font-sans-serif: Roboto, system-ui, -apple-system, "Segoe UI", sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --bs-body-font-family: var(--bs-font-sans-serif);


### PR DESCRIPTION
fixes #935 

## What this PR does
- Make sure all images on the site have width/height defined
- The width/height definition does not need pixels

## Testing


- https://validator.w3.org/nu/?doc=https%3A%2F%2Fdev-benefits.calitp.org%2Fmst
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/3673236/195694310-1e10b1cb-0c75-49ac-9473-cdb7ad86ccfb.png">
<img width="1382" alt="image" src="https://user-images.githubusercontent.com/3673236/195694335-d75d95e7-8f0f-4923-bfc2-52339f762feb.png">


<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/195694636-cbfb3ac0-e8ef-484c-b1d8-6bdbc082679a.png">

