### PR TITLE
CI: handle path-filtered but required checks

### DIFF
--- a/.github/workflows/codeql-ignore.yml
+++ b/.github/workflows/codeql-ignore.yml
@@ -1,0 +1,26 @@
+# Since the CodeQL check is required and filters to .js and .py files, we need another check with a job of the same name for all other files.
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+name: Skip CodeQL on ignored paths
+
+on:
+  push:
+    path-ignore:
+      - "**.js"
+      - "**.py"
+  pull_request:
+    branches: [dev, test, prod]
+    path-ignore:
+      - "**.js"
+      - "**.py"
+
+jobs:
+  codeql:
+    name: CodeQL Analyze
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        language: ["javascript", "python"]
+
+    steps:
+      - run: 'echo "No build required" '


### PR DESCRIPTION
This is to try and get #1225 to pass its required checks. I think the problem is that our CodeQL workflow is set to run only if `.js` or `.py` files were changed AND is a required check (for the target branch). The fix here is to add another workflow with a job with the same name that will run for the non-`.js`/`.py` files.

References
 - https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
 - https://stackoverflow.com/q/70927785