### PR TITLE
chore(CI): simplify starting client for UI tests

### DIFF
--- a/.github/workflows/tests-ui.yml
+++ b/.github/workflows/tests-ui.yml
@@ -16,30 +16,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
 
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Build Dockerfile
-        id: build-client-image
-        uses: docker/build-push-action@v4
-        with:
-          builder: ${{ steps.buildx.outputs.name }}
-          cache-from: type=gha,scope=cal-itp
-          cache-to: type=gha,scope=cal-itp,mode=max
-          context: .
-          file: appcontainer/Dockerfile
-          push: false
-          load: true
-          tags: benefits_client:${{ github.sha }}
-
       - name: Start app
         run: |
-          docker run \
-            --detach \
-            -p 8000:8000 \
-            -v ${{ github.workspace }}/fixtures:/home/calitp/app/fixtures \
-            benefits_client:${{ github.sha }}
+          touch .env
+          docker compose up --detach client
 
       - name: Run Lighthouse tests for a11y
         uses: treosh/lighthouse-ci-action@9.3.1


### PR DESCRIPTION
Discovered this was possible as part of https://github.com/cal-itp/benefits/pull/1263.