### PR TITLE
fix(css): use rem for 12px font size

### DIFF
--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -31,6 +31,7 @@
   --font-size-24px: calc(24rem / 16);
   --font-size-16px: calc(16rem / 16);
   --font-size-14px: calc(14rem / 16);
+  --font-size-12px: calc(12rem / 16);
 }
 
 @media (min-width: 992px) {
@@ -378,7 +379,7 @@ footer .footer-links li a:visited {
 @media (min-width: 992px) {
   .signout-link,
   .signout-link:visited {
-    font-size: 12px;
+    font-size: var(--font-size-12px);
     text-decoration: underline !important;
     letter-spacing: var(--body-letter-spacing);
     border: none;


### PR DESCRIPTION
closes #778 

I had forgotten one line of CSS in yesterday's PR: https://github.com/cal-itp/benefits/pull/1062

When the browser's default font size is set to 32px:
| Before     | After     |
| --------  | -------- |
| <img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/197831785-233412ab-245f-4bda-8313-cf28b260e64e.png">  | <img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/197831807-6e93c970-efae-4170-a1f2-f450c09c45e9.png"> |
| 12px     | calc(12rem / 16)     |
