### PR TITLE
Fix: replace State Template JS with Bootstrap

### DIFF
--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -122,8 +122,10 @@
     {% comment %}
       CA State Template v6.0.7 comes with Bootstrap v5.1.3
       see https://github.com/Office-of-Digital-Services/California-State-Web-Template/releases/tag/v6.0.7
+
+      But we aren't using CA State Template Javascript, so include Bootstrap directly
     {% endcomment %}
-    <script src="https://california.azureedge.net/cdt/statetemplate/6.0.7/js/cagov.core.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
 
     <script>
       $(function() {

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -27,7 +27,7 @@
       CA State Template v6.0.7 does not include jQuery
       See https://github.com/Office-of-Digital-Services/California-State-Web-Template/releases/tag/v6.0.7
     {% endcomment %}
-    <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.1/dist/jquery.min.js" integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ=" crossorigin="anonymous"></script>
 
     {% include "core/includes/analytics.html" with api_key=analytics.api_key uid=analytics.uid did=analytics.did %}
   </head>

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -9,7 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="description" content="{% translate "core.pages.help.about.p[0]" %}">
     {# djlint:off #}
-    <title>{% block page_title %}{% if page.title %}{{ page.title }} | {% endif %}{% endblock page_title %}{% translate "core.pages.title.suffix" %}</title>
+    <title>{% block page_title %}{% if page.title %}{{ page.title }}&nbsp;|&nbsp;{% endif %}{% endblock page_title %}{% translate "core.pages.title.suffix" %}</title>
     {# djlint:on #}
 
     <link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet" type="text/css">

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -27,7 +27,7 @@
       CA State Template v6.0.7 does not include jQuery
       See https://github.com/Office-of-Digital-Services/California-State-Web-Template/releases/tag/v6.0.7
     {% endcomment %}
-    <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
 
     {% include "core/includes/analytics.html" with api_key=analytics.api_key uid=analytics.uid did=analytics.did %}
   </head>

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -283,7 +283,6 @@ CSP_SCRIPT_SRC = [
     "'unsafe-inline'",
     "https://cdn.amplitude.com/libs/",
     "https://cdn.jsdelivr.net/",
-    "https://code.jquery.com/",
     "*.littlepay.com",
 ]
 env_script_src = _filter_empty(os.environ.get("DJANGO_CSP_SCRIPT_SRC", "").split(","))

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -281,8 +281,8 @@ if len(env_frame_src) > 0:
 
 CSP_SCRIPT_SRC = [
     "'unsafe-inline'",
-    "https://california.azureedge.net/",
     "https://cdn.amplitude.com/libs/",
+    "https://cdn.jsdelivr.net/",
     "https://code.jquery.com/",
     "*.littlepay.com",
 ]


### PR DESCRIPTION
Closes #1113 

We weren't actually using anything from the `cagov.core.js` JavaScript from the CA State Template. This PR removes our reference to that file to stop the flood of JS console errors.

Instead we reference Bootstrap directly via CDN, as we do make use of Bootstrap features and likely will use more in future iterations.

Also updates jQuery:

* To use the same CDN we use for Bootstrap, simplifying the Content Security Policy (CSP)
* From `3.6.0` to `3.6.1` -- minor update with bugfixes

Tested thoroughly with all flows with reCAPTCHA enabled:

* CC verified + enrollment
* CC unverified
* Login verified + enrollment [+ sign out]
* Login unverified [+ sign out]