### PR TITLE
Fix: reCAPTCHA + HTML5 form validation

### DIFF
--- a/benefits/core/context_processors.py
+++ b/benefits/core/context_processors.py
@@ -36,14 +36,3 @@ def authentication(request):
 def debug(request):
     """Context processor adds debug information to request context."""
     return {"debug": session.context_dict(request)}
-
-
-def recaptcha(request):
-    """Context processor adds recaptcha information to request context."""
-    return {
-        "recaptcha": {
-            "api_url": settings.RECAPTCHA_API_URL,
-            "enabled": settings.RECAPTCHA_ENABLED,
-            "site_key": settings.RECAPTCHA_SITE_KEY,
-        }
-    }

--- a/benefits/core/middleware.py
+++ b/benefits/core/middleware.py
@@ -13,7 +13,7 @@ from django.utils.decorators import decorator_from_middleware
 from django.utils.deprecation import MiddlewareMixin
 from django.views import i18n
 
-from . import analytics, session, viewmodels
+from . import analytics, recaptcha, session, viewmodels
 
 
 logger = logging.getLogger(__name__)
@@ -173,4 +173,17 @@ class LogErrorToAzure(MiddlewareMixin):
         msg = getattr(exception, "message", repr(exception))
         self.azure_logger.exception(msg, exc_info=exception)
 
+        return None
+
+
+class RecaptchaEnabled(MiddlewareMixin):
+    """Middleware configures the request with required reCAPTCHA settings."""
+
+    def process_request(self, request):
+        if settings.RECAPTCHA_ENABLED:
+            request.recaptcha = {
+                "data_field": recaptcha.DATA_FIELD,
+                "script_api": settings.RECAPTCHA_API_KEY_URL,
+                "site_key": settings.RECAPTCHA_SITE_KEY,
+            }
         return None

--- a/benefits/core/recaptcha.py
+++ b/benefits/core/recaptcha.py
@@ -6,7 +6,7 @@ import requests
 from django.conf import settings
 
 
-_POST_DATA = "g-recaptcha-response"
+DATA_FIELD = "g-recaptcha-response"
 
 
 def has_error(form) -> bool:
@@ -22,10 +22,10 @@ def verify(form_data: dict) -> bool:
     if not settings.RECAPTCHA_ENABLED:
         return True
 
-    if not form_data or _POST_DATA not in form_data:
+    if not form_data or DATA_FIELD not in form_data:
         return False
 
-    payload = dict(secret=settings.RECAPTCHA_SECRET_KEY, response=form_data[_POST_DATA])
+    payload = dict(secret=settings.RECAPTCHA_SECRET_KEY, response=form_data[DATA_FIELD])
     response = requests.post(settings.RECAPTCHA_VERIFY_URL, payload).json()
 
     return bool(response["success"])

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -129,20 +129,20 @@
     <script src="https://california.azureedge.net/cdt/statetemplate/6.0.7/js/cagov.core.min.js"></script>
 
     <script>
-            $(function() {
-                document.cookie = "testcookie"
-                if (document.cookie.indexOf("testcookie") < 0) {
-                    $(".nocookies").removeClass("d-none");
-                }
-                else {
-                    document.cookie = "testcookie; expires=Thu, 01-Jan-1970 00:00:01 GMT";
-                    $(".nocookies").addClass("d-none");
-                }
+      $(function() {
+        document.cookie = "testcookie"
+        if (document.cookie.indexOf("testcookie") < 0) {
+          $(".nocookies").removeClass("d-none");
+        }
+        else {
+          document.cookie = "testcookie; expires=Thu, 01-Jan-1970 00:00:01 GMT";
+          $(".nocookies").addClass("d-none");
+        }
 
-                $("a[href^='https'], a[href^='tel'], [href*='#']").on("click", function(e) {
-                    amplitude.getInstance().logEvent('clicked link', {'href': e.target.href, 'path': window.location.pathname});
-                });
-            });
+        $("a[href^='https'], a[href^='tel'], [href*='#']").on("click", function(e) {
+          amplitude.getInstance().logEvent('clicked link', {'href': e.target.href, 'path': window.location.pathname});
+        });
+      });
     </script>
 
     {% if request.recaptcha %}<script src="{{ request.recaptcha.script_api }}"></script>{% endif %}

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -144,5 +144,7 @@
                 });
             });
     </script>
