### PR TITLE
fix(CI): send API check failure notifications to Slack

### DIFF
--- a/.github/workflows/check-api.yml
+++ b/.github/workflows/check-api.yml
@@ -75,3 +75,13 @@ jobs:
           --cacert $temp_dir/cacert.ca > $temp_dir/payload.txt
 
           test $(head -n 1 $temp_dir/payload.txt | grep -o 201)
+
+      # https://www.ravsam.in/blog/send-slack-notification-when-github-actions-fails/#using-notify-slack-action
+      - name: Report failure to Slack
+        if: always()
+        uses: ravsamhq/notify-slack-action@v1
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}


### PR DESCRIPTION
Was looking at https://github.com/cal-itp/benefits/issues/832#issuecomment-1323080591 after [the Payments Data team also came up with the failure scenario](https://docs.google.com/spreadsheets/d/1f1-fM7wJvxCUWvgzaq02Cyr_kPb5ubfCS64wnhZ5wWk/edit#gid=584616034) of the Littlepay API being down, and I realized this would be easy to resolve.

- [x] [Create Slack App](https://api.slack.com/apps/A04JKQEQU9W/general)
- [x] Set `SLACK_WEBHOOK_URL` in [Actions secrets](https://github.com/cal-itp/benefits/settings/secrets/actions)