### PR TITLE
Chore: always show the user the eligibility index

### DIFF
--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -74,12 +74,7 @@ def index(request):
             page.forms = [form]
             response = TemplateResponse(request, TEMPLATE_INDEX, ctx)
     else:
-        if agency.eligibility_verifiers.count() == 1:
-            verifier = agency.eligibility_verifiers.first()
-            session.update(request, verifier=verifier)
-            response = redirect(eligibility_start)
-        else:
-            response = TemplateResponse(request, TEMPLATE_INDEX, ctx)
+        response = TemplateResponse(request, TEMPLATE_INDEX, ctx)
 
     return response
 

--- a/tests/pytest/eligibility/test_views.py
+++ b/tests/pytest/eligibility/test_views.py
@@ -92,8 +92,11 @@ def test_index_get_agency_single_verifier(
     path = reverse(ROUTE_INDEX)
     response = client.get(path)
 
-    assert response.status_code == 302
-    assert response.url == reverse(ROUTE_START)
+    assert response.status_code == 200
+    assert response.template_name == TEMPLATE_INDEX
+    assert "page" in response.context_data
+    assert len(response.context_data["page"].forms) > 0
+    assert isinstance(response.context_data["page"].forms[0], EligibilityVerifierSelectionForm)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Closes #1200 

Unit test was updated and passes. To test in the browser, update your sample data so that `mst_agency` only has one verifier.