### PR TITLE
chore(terraform): remove certificate binding

### DIFF
--- a/docs/deployment/infrastructure.md
+++ b/docs/deployment/infrastructure.md
@@ -62,7 +62,7 @@ flowchart LR
     end
 ```
 
-[Front Door](https://docs.microsoft.com/en-us/azure/frontdoor/front-door-overview) also includes the [Web Application Firewall (WAF)](https://docs.microsoft.com/en-us/azure/web-application-firewall/afds/afds-overview). Both are managed by the DevSecOps team.
+[Front Door](https://docs.microsoft.com/en-us/azure/frontdoor/front-door-overview) also includes the [Web Application Firewall (WAF)](https://docs.microsoft.com/en-us/azure/web-application-firewall/afds/afds-overview) and handles TLS termination. Front Door is managed by the DevSecOps team.
 
 On this page, "slot" will refer to the true [App Service slots](https://docs.microsoft.com/en-us/azure/app-service/deploy-staging-slots) for the different environments, or the overarching App Service resource for `production`. The latter is basically an implicit slot.
 
@@ -198,7 +198,5 @@ The following steps are required to set up the environment, with linked issues t
 - Set required [App Service configuration](../configuration/environment-variables.md)
 - [Upload configuration data](../configuration/data.md) to the storage container
 - [Set up webhook from GitHub](https://github.com/cal-itp/benefits/settings/hooks) to [App Service Deployment Center](https://learn.microsoft.com/en-us/azure/app-service/deploy-ci-cd-custom-container?tabs=acr&pivots=container-linux) for the `Packages` event
-- [Import the wildcard certificate (`*.calitp.org`) to the Key Vault](https://learn.microsoft.com/en-us/azure/key-vault/certificates/tutorial-import-certificate?tabs=azure-portal)
-- Bind the certificates to the slots - [#704](https://github.com/cal-itp/benefits/issues/704)
 
 This is not a complete step-by-step guide; more a list of things to remember. This may be useful as part of [incident response](https://docs.google.com/document/d/1qtev8qItPiTB4Tp9FQ87XsLtWZ4HlNXqoe9vF2VuGcY/edit#).

--- a/terraform/key_vault.tf
+++ b/terraform/key_vault.tf
@@ -11,30 +11,11 @@ resource "azurerm_key_vault" "main" {
   }
 }
 
-# allow App Service to access the certificate
-# https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-certificate?tabs=apex%2Cportal#authorize-app-service-to-read-from-the-vault
-resource "azurerm_key_vault_access_policy" "app_service_cert" {
-  key_vault_id = azurerm_key_vault.main.id
-  tenant_id    = data.azurerm_client_config.current.tenant_id
-  object_id    = "abfa0a7c-a6b6-4736-8310-5855508787cd"
-
-  certificate_permissions = [
-    "Get",
-  ]
-  secret_permissions = [
-    "Get",
-  ]
-}
-
 resource "azurerm_key_vault_access_policy" "devsecops" {
   key_vault_id = azurerm_key_vault.main.id
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = var.DEVSECOPS_OBJECT_ID
 
-  # allow the pipeline to access the certificate (below)
-  certificate_permissions = [
-    "Get",
-  ]
   key_permissions = [
     "Get",
     "List",
@@ -57,15 +38,6 @@ resource "azurerm_key_vault_access_policy" "devsecops" {
     "Recover",
     "Backup",
     "Restore",
-  ]
-}
-
-data "azurerm_key_vault_certificate" "wildcard" {
-  name         = "calitp-org-wildcard-cert"
-  key_vault_id = azurerm_key_vault.main.id
-
-  depends_on = [
-    azurerm_key_vault_access_policy.devsecops
   ]
 }
 


### PR DESCRIPTION
Closes #704.

Per DevSecOps email 10/27/22:

> Front Door TLS/SSL offload terminates the TLS connection … connections to the backend happen over the public IP

I also removed the bindings from all slots and they continued to work. Therefore, the wildcard certificate isn't actually used by App Service.