### PR TITLE
Chore(terraform): allow configuring recaptcha for separate slots

### DIFF
--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -58,6 +58,8 @@ resource "azurerm_linux_web_app" "main" {
       "DJANGO_LOAD_SAMPLE_DATA",
       "DJANGO_LOG_LEVEL",
       "DJANGO_MIGRATIONS_DIR",
+      "DJANGO_RECAPTCHA_SECRET_KEY",
+      "DJANGO_RECAPTCHA_SITE_KEY",
       "DJANGO_TRUSTED_ORIGINS",
 
       # populated through auto-instrumentation


### PR DESCRIPTION
These were set in the Azure portal. We just need to update Terraform to match.