+
+    {% if recaptcha.enabled %}<script src="{{ recaptcha.api_url }}?render={{ recaptcha.site_key }}"></script>{% endif %}
   </body>
 </html>

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -145,6 +145,6 @@
             });
     </script>
 
-    {% if recaptcha.enabled %}<script src="{{ recaptcha.api_url }}?render={{ recaptcha.site_key }}"></script>{% endif %}
+    {% if request.recaptcha %}<script src="{{ request.recaptcha.script_api }}"></script>{% endif %}
   </body>
 </html>

--- a/benefits/core/templates/core/includes/form.html
+++ b/benefits/core/templates/core/includes/form.html
@@ -35,16 +35,9 @@
           </div>
         {% endif %}
         <div class="col-lg-3 offset-2 offset-sm-2 offset-lg-0 col-sm-8 col-8">
-          {% if form.recaptcha_enabled %}
-            <button class="btn btn-lg btn-primary g-recaptcha"
-                    data-sitekey="{{ recaptcha.site_key }}"
-                    data-callback="onSubmit"
-                    data-action="submit">
+          <button class="btn btn-lg btn-primary" form="{{ form.id }}" data-action="submit" type="submit">
               {{ form.submit_value }}
             </button>
-          {% else %}
-            <button class="btn btn-lg btn-primary" data-action="submit">{{ form.submit_value }}</button>
-          {% endif %}
         </div>
       </div>
     {% endif %}
@@ -61,7 +54,7 @@
       $(function(){
         $("#{{ form.id }}").on("submit", function(e) {
           if ("{{ form.submitting_value }}" !== "") {
-            $("button[data-action='submit']", this)
+            $("button[type=submit]", this)
               .attr("role", "status")
               .attr("disabled", "true")
               .text("{{ form.submitting_value }}")

--- a/benefits/core/templates/core/includes/form.html
+++ b/benefits/core/templates/core/includes/form.html
@@ -36,18 +36,10 @@
         {% endif %}
         <div class="col-lg-3 offset-2 offset-sm-2 offset-lg-0 col-sm-8 col-8">
           <button class="btn btn-lg btn-primary" form="{{ form.id }}" data-action="submit" type="submit">
-              {{ form.submit_value }}
-            </button>
+            {{ form.submit_value }}
+          </button>
         </div>
       </div>
-    {% endif %}
-
-    {% if form.recaptcha_enabled %}
-      <script>
-        function onSubmit(token) {
-          $("#{{ form.id }}").submit();
-        }
-      </script>
     {% endif %}
 
     <script>
@@ -63,6 +55,37 @@
         });
       });
     </script>
+
+    {% if form.recaptcha_enabled %}
+      <!-- Adapted from https://stackoverflow.com/a/63290578/453168 -->
+
+      <!-- hidden input field will later send g-recaptcha token back to our server -->
+      <input type="hidden" name="g-recaptcha-response" value="">
+
+      <script>
+        function recaptchaSubmit($event) {
+          // Checks the validity of the form. Return if invalid; HTML5 validation errors should display
+          if (!$event.target.form.checkValidity()) {
+            return;
+          }
+          // Form is client-side valid; taking over the remainder of processing
+          $event.preventDefault();
+
+          grecaptcha.ready(function() {
+            grecaptcha.execute("{{ recaptcha.site_key }}", { action: "submit" }).then(function(token) {
+                // Add the token to hidden form element
+                $event.target.form.elements['g-recaptcha-response'].value = token;
+                // submit the form to server
+                $event.target.form.submit();
+            });
+          });
+        };
+
+        // bind the above handler to button click
+        $("button[type=submit]", "#{{ form.id }}").on("click", recaptchaSubmit);
+      </script>
+    {% endif %}
+
   </form>
 
 {% endif %}

--- a/benefits/core/templates/core/includes/form.html
+++ b/benefits/core/templates/core/includes/form.html
@@ -3,7 +3,7 @@
 
   {% url form.action_url as form_action %}
 
-  <form action="{{ form_action }}" method="{{ form.method | default:"post" | upper }}" role="form">
+  <form id="{{ form.id }}" action="{{ form_action }}" method="{{ form.method | default:"post" | upper }}" role="form">
     {% csrf_token %}
 
     <div class="row form-container">
@@ -52,24 +52,24 @@
     {% if recaptcha.enabled %}
       <script src="{{ recaptcha.api_url }}"></script>
       <script>
-                function onSubmit(token) {
-                    $("form[action='{{form_action}}']").submit();
-                }
+        function onSubmit(token) {
+          $("#{{ form.id }}").submit();
+        }
       </script>
     {% endif %}
 
     <script>
-            $(function(){
-                $("form[action='{{form_action}}']").on("submit", function(e) {
-                    if ("{{ form.submitting_value }}" !== "") {
-                        $("button[data-action='submit']", this)
-                            .attr("role", "status")
-                            .attr("disabled", "true")
-                            .text("{{ form.submitting_value }}")
-                            .addClass("disabled");
-                    }
-                });
-            });
+      $(function(){
+        $("#{{ form.id }}").on("submit", function(e) {
+          if ("{{ form.submitting_value }}" !== "") {
+            $("button[data-action='submit']", this)
+              .attr("role", "status")
+              .attr("disabled", "true")
+              .text("{{ form.submitting_value }}")
+              .addClass("disabled");
+          }
+        });
+      });
     </script>
   </form>
 

--- a/benefits/core/templates/core/includes/form.html
+++ b/benefits/core/templates/core/includes/form.html
@@ -50,7 +50,6 @@
     {% endif %}
 
     {% if form.recaptcha_enabled %}
-      <script src="{{ recaptcha.api_url }}"></script>
       <script>
         function onSubmit(token) {
           $("#{{ form.id }}").submit();

--- a/benefits/core/templates/core/includes/form.html
+++ b/benefits/core/templates/core/includes/form.html
@@ -56,11 +56,15 @@
       });
     </script>
 
