### PR TITLE
add tests for Sentry revision code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.env
 *.mo
 *.tfbackend
+*.tmp
 benefits/core/migrations/0002_*.py
 !benefits/core/migrations/0002_sample_data.py
 static/

--- a/benefits/sentry.py
+++ b/benefits/sentry.py
@@ -24,9 +24,18 @@ def get_git_revision_hash():
     return subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("ascii").strip()
 
 
-def get_sha_path():
+def get_sha_file_path():
     current_file = os.path.dirname(os.path.abspath(__file__))
     return os.path.join(current_file, "..", "static", "sha.txt")
+
+
+def get_sha_from_file():
+    sha_path = get_sha_file_path()
+    if os.path.isfile(sha_path):
+        with open(sha_path) as f:
+            return f.read().strip()
+    else:
+        return None
 
 
 def get_release() -> str:
@@ -35,10 +44,9 @@ def get_release() -> str:
     if git_available() and is_git_directory():
         return get_git_revision_hash()
     else:
-        sha_path = get_sha_path()
-        if os.path.isfile(sha_path):
-            with open(sha_path) as f:
-                return f.read().strip()
+        sha = get_sha_from_file()
+        if sha:
+            return sha
         else:
             # one of the above *should* always be available, but including this just in case
             return VERSION

--- a/tests/pytest/test_sentry.py
+++ b/tests/pytest/test_sentry.py
@@ -1,0 +1,37 @@
+from benefits import VERSION
+from benefits.sentry import get_release
+
+
+def test_git(mocker):
+    mocker.patch("benefits.sentry.git_available", return_value=True)
+    mocker.patch("benefits.sentry.is_git_directory", return_value=True)
+
+    fake_sha = "123"
+    mocker.patch("benefits.sentry.get_git_revision_hash", return_value=fake_sha)
+
+    assert get_release() == fake_sha
+
+
+def test_sha_file(mocker):
+    mocker.patch("benefits.sentry.git_available", return_value=True)
+    mocker.patch("benefits.sentry.is_git_directory", return_value=False)
+
+    fake_sha = "123"
+    mocker.patch("benefits.sentry.get_sha_from_file", return_value=fake_sha)
+
+    assert get_release() == fake_sha
+
+
+def test_no_git(mocker):
+    mocker.patch("benefits.sentry.git_available", return_value=False)
+    mocker.patch("benefits.sentry.get_sha_from_file", return_value=None)
+
+    assert get_release() == VERSION
+
+
+def test_git_no_repo(mocker):
+    mocker.patch("benefits.sentry.git_available", return_value=True)
+    mocker.patch("benefits.sentry.is_git_directory", return_value=False)
+    mocker.patch("benefits.sentry.get_sha_from_file", return_value=None)
+
+    assert get_release() == VERSION


### PR DESCRIPTION
As requested in https://github.com/cal-itp/benefits/pull/1275#pullrequestreview-1299947900. Given that code calls out to the `git` executable and filesystem so much, a lot needs to be mocked, so not sure these tests add a lot of value 🤷 Coverage:

![image](https://user-images.githubusercontent.com/86842/219284288-65ff1392-1a15-4a71-b7ae-03c1b6c6ddaf.png)

Generated with

```sh
pytest --cov=benefits --cov-report=html tests/pytest/test_sentry.py
open htmlcov/index.html
```