### PR TITLE
Fix: agency selector with n cards

### DIFF
--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -565,7 +565,7 @@ h1 + .media-list, /* A .media-list immediately following the h1: Enrollment Succ
 
 :root {
   --card-title-font-size: var(--font-size-18px);
-  --card-title-line-height: 21.6px;
+  --card-title-line-height: calc(21.6rem / 16);
   --card-title-letter-spacing: 0.03em;
   --card-x-padding: calc(10rem / 16);
   --card-body-x-padding: 0;
@@ -578,14 +578,14 @@ h1 + .media-list, /* A .media-list immediately following the h1: Enrollment Succ
 @media (min-width: 992px) {
   :root {
     --card-title-font-size: var(--font-size-20px);
-    --card-title-line-height: 24px;
+    --card-title-line-height: calc(24rem / 16);
     --card-title-letter-spacing: 0.05rem;
     --card-x-padding: calc(35rem / 16);
     --card-body-x-padding: calc(40rem / 16);
     --card-body-y-padding: 0;
     --card-border-width: var(--font-size-20px);
-    --card-max-width: 340px;
-    --card-min-height: 185px;
+    --card-max-width: calc(340rem / 16);
+    --card-min-height: calc(185rem / 16);
   }
 }
 

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -571,6 +571,8 @@ h1 + .media-list, /* A .media-list immediately following the h1: Enrollment Succ
   --card-body-x-padding: 0;
   --card-body-y-padding: 0.75rem;
   --card-border-width: var(--font-size-12px);
+  --card-max-width: 100%;
+  --card-min-height: 100%;
 }
 
 @media (min-width: 992px) {
@@ -582,6 +584,8 @@ h1 + .media-list, /* A .media-list immediately following the h1: Enrollment Succ
     --card-body-x-padding: calc(40rem / 16);
     --card-body-y-padding: 0;
     --card-border-width: var(--font-size-20px);
+    --card-max-width: 340px;
+    --card-min-height: 185px;
   }
 }
 
@@ -599,6 +603,8 @@ a.card:focus-visible {
   transition: 0.3s;
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
   padding: var(--card-body-y-padding) var(--card-x-padding);
+  max-width: var(--card-max-width);
+  min-height: var(--card-min-height);
 }
 
 .card:hover {
@@ -758,10 +764,8 @@ a.card:focus-visible {
 
 #agency-selector .col:first-child .card {
   margin-top: 2rem;
-  margin-bottom: 1rem;
 }
 
 #agency-selector .col:last-child .card {
-  margin-top: 1rem;
   margin-bottom: 2rem;
 }


### PR DESCRIPTION
Closes #1219 

This PR sets a max-width and min-height for cards shown on the agency selector modal. I also fixed some units to be `rem`-based.

### Screenshots

#### 1 agency
| Desktop | Mobile |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/25497886/215583903-d37b2ccd-8d6e-4c7d-8997-d86e46b6af06.png) | ![image](https://user-images.githubusercontent.com/25497886/215583839-78ed8555-d35e-4053-a77a-4aa0040c9924.png) |

#### 2 agencies
| Desktop | Mobile |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/25497886/215583990-ade5a588-2bdf-46c8-b5e2-f5bf2c91d1c4.png) | ![image](https://user-images.githubusercontent.com/25497886/215584067-16c57032-39f1-476f-af3e-d63d1ecb114b.png) |

#### 4 agencies
| Desktop | Mobile |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/25497886/215584361-9f7a7b78-aac7-431a-85a4-7971d4685107.png) | ![image](https://user-images.githubusercontent.com/25497886/215584309-5744d254-ae66-42b4-bfaf-21321a379d15.png) |