-    {% if form.recaptcha_enabled %}
-      <!-- Adapted from https://stackoverflow.com/a/63290578/453168 -->
+    {% if request.recaptcha %}
+      {% comment %}
+        Adapted from https://stackoverflow.com/a/63290578/453168
+      {% endcomment %}
 
-      <!-- hidden input field will later send g-recaptcha token back to our server -->
-      <input type="hidden" name="g-recaptcha-response" value="">
+      {% comment %}
+        hidden input field will later send g-recaptcha token back to server
+      {% endcomment %}
+      <input type="hidden" name="{{ request.recaptcha.data_field }}" value="">
 
       <script>
         function recaptchaSubmit($event) {
@@ -68,13 +72,13 @@
           if (!$event.target.form.checkValidity()) {
             return;
           }
-          // Form is client-side valid; taking over the remainder of processing
+          // form is client-side valid; taking over the remainder of processing
           $event.preventDefault();
 
           grecaptcha.ready(function() {
-            grecaptcha.execute("{{ recaptcha.site_key }}", { action: "submit" }).then(function(token) {
+            grecaptcha.execute("{{ request.recaptcha.site_key }}", { action: "submit" }).then(function(token) {
                 // Add the token to hidden form element
-                $event.target.form.elements['g-recaptcha-response'].value = token;
+                $event.target.form.elements["{{ request.recaptcha.data_field }}"].value = token;
                 // submit the form to server
                 $event.target.form.submit();
             });
@@ -87,5 +91,4 @@
     {% endif %}
 
   </form>
-
 {% endif %}

--- a/benefits/core/templates/core/includes/form.html
+++ b/benefits/core/templates/core/includes/form.html
@@ -35,7 +35,7 @@
           </div>
         {% endif %}
         <div class="col-lg-3 offset-2 offset-sm-2 offset-lg-0 col-sm-8 col-8">
-          {% if recaptcha.enabled %}
+          {% if form.recaptcha_enabled %}
             <button class="btn btn-lg btn-primary g-recaptcha"
                     data-sitekey="{{ recaptcha.site_key }}"
                     data-callback="onSubmit"
@@ -49,7 +49,7 @@
       </div>
     {% endif %}
 
-    {% if recaptcha.enabled %}
+    {% if form.recaptcha_enabled %}
       <script src="{{ recaptcha.api_url }}"></script>
       <script>
         function onSubmit(token) {

--- a/benefits/eligibility/forms.py
+++ b/benefits/eligibility/forms.py
@@ -4,7 +4,6 @@ The eligibility application: Form definition for the eligibility verification fl
 import logging
 
 from django import forms
-from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
 from benefits.core import models, recaptcha, widgets
@@ -19,8 +18,6 @@ class EligibilityVerifierSelectionForm(forms.Form):
     action_url = "eligibility:index"
     id = "verifier-selection"
     method = "POST"
-    # we want recaptcha enabled on this form if configured globally
-    recaptcha_enabled = settings.RECAPTCHA_ENABLED
 
     verifier = forms.ChoiceField(label="", widget=widgets.VerifierRadioSelect)
     # sets label to empty string so the radio_select template can override the label style
@@ -43,8 +40,6 @@ class EligibilityVerificationForm(forms.Form):
     action_url = "eligibility:confirm"
     id = "eligibility-verification"
     method = "POST"
-    # we want recaptcha enabled on this form if configured globally
-    recaptcha_enabled = settings.RECAPTCHA_ENABLED
 
     submit_value = _("eligibility.forms.confirm.submit")
     submitting_value = _("eligibility.forms.confirm.submitting")

--- a/benefits/eligibility/forms.py
+++ b/benefits/eligibility/forms.py
@@ -4,6 +4,7 @@ The eligibility application: Form definition for the eligibility verification fl
 import logging
 
 from django import forms
+from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
 from benefits.core import models, recaptcha, widgets
@@ -18,6 +19,8 @@ class EligibilityVerifierSelectionForm(forms.Form):
     action_url = "eligibility:index"
     id = "verifier-selection"
     method = "POST"
+    # we want recaptcha enabled on this form if configured globally
+    recaptcha_enabled = settings.RECAPTCHA_ENABLED
 
     verifier = forms.ChoiceField(label="", widget=widgets.VerifierRadioSelect)
     # sets label to empty string so the radio_select template can override the label style
@@ -40,6 +43,8 @@ class EligibilityVerificationForm(forms.Form):
     action_url = "eligibility:confirm"
     id = "eligibility-verification"
     method = "POST"
+    # we want recaptcha enabled on this form if configured globally
+    recaptcha_enabled = settings.RECAPTCHA_ENABLED
 
     submit_value = _("eligibility.forms.confirm.submit")
     submitting_value = _("eligibility.forms.confirm.submitting")

--- a/benefits/eligibility/forms.py
+++ b/benefits/eligibility/forms.py
@@ -16,7 +16,7 @@ class EligibilityVerifierSelectionForm(forms.Form):
     """Form to capture eligibility verifier selection."""
 
     action_url = "eligibility:index"
-    id = "verifier-selection"
+    id = "form-verifier-selection"
     method = "POST"
 
     verifier = forms.ChoiceField(label="", widget=widgets.VerifierRadioSelect)
@@ -42,7 +42,7 @@ class EligibilityVerificationForm(forms.Form):
     """Form to collect eligibility verification details."""
 
     action_url = "eligibility:confirm"
-    id = "eligibility-verification"
+    id = "form-eligibility-verification"
     method = "POST"
 
     submit_value = _("eligibility.forms.confirm.submit")

--- a/benefits/eligibility/forms.py
+++ b/benefits/eligibility/forms.py
@@ -33,6 +33,10 @@ class EligibilityVerifierSelectionForm(forms.Form):
             v.id: _(v.selection_label_description) for v in verifiers if v.selection_label_description
         }
 
+    def clean(self):
+        if not recaptcha.verify(self.data):
+            raise forms.ValidationError("reCAPTCHA failed")
+
 
 class EligibilityVerificationForm(forms.Form):
     """Form to collect eligibility verification details."""

--- a/benefits/eligibility/forms.py
+++ b/benefits/eligibility/forms.py
@@ -16,6 +16,7 @@ class EligibilityVerifierSelectionForm(forms.Form):
     """Form to capture eligibility verifier selection."""
 
     action_url = "eligibility:index"
+    id = "verifier-selection"
     method = "POST"
 
     verifier = forms.ChoiceField(label="", widget=widgets.VerifierRadioSelect)
@@ -37,6 +38,7 @@ class EligibilityVerificationForm(forms.Form):
     """Form to collect eligibility verification details."""
 
     action_url = "eligibility:confirm"
+    id = "eligibility-verification"
     method = "POST"
 
     submit_value = _("eligibility.forms.confirm.submit")

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -20,6 +20,7 @@ ROUTE_INDEX = "eligibility:index"
 ROUTE_START = "eligibility:start"
 ROUTE_LOGIN = "oauth:login"
 ROUTE_CONFIRM = "eligibility:confirm"
+ROUTE_UNVERIFIED = "eligibility:unverified"
 ROUTE_ENROLLMENT = "enrollment:index"
 
 TEMPLATE_INDEX = "eligibility/index.html"
@@ -151,6 +152,8 @@ def confirm(request):
         eligibility = session.eligibility(request)
         return verified(request, [eligibility.name])
 
+    unverified_view = reverse(ROUTE_UNVERIFIED)
+
     agency = session.agency(request)
     verifier = session.verifier(request)
     types_to_verify = verify.typenames_to_verify(agency, verifier)
@@ -163,7 +166,7 @@ def confirm(request):
         if verified_types:
             return verified(request, verified_types)
         else:
-            return unverified(request)
+            return redirect(unverified_view)
 
     # GET/POST for Eligibility API verification
     page = viewmodels.Page(
@@ -204,7 +207,7 @@ def confirm(request):
             return TemplateResponse(request, TEMPLATE_CONFIRM, ctx)
         # no types were verified
         elif len(verified_types) == 0:
-            return unverified(request)
+            return redirect(unverified_view)
         # type(s) were verified
         else:
             return verified(request, verified_types)

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -141,6 +141,7 @@ def start(request):
 @decorator_from_middleware(AgencySessionRequired)
 @decorator_from_middleware(LoginRequired)
 @decorator_from_middleware(RateLimit)
+@decorator_from_middleware(RecaptchaEnabled)
 @decorator_from_middleware(VerifierSessionRequired)
 def confirm(request):
     """View handler for the eligibility verification form."""

--- a/benefits/enrollment/forms.py
+++ b/benefits/enrollment/forms.py
@@ -8,7 +8,7 @@ class CardTokenizeSuccessForm(forms.Form):
     """Form to bring client card token back to server."""
 
     action_url = "enrollment:index"
-    id = "card-tokenize-success"
+    id = "form-card-tokenize-success"
     method = "POST"
 
     # hidden input with no label
@@ -18,7 +18,7 @@ class CardTokenizeSuccessForm(forms.Form):
 class CardTokenizeFailForm(forms.Form):
     """Form to indicate card tokenization failure to server."""
 
-    id = "card-tokenize-fail"
+    id = "form-card-tokenize-fail"
     method = "POST"
 
     def __init__(self, action_url, *args, **kwargs):

--- a/benefits/enrollment/forms.py
+++ b/benefits/enrollment/forms.py
@@ -8,6 +8,7 @@ class CardTokenizeSuccessForm(forms.Form):
     """Form to bring client card token back to server."""
 
     action_url = "enrollment:index"
+    id = "card-tokenize-success"
     method = "POST"
 
     # hidden input with no label
@@ -17,6 +18,7 @@ class CardTokenizeSuccessForm(forms.Form):
 class CardTokenizeFailForm(forms.Form):
     """Form to indicate card tokenization failure to server."""
 
+    id = "card-tokenize-fail"
     method = "POST"
 
     def __init__(self, action_url, *args, **kwargs):

--- a/benefits/enrollment/forms.py
+++ b/benefits/enrollment/forms.py
@@ -10,6 +10,9 @@ class CardTokenizeSuccessForm(forms.Form):
     action_url = "enrollment:index"
     id = "card-tokenize-success"
     method = "POST"
+    # we don't need recaptcha on this form, it is a single hidden field submitted
+    # by a javascript callback
+    recaptcha_enabled = False
 
     # hidden input with no label
     card_token = forms.CharField(widget=forms.HiddenInput(), label="")
@@ -20,6 +23,9 @@ class CardTokenizeFailForm(forms.Form):
 
     id = "card-tokenize-fail"
     method = "POST"
+    # we don't need recaptcha on this form, it is a single hidden field submitted
+    # by a javascript callback
+    recaptcha_enabled = False
 
     def __init__(self, action_url, *args, **kwargs):
         # init super with an empty data dict

--- a/benefits/enrollment/forms.py
+++ b/benefits/enrollment/forms.py
@@ -10,9 +10,6 @@ class CardTokenizeSuccessForm(forms.Form):
     action_url = "enrollment:index"
     id = "card-tokenize-success"
     method = "POST"
-    # we don't need recaptcha on this form, it is a single hidden field submitted
-    # by a javascript callback
-    recaptcha_enabled = False
 
     # hidden input with no label
     card_token = forms.CharField(widget=forms.HiddenInput(), label="")
@@ -23,9 +20,6 @@ class CardTokenizeFailForm(forms.Form):
 
     id = "card-tokenize-fail"
     method = "POST"
-    # we don't need recaptcha on this form, it is a single hidden field submitted
-    # by a javascript callback
-    recaptcha_enabled = False
 
     def __init__(self, action_url, *args, **kwargs):
         # init super with an empty data dict

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -133,7 +133,6 @@ template_ctx_processors = [
     "django.contrib.messages.context_processors.messages",
     "benefits.core.context_processors.analytics",
     "benefits.core.context_processors.authentication",
-    "benefits.core.context_processors.recaptcha",
 ]
 
 if DEBUG:
@@ -250,6 +249,7 @@ RATE_LIMIT_ENABLED = all((RATE_LIMIT > 0, len(RATE_LIMIT_METHODS) > 0, RATE_LIMI
 
 RECAPTCHA_API_URL = os.environ.get("DJANGO_RECAPTCHA_API_URL", "https://www.google.com/recaptcha/api.js")
 RECAPTCHA_SITE_KEY = os.environ.get("DJANGO_RECAPTCHA_SITE_KEY")
+RECAPTCHA_API_KEY_URL = f"{RECAPTCHA_API_URL}?render={RECAPTCHA_SITE_KEY}"
 RECAPTCHA_SECRET_KEY = os.environ.get("DJANGO_RECAPTCHA_SECRET_KEY")
 RECAPTCHA_VERIFY_URL = os.environ.get("DJANGO_RECAPTCHA_VERIFY_URL", "https://www.google.com/recaptcha/api/siteverify")
 RECAPTCHA_ENABLED = all((RECAPTCHA_API_URL, RECAPTCHA_SITE_KEY, RECAPTCHA_SECRET_KEY, RECAPTCHA_VERIFY_URL))


### PR DESCRIPTION
Fixes #1068 

Based on an answer to this SO post: https://stackoverflow.com/q/41665935/453168

## What this PR does

### Uses programmatic reCAPTCHA validation

This is the main issue being solved. reCAPTCHA v3 supports two options:

* [Automatically bind the challenge to a button](https://developers.google.com/recaptcha/docs/v3#automatically_bind_the_challenge_to_a_button) (existing implementation)

* [Programmatically invoke the challenge](https://developers.google.com/recaptcha/docs/v3#programmatically_invoke_the_challenge) (new implementation in this PR)

Using a programmatic challenge allows the browser's HTML5 form validation a chance to kick-in before reCAPTCHA's checks,
which isn't possible with the challenge button auto-bind.

### Refactors how templates get reCAPTCHA data

Before we used a [Django context processor](https://docs.djangoproject.com/en/4.1/ref/templates/api/#writing-your-own-context-processors), which gave the data to _every request context_, even those that didn't need it:

```python
def recaptcha(request):
    """Context processor adds recaptcha information to request context."""
    return {
        "recaptcha": {
            "api_url": settings.RECAPTCHA_API_URL,
            "enabled": settings.RECAPTCHA_ENABLED,
            "site_key": settings.RECAPTCHA_SITE_KEY,
        }
    }
```

This PR introduces a Middleware, following our usual pattern where we can apply the middleware per-view that needs it, which adds the reCAPTCHA data directly to the `request`:

```python
class RecaptchaEnabled(MiddlewareMixin):
    """Middleware configures the request with required reCAPTCHA settings."""

    def process_request(self, request):
        if settings.RECAPTCHA_ENABLED:
            request.recaptcha = {
                "data_field": recaptcha.DATA_FIELD,
                "script_api": settings.RECAPTCHA_API_KEY_URL,
                "site_key": settings.RECAPTCHA_SITE_KEY,
            }
        return None

# later in views.py

@decorator_from_middleware(RecaptchaEnabled)
def confirm(request):
    """View handler for the eligibility verification form."""
    # etc.
```

This makes it more explicit which views use reCAPTCHA, and also makes using reCAPTCHA data easy from templates. Like in `base.html` where we include the reCAPTCHA API library _only once_ and _only if needed_:

```html
<html>
    <body>
        <!-- etc -->

        {% if request.recaptcha %}<script src="{{ request.recaptcha.script_api }}"></script>{% endif %}
    </body>
</html>
```

### Makes the `eligibility:unverified` path a redirect

This has a couple advantages:

* (the reason for this change): creates a _new request_, clearing reCAPTCHA data from prior `/eligiblity/confirm` request
* Mirrors how the `eligibility:verified` path works (ultimately a redirect to `enrollment:index`)
* URL is now `/eligiblity/unverified` instead of `/eligibility/confirm`, a more accurate UX

## Testing this PR

### Setup

Add this to your `.vscode/launch.json` under the `Django: Benefits Client, Debug=False` entry's `env`:

```jsonc
{
  "name": "Django: Benefits Client, Debug=False",
  // other fields...
  "env": {
    // existing fields...
   // add these 2 entries with the values for the test reCAPTCHA site
    "DJANGO_RECAPTCHA_SITE_KEY": "<SITE KEY HERE>",
    "DJANGO_RECAPTCHA_SECRET_KEY": "<SECRET KEY HERE>"
  }
}
```

### Eligibility index

reCAPTCHA library included once at the bottom of `<body>`:

![image](https://user-images.githubusercontent.com/1783439/195950087-9a79c24d-a991-474d-8a35-1cd3101ba176.png)

HTML5 validation works, form submits with valid data:

![choose-benefit-validation](https://user-images.githubusercontent.com/1783439/195950281-d2be04f5-6467-40eb-b54c-fdd194f739d2.gif)

### Eligibility confirm

reCAPTCHA library included once at the bottom of `<body>`:

![image](https://user-images.githubusercontent.com/1783439/195950425-ae7bc71c-89e5-4ad4-a947-78b988189052.png)

HTML5 validation works, form submits with valid data:

![confirm-validation](https://user-images.githubusercontent.com/1783439/195950539-24880b09-7ff7-4238-8d37-a122ceadfd70.gif)

### Other pages

Every other page should not have the reCAPTCHA library or any reCAPTCHA handling for form elements. 

E.g. the homepage does not include reCAPTCHA:

![image](https://user-images.githubusercontent.com/1783439/195949947-c2c8b0bf-f3c2-49f9-8873-2e06271d7b6c.png)

Nor does the `eligibility:start` page:

![image](https://user-images.githubusercontent.com/1783439/195950380-e7c3b460-cf23-4727-8550-75d6527bdb6f.png)
