### PR TITLE
Feat: add sqlite-viewer extension to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,6 +27,7 @@
     "monosans.djlint",
     "ms-python.python",
     "ms-python.vscode-pylance",
-    "mrorz.language-gettext"
+    "mrorz.language-gettext",
+    "qwtel.sqlite-viewer"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,5 +32,8 @@
   },
   "[terraform-vars]": {
     "editor.defaultFormatter": "hashicorp.terraform"
+  },
+  "workbench.editorAssociations": {
+    "*.db": "sqlite-viewer.option"
   }
 }


### PR DESCRIPTION
Closes #341.

This extension provides a basic GUI into the Django database for debugging purposes:

![sqlite-viewer](https://user-images.githubusercontent.com/1783439/206018212-66ba4c68-da2e-4739-825c-bed8d92d1c20.gif)
