### PR TITLE
fix(devcontainer): use new VSCode settings/extensions configuration format

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,27 +7,31 @@
   "workspaceFolder": "/home/calitp/app",
   "postStartCommand": ["/bin/bash", "bin/init.sh"],
   "postAttachCommand": ["/bin/bash", ".devcontainer/postAttach.sh"],
-  // Set *default* container specific settings.json values on container create.
-  "settings": {
-    "terminal.integrated.defaultProfile.linux": "bash",
-    "terminal.integrated.profiles.linux": {
-      "bash": {
-        "path": "/bin/bash"
-      }
+  "customizations": {
+    "vscode": {
+      // Set *default* container specific settings.json values on container create.
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "terminal.integrated.profiles.linux": {
+          "bash": {
+            "path": "/bin/bash"
+          }
+        }
+      },
+      // Add the IDs of extensions you want installed when the container is created.
+      "extensions": [
+        "batisteo.vscode-django",
+        "bpruitt-goddard.mermaid-markdown-syntax-highlighting",
+        "eamodio.gitlens",
+        "esbenp.prettier-vscode",
+        "hashicorp.terraform",
+        "mhutchie.git-graph",
+        "monosans.djlint",
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "mrorz.language-gettext",
+        "qwtel.sqlite-viewer"
+      ]
     }
-  },
-  // Add the IDs of extensions you want installed when the container is created.
-  "extensions": [
-    "batisteo.vscode-django",
-    "bpruitt-goddard.mermaid-markdown-syntax-highlighting",
-    "eamodio.gitlens",
-    "esbenp.prettier-vscode",
-    "hashicorp.terraform",
-    "mhutchie.git-graph",
-    "monosans.djlint",
-    "ms-python.python",
-    "ms-python.vscode-pylance",
-    "mrorz.language-gettext",
-    "qwtel.sqlite-viewer"
-  ]
+  }
 }


### PR DESCRIPTION
Was getting this warning:

<img width="670" alt="Screenshot 2023-02-10 at 7 42 18 PM" src="https://user-images.githubusercontent.com/86842/218227583-ae656da2-7c4a-4bcb-ba25-e203e9995963.png">

View the change [ignoring whitespace](https://github.com/cal-itp/benefits/pull/1257/files?diff=unified&w=1).