### PR TITLE
Fix: sample server key files

### DIFF
--- a/.devcontainer/server/settings.py
+++ b/.devcontainer/server/settings.py
@@ -4,14 +4,14 @@ LOG_LEVEL = "DEBUG"
 
 # Eligibility Verification settings
 
-CLIENT_KEY_PATH = "https://raw.githubusercontent.com/cal-itp/eligibility-server/main/keys/client.pub"
-SERVER_PRIVATE_KEY_PATH = "https://raw.githubusercontent.com/cal-itp/eligibility-server/main/keys/server.key"
-SERVER_PUBLIC_KEY_PATH = "https://raw.githubusercontent.com/cal-itp/eligibility-server/main/keys/server.pub"
+CLIENT_KEY_PATH = "https://raw.githubusercontent.com/cal-itp/eligibility-server/dev/keys/client.pub"
+SERVER_PRIVATE_KEY_PATH = "https://raw.githubusercontent.com/cal-itp/eligibility-server/dev/keys/server.key"
+SERVER_PUBLIC_KEY_PATH = "https://raw.githubusercontent.com/cal-itp/eligibility-server/dev/keys/server.pub"
 SUB_FORMAT_REGEX = r".+"
 
 # Data settings
 
-IMPORT_FILE_PATH = "https://raw.githubusercontent.com/cal-itp/eligibility-server/main/data/server.csv"
+IMPORT_FILE_PATH = "https://raw.githubusercontent.com/cal-itp/eligibility-server/dev/data/server.csv"
 INPUT_HASH_ALGO = ""
 
 # CSV-specific settings


### PR DESCRIPTION
The `main` branch of `eligibility-server` was deleted in cal-itp/eligibility-server#186. 

#1122 missed these references.