### PR TITLE
Feat: set Key Vault values

### DIFF
--- a/benefits/core/migrations/0002_sample_data.py
+++ b/benefits/core/migrations/0002_sample_data.py
@@ -230,7 +230,7 @@ PEM DATA
         short_name=os.environ.get("SACRT_AGENCY_SHORT_NAME", "SacRT (sample)"),
         long_name=os.environ.get("SACRT_AGENCY_LONG_NAME", "Sacramento Regional Transit (sample)"),
         agency_id="sacrt",
-        merchant_id="sacrt",
+        merchant_id=os.environ.get("SACRT_AGENCY_MERCHANT_ID", "sacrt"),
         info_url="https://sacrt.com/",
         phone="916-321-2877",
         active=True,

--- a/benefits/core/migrations/0002_sample_data.py
+++ b/benefits/core/migrations/0002_sample_data.py
@@ -16,11 +16,16 @@ def load_sample_data(app, *args, **kwargs):
 
     EligibilityType = app.get_model("core", "EligibilityType")
 
-    senior_type = EligibilityType.objects.create(
-        name="senior", label="Senior", group_id=os.environ.get("MST_SENIOR_GROUP_ID", "group1")
+    mst_senior_type = EligibilityType.objects.create(
+        name="senior", label="Senior Discount (MST)", group_id=os.environ.get("MST_SENIOR_GROUP_ID", "group1")
     )
-    courtesy_card_type = EligibilityType.objects.create(
-        name="courtesy_card", label="Courtesy Card", group_id=os.environ.get("MST_COURTESY_CARD_GROUP_ID", "group2")
+    mst_courtesy_card_type = EligibilityType.objects.create(
+        name="courtesy_card",
+        label="Courtesy Card Discount (MST)",
+        group_id=os.environ.get("MST_COURTESY_CARD_GROUP_ID", "group2"),
+    )
+    sacrt_senior_type = EligibilityType.objects.create(
+        name="senior", label="Senior Discount (SacRT)", group_id=os.environ.get("SACRT_SENIOR_GROUP_ID", "group3")
     )
 
     PemData = app.get_model("core", "PemData")
@@ -119,9 +124,9 @@ PEM DATA
 
     EligibilityVerifier = app.get_model("core", "EligibilityVerifier")
 
-    oauth_claims_verifier = EligibilityVerifier.objects.create(
-        name=os.environ.get("OAUTH_VERIFIER_NAME", "OAuth claims via Login.gov"),
-        eligibility_type=senior_type,
+    mst_oauth_claims_verifier = EligibilityVerifier.objects.create(
+        name=os.environ.get("MST_OAUTH_VERIFIER_NAME", "OAuth claims via Login.gov (MST)"),
+        eligibility_type=mst_senior_type,
         auth_provider=auth_provider,
         selection_label=_("eligibility.pages.index.login_gov.label"),
         selection_label_description=_("eligibility.pages.index.login_gov.description"),
@@ -141,12 +146,12 @@ PEM DATA
         enrollment_success_expiry_item_details=None,
     )
 
-    courtesy_card_verifier = EligibilityVerifier.objects.create(
+    mst_courtesy_card_verifier = EligibilityVerifier.objects.create(
         name=os.environ.get("COURTESY_CARD_VERIFIER", "Eligibility Server Verifier"),
         api_url=os.environ.get("COURTESY_CARD_VERIFIER_API_URL", "http://server:8000/verify"),
         api_auth_header=os.environ.get("COURTESY_CARD_VERIFIER_API_AUTH_HEADER", "X-Server-API-Key"),
         api_auth_key=os.environ.get("COURTESY_CARD_VERIFIER_API_AUTH_KEY", "server-auth-token"),
-        eligibility_type=courtesy_card_type,
+        eligibility_type=mst_courtesy_card_type,
         public_key=server_public_key,
         jwe_cek_enc=os.environ.get("COURTESY_CARD_VERIFIER_JWE_CEK_ENC", "A256CBC-HS512"),
         jwe_encryption_alg=os.environ.get("COURTESY_CARD_VERIFIER_JWE_ENCRYPTION_ALG", "RSA-OAEP"),
@@ -179,6 +184,28 @@ PEM DATA
         enrollment_success_confirm_item_details=_("enrollment.pages.success.mst_cc.confirm_item.details"),
         enrollment_success_expiry_item_heading=_("enrollment.pages.success.mst_cc.expiry_item.heading"),
         enrollment_success_expiry_item_details=_("enrollment.pages.success.mst_cc.expiry_item.details"),
+    )
+
+    sacrt_oauth_claims_verifier = EligibilityVerifier.objects.create(
+        name=os.environ.get("SACRT_OAUTH_VERIFIER_NAME", "OAuth claims via Login.gov (SacRT)"),
+        eligibility_type=sacrt_senior_type,
+        auth_provider=auth_provider,
+        selection_label=_("eligibility.pages.index.login_gov.label"),
+        selection_label_description=_("eligibility.pages.index.login_gov.description"),
+        start_title=_("eligibility.pages.start.login_gov.title"),
+        start_headline=_("eligibility.pages.start.login_gov.headline"),
+        start_item_heading=_("eligibility.pages.start.login_gov.start_item.heading"),
+        start_item_details=_("eligibility.pages.start.login_gov.start_item.details"),
+        start_help_anchor="login-gov",
+        unverified_title=_("eligibility.pages.unverified.login_gov.title"),
+        unverified_blurb=_("eligibility.pages.unverified.login_gov.p[0]"),
+        eligibility_confirmed_item_heading=_("enrollment.pages.index.login_gov.eligibility_confirmed_item.heading"),
+        eligibility_confirmed_item_details=_(
+            "enrollment.pages.index.login_gov.eligibility_confirmed_item.details%(transit_agency_short_name)s"
+        ),
+        enrollment_success_confirm_item_details=_("enrollment.pages.success.login_gov.confirm_item.details"),
+        enrollment_success_expiry_item_heading=None,
+        enrollment_success_expiry_item_details=None,
     )
 
     PaymentProcessor = app.get_model("core", "PaymentProcessor")
@@ -222,8 +249,8 @@ PEM DATA
         payment_processor=payment_processor,
         eligibility_index_intro=_("eligibility.pages.index.p[0].mst"),
     )
-    mst_agency.eligibility_types.set([senior_type, courtesy_card_type])
-    mst_agency.eligibility_verifiers.set([oauth_claims_verifier, courtesy_card_verifier])
+    mst_agency.eligibility_types.set([mst_senior_type, mst_courtesy_card_type])
+    mst_agency.eligibility_verifiers.set([mst_oauth_claims_verifier, mst_courtesy_card_verifier])
 
     sacrt_agency = TransitAgency.objects.create(
         slug="sacrt",
@@ -240,8 +267,8 @@ PEM DATA
         payment_processor=payment_processor,
         eligibility_index_intro=_("eligibility.pages.index.p[0].sacrt"),
     )
-    sacrt_agency.eligibility_types.set([senior_type])
-    sacrt_agency.eligibility_verifiers.set([oauth_claims_verifier])
+    sacrt_agency.eligibility_types.set([sacrt_senior_type])
+    sacrt_agency.eligibility_verifiers.set([sacrt_oauth_claims_verifier])
 
 
 class Migration(migrations.Migration):

--- a/docs/deployment/.pages
+++ b/docs/deployment/.pages
@@ -1,0 +1,7 @@
+nav:
+  - README.md
+  - infrastructure.md
+  - secrets.md
+  - release.md
+  - troubleshooting.md
+  - workflows.md

--- a/docs/deployment/secrets.md
+++ b/docs/deployment/secrets.md
@@ -1,0 +1,27 @@
+# Setting secrets
+
+Secret values used by the Benefits application (such as API keys, private keys, certificates, etc.) are stored in an Azure Key Vault for each environment.
+
+To set a secret, you can use the [Azure portal](https://learn.microsoft.com/en-us/azure/key-vault/secrets/quick-create-portal?source=recommendations) or the [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/keyvault/secret?view=azure-cli-latest#az-keyvault-secret-set).
+
+There are helper scripts under `terraform/secrets` which build up the Azure CLI command, given some inputs. The usage is as follows:
+
+First, make sure you are set up for [local development](../infrastructure/#local-development) and that you are in the `terraform/secrets` directory.
+
+```bash
+cd terraform/secrets
+```
+
+To set a secret by providing a value:
+
+```bash
+./value.sh <environment_letter> <secret_name> <secret_value>
+```
+
+where `environment_letter` is `D` for development, `T` for test, and `P` for production.
+
+To set a secret by providing the path of a file containing the secret (useful for [multi-line secrets](https://learn.microsoft.com/en-us/azure/key-vault/secrets/multiline-secrets)):
+
+```bash
+./file.sh <environment_letter> <secret_name> <file_path>
+```

--- a/terraform/secrets/README.md
+++ b/terraform/secrets/README.md
@@ -1,0 +1,1 @@
+[Documentation](https://docs.calitp.org/benefits/deployment/secrets/)

--- a/terraform/secrets/file.sh
+++ b/terraform/secrets/file.sh
@@ -9,4 +9,4 @@ env=$1
 secret_name=$2
 file_path=$3
 
-az keyvault secret set --vault-name "KV-CDT-PUB-CALITP-$env-001" --name $secret_name --file $file_path
+az keyvault secret set --vault-name "KV-CDT-PUB-CALITP-$env-001" --name $secret_name --file "$file_path"

--- a/terraform/secrets/file.sh
+++ b/terraform/secrets/file.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-env=$1
-secret_name=$2
-file_path=$3
-
 if [ $# -ne 3 ]; then
   echo "Usage: $0 <D|T|P> <secret_name> <file_path>"
   exit 1
 fi
+
+env=$1
+secret_name=$2
+file_path=$3
 
 az keyvault secret set --vault-name "KV-CDT-PUB-CALITP-$env-001" --name $1 --file $2

--- a/terraform/secrets/file.sh
+++ b/terraform/secrets/file.sh
@@ -9,4 +9,4 @@ env=$1
 secret_name=$2
 file_path=$3
 
-az keyvault secret set --vault-name "KV-CDT-PUB-CALITP-$env-001" --name $1 --file $2
+az keyvault secret set --vault-name "KV-CDT-PUB-CALITP-$env-001" --name $secret_name --file $file_path

--- a/terraform/secrets/file.sh
+++ b/terraform/secrets/file.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+env=$1
+secret_name=$2
+file_path=$3
+
+if [ $# -ne 3 ]; then
+  echo "Usage: $0 <D|T|P> <secret_name> <file_path>"
+  exit 1
+fi
+
+az keyvault secret set --vault-name "KV-CDT-PUB-CALITP-$env-001" --name $1 --file $2

--- a/terraform/secrets/value.sh
+++ b/terraform/secrets/value.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+env=$1
+secret_name=$2
+secret_value=$3
+
+if [ $# -ne 3 ]; then
+  echo "Usage: $0 <D|T|P> <secret_name> <secret_value>"
+  exit 1
+fi
+
+az keyvault secret set --vault-name "KV-CDT-PUB-CALITP-$env-001" --name $1 --value "$2"

--- a/terraform/secrets/value.sh
+++ b/terraform/secrets/value.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-env=$1
-secret_name=$2
-secret_value=$3
-
 if [ $# -ne 3 ]; then
   echo "Usage: $0 <D|T|P> <secret_name> <secret_value>"
   exit 1
 fi
+
+env=$1
+secret_name=$2
+secret_value=$3
 
 az keyvault secret set --vault-name "KV-CDT-PUB-CALITP-$env-001" --name $1 --value "$2"

--- a/terraform/secrets/value.sh
+++ b/terraform/secrets/value.sh
@@ -9,4 +9,4 @@ env=$1
 secret_name=$2
 secret_value=$3
 
-az keyvault secret set --vault-name "KV-CDT-PUB-CALITP-$env-001" --name $1 --value "$2"
+az keyvault secret set --vault-name "KV-CDT-PUB-CALITP-$env-001" --name $secret_name --value "$secret_value"


### PR DESCRIPTION
Closes #1242 

Secret values from our `dev`, `test`, and `prod` data migrations have been added to their respective Key Vaults in Azure.

### Naming convention
From [Azure docs](https://learn.microsoft.com/en-us/azure/key-vault/secrets/quick-create-portal#add-a-secret-to-key-vault):
> The secret name must be unique within a Key Vault. The name must be a 1-127 character string, starting with a letter and containing only 0-9, a-z, A-Z, and -.

So the naming convention I used is to take the environment variable name, replace `_` with `-`, and make all characters lowercase.

### Changes in this PR
Our sample data migration file was missing a few environment variables that we need for values in our real data migrations, so I added them in this PR.

I also added documentation on how to set secrets in Key Vault and some helper scripts for running the Azure CLI command.