### PR TITLE
chore: set up Sentry

### DIFF
--- a/appcontainer/requirements.txt
+++ b/appcontainer/requirements.txt
@@ -5,4 +5,5 @@ eligibility-api==2023.01.1
 opencensus-ext-azure==1.1.6
 opencensus-ext-django==0.8.0
 requests==2.28.2
+sentry-sdk==1.15.0
 six==1.16.0

--- a/benefits/sentry.py
+++ b/benefits/sentry.py
@@ -2,14 +2,39 @@ from benefits import VERSION
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
 import os
+import subprocess
+
+
+SENTRY_ENVIRONMENT = os.environ.get("SENTRY_ENVIRONMENT", "local")
+
+
+# https://stackoverflow.com/a/21901260/358804
+def get_git_revision_hash():
+    return subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("ascii").strip()
+
+
+def get_sha_path():
+    current_file = os.path.dirname(os.path.abspath(__file__))
+    return os.path.join(current_file, "..", "static", "sha.txt")
+
+
+def get_release() -> str:
+    """On 'local' and 'dev', returns the Git SHA. Otherwise, returns the VERSION."""
+
+    sha_path = get_sha_path()
+    if SENTRY_ENVIRONMENT == "local":
+        return get_git_revision_hash()
+    elif SENTRY_ENVIRONMENT == "dev" and os.path.isfile(sha_path):
+        with open(sha_path) as f:
+            return f.read().strip()
+    else:
+        return VERSION
 
 
 def configure():
     SENTRY_DSN = os.environ.get("SENTRY_DSN")
     if SENTRY_DSN:
         print("Enabling Sentry…")
-
-        SENTRY_ENVIRONMENT = os.environ.get("SENTRY_ENVIRONMENT", "local")
 
         # https://docs.sentry.io/platforms/python/configuration/
         sentry_sdk.init(
@@ -19,7 +44,7 @@ def configure():
             ],
             traces_sample_rate=1.0,
             environment=SENTRY_ENVIRONMENT,
-            release=VERSION,
+            release=get_release(),
         )
     else:
         print("SENTRY_DSN not set, so won't send events")

--- a/benefits/sentry.py
+++ b/benefits/sentry.py
@@ -34,7 +34,8 @@ def get_release() -> str:
 def configure():
     SENTRY_DSN = os.environ.get("SENTRY_DSN")
     if SENTRY_DSN:
-        print("Enabling Sentry…")
+        release = get_release()
+        print(f"Enabling Sentry for environment '{SENTRY_ENVIRONMENT}', release '{release}'...")
 
         # https://docs.sentry.io/platforms/python/configuration/
         sentry_sdk.init(
@@ -44,7 +45,7 @@ def configure():
             ],
             traces_sample_rate=1.0,
             environment=SENTRY_ENVIRONMENT,
-            release=get_release(),
+            release=release,
             in_app_include=["benefits"],
         )
     else:

--- a/benefits/sentry.py
+++ b/benefits/sentry.py
@@ -45,6 +45,7 @@ def configure():
             traces_sample_rate=1.0,
             environment=SENTRY_ENVIRONMENT,
             release=get_release(),
+            in_app_include=["benefits"],
         )
     else:
         print("SENTRY_DSN not set, so won't send events")

--- a/benefits/sentry.py
+++ b/benefits/sentry.py
@@ -1,0 +1,25 @@
+from benefits import VERSION
+import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
+import os
+
+
+def configure():
+    SENTRY_DSN = os.environ.get("SENTRY_DSN")
+    if SENTRY_DSN:
+        print("Enabling Sentry…")
+
+        SENTRY_ENVIRONMENT = os.environ.get("SENTRY_ENVIRONMENT", "local")
+
+        # https://docs.sentry.io/platforms/python/configuration/
+        sentry_sdk.init(
+            dsn=SENTRY_DSN,
+            integrations=[
+                DjangoIntegration(),
+            ],
+            traces_sample_rate=1.0,
+            environment=SENTRY_ENVIRONMENT,
+            release=VERSION,
+        )
+    else:
+        print("SENTRY_DSN not set, so won't send events")

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -3,6 +3,8 @@ Django settings for benefits project.
 """
 import os
 import benefits.logging
+import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
 
 
 def _filter_empty(ls):
@@ -226,6 +228,26 @@ STATIC_ROOT = os.path.join(BASE_DIR, "static")
 # Logging configuration
 LOG_LEVEL = os.environ.get("DJANGO_LOG_LEVEL", "DEBUG" if DEBUG else "WARNING")
 LOGGING = benefits.logging.get_config(LOG_LEVEL, enable_azure=ENABLE_AZURE_INSIGHTS)
+
+SENTRY_DSN = os.environ.get("SENTRY_DSN")
+if SENTRY_DSN:
+    print("Enabling Sentry…")
+
+    sentry_sdk.init(
+        dsn=SENTRY_DSN,
+        integrations=[
+            DjangoIntegration(),
+        ],
+        # Set traces_sample_rate to 1.0 to capture 100%
+        # of transactions for performance monitoring.
+        # We recommend adjusting this value in production.
+        traces_sample_rate=1.0,
+        # If you wish to associate users to errors (assuming you are using
+        # django.contrib.auth) you may enable sending PII data.
+        send_default_pii=True,
+    )
+else:
+    print("SENTRY_DSN not set, so won't send events")
 
 # Analytics configuration
 

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -2,6 +2,7 @@
 Django settings for benefits project.
 """
 import os
