### PR TITLE
Fix: small issues on environment variable docs

### DIFF
--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -183,3 +183,7 @@ Enables [sending events to Sentry](../../deployment/troubleshooting/#error-monit
     [`environment` config value](https://docs.sentry.io/platforms/python/configuration/options/#environment)
 
 Segments errors by which deployment they occur in. This defaults to `local`, and can be set to match one of the [environment names](../../deployment/infrastructure/#environments).
+
+[app-service-config]: https://docs.microsoft.com/en-us/azure/app-service/configure-common?tabs=portal
+[benefits-secrets]: https://github.com/cal-itp/benefits-secrets
+[getting-started_create-env]: ../getting-started/README.md#create-an-environment-file

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -151,7 +151,7 @@ Comma-separated list of hosts which are trusted origins for unsafe requests (e.g
 
     You must change this setting when deploying the app to a non-localhost domain
 
-Comma-separated list of User-Agent strings which, when present as an HTTP header, should only receive healthcheck responses. Used by our `HealthcheckUserAgent` middleware.
+Comma-separated list of User-Agent strings which, when present as an HTTP header, should only receive healthcheck responses. Used by our `HealthcheckUserAgents` middleware.
 
 ## Cypress tests
 

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -149,7 +149,7 @@ Comma-separated list of hosts which are trusted origins for unsafe requests (e.g
 
 !!! warning "Deployment configuration"
 
-   You must change this setting when deploying the app to a non-localhost domain
+    You must change this setting when deploying the app to a non-localhost domain
 
 Comma-separated list of User-Agent strings which, when present as an HTTP header, should only receive healthcheck responses. Used by our `HealthcheckUserAgent` middleware.
 


### PR DESCRIPTION
While updating documentation for #1242, I noticed some broken links and that a call-out was not formatted correctly.

| Description | Screenshot |
| --- | --- |
| Broken Links | ![image](https://user-images.githubusercontent.com/25497886/220697763-fcd72c1d-3fb1-4b49-b4d9-8936f246d215.png) |
| Incorrectly formatted call-out | ![image](https://user-images.githubusercontent.com/25497886/220697870-e907fbe6-570d-455c-acb8-2759b14ca526.png) |

This PR fixes those two issues.