### PR TITLE
rename the email resource

### DIFF
--- a/terraform/monitor.tf
+++ b/terraform/monitor.tf
@@ -54,7 +54,7 @@ data "azurerm_key_vault_secret" "slack_benefits_notify_email" {
   key_vault_id = azurerm_key_vault.main.id
 }
 
-resource "azurerm_monitor_action_group" "dev_email" {
+resource "azurerm_monitor_action_group" "eng_email" {
   name                = "benefits-notify Slack channel email"
   resource_group_name = data.azurerm_resource_group.prod.name
   short_name          = "slack-notify"
@@ -67,4 +67,11 @@ resource "azurerm_monitor_action_group" "dev_email" {
   lifecycle {
     ignore_changes = [tags]
   }
+}
+
+# migrations
+
+moved {
+  from = azurerm_monitor_action_group.dev_email
+  to   = azurerm_monitor_action_group.eng_email
 }

--- a/terraform/uptime.tf
+++ b/terraform/uptime.tf
@@ -1,7 +1,7 @@
 module "dev_healthcheck" {
   source = "./uptime"
 
-  action_group_id      = azurerm_monitor_action_group.dev_email.id
+  action_group_id      = azurerm_monitor_action_group.eng_email.id
   application_insights = azurerm_application_insights.prod
   name                 = "dev-healthcheck"
   url                  = "https://dev-benefits.calitp.org/healthcheck"
@@ -10,7 +10,7 @@ module "dev_healthcheck" {
 module "test_healthcheck" {
   source = "./uptime"
 
-  action_group_id      = azurerm_monitor_action_group.dev_email.id
+  action_group_id      = azurerm_monitor_action_group.eng_email.id
   application_insights = azurerm_application_insights.prod
   name                 = "test-healthcheck"
   url                  = "https://test-benefits.calitp.org/healthcheck"
@@ -19,7 +19,7 @@ module "test_healthcheck" {
 module "prod_healthcheck" {
   source = "./uptime"
 
-  action_group_id      = azurerm_monitor_action_group.dev_email.id
+  action_group_id      = azurerm_monitor_action_group.eng_email.id
   application_insights = azurerm_application_insights.prod
   name                 = "prod-healthcheck"
   url                  = "https://benefits.calitp.org/healthcheck"


### PR DESCRIPTION
Split out from https://github.com/cal-itp/benefits/pull/1074.

"dev" gets used as an environment name, and the team is more regularly referred to as "Engineering" anyway. Just a refactor.