+from benefits import VERSION
 import benefits.logging
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
@@ -233,18 +234,17 @@ SENTRY_DSN = os.environ.get("SENTRY_DSN")
 if SENTRY_DSN:
     print("Enabling Sentry…")
 
+    SENTRY_ENVIRONMENT = os.environ.get("SENTRY_ENVIRONMENT", "local")
+
+    # https://docs.sentry.io/platforms/python/configuration/
     sentry_sdk.init(
         dsn=SENTRY_DSN,
         integrations=[
             DjangoIntegration(),
         ],
-        # Set traces_sample_rate to 1.0 to capture 100%
-        # of transactions for performance monitoring.
-        # We recommend adjusting this value in production.
         traces_sample_rate=1.0,
-        # If you wish to associate users to errors (assuming you are using
-        # django.contrib.auth) you may enable sending PII data.
-        send_default_pii=True,
+        environment=SENTRY_ENVIRONMENT,
+        release=VERSION,
     )
 else:
     print("SENTRY_DSN not set, so won't send events")

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -2,10 +2,8 @@
 Django settings for benefits project.
 """
 import os
-from benefits import VERSION
+from benefits import sentry
 import benefits.logging
-import sentry_sdk
-from sentry_sdk.integrations.django import DjangoIntegration
 
 
 def _filter_empty(ls):
@@ -230,24 +228,7 @@ STATIC_ROOT = os.path.join(BASE_DIR, "static")
 LOG_LEVEL = os.environ.get("DJANGO_LOG_LEVEL", "DEBUG" if DEBUG else "WARNING")
 LOGGING = benefits.logging.get_config(LOG_LEVEL, enable_azure=ENABLE_AZURE_INSIGHTS)
 
-SENTRY_DSN = os.environ.get("SENTRY_DSN")
-if SENTRY_DSN:
-    print("Enabling Sentry…")
-
-    SENTRY_ENVIRONMENT = os.environ.get("SENTRY_ENVIRONMENT", "local")
-
-    # https://docs.sentry.io/platforms/python/configuration/
-    sentry_sdk.init(
-        dsn=SENTRY_DSN,
-        integrations=[
-            DjangoIntegration(),
-        ],
-        traces_sample_rate=1.0,
-        environment=SENTRY_ENVIRONMENT,
-        release=VERSION,
-    )
-else:
-    print("SENTRY_DSN not set, so won't send events")
+sentry.configure()
 
 # Analytics configuration
 

--- a/benefits/urls.py
+++ b/benefits/urls.py
@@ -16,12 +16,20 @@ handler403 = "benefits.core.views.bad_request"
 handler404 = "benefits.core.views.page_not_found"
 handler500 = "benefits.core.views.server_error"
 
+
+# based on
+# https://docs.sentry.io/platforms/python/guides/django/#verify
+def trigger_error(request):
+    raise RuntimeError("Test error")
+
+
 urlpatterns = [
     path("", include("benefits.core.urls")),
     path("eligibility/", include("benefits.eligibility.urls")),
     path("enrollment/", include("benefits.enrollment.urls")),
     path("i18n/", include("django.conf.urls.i18n")),
     path("oauth/", include("benefits.oauth.urls")),
+    path("sentry-debug/", trigger_error),
 ]
 
 if settings.ADMIN:

--- a/benefits/urls.py
+++ b/benefits/urls.py
@@ -16,21 +16,22 @@ handler403 = "benefits.core.views.bad_request"
 handler404 = "benefits.core.views.page_not_found"
 handler500 = "benefits.core.views.server_error"
 
-
-# based on
-# https://docs.sentry.io/platforms/python/guides/django/#verify
-def trigger_error(request):
-    raise RuntimeError("Test error")
-
-
 urlpatterns = [
     path("", include("benefits.core.urls")),
     path("eligibility/", include("benefits.eligibility.urls")),
     path("enrollment/", include("benefits.enrollment.urls")),
     path("i18n/", include("django.conf.urls.i18n")),
     path("oauth/", include("benefits.oauth.urls")),
-    path("sentry-debug/", trigger_error),
 ]
+
+if settings.DEBUG:
+    # based on
+    # https://docs.sentry.io/platforms/python/guides/django/#verify
+
+    def trigger_error(request):
+        raise RuntimeError("Test error")
+
+    urlpatterns.append(path("error/", trigger_error))
 
 if settings.ADMIN:
     from django.contrib import admin

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -181,3 +181,11 @@ Enables [log collection](../../deployment/troubleshooting/#logs). Set the value 
     [Data Source Name (DSN)](https://docs.sentry.io/product/sentry-basics/dsn-explainer/)
 
 Enables [sending events to Sentry](../../deployment/troubleshooting/#error-monitoring).
+
+### `SENTRY_ENVIRONMENT`
+
+!!! tldr "Sentry docs"
+
+    [`environment` config value](https://docs.sentry.io/platforms/python/configuration/options/#environment)
+
+Segments errors by which deployment they occur in. This defaults to `local`, and can be set to match one of the [environment names](../../deployment/infrastructure/#environments).

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -171,3 +171,13 @@ Enables [log collection](../../deployment/troubleshooting/#logs). Set the value 
 [app-service-config]: https://docs.microsoft.com/en-us/azure/app-service/configure-common?tabs=portal
 [benefits-secrets]: https://github.com/cal-itp/benefits-secrets
 [getting-started_create-env]: ../getting-started/README.md#create-an-environment-file
+
+## Sentry
+
+### `SENTRY_DSN`
+
+!!! tldr "Sentry docs"
+
+    [Data Source Name (DSN)](https://docs.sentry.io/product/sentry-basics/dsn-explainer/)
+
+Enables [sending events to Sentry](../../deployment/troubleshooting/#error-monitoring).

--- a/docs/deployment/troubleshooting.md
+++ b/docs/deployment/troubleshooting.md
@@ -51,6 +51,8 @@ Cal-ITP's Sentry instance collects both [errors ("Issues")](https://sentry.calit
 
 [Alerts are sent to #benefits-notify in Slack.](https://sentry.calitp.org/organizations/sentry/alerts/rules/benefits/9/details/) [Others can be configured.](https://sentry.calitp.org/organizations/sentry/alerts/rules/)
 
+You can troubleshoot Sentry itself by [turning on debug mode](../../configuration/environment-variables/#django_debug) and visiting `/error/`.
+
 ## Specific issues
 
 This section serves as the [runbook](https://www.pagerduty.com/resources/learn/what-is-a-runbook/) for Benefits.

--- a/docs/deployment/troubleshooting.md
+++ b/docs/deployment/troubleshooting.md
@@ -45,6 +45,12 @@ az webapp log tail --resource-group RG-CDT-PUB-VIP-CALITP-P-001 --name AS-CDT-PU
 
 <https://as-cdt-pub-vip-calitp-p-001-dev.scm.azurewebsites.net/api/logs/docker>
 
+### Sentry
+
+Cal-ITP's Sentry instance collects both [errors ("Issues")](https://sentry.calitp.org/organizations/sentry/issues/?project=3) and app [performance info](https://sentry.calitp.org/organizations/sentry/performance/?project=3).
+
+[Alerts are sent to #benefits-notify in Slack.](https://sentry.calitp.org/organizations/sentry/alerts/rules/benefits/9/details/) [Others can be configured.](https://sentry.calitp.org/organizations/sentry/alerts/rules/)
+
 ## Specific issues
 
 This section serves as the [runbook](https://www.pagerduty.com/resources/learn/what-is-a-runbook/) for Benefits.


### PR DESCRIPTION
Part of #1258. Closes https://github.com/cal-itp/benefits/issues/733.

Adds Sentry error and performance monitoring. [Sample Issue captured by Sentry.](https://sentry.calitp.org/organizations/sentry/issues/39931/)

![Screenshot 2023-02-13 at 15-55-24 RuntimeError Test error - sentry - benefits](https://user-images.githubusercontent.com/86842/218572672-e7916855-87a4-4290-a83e-da10e32270f9.png)

Doesn't touch the Azure Monitor integration.