### PR TITLE
Chore: eligibility-server dev image and branch

### DIFF
--- a/.devcontainer/server/settings.py
+++ b/.devcontainer/server/settings.py
@@ -4,14 +4,14 @@ LOG_LEVEL = "DEBUG"
 
 # Eligibility Verification settings
 
-CLIENT_KEY_PATH = "https://raw.githubusercontent.com/cal-itp/eligibility-server/main/keys/client.pub"
-SERVER_PRIVATE_KEY_PATH = "https://raw.githubusercontent.com/cal-itp/eligibility-server/main/keys/server.key"
-SERVER_PUBLIC_KEY_PATH = "https://raw.githubusercontent.com/cal-itp/eligibility-server/main/keys/server.pub"
+CLIENT_KEY_PATH = "https://raw.githubusercontent.com/cal-itp/eligibility-server/dev/keys/client.pub"
+SERVER_PRIVATE_KEY_PATH = "https://raw.githubusercontent.com/cal-itp/eligibility-server/dev/keys/server.key"
+SERVER_PUBLIC_KEY_PATH = "https://raw.githubusercontent.com/cal-itp/eligibility-server/dev/keys/server.pub"
 SUB_FORMAT_REGEX = r".+"
 
 # Data settings
 
-IMPORT_FILE_PATH = "https://raw.githubusercontent.com/cal-itp/eligibility-server/main/data/server.csv"
+IMPORT_FILE_PATH = "https://raw.githubusercontent.com/cal-itp/eligibility-server/dev/data/server.csv"
 INPUT_HASH_ALGO = ""
 
 # CSV-specific settings

--- a/.github/workflows/tests-feature.yml
+++ b/.github/workflows/tests-feature.yml
@@ -45,7 +45,7 @@ jobs:
           docker run \
             --detach \
             -p 5000:5000 \
-            ghcr.io/cal-itp/eligibility-server:main
+            ghcr.io/cal-itp/eligibility-server:dev
 
       - name: Run feature tests
         uses: cypress-io/github-action@v2

--- a/benefits/core/migrations/0002_sample_data.py
+++ b/benefits/core/migrations/0002_sample_data.py
@@ -20,7 +20,7 @@ def load_sample_data(app, *args, **kwargs):
 
     server_public_key = PemData.objects.create(
         label="Eligibility server public key",
-        remote_url="https://raw.githubusercontent.com/cal-itp/eligibility-server/main/keys/server.pub",
+        remote_url="https://raw.githubusercontent.com/cal-itp/eligibility-server/dev/keys/server.pub",
     )
 
     client_private_key = PemData.objects.create(

--- a/compose.yml
+++ b/compose.yml
@@ -36,7 +36,7 @@ services:
       - ./:/home/calitp/app
 
   server:
-    image: ghcr.io/cal-itp/eligibility-server:main
+    image: ghcr.io/cal-itp/eligibility-server:dev
     env_file: .devcontainer/server/.env.server
     ports:
       - "8000"


### PR DESCRIPTION
This PR updates Benefits to use eligibility-server's `dev` image and branch.

See cal-itp/eligibility-server#169