### PR TITLE
Docs: update Courtesy Card diagram

### DIFF
--- a/docs/use-cases/courtesy-cards.md
+++ b/docs/use-cases/courtesy-cards.md
@@ -9,6 +9,7 @@ flowchart LR
     rider((User's browser))
     api[Eligibility Server]
     data[Hashed Courtesy Card data]
+    velocity[SQL Server]
 
     rider --> Benefits
 
@@ -21,8 +22,12 @@ flowchart LR
     subgraph MST Azure
         api --> data
     end
+    
+    subgraph MST Velocity
+        velocity --> hashfields
+    end
 
-    Velocity --> data
+    hashfields --> data
 ```
 
 Notes:

--- a/docs/use-cases/courtesy-cards.md
+++ b/docs/use-cases/courtesy-cards.md
@@ -22,7 +22,7 @@ flowchart LR
     subgraph MST Azure
         api --> data
     end
-    
+
     subgraph MST Velocity
         velocity --> hashfields
     end


### PR DESCRIPTION
Include [`hashfields`](/cal-itp/hashfields) and the SQL Server to show how data flows to Azure