### PR TITLE
chore(pipeline): don't wait for input to Terraform

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,5 +29,8 @@
   "python.testing.unittestEnabled": false,
   "[terraform]": {
     "editor.defaultFormatter": "hashicorp.terraform"
+  },
+  "[terraform-vars]": {
+    "editor.defaultFormatter": "hashicorp.terraform"
   }
 }

--- a/terraform/azure-pipelines.yml
+++ b/terraform/azure-pipelines.yml
@@ -27,6 +27,8 @@ stages:
               provider: azurerm
               command: init
               workingDirectory: "$(System.DefaultWorkingDirectory)/terraform"
+              # https://developer.hashicorp.com/terraform/tutorials/automation/automate-terraform#automated-terraform-cli-workflow
+              commandOptions: -input=false
               # service connection
               backendServiceArm: Production
               # needs to match main.tf
@@ -41,7 +43,7 @@ stages:
               command: plan
               # wait for lock to be released, in case being used by another pipeline run
               # https://discuss.hashicorp.com/t/terraform-plan-wait-for-lock-to-be-released/6870/2
-              commandOptions: -lock-timeout=2m
+              commandOptions: -input=false -lock-timeout=2m
               workingDirectory: "$(System.DefaultWorkingDirectory)/terraform"
               # service connection
               environmentServiceNameAzureRM: Production
@@ -51,7 +53,7 @@ stages:
               provider: azurerm
               command: apply
               # (ditto the lock comment above)
-              commandOptions: -lock-timeout=2m
+              commandOptions: -input=false -lock-timeout=2m
               workingDirectory: "$(System.DefaultWorkingDirectory)/terraform"
               # service connection
               environmentServiceNameAzureRM: Production


### PR DESCRIPTION
Split out from https://github.com/cal-itp/benefits/pull/1074. Part of #803.

While we aren't currently using any variables in our pipeline, when we've introduced them in the past and not had them set in the pipeline, runs end up hanging until they time out. This will avoid that problem going forward.