### PR TITLE
fix(Terraform): add missing sticky settings

### DIFF
--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -55,9 +55,13 @@ resource "azurerm_linux_web_app" "main" {
       # custom config
       "ANALYTICS_KEY",
       "DJANGO_ALLOWED_HOSTS",
+      "DJANGO_DEBUG",
       "DJANGO_LOAD_SAMPLE_DATA",
       "DJANGO_LOG_LEVEL",
       "DJANGO_MIGRATIONS_DIR",
+      "DJANGO_RATE_LIMIT",
+      "DJANGO_RATE_LIMIT_METHODS",
+      "DJANGO_RATE_LIMIT_PERIOD",
       "DJANGO_RECAPTCHA_SECRET_KEY",
       "DJANGO_RECAPTCHA_SITE_KEY",
       "DJANGO_TRUSTED_ORIGINS",


### PR DESCRIPTION
Noticed them in [this pipeline run](https://calenterprise.visualstudio.com/CDT.OET.CAL-ITP/_build/results?buildId=37917&view=logs&j=e2b2897c-f736-5615-5c9c-c20ddcd4aa73&t=2ab79bdb-a159-573f-a6a0-2465f94c501e&l=78).