### PR TITLE
Fix: Landing Page - Decrease main container height on mobile

### DIFF
--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -699,7 +699,7 @@ a.card:focus-visible {
 /* These pages have a full-width and full-height background image, creating the need to re-set the Footer margin top to 0 */
 
 :root {
-  --landing-main-height: 100vh;
+  --landing-main-height: calc(100vh - 80px); /* Header Height (80px) */
   --landing-background: url("/static/img/benefits-bg-mobile.jpg") no-repeat
     var(--primary-color);
   --landing-box-background: var(--bs-white);
@@ -725,7 +725,6 @@ a.card:focus-visible {
 }
 
 .landing main#main-content {
-  min-height: var(--landing-main-height);
   background: var(--landing-background);
   background-size: cover;
 }


### PR DESCRIPTION
fix #1213 

## What this PR does
- For the landing page on mobile, set the height of the main container to 100vh - 80px (header height). 
- The footer should be the only thing "under" the scroll now on mobile

## Testing
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/218831962-b474b2c1-4639-492f-8bdf-9dd08e019c95.png">

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/218832021-b2118503-eef0-44a5-bb9a-a84a99d9b783.png">
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/218832063-7eda0b41-efa7-4254-aabc-367917f742d9.png">
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/218832104-0fbbb8d0-9d38-499c-b751-b3ecaf7971ae.png">

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/218832194-b3bbfa93-b9d2-4091-adf7-1daa1b6d4149.png">
