### PR TITLE
Update SacRT copy, and add Spanish translations

### DIFF
--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -147,8 +147,9 @@ msgstr ""
 
 msgid "eligibility.pages.index.p[0].sacrt"
 msgstr ""
-"You can tap your credit or debit card when you board a SacRT bus, and your "
-"discounted fare will automatically apply every time you ride. "
+"You can tap your credit or debit card when you board SacRT public "
+"transportation, and your discounted fare will automatically apply every time "
+"you ride. "
 
 msgid "core.pages.help.about.p[0]"
 msgstr ""

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -427,7 +427,7 @@ msgid "core.pages.index.title"
 msgstr "Elija Proveedor"
 
 msgid "core.pages.index.headline"
-msgstr "TODO: Conecte su beneficio a su tarjeta de sin contacto"
+msgstr "Conecte su beneficio del transporte a su tarjeta de sin contacto"
 
 msgid "core.pages.index.button"
 msgstr "Elija Su Proveedor"
@@ -439,7 +439,7 @@ msgid "core.pages.agency_index.title"
 msgstr "Introducción"
 
 msgid "core.pages.agency_index.mst_cc.headline"
-msgstr "Conecte su beneficio de MST a su tarjeta de sin contacto"
+msgstr "Conecte su beneficio del transporte de MST a su tarjeta de sin contacto"
 
 msgid "core.buttons.back"
 msgstr "Regresar a la página principal"

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -341,7 +341,7 @@ msgid "core.pages.help.foss.link"
 msgstr "GitHub"
 
 msgid "core.pages.index.agency_selector.headline"
-msgstr "TODO: Please choose your transit provider:"
+msgstr "Por favor, elija su proveedor de transporte:"
 
 msgid "core.pages.index.agency_selector%(agency_short_name)s"
 msgstr "%(agency_short_name)s logo"
@@ -424,13 +424,13 @@ msgid "core.buttons.wait"
 msgstr "Espere por favor..."
 
 msgid "core.pages.index.title"
-msgstr "Elija proveedor"
+msgstr "Elija Proveedor"
 
 msgid "core.pages.index.headline"
 msgstr "TODO: Conecte su beneficio a su tarjeta de sin contacto"
 
 msgid "core.pages.index.button"
-msgstr "Elija proveedor"
+msgstr "Elija Su Proveedor"
 
 msgid "core.pages.index.continue"
 msgstr "Empezar"

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -154,9 +154,9 @@ msgstr ""
 
 msgid "eligibility.pages.index.p[0].sacrt"
 msgstr ""
-"Puede acercar su tarjeta de crédito o débito cuando aborde un autobús de "
-"SacRT y su tarifa con descuento se aplicará automáticamente cada vez que "
-"viaje. "
+"Puede acercar su tarjeta de crédito o débito cuando aborde el transporte "
+"público SacRT y su tarifa con descuento se aplicará automáticamente cada vez "
+"que viaje. "
 
 msgid "core.pages.help.about.p[0]"
 msgstr ""


### PR DESCRIPTION
Feedback from the demo yesterday was to change "SacRT bus" to "SacRT public transportation" and to check Spanish translations for new copy changes.

Paired with @srhhnry to make these changes and close #1210.