### PR TITLE
Docs: configuring a new transit agency

### DIFF
--- a/docs/configuration/.pages
+++ b/docs/configuration/.pages
@@ -6,3 +6,4 @@ nav:
   - oauth.md
   - rate-limit.md
   - recaptcha.md
+  - transit-agency.md

--- a/docs/configuration/data.md
+++ b/docs/configuration/data.md
@@ -16,7 +16,7 @@
 
 ## Introduction
 
-Django [data migrations](https://docs.djangoproject.com/en/4.0/topics/migrations/#data-migrations) can be used to load the database with instances of the app's model classes, defined in [`benefits/core/models.py`][core-models].
+Django [data migrations](https://docs.djangoproject.com/en/4.0/topics/migrations/#data-migrations) are used to load the database with instances of the app's model classes, defined in [`benefits/core/models.py`][core-models].
 
 Migrations are run as the application starts up. See the [`bin/init.sh`][init] script.
 

--- a/docs/configuration/transit-agency.md
+++ b/docs/configuration/transit-agency.md
@@ -10,7 +10,7 @@ Note that a `TransitAgency` model requires:
 - a list of `EligibilityVerifier`s used to verify one of those supported eligibility types
 - a `PaymentProcessor` for enrolling the user's contactless card for discounts
 
-Also note that these steps assume the transit agency is using Littlepay as their payment processor. Support for integration with other payment processors may be added in the future.
+Also note that these steps assume the transit agency is using Littlepay as their payment processor. Support for integration with [other payment processors](https://www.camobilitymarketplace.org/contracts/) may be added in the future.
 
 ## Configuration for development and testing
 

--- a/docs/configuration/transit-agency.md
+++ b/docs/configuration/transit-agency.md
@@ -42,7 +42,7 @@ At this point, Cal-ITP and transit agency staff can coordinate to do on-the-grou
 
 ### Production validation testing
 
-1. Transit agency staff (or Cal-IT staff) does live test in the field.
+1. Transit agency staff (or Cal-ITP staff) does live test in the field.
 1. Transit agency staff uses the Merchant Portal to verify the taps and discounts were successful.
 1. Cal-ITP uses logs from Azure to verify the user was associated to the customer group.
 1. Cal-ITP verifies that Amplitude analytic events are being sent.

--- a/docs/configuration/transit-agency.md
+++ b/docs/configuration/transit-agency.md
@@ -1,0 +1,24 @@
+# Configuring a new transit agency
+
+Before starting any configuration, the Cal-ITP team and transit agency staff should have a kickoff meeting to confirm that information provided is complete, implementation plan is feasible, and any approvals needed have been obtained.
+
+Then, the following steps are done by the Cal-ITP team to configure a new transit agency in the Benefits application.
+
+Note that a `TransitAgency` model requires:
+
+- a list of supported `EligibilityType`s
+- a list of `EligibilityVerifier`s used to verify one of those supported eligibility types
+- a `PaymentProcessor` for enrolling the user's contactless card for discounts
+
+Also note that these steps assume the transit agency is using Littlepay as their payment processor. Support for integration with other payment processors may be added in the future.
+
+## Configuration for development and testing
+
+For development and testing, only a Littlepay customer group is needed since there is no need to interact with any discount product. (We don't have a way to tap a card against the QA system to trigger a discount and therefore have no reason to associate the group with any product.)
+
+### Steps
+
+1. Cal-ITP uses the transit agency's Littlepay merchant ID to create a customer group in the Littlepay QA environment for each type of eligibility (e.g. senior).
+1. For each group that's created, a group ID will be returned and should be set as the `group_id` on a new `EligibilityType` in the Benefits database. (See [Configuration data](../data/) for more on loading the database.)
+1. Cal-ITP creates a new `EligibilityVerifier` in the database for each supported eligibility type. This will require configuration for either [API](https://docs.calitp.org/eligibility-api)-based verification or verification through an [OAuth Open ID Connect provider](../oauth/) (e.g. Login.gov).
+1. Cal-ITP creates a new `TransitAgency` in the database and associates it with the new `EligibilityType`s and `EligibilityVerifier`s as well as the existing Littlepay `PaymentProcessor`.

--- a/docs/configuration/transit-agency.md
+++ b/docs/configuration/transit-agency.md
@@ -20,5 +20,5 @@ For development and testing, only a Littlepay customer group is needed since the
 
 1. Cal-ITP uses the transit agency's Littlepay merchant ID to create a customer group in the Littlepay QA environment for each type of eligibility (e.g. senior).
 1. For each group that's created, a group ID will be returned and should be set as the `group_id` on a new `EligibilityType` in the Benefits database. (See [Configuration data](../data/) for more on loading the database.)
-1. Cal-ITP creates a new `EligibilityVerifier` in the database for each supported eligibility type. This will require configuration for either [API](https://docs.calitp.org/eligibility-api)-based verification or verification through an [OAuth Open ID Connect provider](../oauth/) (e.g. Login.gov).
+1. Cal-ITP creates a new `EligibilityVerifier` in the database for each supported eligibility type. This will require configuration for either [API](https://docs.calitp.org/eligibility-api/specification/)-based verification or verification through an [OAuth Open ID Connect provider](../oauth/) (e.g. Login.gov).
 1. Cal-ITP creates a new `TransitAgency` in the database and associates it with the new `EligibilityType`s and `EligibilityVerifier`s as well as the existing Littlepay `PaymentProcessor`.

--- a/docs/configuration/transit-agency.md
+++ b/docs/configuration/transit-agency.md
@@ -32,6 +32,7 @@ For production validation, both a customer group and discount product are needed
 ### Steps
 
 1. Transit agency staff creates the discount product in production Littlepay (if it does not already exist).
+1. Transit agency staff takes a screenshot of the discount product in the Merchant Portal, making sure the browser URL is visible, and sends that to Cal-ITP.
 1. Cal-ITP creates a customer group **for testing purposes** in production Littlepay.
 1. Cal-ITP associates the group with the product.
 1. Cal-ITP creates a new `EligibilityType` **for testing purposes** in the Benefits database and sets the `group_id` to the ID of the newly-created group.

--- a/docs/configuration/transit-agency.md
+++ b/docs/configuration/transit-agency.md
@@ -30,10 +30,11 @@ For production validation, both a customer group and discount product are needed
 ### Steps
 
 1. Transit agency staff creates the discount product in production Littlepay (if it does not already exist).
-1. Cal-ITP creates a customer group **for testing purposes** in production Littlepay and associates the group with the product.
+1. Cal-ITP creates a customer group **for testing purposes** in production Littlepay.
+1. Cal-ITP associates the group with the product.
 1. Cal-ITP sets that group's ID as the `group_id` for a new `EligibilityType` in the Benefits database.
 1. Cal-ITP creates a new `EligibilityVerifier` with configuration **for a testing environment** to ensure successful eligibility verification. (For example, use sandbox Login.gov instead of production Login.gov.)
-1. Cal-ITP creates a new `TransitAgency` in the database with the proper associations to eligibility types, verifiers, and payment processors.
+1. Cal-ITP creates a new `TransitAgency` in the database with the proper associations to eligibility types, verifiers, and payment processor.
 
 At this point, Cal-ITP and transit agency staff can coordinate to do on-the-ground testing where a live card is tapped on a live payment validator.
 
@@ -50,10 +51,11 @@ Once production validation is done, the transit agency can be added to the produ
 
 ### Steps
 
-1. Cal-ITP creates a customer group **for production use** in production Littlepay and associates the group with the discount product created [previously during production validation](#configuration-for-production-validation).
+1. Cal-ITP creates a customer group **for production use** in production Littlepay.
+1. Cal-ITP associates the group with the discount product created [previously during production validation](#configuration-for-production-validation).
 1. Cal-ITP sets that group's ID as the `group_id` for a new `EligibilityType` in the Benefits database.
 1. Cal-ITP creates a new `EligibilityVerifier` with configuration for the **production** eligibility verification system.
-1. Cal-ITP creates a new `TransitAgency` in the database with proper associations to eligibility tpes, verifiers, and payment processors.
+1. Cal-ITP creates a new `TransitAgency` in the database with proper associations to eligibility types, verifiers, and payment processor.
 
 ### Cleanup
 

--- a/docs/configuration/transit-agency.md
+++ b/docs/configuration/transit-agency.md
@@ -9,6 +9,8 @@ Note that a `TransitAgency` model requires:
 - a list of supported `EligibilityType`s
 - a list of `EligibilityVerifier`s used to verify one of those supported eligibility types
 - a `PaymentProcessor` for enrolling the user's contactless card for discounts
+- an `info_url` and `phone` for users to contact customer service
+- an SVG or PNG file of the transit agency's logo
 
 Also note that these steps assume the transit agency is using Littlepay as their payment processor. Support for integration with [other payment processors](https://www.camobilitymarketplace.org/contracts/) may be added in the future.
 

--- a/docs/configuration/transit-agency.md
+++ b/docs/configuration/transit-agency.md
@@ -20,5 +20,26 @@ For development and testing, only a Littlepay customer group is needed since the
 
 1. Cal-ITP uses the transit agency's Littlepay merchant ID to create a customer group in the Littlepay QA environment for each type of eligibility (e.g. senior).
 1. For each group that's created, a group ID will be returned and should be set as the `group_id` on a new `EligibilityType` in the Benefits database. (See [Configuration data](../data/) for more on loading the database.)
-1. Cal-ITP creates a new `EligibilityVerifier` in the database for each supported eligibility type. This will require configuration for either [API](https://docs.calitp.org/eligibility-api/specification/)-based verification or verification through an [OAuth Open ID Connect provider](../oauth/) (e.g. Login.gov).
+1. Cal-ITP creates a new `EligibilityVerifier` in the database for each supported eligibility type. This will require configuration for either [API](https://docs.calitp.org/eligibility-api/specification/)-based verification or verification through an [OAuth Open ID Connect provider](../oauth/) (e.g. sandbox Login.gov) -- either way, this resource should be meant for testing.
 1. Cal-ITP creates a new `TransitAgency` in the database and associates it with the new `EligibilityType`s and `EligibilityVerifier`s as well as the existing Littlepay `PaymentProcessor`.
+
+## Configuration for production validation
+
+For production validation, both a customer group and discount product are needed. The customer group used here is a temporary one for testing only. Production validation is done against the Benefits test environment to avoid disruption of the production environment.
+
+### Steps
+
+1. Transit agency staff creates the discount product in production Littlepay (if it does not already exist).
+1. Cal-ITP creates a customer group **for testing purposes** in production Littlepay and associates the group with the product.
+1. Cal-ITP sets that group's ID as the `group_id` for a new `EligibilityType` in the Benefits database.
+1. Cal-ITP creates a new `EligibilityVerifier` with configuration **for a testing environment** to ensure successful eligibility verification. (For example, use sandbox Login.gov instead of production Login.gov.)
+1. Cal-ITP creates a new `TransitAgency` in the database with the proper associations to eligibility types, verifiers, and payment processors.
+
+At this point, Cal-ITP and transit agency staff can coordinate to do on-the-ground testing where a live card is tapped on a live payment validator.
+
+### Production validation testing
+
+1. Transit agency staff (or Cal-IT staff) does live test in the field.
+1. Transit agency staff uses the Merchant Portal to verify the taps and discounts were successful.
+1. Cal-ITP uses logs from Azure to verify the user was associated to the customer group.
+1. Cal-ITP verifies that Amplitude analytic events are being sent.

--- a/docs/configuration/transit-agency.md
+++ b/docs/configuration/transit-agency.md
@@ -27,16 +27,17 @@ For development and testing, only a Littlepay customer group is needed since the
 
 ## Configuration for production validation
 
-For production validation, both a customer group and discount product are needed. The customer group used here is a temporary one for testing only. Production validation is done against the Benefits test environment to avoid disruption of the production environment.
+For production validation, both a customer group and discount product are needed. The customer group used here is a temporary one for testing only. Production validation is done against the Benefits **test environment** to avoid disruption of the production environment.
 
 ### Steps
 
 1. Transit agency staff creates the discount product in production Littlepay (if it does not already exist).
 1. Cal-ITP creates a customer group **for testing purposes** in production Littlepay.
 1. Cal-ITP associates the group with the product.
-1. Cal-ITP sets that group's ID as the `group_id` for a new `EligibilityType` in the Benefits database.
+1. Cal-ITP creates a new `EligibilityType` **for testing purposes** in the Benefits database and sets the `group_id` to the ID of the newly-created group.
 1. Cal-ITP creates a new `EligibilityVerifier` with configuration **for a testing environment** to ensure successful eligibility verification. (For example, use sandbox Login.gov instead of production Login.gov.)
-1. Cal-ITP creates a new `TransitAgency` in the database with the proper associations to eligibility types, verifiers, and payment processor.
+1. Cal-ITP creates a new `PaymentProcessor` **for testing purposes** with configuration for production Littlepay.
+1. Cal-ITP updates the existing `TransitAgency` (created [previously](#configuration-for-development-and-testing)) with associations to the eligibility types, verifiers, and payment processor that were just created for testing.
 
 At this point, Cal-ITP and transit agency staff can coordinate to do on-the-ground testing where a live card is tapped on a live payment validator.
 
@@ -61,7 +62,8 @@ Once production validation is done, the transit agency can be added to the produ
 
 ### Cleanup
 
-At this point, the customer group that was created in production Littlepay for testing purposes can be deleted.
+At this point, the customer group that was created in production Littlepay for testing purposes can be deleted. The temporary production validation objects in the Benefits database can also be deleted.
 
 1. Remove the association between the test customer group and discount product.
 1. Delete the test customer group.
+1. Remove temporary `EligibilityType`s, `EligibilityVerifier`s, and `PaymentProcessor` that were [created](#steps_1) in the Benefits test environment.

--- a/docs/configuration/transit-agency.md
+++ b/docs/configuration/transit-agency.md
@@ -43,3 +43,21 @@ At this point, Cal-ITP and transit agency staff can coordinate to do on-the-grou
 1. Transit agency staff uses the Merchant Portal to verify the taps and discounts were successful.
 1. Cal-ITP uses logs from Azure to verify the user was associated to the customer group.
 1. Cal-ITP verifies that Amplitude analytic events are being sent.
+
+## Configuration for production
+
+Once production validation is done, the transit agency can be added to the production Benefits database.
+
+### Steps
+
+1. Cal-ITP creates a customer group **for production use** in production Littlepay and associates the group with the discount product created [previously during production validation](#configuration-for-production-validation).
+1. Cal-ITP sets that group's ID as the `group_id` for a new `EligibilityType` in the Benefits database.
+1. Cal-ITP creates a new `EligibilityVerifier` with configuration for the **production** eligibility verification system.
+1. Cal-ITP creates a new `TransitAgency` in the database with proper associations to eligibility tpes, verifiers, and payment processors.
+
+### Cleanup
+
+At this point, the customer group that was created in production Littlepay for testing purposes can be deleted.
+
+1. Remove the association between the test customer group and discount product.
+1. Delete the test customer group.


### PR DESCRIPTION
Closes #309 

This PR adds technical documentation on the steps needed to add a new transit agency to Benefits.