### PR TITLE
fix Azure exception handling

### DIFF
--- a/appcontainer/requirements.txt
+++ b/appcontainer/requirements.txt
@@ -2,7 +2,7 @@ Authlib==1.2.0
 Django==4.1.6
 django-csp==3.7
 eligibility-api==2023.01.1
-opencensus-ext-azure==1.1.6
+opencensus-ext-azure==1.1.8
 opencensus-ext-django==0.8.0
 requests==2.28.2
 six==1.16.0

--- a/benefits/core/middleware.py
+++ b/benefits/core/middleware.py
@@ -162,11 +162,17 @@ class LoginRequired(MiddlewareMixin):
 
 
 # https://github.com/census-instrumentation/opencensus-python/issues/766
-class LogErrorToAzure(MiddlewareMixin):
+class LogErrorToAzure:
     def __init__(self, get_response):
         self.get_response = get_response
         # wait to do this here to be sure the handler is initialized
         self.azure_logger = logging.getLogger("azure")
+
+    def __call__(self, request):
+        # boilerplate
+        # https://docs.djangoproject.com/en/4.1/topics/http/middleware/#writing-your-own-middleware
+        response = self.get_response(request)
+        return response
 
     def process_exception(self, request, exception):
         # https://stackoverflow.com/a/45532289

--- a/benefits/core/middleware.py
+++ b/benefits/core/middleware.py
@@ -21,17 +21,6 @@ HEALTHCHECK_PATH = "/healthcheck"
 TEMPLATE_USER_ERROR = "200_user_error.html"
 
 
-# boilerplate
-# https://docs.djangoproject.com/en/4.1/topics/http/middleware/#writing-your-own-middleware
-class BaseMiddleware:
-    def __init__(self, get_response):
-        self.get_response = get_response
-
-    def __call__(self, request):
-        response = self.get_response(request)
-        return response
-
-
 def user_error(request):
     home = viewmodels.Button.home(request)
     page = viewmodels.ErrorPage.user_error(button=home)
@@ -173,7 +162,7 @@ class LoginRequired(MiddlewareMixin):
 
 
 # https://github.com/census-instrumentation/opencensus-python/issues/766
-class LogErrorToAzure(BaseMiddleware):
+class LogErrorToAzure(MiddlewareMixin):
     def __init__(self, get_response):
         super().__init__(get_response)
         # wait to do this here to be sure the handler is initialized

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -84,7 +84,7 @@ if ENABLE_AZURE_INSIGHTS:
 # only used if enabled above
 OPENCENSUS = {
     "TRACE": {
-        "SAMPLER": "opencensus.trace.samplers.ProbabilitySampler(rate=1)",
+        "SAMPLER": "opencensus.trace.samplers.AlwaysOnSampler()",
         "EXPORTER": "opencensus.ext.azure.trace_exporter.AzureExporter()",
     }
 }


### PR DESCRIPTION
Fixes https://github.com/cal-itp/benefits/issues/861.

I had initially thought there was an issue with OpenCensus compatibility overall, but it appears the (remaining) problem was with our custom middleware. Set the `APPLICATIONINSIGHTS_CONNECTION_STRING` locally and was able to see errors show up in Azure:

<img width="1179" alt="Screenshot 2023-02-11 at 4 07 31 PM" src="https://user-images.githubusercontent.com/86842/218281213-0733d554-4428-4503-893f-c0d4d56b52a4.png">