### PR TITLE
fix(docs): add missing system interconnections to architecture diagram

### DIFF
--- a/docs/deployment/infrastructure.md
+++ b/docs/deployment/infrastructure.md
@@ -13,21 +13,23 @@ flowchart LR
     %% dmv[DMV Eligibility Verification API]
     benefits[Benefits application]
     style benefits stroke-width:5px
-    %% recaptcha[Google reCAPTCHA]
+    recaptcha[Google reCAPTCHA]
     rider((User's browser))
     idg[Identity Gateway]
+    mst_elig[MST Courtesy Card Eligibility Server]
 
     rider --> benefits
     rider --> Login.gov
-    %% rider --> recaptcha
+    rider --> recaptcha
     rider --> Littlepay
     rider --> Amplitude
 
     benefits <--> idg
-    %% benefits <--> recaptcha
+    benefits <--> recaptcha
     %% benefits --> dmv
     benefits --> Amplitude
     benefits <--> Littlepay
+    benefits --> mst_elig
 
     idg <--> Login.gov
 ```


### PR DESCRIPTION
Noticed this while looking at the docs. I _think_ this brings it up to date.

<img width="818" alt="Screenshot 2023-01-31 at 8 44 50 PM" src="https://user-images.githubusercontent.com/86842/215924663-32bd6862-3b7e-47ba-abb5-214f25a012f9.png">
