### PR TITLE
Feat: Add numeric keyboard/maxlength 5 to sub input

### DIFF
--- a/benefits/core/migrations/0001_initial.py
+++ b/benefits/core/migrations/0001_initial.py
@@ -58,6 +58,8 @@ class Migration(migrations.Migration):
                 ("form_sub_help_text", models.TextField(null=True)),
                 ("form_sub_placeholder", models.TextField(null=True)),
                 ("form_sub_pattern", models.TextField(null=True)),
+                ("form_inputmode", models.TextField(null=True)),
+                ("form_max_length", models.PositiveSmallIntegerField(null=True)),
                 ("form_name_label", models.TextField(null=True)),
                 ("form_name_help_text", models.TextField(null=True)),
                 ("form_name_placeholder", models.TextField(null=True)),

--- a/benefits/core/migrations/0001_initial.py
+++ b/benefits/core/migrations/0001_initial.py
@@ -58,7 +58,7 @@ class Migration(migrations.Migration):
                 ("form_sub_help_text", models.TextField(null=True)),
                 ("form_sub_placeholder", models.TextField(null=True)),
                 ("form_sub_pattern", models.TextField(null=True)),
-                ("form_inputmode", models.TextField(null=True)),
+                ("form_input_mode", models.TextField(null=True)),
                 ("form_max_length", models.PositiveSmallIntegerField(null=True)),
                 ("form_name_label", models.TextField(null=True)),
                 ("form_name_help_text", models.TextField(null=True)),

--- a/benefits/core/migrations/0002_sample_data.py
+++ b/benefits/core/migrations/0002_sample_data.py
@@ -140,7 +140,7 @@ PEM DATA
         form_sub_help_text=_("eligibility.forms.confirm.mst_cc.fields.sub.help_text"),
         form_sub_placeholder="12345",
         form_sub_pattern=r"\d{5}",
-        form_inputmode="numeric",
+        form_input_mode="numeric",
         form_max_length=5,
         form_name_label=_("eligibility.forms.confirm.mst_cc.fields.name"),
         form_name_help_text=_("eligibility.forms.confirm.mst_cc.fields.name.help_text"),

--- a/benefits/core/migrations/0002_sample_data.py
+++ b/benefits/core/migrations/0002_sample_data.py
@@ -140,6 +140,8 @@ PEM DATA
         form_sub_help_text=_("eligibility.forms.confirm.mst_cc.fields.sub.help_text"),
         form_sub_placeholder="12345",
         form_sub_pattern=r"\d{5}",
+        form_inputmode="numeric",
+        form_max_length=5,
         form_name_label=_("eligibility.forms.confirm.mst_cc.fields.name"),
         form_name_help_text=_("eligibility.forms.confirm.mst_cc.fields.name.help_text"),
         form_name_placeholder="Garcia",

--- a/benefits/core/models.py
+++ b/benefits/core/models.py
@@ -108,7 +108,7 @@ class EligibilityVerifier(models.Model):
     # A regular expression used to validate the 'sub' API field before sending to this verifier
     form_sub_pattern = models.TextField(null=True)
     # Input mode can be "numeric", "tel", "search", etc. to override default "text" keyboard on mobile devices
-    form_inputmode = models.TextField(null=True)
+    form_input_mode = models.TextField(null=True)
     # The maximum length accepted for the 'sub' API field before sending to this verifier
     form_max_length = models.PositiveSmallIntegerField(null=True)
     form_name_label = models.TextField(null=True)

--- a/benefits/core/models.py
+++ b/benefits/core/models.py
@@ -107,6 +107,10 @@ class EligibilityVerifier(models.Model):
     form_sub_placeholder = models.TextField(null=True)
     # A regular expression used to validate the 'sub' API field before sending to this verifier
     form_sub_pattern = models.TextField(null=True)
