### PR TITLE
Audit: Run the site through Lighthouse, HTML5 Validator

### DIFF
--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -59,13 +59,13 @@
           <span class="navbar-brand p-0">
             <img class="sm d-lg-none"
                  src="{% static "img/logo-sm.svg" %}"
-                 width="90px"
-                 height="51.3px"
+                 width="90"
+                 height="51.3"
                  alt="{% translate "core.logos.small" context "image alt text" %}"/>
             <img class="lg d-none d-lg-block"
                  src="{% static "img/logo-lg.svg" %}"
-                 width="220px"
-                 height="50px"
+                 width="220"
+                 height="50"
                  alt="{% translate "core.logos.large" context "image alt text" %}"/>
           </span>
           <span class="form-inline">{% include "core/includes/lang-selector.html" %}</span>

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -68,7 +68,7 @@
                  height="50"
                  alt="{% translate "core.logos.large" context "image alt text" %}"/>
           </span>
-          <span class="form-inline">{% include "core/includes/lang-selector.html" %}</span>
+          <div class="form-inline">{% include "core/includes/lang-selector.html" %}</div>
         </div>
       </div>
     </header>

--- a/benefits/core/templates/core/help.html
+++ b/benefits/core/templates/core/help.html
@@ -17,8 +17,8 @@
 
         <p class="contactless-symbol">
           <img class="icon mx-auto d-block"
-               width="40px"
-               height="50px"
+               width="40"
+               height="50"
                src="{% static 'img/icon/contactless.svg' %}"
                alt="{% translate "core.icons.contactless" context "image alt text" %}"/>
         </p>

--- a/benefits/core/templates/core/help.html
+++ b/benefits/core/templates/core/help.html
@@ -17,6 +17,8 @@
 
         <p class="contactless-symbol">
           <img class="icon mx-auto d-block"
+               width="40px"
+               height="50px"
                src="{% static 'img/icon/contactless.svg' %}"
                alt="{% translate "core.icons.contactless" context "image alt text" %}"/>
         </p>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ include = '\.pyi?$'
 # Configuration for djlint
 
 [tool.djlint]
-ignore = "H006,H017,H021,H025,H031"
+ignore = "H017,H025,H031"
 indent = 2
 max_attribute_length = 127
 max_line_length = 127

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ include = '\.pyi?$'
 # Configuration for djlint
 
 [tool.djlint]
-ignore = "H017,H025,H031"
+ignore = "H017,H031"
 indent = 2
 max_attribute_length = 127
 max_line_length = 127


### PR DESCRIPTION
closes #935 

## What this PR does
- Adds image dimensions to HTML as numbers, not pixels. Pixels is wrong.
- Changes the lang selector from a span to a div. It should not be a span.
- Adds back 2 linter rules that we are not 100% compliant with.


## Why
- Should address all ERROR level feedback from HTML5 validator: https://validator.w3.org/nu/?doc=https%3A%2F%2Fdev-benefits.calitp.org%2Fmst

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/195706956-4f2a0de6-4f9d-4b8b-845f-5a4255c1ef88.png">

- Should address/attempt to address all Issues on Google Chrome DevTools: https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/1665691993150-92376.report.html