### PR TITLE
docs(infrastructure): document missing environment setup steps

### DIFF
--- a/docs/deployment/infrastructure.md
+++ b/docs/deployment/infrastructure.md
@@ -1,6 +1,6 @@
 # Infrastructure
 
-The infrastructure is configured as code via [Terraform](https://www.terraform.io/), for [various reasons](https://techcommunity.microsoft.com/t5/fasttrack-for-azure/the-benefits-of-infrastructure-as-code/ba-p/2069350). There are two subscriptions, with a single [resource group](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/manage-resource-groups-portal) under each:
+The infrastructure is configured as code via [Terraform](https://www.terraform.io/), for [various reasons](https://techcommunity.microsoft.com/t5/fasttrack-for-azure/the-benefits-of-infrastructure-as-code/ba-p/2069350). Within the `CDT Digital CA` directory ([how to switch](https://learn.microsoft.com/en-us/azure/devtest/offer/how-to-change-directory-tenants-visual-studio-azure)), there are two subscriptions, with a single [resource group](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/manage-resource-groups-portal) under each:
 
 - `CDT/ODI Development` - Meant for experimentation with short-lived resources
 - `CDT/ODI Production` - All resources in here should be reflected in Terraform in this repository. The exception is secrets, such as values under [Key Vault](https://azure.microsoft.com/en-us/services/key-vault/) and [App Service application settings](https://docs.microsoft.com/en-us/azure/app-service/configure-common#configure-app-settings). [`prevent_destroy`](https://developer.hashicorp.com/terraform/tutorials/state/resource-lifecycle#prevent-resource-deletion) is used on these Resources.

--- a/docs/deployment/infrastructure.md
+++ b/docs/deployment/infrastructure.md
@@ -194,7 +194,11 @@ Use the following shorthand for conveying the Resource Type as part of the Resou
 The following steps are required to set up the environment, with linked issues to automate them:
 
 - `terraform apply`
+- Set up Slack notifications by [creating a Slack email](https://slack.com/help/articles/206819278-Send-emails-to-Slack) for the [#benefits-notify](https://cal-itp.slack.com/archives/C022HHSEE3F) channel, then [setting it as a Secret in the Key Vault](https://learn.microsoft.com/en-us/azure/key-vault/secrets/quick-create-portal#add-a-secret-to-key-vault) named `slack-benefits-notify-email`
 - Set required [App Service configuration](../configuration/environment-variables.md)
+- [Upload configuration data](../configuration/data.md) to the storage container
+- [Set up webhook from GitHub](https://github.com/cal-itp/benefits/settings/hooks) to [App Service Deployment Center](https://learn.microsoft.com/en-us/azure/app-service/deploy-ci-cd-custom-container?tabs=acr&pivots=container-linux) for the `Packages` event
+- [Import the wildcard certificate (`*.calitp.org`) to the Key Vault](https://learn.microsoft.com/en-us/azure/key-vault/certificates/tutorial-import-certificate?tabs=azure-portal)
 - Bind the certificates to the slots - [#704](https://github.com/cal-itp/benefits/issues/704)
 
-This is not a complete step-by-step guide; more a list of things to remember. This may be useful as part of incident response.
+This is not a complete step-by-step guide; more a list of things to remember. This may be useful as part of [incident response](https://docs.google.com/document/d/1qtev8qItPiTB4Tp9FQ87XsLtWZ4HlNXqoe9vF2VuGcY/edit#).

--- a/terraform/monitor.tf
+++ b/terraform/monitor.tf
@@ -47,8 +47,6 @@ resource "azurerm_application_insights" "prod" {
   }
 }
 
-# created manually
-# https://slack.com/help/articles/206819278-Send-emails-to-Slack
 data "azurerm_key_vault_secret" "slack_benefits_notify_email" {
   name         = "slack-benefits-notify-email"
   key_vault_id = azurerm_key_vault.main.id


### PR DESCRIPTION
Split out from https://github.com/cal-itp/benefits/pull/1074.