+    # Input mode can be "numeric", "tel", "search", etc. to override default "text" keyboard on mobile devices
+    form_inputmode = models.TextField(null=True)
+    # The maximum length accepted for the 'sub' API field before sending to this verifier
+    form_max_length = models.PositiveSmallIntegerField(null=True)
     form_name_label = models.TextField(null=True)
     form_name_help_text = models.TextField(null=True)
     form_name_placeholder = models.TextField(null=True)

--- a/benefits/eligibility/forms.py
+++ b/benefits/eligibility/forms.py
@@ -54,6 +54,8 @@ class EligibilityVerificationForm(forms.Form):
         sub_widget = widgets.FormControlTextInput(placeholder=verifier.form_sub_placeholder)
         if verifier.form_sub_pattern:
             sub_widget.attrs.update({"pattern": verifier.form_sub_pattern})
+            sub_widget.attrs.update({"inputmode": "numeric"})
+            sub_widget.attrs.update({"maxlength": 5})
 
         self.fields["sub"] = forms.CharField(
             label=_(verifier.form_sub_label),

--- a/benefits/eligibility/forms.py
+++ b/benefits/eligibility/forms.py
@@ -54,8 +54,8 @@ class EligibilityVerificationForm(forms.Form):
         sub_widget = widgets.FormControlTextInput(placeholder=verifier.form_sub_placeholder)
         if verifier.form_sub_pattern:
             sub_widget.attrs.update({"pattern": verifier.form_sub_pattern})
-        if verifier.form_inputmode:
-            sub_widget.attrs.update({"inputmode": verifier.form_inputmode})
+        if verifier.form_input_mode:
+            sub_widget.attrs.update({"inputmode": verifier.form_input_mode})
         if verifier.form_max_length:
             sub_widget.attrs.update({"maxlength": verifier.form_max_length})
 

--- a/benefits/eligibility/forms.py
+++ b/benefits/eligibility/forms.py
@@ -54,8 +54,10 @@ class EligibilityVerificationForm(forms.Form):
         sub_widget = widgets.FormControlTextInput(placeholder=verifier.form_sub_placeholder)
         if verifier.form_sub_pattern:
             sub_widget.attrs.update({"pattern": verifier.form_sub_pattern})
-            sub_widget.attrs.update({"inputmode": "numeric"})
-            sub_widget.attrs.update({"maxlength": 5})
+        if verifier.form_inputmode:
+            sub_widget.attrs.update({"inputmode": verifier.form_inputmode})
+        if verifier.form_max_length:
+            sub_widget.attrs.update({"maxlength": verifier.form_max_length})
 
         self.fields["sub"] = forms.CharField(
             label=_(verifier.form_sub_label),


### PR DESCRIPTION
closes #1060 

## What this PR does
- Allow the user to use numeric keyboard for the sub input on mobile
- Add a 5-character max length for the sub input

### Model changes
- Adds `form_input_mode` (String), `form_max_length` (Integer)
- Form input mode must be one of these strings: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode#values
- Max length: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/maxlength

### Database migration changes
- Sets `form_inputmode` to `numeric` and `form_max_length` to 5 for the MST_CC sample data eligibility verifier

## How to test
- Test that the rest of the forms don't have any regressions
- Use iOS Simulator (on XCode on Mac) (or any other Windows tool?) to see if the numeric input opens on the sub field
- Test that the regex validation still works

- Regex still works:
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/195717865-f4508c94-61cc-44c5-9ee7-f7ff41ad8b16.png">

- iOS keyboard: Numeric for sub, regular for name
<img width="990" alt="image" src="https://user-images.githubusercontent.com/3673236/195718679-c6360e3f-3232-43e9-bd5d-178330f6a856.png">
<img width="520" alt="image" src="https://user-images.githubusercontent.com/3673236/195718829-95fed04d-5e66-4162-bc56-2f4de7efc1b4.png">


## Post-merge
- Update migrations sample data to include these 2 new key/values:

```python
        form_input_mode="numeric",
        form_max_length=5,
```