### PR TITLE
Fix: eligibility types in events

### DIFF
--- a/benefits/eligibility/analytics.py
+++ b/benefits/eligibility/analytics.py
@@ -11,6 +11,7 @@ class EligibilityEvent(core.Event):
         super().__init__(request, event_type)
         # overwrite core.Event eligibility_types
         self.update_event_properties(eligibility_types=eligibility_types)
+        self.update_user_properties(eligibility_types=eligibility_types)
 
 
 class SelectedVerifierEvent(EligibilityEvent):

--- a/tests/pytest/eligibility/test_analytics.py
+++ b/tests/pytest/eligibility/test_analytics.py
@@ -4,7 +4,7 @@ from benefits.eligibility.analytics import EligibilityEvent, ReturnedEligibility
 
 
 @pytest.mark.django_db
-def test_EligibilityEvent_overwrites_event_eligibility_types(app_request, mocker):
+def test_EligibilityEvent_overwrites_eligibility_types(app_request, mocker):
     key, type1, type2 = "eligibility_types", "type1", "type2"
     mocker.patch("benefits.core.analytics.session.eligibility", return_value=[type1])
     mocker.patch("benefits.core.analytics.EligibilityType.get_names", return_value=[type1])
@@ -16,10 +16,10 @@ def test_EligibilityEvent_overwrites_event_eligibility_types(app_request, mocker
     assert type2 in event.event_properties[key]
     assert type1 not in event.event_properties[key]
 
-    # user_properties should not have been overwritten
+    # user_properties should have been overwritten
     assert key in event.user_properties
-    assert type1 in event.user_properties[key]
-    assert type2 not in event.user_properties[key]
+    assert type2 in event.user_properties[key]
+    assert type1 not in event.user_properties[key]
 
 
 @pytest.mark.django_db

--- a/tests/pytest/eligibility/test_analytics.py
+++ b/tests/pytest/eligibility/test_analytics.py
@@ -1,6 +1,6 @@
 import pytest
 
-from benefits.eligibility.analytics import EligibilityEvent, ReturnedEligibilityEvent
+from benefits.eligibility.analytics import EligibilityEvent
 
 
 @pytest.mark.django_db
@@ -20,17 +20,3 @@ def test_EligibilityEvent_overwrites_eligibility_types(app_request, mocker):
     assert key in event.user_properties
     assert type2 in event.user_properties[key]
     assert type1 not in event.user_properties[key]
-
-
-@pytest.mark.django_db
-def test_ReturnedEligibilityEvent_success_overwrites_user_eligibility_types(app_request, mocker):
-    key, type1, type2 = "eligibility_types", "type1", "type2"
-    mocker.patch("benefits.core.analytics.session.eligibility", return_value=[type1])
-    mocker.patch("benefits.core.analytics.EligibilityType.get_names", return_value=[type1])
-
-    event = ReturnedEligibilityEvent(app_request, eligibility_types=[type2], status="success")
-
-    # user_properties should have been overwritten
-    assert key in event.user_properties
-    assert type1 not in event.user_properties[key]
-    assert type2 in event.user_properties[key]


### PR DESCRIPTION
Closes #1228 

Changes the base `EligibilityEvent` to always set the `user_properties` with new `eligibility_types`, in addition to the `event_properties`.

Updated the tests as well.

See https://github.com/cal-itp/benefits/issues/1228#issuecomment-1411075074 for resolution on the other (OAuth) event issue.