### PR TITLE
manage production storage account binding in Terraform

### DIFF
--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -84,11 +84,10 @@ resource "azurerm_linux_web_app" "main" {
   storage_account {
     access_key   = azurerm_storage_account.main.primary_access_key
     account_name = azurerm_storage_account.main.name
-    # use the same name
-    name       = azurerm_storage_container.config_prod.name
-    type       = "AzureBlob"
-    share_name = azurerm_storage_container.config_prod.name
-    mount_path = "/home/calitp/app/config"
+    name         = "benefits-config"
+    type         = "AzureBlob"
+    share_name   = azurerm_storage_container.config_prod.name
+    mount_path   = "/home/calitp/app/config"
   }
 
   lifecycle {

--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -10,8 +10,7 @@ resource "azurerm_service_plan" "main" {
   }
 }
 
-# app_settings and storage_account are managed manually through the portal since they contain secrets. Issue to move the latter in:
-# https://github.com/cal-itp/benefits/issues/686
+# app_settings are managed manually through the portal since they contain secrets
 
 resource "azurerm_linux_web_app" "main" {
   name                      = "AS-CDT-PUB-VIP-CALITP-P-001"
@@ -82,9 +81,19 @@ resource "azurerm_linux_web_app" "main" {
     ])
   }
 
+  storage_account {
+    access_key   = azurerm_storage_account.main.primary_access_key
+    account_name = azurerm_storage_account.main.name
+    # use the same name
+    name       = azurerm_storage_container.config_prod.name
+    type       = "AzureBlob"
+    share_name = azurerm_storage_container.config_prod.name
+    mount_path = "/home/calitp/app/config"
+  }
+
   lifecycle {
     prevent_destroy = true
-    ignore_changes  = [app_settings, storage_account, tags]
+    ignore_changes  = [app_settings, tags]
   }
 }
 


### PR DESCRIPTION
It was happening on dev and test as of https://github.com/cal-itp/benefits/pull/821; this adds it to production.

- [ ] Confirm the `plan` shows no changes