### PR TITLE
Make the app work at 200% zoom/double the font size

### DIFF
--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -433,12 +433,12 @@ footer .footer-links li a:visited {
 /* Form Container: Must use .form-container parent to use these styles */
 
 :root {
-  --form-input-gap: 22px;
+  --form-input-gap: calc(22rem / 16);
 }
 
 @media (min-width: 992px) {
   :root {
-    --form-input-gap: 42px;
+    --form-input-gap: calc(42rem / 16);
   }
 }
 
@@ -450,7 +450,7 @@ footer .footer-links li a:visited {
   font-size: var(--bs-body-font-size);
   font-weight: var(--medium-font-weight);
   letter-spacing: var(--body-letter-spacing);
-  padding-bottom: 12px;
+  padding-bottom: calc(12rem / 16);
 }
 
 .form-container .form-control {
@@ -472,7 +472,7 @@ footer .footer-links li a:visited {
 :root {
   --radio-button-size: calc(24rem / 16);
   --radio-input-color: var(--standout-color);
-  --radio-input-gap: calc(40rem / 16);
+  --radio-input-gap: calc(24rem / 16);
 }
 
 @media (min-width: 992px) {

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -33,6 +33,7 @@
   --font-size-14px: calc(14rem / 16);
   --font-size-12px: calc(12rem / 16);
   --border-width: calc(2rem / 16);
+  --border-radius: calc(3rem / 16);
 }
 
 @media (min-width: 992px) {
@@ -387,8 +388,8 @@ footer .footer-links li a:visited {
   font-size: var(--bs-body-font-size);
   color: var(--primary-color) !important;
   padding: 2px 4px;
-  border-radius: 3px;
-  border: 2px solid var(--primary-color);
+  border-radius: var(--border-radius);
+  border: var(--border-width) solid var(--primary-color);
   letter-spacing: 0.02em;
   font-weight: 500 !important;
   text-decoration: none !important;
@@ -453,8 +454,8 @@ footer .footer-links li a:visited {
 }
 
 .form-container .form-control {
-  border-width: 2px;
-  border-radius: 3px;
+  border-width: var(--border-width);
+  border-radius: var(--border-radius);
   border-color: var(--primary-color);
   color: var(--text-primary-color);
   font-size: var(--font-size-24px);
@@ -511,35 +512,35 @@ footer .footer-links li a:visited {
 /* Media List */
 
 :root {
-  --media-item-icon-size: 64px;
-  --media-item-gap: 24px;
-  --media-item-icon-margin: 24px;
-  --media-title-margin-top: 24px;
+  --media-item-icon-size: calc(64rem / 16);
+  --media-item-gap: calc(24rem / 16);
+  --media-item-icon-margin: calc(24rem / 16);
+  --media-title-margin-top: calc(24rem / 16);
 }
 
 @media (min-width: 992px) {
   :root {
-    --media-item-icon-size: 90px;
-    --media-item-gap: 62px;
-    --media-item-icon-margin: 32px;
-    --media-title-margin-top: 64px;
+    --media-item-icon-size: calc(90rem / 16);
+    --media-item-gap: calc(62rem / 16);
+    --media-item-icon-margin: calc(32rem / 16);
+    --media-title-margin-top: calc(64rem / 16);
   }
 }
 
 h1 + .media-list, /* A .media-list immediately following the h1: Enrollment Success, but not Eligibility Start */
 .media-body--details p:not(:first-of-type) {
   /* All the p within .media-body--details, except for the first p - Any media item with more than one p */
-  padding-top: 24px;
+  padding-top: calc(24rem / 16);
 }
 
 .media-title {
   margin-top: var(--media-title-margin-top);
-  margin-bottom: 24px;
+  margin-bottom: calc(24rem / 16);
 }
 
 .media-list {
   gap: var(--media-item-gap);
-  margin-bottom: 64px;
+  margin-bottom: calc(64rem / 16);
 }
 
 .media-list .media .media-line .icon {
@@ -550,7 +551,7 @@ h1 + .media-list, /* A .media-list immediately following the h1: Enrollment Succ
 
 .media-list .media .media-body--details,
 .media-list .media .media-body--items li:first-child {
-  padding-top: 5px;
+  padding-top: calc(5rem / 16);
 }
 
 .media-list .media .media-body--items li {

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -156,7 +156,7 @@ h4 {
 h1 {
   font-size: var(--h1-font-size);
   text-align: var(--h1-text-align);
-  padding-top: 70px;
+  padding-top: calc(70rem / 16);
 }
 
 /* H2 */
@@ -376,7 +376,7 @@ footer .footer-links li a:visited {
 /* Nav Buttons: Previous Page, Sign Out */
 
 .nav-button-row {
-  height: 70px;
+  height: calc(70rem / 16);
 }
 
 /* Custom button: Sign Out */

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -32,6 +32,7 @@
   --font-size-16px: calc(16rem / 16);
   --font-size-14px: calc(14rem / 16);
   --font-size-12px: calc(12rem / 16);
+  --border-width: calc(2rem / 16);
 }
 
 @media (min-width: 992px) {
@@ -468,14 +469,14 @@ footer .footer-links li a:visited {
 /* Forms: Radio Buttons */
 
 :root {
-  --radio-button-size: 24px;
+  --radio-button-size: calc(24rem / 16);
   --radio-input-color: var(--standout-color);
-  --radio-input-gap: 40px;
+  --radio-input-gap: calc(40rem / 16);
 }
 
 @media (min-width: 992px) {
   :root {
-    --radio-input-gap: 15px;
+    --radio-input-gap: calc(15rem / 16);
   }
 }
 
@@ -488,7 +489,7 @@ footer .footer-links li a:visited {
 }
 
 .radio-input-group:not(:first-child) {
-  padding-top: 24px;
+  padding-top: calc(24rem / 16);
 }
 
 .radio-input {
@@ -498,13 +499,13 @@ footer .footer-links li a:visited {
   appearance: none;
   width: var(--radio-button-size);
   height: var(--radio-button-size);
-  border: 2px solid var(--radio-input-color);
-  margin: 3px 0;
+  border: var(--border-width) solid var(--radio-input-color);
+  margin: calc(3rem / 16) 0;
 }
 
 .radio-input:checked {
   background-color: var(--radio-input-color);
-  box-shadow: inset 0 0 0 2px var(--bs-white);
+  box-shadow: inset 0 0 0 var(--border-width) var(--bs-white);
 }
 
 /* Media List */

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -631,7 +631,7 @@ h1 + .media-list, /* A .media-list immediately following the h1: Enrollment Succ
   background: var(--agency-index-box-background);
   border-top: var(--agency-index-box-border);
   color: var(--agency-index-text-color);
-  margin-bottom: 32px;
+  margin-bottom: calc(32rem / 16);
 }
 
 .agency-index .box .btn.btn-lg.btn-primary {

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -43,7 +43,7 @@
 
 @font-face {
   font-family: "Public Sans";
-  font-weight: 700;
+  font-weight: var(--bold-font-weight);
   font-style: normal;
   src: local("PublicSans"), url("../fonts/PublicSans-Bold.woff") format("woff");
 }


### PR DESCRIPTION
closes #1079 

## What this PR does
- For specific UI components, convert the pixel measurements to rems, using `calc(##rem / 16)`
- Radio button component: Mobile distance between radio button text has been reduced from 40px to 24px.
- Components that are not converted: Button measurements that control button height, button width. Button font size _does_ use rems. Button width will remain controlled by Bootstrap column percentages. Button heights will remain static pixels. 
- Components that are not converted: Footer height, Header height are not converted to rem. Rationale: There is possible upcoming Header style changes. The Footer/Header heights are fine for now as the content within the footer/header are not getting blocked or have any other visual/user interaction issues.

## How to test this PR
- Change browser font size to 32 px and go through a full CC flow
- Re-set the browser font to 16 px, and manually zoom the app into 200% on your Desktop browser, and go thru full CC flow

## Note
The Radio Input button mobile distance change request came from Sarah on Slack