### PR TITLE
chore(Terraform): remove hostname bindings for dev and test slots

### DIFF
--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -164,11 +164,6 @@ resource "azurerm_linux_web_app_slot" "dev" {
   }
 }
 
-resource "azurerm_app_service_slot_custom_hostname_binding" "dev" {
-  app_service_slot_id = azurerm_linux_web_app_slot.dev.id
-  hostname            = "dev-benefits.calitp.org"
-}
-
 ## TEST ##
 
 resource "azurerm_linux_web_app_slot" "test" {
@@ -218,11 +213,6 @@ resource "azurerm_linux_web_app_slot" "test" {
     share_name = azurerm_storage_container.config_test.name
     mount_path = "/home/calitp/app/config"
   }
-}
-
-resource "azurerm_app_service_slot_custom_hostname_binding" "test" {
-  app_service_slot_id = azurerm_linux_web_app_slot.test.id
-  hostname            = "test-benefits.calitp.org"
 }
 
 # migrations


### PR DESCRIPTION
They will be re-added when moved to the new App Service instances in https://github.com/cal-itp/benefits/pull/1074.