### PR TITLE
Feat: specify app settings as code

### DIFF
--- a/docs/deployment/infrastructure.md
+++ b/docs/deployment/infrastructure.md
@@ -95,7 +95,7 @@ Within the `CDT Digital CA` directory ([how to switch](https://learn.microsoft.c
 
 All resources in these Resource Groups should be reflected in Terraform in this repository. The exceptions are:
 
-- Secrets, such as values under [Key Vault](https://azure.microsoft.com/en-us/services/key-vault/) and [App Service application settings](https://docs.microsoft.com/en-us/azure/app-service/configure-common#configure-app-settings). [`prevent_destroy`](https://developer.hashicorp.com/terraform/tutorials/state/resource-lifecycle#prevent-resource-deletion) is used on these Resources.
+- Secrets, such as values under [Key Vault](https://azure.microsoft.com/en-us/services/key-vault/). [`prevent_destroy`](https://developer.hashicorp.com/terraform/tutorials/state/resource-lifecycle#prevent-resource-deletion) is used on these Resources.
 - [Things managed by DevSecOps](#ownership)
 
 You'll see these referenced in Terraform as [data sources](https://developer.hashicorp.com/terraform/language/data-sources).

--- a/docs/deployment/secrets.md
+++ b/docs/deployment/secrets.md
@@ -25,3 +25,17 @@ To set a secret by providing the path of a file containing the secret (useful fo
 ```bash
 ./file.sh <environment_letter> <secret_name> <file_path>
 ```
+
+## Refreshing secrets
+
+To make sure the Benefits application uses the latest secret values in Key Vault, you will need to make a change to the app service's configuration. If you don't do this step, the application will instead use cached values, which may not be what you expect. See the [Azure docs](https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references?tabs=azure-cli#rotation) for more details.
+
+The steps are:
+
+1. After setting new secret values, go to the App Service configuration in Azure Portal, and change the value of the setting named `change_me_to_refresh_secrets`.
+1. Save your changes.
+
+The effects of following those steps should be:
+
+- A restart of the App Service is triggered.
+- The next time that our Azure infrastructure pipeline is run, the value of `change_me_to_refresh_secrets` is set back to the value defined in our Terraform file for the App Service resource.

--- a/docs/deployment/secrets.md
+++ b/docs/deployment/secrets.md
@@ -26,6 +26,12 @@ To set a secret by providing the path of a file containing the secret (useful fo
 ./file.sh <environment_letter> <secret_name> <file_path>
 ```
 
+To verify the value of a secret, you can use the helper script named `read.sh`.
+
+```bash
+./read.sh <environment_letter> <secret_name>
+```
+
 ## Refreshing secrets
 
 To make sure the Benefits application uses the latest secret values in Key Vault, you will need to make a change to the app service's configuration. If you don't do this step, the application will instead use cached values, which may not be what you expect. See the [Azure docs](https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references?tabs=azure-cli#rotation) for more details.

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -73,4 +73,4 @@ docker compose down
 [docker]: https://www.docker.com/products/docker-desktop
 [sample-data]: https://github.com/cal-itp/benefits/tree/dev/benefits/core/migrations/0002_sample_data.py
 
-[data-migration](https://github.com/cal-itp/benefits/tree/dev/benefits/core/migrations)
+[data-migration]: (https://github.com/cal-itp/benefits/tree/dev/benefits/core/migrations)

--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -64,71 +64,71 @@ resource "azurerm_linux_web_app" "main" {
     "WEBSITES_ENABLE_APP_SERVICE_STORAGE" = "false",
     "WEBSITES_PORT"                       = "8000",
 
-    "ANALYTICS_KEY" = local.is_dev ? null : "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=analytics-key)",
+    "ANALYTICS_KEY" = local.is_dev ? null : "${local.secret_prefix}analytics-key)",
 
     # Django settings
-    "DJANGO_ADMIN"            = (local.is_prod || local.is_test) ? null : "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-admin)",
-    "DJANGO_ALLOWED_HOSTS"    = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-allowed-hosts)",
-    "DJANGO_DEBUG"            = local.is_prod ? null : "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-debug)",
+    "DJANGO_ADMIN"            = (local.is_prod || local.is_test) ? null : "${local.secret_prefix}django-admin)",
+    "DJANGO_ALLOWED_HOSTS"    = "${local.secret_prefix}django-allowed-hosts)",
+    "DJANGO_DEBUG"            = local.is_prod ? null : "${local.secret_prefix}django-debug)",
     "DJANGO_LOAD_SAMPLE_DATA" = "false",
     "DJANGO_LOG_LEVEL"        = "DEBUG",
     "DJANGO_MIGRATIONS_DIR"   = "./config",
 
-    "DJANGO_RATE_LIMIT"         = local.is_dev ? null : "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-rate-limit)",
-    "DJANGO_RATE_LIMIT_METHODS" = local.is_dev ? null : "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-rate-limit-methods)",
-    "DJANGO_RATE_LIMIT_PERIOD"  = local.is_dev ? null : "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-rate-limit-period)",
+    "DJANGO_RATE_LIMIT"         = local.is_dev ? null : "${local.secret_prefix}django-rate-limit)",
+    "DJANGO_RATE_LIMIT_METHODS" = local.is_dev ? null : "${local.secret_prefix}django-rate-limit-methods)",
+    "DJANGO_RATE_LIMIT_PERIOD"  = local.is_dev ? null : "${local.secret_prefix}django-rate-limit-period)",
 
-    "DJANGO_RECAPTCHA_SECRET_KEY" = local.is_dev ? null : "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-recaptcha-secret-key)",
-    "DJANGO_RECAPTCHA_SITE_KEY"   = local.is_dev ? null : "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-recaptcha-site-key)",
+    "DJANGO_RECAPTCHA_SECRET_KEY" = local.is_dev ? null : "${local.secret_prefix}django-recaptcha-secret-key)",
+    "DJANGO_RECAPTCHA_SITE_KEY"   = local.is_dev ? null : "${local.secret_prefix}django-recaptcha-site-key)",
 
-    "DJANGO_SECRET_KEY"      = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-secret-key)",
-    "DJANGO_TRUSTED_ORIGINS" = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-trusted-origins)",
+    "DJANGO_SECRET_KEY"      = "${local.secret_prefix}django-secret-key)",
+    "DJANGO_TRUSTED_ORIGINS" = "${local.secret_prefix}django-trusted-origins)",
 
-    "HEALTHCHECK_USER_AGENTS" = local.is_dev ? null : "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=healthcheck-user-agents)",
+    "HEALTHCHECK_USER_AGENTS" = local.is_dev ? null : "${local.secret_prefix}healthcheck-user-agents)",
 
     # Sentry
-    "SENTRY_DSN"         = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=sentry-dsn)",
+    "SENTRY_DSN"         = "${local.secret_prefix}sentry-dsn)",
     "SENTRY_ENVIRONMENT" = local.env_name,
 
     # Environment variables for data migration
-    "MST_SENIOR_GROUP_ID"                            = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=mst-senior-group-id)",
-    "MST_COURTESY_CARD_GROUP_ID"                     = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=mst-courtesy-card-group-id)"
-    "SACRT_SENIOR_GROUP_ID"                          = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=sacrt-senior-group-id)"
-    "CLIENT_PRIVATE_KEY"                             = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=client-private-key)"
-    "CLIENT_PUBLIC_KEY"                              = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=client-public-key)"
-    "SERVER_PUBLIC_KEY_URL"                          = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=server-public-key-url)"
-    "PAYMENT_PROCESSOR_CLIENT_CERT"                  = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=payment-processor-client-cert)"
-    "PAYMENT_PROCESSOR_CLIENT_CERT_PRIVATE_KEY"      = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=payment-processor-client-cert-private-key)"
-    "PAYMENT_PROCESSOR_CLIENT_CERT_ROOT_CA"          = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=payment-processor-client-cert-root-ca)"
-    "AUTH_PROVIDER_CLIENT_NAME"                      = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=auth-provider-client-name)"
-    "AUTH_PROVIDER_CLIENT_ID"                        = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=auth-provider-client-id)"
-    "AUTH_PROVIDER_AUTHORITY"                        = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=auth-provider-authority)"
-    "AUTH_PROVIDER_SCOPE"                            = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=auth-provider-scope)"
-    "AUTH_PROVIDER_CLAIM"                            = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=auth-provider-claim)"
-    "MST_OAUTH_VERIFIER_NAME"                        = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=mst-oauth-verifier-name)"
-    "COURTESY_CARD_VERIFIER"                         = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=courtesy-card-verifier)"
-    "COURTESY_CARD_VERIFIER_API_URL"                 = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=courtesy-card-verifier-api-url)"
-    "COURTESY_CARD_VERIFIER_API_AUTH_HEADER"         = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=courtesy-card-verifier-api-auth-header)"
-    "COURTESY_CARD_VERIFIER_API_AUTH_KEY"            = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=courtesy-card-verifier-api-auth-key)"
-    "COURTESY_CARD_VERIFIER_JWE_CEK_ENC"             = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=courtesy-card-verifier-jwe-cek-enc)"
-    "COURTESY_CARD_VERIFIER_JWE_ENCRYPTION_ALG"      = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=courtesy-card-verifier-jwe-encryption-alg)"
-    "COURTESY_CARD_VERIFIER_JWS_SIGNING_ALG"         = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=courtesy-card-verifier-jws-signing-alg)"
-    "SACRT_OAUTH_VERIFIER_NAME"                      = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=sacrt-oauth-verifier-name)"
-    "PAYMENT_PROCESSOR_NAME"                         = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=payment-processor-name)"
-    "PAYMENT_PROCESSOR_API_BASE_URL"                 = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=payment-processor-api-base-url)"
-    "PAYMENT_PROCESSOR_API_ACCESS_TOKEN_ENDPOINT"    = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=payment-processor-api-access-token-endpoint)"
-    "PAYMENT_PROCESSOR_API_ACCESS_TOKEN_REQUEST_KEY" = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=payment-processor-api-access-token-request-key)"
-    "PAYMENT_PROCESSOR_API_ACCESS_TOKEN_REQUEST_VAL" = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=payment-processor-api-access-token-request-val)"
-    "PAYMENT_PROCESSOR_CARD_TOKENIZE_URL"            = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=payment-processor-card-tokenize-url)"
-    "PAYMENT_PROCESSOR_CARD_TOKENIZE_FUNC"           = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=payment-processor-card-tokenize-func)"
-    "PAYMENT_PROCESSOR_CARD_TOKENIZE_ENV"            = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=payment-processor-card-tokenize-env)"
-    "MST_AGENCY_SHORT_NAME"                          = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=mst-agency-short-name)"
-    "MST_AGENCY_LONG_NAME"                           = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=mst-agency-long-name)"
-    "MST_AGENCY_JWS_SIGNING_ALG"                     = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=mst-agency-jws-signing-alg)"
-    "SACRT_AGENCY_SHORT_NAME"                        = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=sacrt-agency-short-name)"
-    "SACRT_AGENCY_LONG_NAME"                         = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=sacrt-agency-long-name)"
-    "SACRT_AGENCY_MERCHANT_ID"                       = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=sacrt-agency-merchant-id)"
-    "SACRT_AGENCY_JWS_SIGNING_ALG"                   = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=sacrt-agency-jws-signing-alg)"
+    "MST_SENIOR_GROUP_ID"                            = "${local.secret_prefix}mst-senior-group-id)",
+    "MST_COURTESY_CARD_GROUP_ID"                     = "${local.secret_prefix}mst-courtesy-card-group-id)"
+    "SACRT_SENIOR_GROUP_ID"                          = "${local.secret_prefix}sacrt-senior-group-id)"
+    "CLIENT_PRIVATE_KEY"                             = "${local.secret_prefix}client-private-key)"
+    "CLIENT_PUBLIC_KEY"                              = "${local.secret_prefix}client-public-key)"
+    "SERVER_PUBLIC_KEY_URL"                          = "${local.secret_prefix}server-public-key-url)"
+    "PAYMENT_PROCESSOR_CLIENT_CERT"                  = "${local.secret_prefix}payment-processor-client-cert)"
+    "PAYMENT_PROCESSOR_CLIENT_CERT_PRIVATE_KEY"      = "${local.secret_prefix}payment-processor-client-cert-private-key)"
+    "PAYMENT_PROCESSOR_CLIENT_CERT_ROOT_CA"          = "${local.secret_prefix}payment-processor-client-cert-root-ca)"
+    "AUTH_PROVIDER_CLIENT_NAME"                      = "${local.secret_prefix}auth-provider-client-name)"
+    "AUTH_PROVIDER_CLIENT_ID"                        = "${local.secret_prefix}auth-provider-client-id)"
+    "AUTH_PROVIDER_AUTHORITY"                        = "${local.secret_prefix}auth-provider-authority)"
+    "AUTH_PROVIDER_SCOPE"                            = "${local.secret_prefix}auth-provider-scope)"
+    "AUTH_PROVIDER_CLAIM"                            = "${local.secret_prefix}auth-provider-claim)"
+    "MST_OAUTH_VERIFIER_NAME"                        = "${local.secret_prefix}mst-oauth-verifier-name)"
+    "COURTESY_CARD_VERIFIER"                         = "${local.secret_prefix}courtesy-card-verifier)"
+    "COURTESY_CARD_VERIFIER_API_URL"                 = "${local.secret_prefix}courtesy-card-verifier-api-url)"
+    "COURTESY_CARD_VERIFIER_API_AUTH_HEADER"         = "${local.secret_prefix}courtesy-card-verifier-api-auth-header)"
+    "COURTESY_CARD_VERIFIER_API_AUTH_KEY"            = "${local.secret_prefix}courtesy-card-verifier-api-auth-key)"
+    "COURTESY_CARD_VERIFIER_JWE_CEK_ENC"             = "${local.secret_prefix}courtesy-card-verifier-jwe-cek-enc)"
+    "COURTESY_CARD_VERIFIER_JWE_ENCRYPTION_ALG"      = "${local.secret_prefix}courtesy-card-verifier-jwe-encryption-alg)"
+    "COURTESY_CARD_VERIFIER_JWS_SIGNING_ALG"         = "${local.secret_prefix}courtesy-card-verifier-jws-signing-alg)"
+    "SACRT_OAUTH_VERIFIER_NAME"                      = "${local.secret_prefix}sacrt-oauth-verifier-name)"
+    "PAYMENT_PROCESSOR_NAME"                         = "${local.secret_prefix}payment-processor-name)"
+    "PAYMENT_PROCESSOR_API_BASE_URL"                 = "${local.secret_prefix}payment-processor-api-base-url)"
+    "PAYMENT_PROCESSOR_API_ACCESS_TOKEN_ENDPOINT"    = "${local.secret_prefix}payment-processor-api-access-token-endpoint)"
+    "PAYMENT_PROCESSOR_API_ACCESS_TOKEN_REQUEST_KEY" = "${local.secret_prefix}payment-processor-api-access-token-request-key)"
+    "PAYMENT_PROCESSOR_API_ACCESS_TOKEN_REQUEST_VAL" = "${local.secret_prefix}payment-processor-api-access-token-request-val)"
+    "PAYMENT_PROCESSOR_CARD_TOKENIZE_URL"            = "${local.secret_prefix}payment-processor-card-tokenize-url)"
+    "PAYMENT_PROCESSOR_CARD_TOKENIZE_FUNC"           = "${local.secret_prefix}payment-processor-card-tokenize-func)"
+    "PAYMENT_PROCESSOR_CARD_TOKENIZE_ENV"            = "${local.secret_prefix}payment-processor-card-tokenize-env)"
+    "MST_AGENCY_SHORT_NAME"                          = "${local.secret_prefix}mst-agency-short-name)"
+    "MST_AGENCY_LONG_NAME"                           = "${local.secret_prefix}mst-agency-long-name)"
+    "MST_AGENCY_JWS_SIGNING_ALG"                     = "${local.secret_prefix}mst-agency-jws-signing-alg)"
+    "SACRT_AGENCY_SHORT_NAME"                        = "${local.secret_prefix}sacrt-agency-short-name)"
+    "SACRT_AGENCY_LONG_NAME"                         = "${local.secret_prefix}sacrt-agency-long-name)"
+    "SACRT_AGENCY_MERCHANT_ID"                       = "${local.secret_prefix}sacrt-agency-merchant-id)"
+    "SACRT_AGENCY_JWS_SIGNING_ALG"                   = "${local.secret_prefix}sacrt-agency-jws-signing-alg)"
   }
 
   lifecycle {

--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -53,10 +53,13 @@ resource "azurerm_linux_web_app" "main" {
     mount_path   = "/home/calitp/app/config"
   }
 
+  app_settings = {
+    "WEBSITES_ENABLE_APP_SERVICE_STORAGE" = "false"
+  }
+
   lifecycle {
     prevent_destroy = true
-    # app_settings are managed manually through the portal since they contain secrets
-    ignore_changes = [app_settings, sticky_settings, tags]
+    ignore_changes  = [tags]
   }
 }
 

--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -54,7 +54,47 @@ resource "azurerm_linux_web_app" "main" {
   }
 
   app_settings = {
-    "WEBSITES_ENABLE_APP_SERVICE_STORAGE" = "false"
+    "WEBSITES_ENABLE_APP_SERVICE_STORAGE" = "false",
+
+    # Environment variables for data migration
+    "MST_SENIOR_GROUP_ID"                            = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=mst-senior-group-id)",
+    "MST_COURTESY_CARD_GROUP_ID"                     = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=mst-courtesy-card-group-id)"
+    "SACRT_SENIOR_GROUP_ID"                          = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=sacrt-senior-group-id)"
+    "CLIENT_PRIVATE_KEY"                             = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=client-private-key)"
+    "CLIENT_PUBLIC_KEY"                              = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=client-public-key)"
+    "SERVER_PUBLIC_KEY_URL"                          = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=server-public-key-url)"
+    "PAYMENT_PROCESSOR_CLIENT_CERT"                  = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=payment-processor-client-cert)"
+    "PAYMENT_PROCESSOR_CLIENT_CERT_PRIVATE_KEY"      = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=payment-processor-client-cert-private-key)"
+    "PAYMENT_PROCESSOR_CLIENT_CERT_ROOT_CA"          = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=payment-processor-client-cert-root-ca)"
+    "AUTH_PROVIDER_CLIENT_NAME"                      = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=auth-provider-client-name)"
+    "AUTH_PROVIDER_CLIENT_ID"                        = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=auth-provider-client-id)"
+    "AUTH_PROVIDER_AUTHORITY"                        = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=auth-provider-authority)"
+    "AUTH_PROVIDER_SCOPE"                            = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=auth-provider-scope)"
+    "AUTH_PROVIDER_CLAIM"                            = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=auth-provider-claim)"
+    "MST_OAUTH_VERIFIER_NAME"                        = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=mst-oauth-verifier-name)"
+    "COURTESY_CARD_VERIFIER"                         = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=courtesy-card-verifier)"
+    "COURTESY_CARD_VERIFIER_API_URL"                 = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=courtesy-card-verifier-api-url)"
+    "COURTESY_CARD_VERIFIER_API_AUTH_HEADER"         = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=courtesy-card-verifier-api-auth-header)"
+    "COURTESY_CARD_VERIFIER_API_AUTH_KEY"            = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=courtesy-card-verifier-api-auth-key)"
+    "COURTESY_CARD_VERIFIER_JWE_CEK_ENC"             = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=courtesy-card-verifier-jwe-cek-enc)"
+    "COURTESY_CARD_VERIFIER_JWE_ENCRYPTION_ALG"      = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=courtesy-card-verifier-jwe-encryption-alg)"
+    "COURTESY_CARD_VERIFIER_JWS_SIGNING_ALG"         = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=courtesy-card-verifier-jws-signing-alg)"
+    "SACRT_OAUTH_VERIFIER_NAME"                      = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=sacrt-oauth-verifier-name)"
+    "PAYMENT_PROCESSOR_NAME"                         = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=payment-processor-name)"
+    "PAYMENT_PROCESSOR_API_BASE_URL"                 = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=payment-processor-api-base-url)"
+    "PAYMENT_PROCESSOR_API_ACCESS_TOKEN_ENDPOINT"    = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=payment-processor-api-access-token-endpoint)"
+    "PAYMENT_PROCESSOR_API_ACCESS_TOKEN_REQUEST_KEY" = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=payment-processor-api-access-token-request-key)"
+    "PAYMENT_PROCESSOR_API_ACCESS_TOKEN_REQUEST_VAL" = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=payment-processor-api-access-token-request-val)"
+    "PAYMENT_PROCESSOR_CARD_TOKENIZE_URL"            = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=payment-processor-card-tokenize-url)"
+    "PAYMENT_PROCESSOR_CARD_TOKENIZE_FUNC"           = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=payment-processor-card-tokenize-func)"
+    "PAYMENT_PROCESSOR_CARD_TOKENIZE_ENV"            = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=payment-processor-card-tokenize-env)"
+    "MST_AGENCY_SHORT_NAME"                          = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=mst-agency-short-name)"
+    "MST_AGENCY_LONG_NAME"                           = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=mst-agency-long-name)"
+    "MST_AGENCY_JWS_SIGNING_ALG"                     = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=mst-agency-jws-signing-alg)"
+    "SACRT_AGENCY_SHORT_NAME"                        = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=sacrt-agency-short-name)"
+    "SACRT_AGENCY_LONG_NAME"                         = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=sacrt-agency-long-name)"
+    "SACRT_AGENCY_MERCHANT_ID"                       = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=sacrt-agency-merchant-id)"
+    "SACRT_AGENCY_JWS_SIGNING_ALG"                   = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=sacrt-agency-jws-signing-alg)"
   }
 
   lifecycle {

--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -71,7 +71,7 @@ resource "azurerm_linux_web_app" "main" {
     "DJANGO_ALLOWED_HOSTS"    = "${local.secret_prefix}django-allowed-hosts)",
     "DJANGO_DEBUG"            = local.is_prod ? null : "${local.secret_prefix}django-debug)",
     "DJANGO_LOAD_SAMPLE_DATA" = "false",
-    "DJANGO_LOG_LEVEL"        = "DEBUG",
+    "DJANGO_LOG_LEVEL"        = "${local.secret_prefix}django-log-level)",
     "DJANGO_MIGRATIONS_DIR"   = "./config",
 
     "DJANGO_RATE_LIMIT"         = local.is_dev ? null : "${local.secret_prefix}django-rate-limit)",

--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -64,27 +64,27 @@ resource "azurerm_linux_web_app" "main" {
     "WEBSITES_ENABLE_APP_SERVICE_STORAGE" = "false",
     "WEBSITES_PORT"                       = "8000",
 
-    "ANALYTICS_KEY" = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=analytics-key)",
+    "ANALYTICS_KEY" = local.is_dev ? null : "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=analytics-key)",
 
     # Django settings
-    "DJANGO_ADMIN"            = local.is_prod ? "false" : "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-admin)",
+    "DJANGO_ADMIN"            = (local.is_prod || local.is_test) ? null : "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-admin)",
     "DJANGO_ALLOWED_HOSTS"    = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-allowed-hosts)",
-    "DJANGO_DEBUG"            = local.is_prod ? "false" : "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-debug)",
+    "DJANGO_DEBUG"            = local.is_prod ? null : "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-debug)",
     "DJANGO_LOAD_SAMPLE_DATA" = "false",
     "DJANGO_LOG_LEVEL"        = "DEBUG",
     "DJANGO_MIGRATIONS_DIR"   = "./config",
 
-    "DJANGO_RATE_LIMIT"         = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-rate-limit)",
-    "DJANGO_RATE_LIMIT_METHODS" = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-rate-limit-methods)",
-    "DJANGO_RATE_LIMIT_PERIOD"  = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-rate-limit-period)",
+    "DJANGO_RATE_LIMIT"         = local.is_dev ? null : "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-rate-limit)",
+    "DJANGO_RATE_LIMIT_METHODS" = local.is_dev ? null : "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-rate-limit-methods)",
+    "DJANGO_RATE_LIMIT_PERIOD"  = local.is_dev ? null : "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-rate-limit-period)",
 
-    "DJANGO_RECAPTCHA_SECRET_KEY" = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-recaptcha-secret-key)",
-    "DJANGO_RECAPTCHA_SITE_KEY"   = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-recaptcha-site-key)",
+    "DJANGO_RECAPTCHA_SECRET_KEY" = local.is_dev ? null : "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-recaptcha-secret-key)",
+    "DJANGO_RECAPTCHA_SITE_KEY"   = local.is_dev ? null : "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-recaptcha-site-key)",
 
     "DJANGO_SECRET_KEY"      = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-secret-key)",
     "DJANGO_TRUSTED_ORIGINS" = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-trusted-origins)",
 
-    "HEALTHCHECK_USER_AGENTS" = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=healthcheck-user-agents)",
+    "HEALTHCHECK_USER_AGENTS" = local.is_dev ? null : "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=healthcheck-user-agents)",
 
     # Sentry
     "SENTRY_DSN"         = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=sentry-dsn)",

--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -61,6 +61,32 @@ resource "azurerm_linux_web_app" "main" {
     "WEBSITES_ENABLE_APP_SERVICE_STORAGE" = "false",
     "WEBSITES_PORT"                       = "8000",
 
+    "ANALYTICS_KEY" = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=analytics-key)",
+
+    # Django settings
+    "DJANGO_ADMIN"            = local.is_prod ? "false" : "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-admin)",
+    "DJANGO_ALLOWED_HOSTS"    = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-allowed-hosts)",
+    "DJANGO_DEBUG"            = local.is_prod ? "false" : "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-debug)",
+    "DJANGO_LOAD_SAMPLE_DATA" = "false",
+    "DJANGO_LOG_LEVEL"        = "DEBUG",
+    "DJANGO_MIGRATIONS_DIR"   = "./config",
+
+    "DJANGO_RATE_LIMIT"           = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-rate-limit)",
+    "DJANGO_RATE_LIMIT_METHODS"   = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-rate-limit-methods)",
+    "DJANGO_RATE_LIMIT_PERIOD"    = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-rate-limit-period)",
+
+    "DJANGO_RECAPTCHA_SECRET_KEY" = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-recaptcha-secret-key)",
+    "DJANGO_RECAPTCHA_SITE_KEY"   = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-recaptcha-site-key)",
+
+    "DJANGO_SECRET_KEY"           = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-secret-key)",
+    "DJANGO_TRUSTED_ORIGINS"      = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-trusted-origins)",
+
+    "HEALTHCHECK_USER_AGENTS" = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=healthcheck-user-agents)",
+
+    # Sentry
+    "SENTRY_DSN" = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=sentry-dsn)",
+    "SENTRY_ENVIRONMENT" = local.env_name,
+
     # Environment variables for data migration
     "MST_SENIOR_GROUP_ID"                            = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=mst-senior-group-id)",
     "MST_COURTESY_CARD_GROUP_ID"                     = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=mst-courtesy-card-group-id)"

--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -54,6 +54,9 @@ resource "azurerm_linux_web_app" "main" {
   }
 
   app_settings = {
+    # app setting used solely for refreshing secrets - see https://github.com/MicrosoftDocs/azure-docs/issues/79855#issuecomment-1265664801
+    "change_me_to_refresh_secrets" = "change me in the portal to refresh all secrets",
+
     "DOCKER_ENABLE_CI"                    = "true",
     "DOCKER_REGISTRY_SERVER_URL"          = "https://ghcr.io/",
     "WEBSITE_HTTPLOGGING_RETENTION_DAYS"  = "99999",
@@ -71,20 +74,20 @@ resource "azurerm_linux_web_app" "main" {
     "DJANGO_LOG_LEVEL"        = "DEBUG",
     "DJANGO_MIGRATIONS_DIR"   = "./config",
 
-    "DJANGO_RATE_LIMIT"           = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-rate-limit)",
-    "DJANGO_RATE_LIMIT_METHODS"   = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-rate-limit-methods)",
-    "DJANGO_RATE_LIMIT_PERIOD"    = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-rate-limit-period)",
+    "DJANGO_RATE_LIMIT"         = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-rate-limit)",
+    "DJANGO_RATE_LIMIT_METHODS" = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-rate-limit-methods)",
+    "DJANGO_RATE_LIMIT_PERIOD"  = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-rate-limit-period)",
 
     "DJANGO_RECAPTCHA_SECRET_KEY" = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-recaptcha-secret-key)",
     "DJANGO_RECAPTCHA_SITE_KEY"   = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-recaptcha-site-key)",
 
-    "DJANGO_SECRET_KEY"           = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-secret-key)",
-    "DJANGO_TRUSTED_ORIGINS"      = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-trusted-origins)",
+    "DJANGO_SECRET_KEY"      = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-secret-key)",
+    "DJANGO_TRUSTED_ORIGINS" = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=django-trusted-origins)",
 
     "HEALTHCHECK_USER_AGENTS" = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=healthcheck-user-agents)",
 
     # Sentry
-    "SENTRY_DSN" = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=sentry-dsn)",
+    "SENTRY_DSN"         = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=sentry-dsn)",
     "SENTRY_ENVIRONMENT" = local.env_name,
 
     # Environment variables for data migration

--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -54,7 +54,12 @@ resource "azurerm_linux_web_app" "main" {
   }
 
   app_settings = {
+    "DOCKER_ENABLE_CI"                    = "true",
+    "DOCKER_REGISTRY_SERVER_URL"          = "https://ghcr.io/",
+    "WEBSITE_HTTPLOGGING_RETENTION_DAYS"  = "99999",
+    "WEBSITE_TIME_ZONE"                   = "America/Los_Angeles",
     "WEBSITES_ENABLE_APP_SERVICE_STORAGE" = "false",
+    "WEBSITES_PORT"                       = "8000",
 
     # Environment variables for data migration
     "MST_SENIOR_GROUP_ID"                            = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName=mst-senior-group-id)",

--- a/terraform/environment.tf
+++ b/terraform/environment.tf
@@ -6,6 +6,7 @@ locals {
   env_letter          = upper(substr(local.env_name, 0, 1))
   subscription_letter = local.is_prod ? "P" : "D"
   hostname            = local.is_prod ? "benefits.calitp.org" : "${local.env_name}-benefits.calitp.org"
+  secret_prefix       = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-CALITP-${local.env_letter}-001;SecretName="
 }
 
 data "azurerm_resource_group" "main" {

--- a/terraform/environment.tf
+++ b/terraform/environment.tf
@@ -1,5 +1,7 @@
 locals {
   is_prod             = terraform.workspace == "default"
+  is_test             = terraform.workspace == "test"
+  is_dev              = !(local.is_prod || local.is_test)
   env_name            = local.is_prod ? "prod" : terraform.workspace
   env_letter          = upper(substr(local.env_name, 0, 1))
   subscription_letter = local.is_prod ? "P" : "D"

--- a/terraform/secrets/read.sh
+++ b/terraform/secrets/read.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 <D|T|P> <secret_name>"
+  exit 1
+fi
+
+env=$1
+secret_name=$2
+
+az keyvault secret show --vault-name "KV-CDT-PUB-CALITP-$env-001" --name "$secret_name"


### PR DESCRIPTION
Closes #1116 and closes #1241

This PR specifies our app settings as code. Settings with secret values make use of Azure Key Vault references.

### Current status of secrets in Key Vault
All data migration secrets have been added to the Key Vaults for `dev`, `test`, and `prod`.
The settings that used to be manually configured on our app services (e.g. Django settings, Azure Docker settings, etc.) have been added to the `dev` Key Vault. 

### Todo
 - [x] Add the manually configured app settings to Key Vaults for `test` and `prod`.
 - [x] Figure out how to conditionally set app settings. For example, `dev` does not need the `HEALTHCHECK_USER_AGENTS` app setting.
 - [x] Update documentation