### PR TITLE
Fix: adapt test for healthcheck user agents

### DIFF
--- a/benefits/core/middleware.py
+++ b/benefits/core/middleware.py
@@ -109,6 +109,18 @@ class Healthcheck:
         return self.get_response(request)
 
 
+class HealthcheckUserAgents(MiddlewareMixin):
+    """Middleware to return healthcheck for user agents specified in HEALTHCHECK_USER_AGENTS."""
+
+    def process_request(self, request):
+        if hasattr(request, "META"):
+            user_agent = request.META.get("HTTP_USER_AGENT", "")
+            if user_agent in settings.HEALTHCHECK_USER_AGENTS:
+                return HttpResponse("Healthy", content_type="text/plain")
+
+        return self.get_response(request)
+
+
 class VerifierSessionRequired(MiddlewareMixin):
     """Middleware raises an exception for sessions lacking an eligibility verifier configuration."""
 

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -49,6 +49,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.locale.LocaleMiddleware",
     "benefits.core.middleware.Healthcheck",
+    "benefits.core.middleware.HealthcheckUserAgents",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
@@ -67,6 +68,7 @@ if ADMIN:
 if DEBUG:
     MIDDLEWARE.append("benefits.core.middleware.DebugSession")
 
+HEALTHCHECK_USER_AGENTS = _filter_empty(os.environ.get("HEALTHCHECK_USER_AGENTS", "").split(","))
 
 CSRF_COOKIE_AGE = None
 CSRF_COOKIE_SAMESITE = "Strict"

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -145,6 +145,14 @@ Django's primary secret, keep this safe!
 
 Comma-separated list of hosts which are trusted origins for unsafe requests (e.g. POST)
 
+### `HEALTHCHECK_USER_AGENTS`
+
+!!! warning "Deployment configuration"
+
+   You must change this setting when deploying the app to a non-localhost domain
+
+Comma-separated list of User-Agent strings which, when present as an HTTP header, should only receive healthcheck responses. Used by our `HealthcheckUserAgent` middleware.
+
 ## Cypress tests
 
 !!! tldr "Cypress docs"

--- a/tests/pytest/core/test_middleware_healthcheck_user_agent.py
+++ b/tests/pytest/core/test_middleware_healthcheck_user_agent.py
@@ -1,0 +1,36 @@
+from django.test import Client
+from django.urls import reverse
+
+import pytest
+
+from benefits.core import session
+from benefits.core.models import TransitAgency
+from benefits.core.views import ROUTE_INDEX, TEMPLATE_PAGE
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("user_agent", ["AlwaysOn", "Edge Health Probe"])
+def test_healthcheck_user_agent(mocker, user_agent):
+    mocker.patch.object(session.settings, "HEALTHCHECK_USER_AGENTS", [user_agent])
+    client = Client(HTTP_USER_AGENT=user_agent)
+
+    response = client.get(reverse(ROUTE_INDEX))
+
+    assert response.status_code == 200
+    assert response.content.decode("UTF-8") == "Healthy"
+
+
+@pytest.mark.django_db
+def test_non_healthcheck_user_agent(mocker, model_TransitAgency, client):
+    # create another Transit Agency by cloning the original to ensure there are multiple
+    # https://stackoverflow.com/a/48149675/453168
+    new_agency = TransitAgency.objects.get(pk=model_TransitAgency.id)
+    new_agency.pk = None
+    new_agency.save()
+
+    mocker.patch.object(session.settings, "HEALTHCHECK_USER_AGENTS", ["AlwaysOn"])
+
+    response = client.get(reverse(ROUTE_INDEX))
+
+    assert response.status_code == 200
+    assert response.template_name == TEMPLATE_PAGE

--- a/tests/pytest/core/test_middleware_healthcheck_user_agent.py
+++ b/tests/pytest/core/test_middleware_healthcheck_user_agent.py
@@ -4,8 +4,7 @@ from django.urls import reverse
 import pytest
 
 from benefits.core import session
-from benefits.core.models import TransitAgency
-from benefits.core.views import ROUTE_INDEX, TEMPLATE_PAGE
+from benefits.core.views import ROUTE_INDEX, TEMPLATE_INDEX
 
 
 @pytest.mark.django_db
@@ -21,16 +20,10 @@ def test_healthcheck_user_agent(mocker, user_agent):
 
 
 @pytest.mark.django_db
-def test_non_healthcheck_user_agent(mocker, model_TransitAgency, client):
-    # create another Transit Agency by cloning the original to ensure there are multiple
-    # https://stackoverflow.com/a/48149675/453168
-    new_agency = TransitAgency.objects.get(pk=model_TransitAgency.id)
-    new_agency.pk = None
-    new_agency.save()
-
+def test_non_healthcheck_user_agent(mocker, client):
     mocker.patch.object(session.settings, "HEALTHCHECK_USER_AGENTS", ["AlwaysOn"])
 
     response = client.get(reverse(ROUTE_INDEX))
 
     assert response.status_code == 200
-    assert response.template_name == TEMPLATE_PAGE
+    assert response.template_name == TEMPLATE_INDEX


### PR DESCRIPTION
The unit test no longer needs to set up TransitAgencies for the index view anymore.