### PR TITLE
Chore: add pull_request trigger to pytest workflow

### DIFF
--- a/.github/workflows/tests-pytest.yml
+++ b/.github/workflows/tests-pytest.yml
@@ -1,6 +1,6 @@
 name: Pytest
 
-on: push
+on: [push, pull_request]
 
 jobs:
   pytest:


### PR DESCRIPTION
#1174 is stuck waiting on our required `pytest` check. 

The workflow needs to have `pull_request` as a trigger for it to run on pull requests from forks (see nasa/cFS#169 for more details).

<img src="https://user-images.githubusercontent.com/25497886/210650939-801a9a1e-fcd2-4812-878f-6a07fa577404.png" width="600">
