### PR TITLE
Agency Index: Mobile edit from Design

### DIFF
--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -452,7 +452,7 @@ footer .footer-links li a:visited {
 :root {
   --radio-button-size: 24px;
   --radio-input-color: var(--standout-color);
-  --radio-input-gap: 40px;
+  --radio-input-gap: 24px;
 }
 
 @media (min-width: 992px) {

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -576,9 +576,7 @@ h1 + .media-list, /* A .media-list immediately following the h1: Enrollment Succ
 /* This page has a full-width and full-height background image, creating the need to re-set the Footer margin top to 0 */
 
 :root {
-  --agency-index-main-height: calc(
-    100vh - 182px
-  ); /* 182px = Header Height (80px) + (Footer Link (50px) * Number of Links (2)) + Underline Height (2px) */
+  --agency-index-main-height: 100vh;
   --agency-index-background: url("/static/img/benefits-bg-mobile.jpg") no-repeat
     var(--primary-color);
   --agency-index-box-background: var(--bs-white);

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -452,7 +452,7 @@ footer .footer-links li a:visited {
 :root {
   --radio-button-size: 24px;
   --radio-input-color: var(--standout-color);
-  --radio-input-gap: 24px;
+  --radio-input-gap: 40px;
 }
 
 @media (min-width: 992px) {


### PR DESCRIPTION
Two requests from @srhhnry 

1. Make Agency Index page show more of the background image on very small phones (iPhone SE): Increased the minimum height of the container to show more image for mobile only:

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/195733731-d9e354a7-0414-4734-af8e-138e008d556c.png">

Compared with on Dev

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/195733816-f85ff9b6-cc80-470e-a029-f51ccec88386.png">
