### PR TITLE
chore: add incident response checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/incident-response.md
+++ b/.github/ISSUE_TEMPLATE/incident-response.md
@@ -1,0 +1,59 @@
+---
+name: Incident response
+about: Use to track the steps that should happen during an incident, such as a data breach or unexpected downtime, even if it's just a suspicion.
+---
+
+_**Do not put sensitive information in this issue or Slack.** Use a file on Google Drive with access restricted._
+
+**Severity:** _High/Medium/Low_
+
+## Initiate
+
+1. [x] Create an issue from this template.
+1. [ ] Declare an incident in the relevant Slack channel, such as [#benefits-general][benefits-general].
+   - Include brief details about the concern.
+1. [ ] Start a video call.
+1. [ ] Share a link to the video call in Slack, asking relevant parties to join.
+1. [ ] Delegate subsequent tasks.
+
+## Assess
+
+- [ ] Determine the impact.
+- [ ] Assign the severity above:
+  - **High:** Possible/confirmed breach of sensitive information, such as production system credentials or personally-identifiable information (PII)
+  - **Medium:** Full Benefits downtime for more than 30 minutes
+  - **Low:** Partial service degredation
+
+### Medium/High incidents
+
+- [ ] Notify [#benefits-general][benefits-general].
+- [ ] If the incident is lasting more than 60 minutes or their customers' data has been breached, notify the impacted transit agencies.
+- [ ] If it's believed to be an ongoing attack (such as DDoS), notify DevSecOps.
+
+## Remediate
+
+- [ ] Take notes in the Slack thread.
+- [ ] Check the [troubleshooting documentation](https://docs.calitp.org/benefits/deployment/troubleshooting/) for relevant information.
+- [ ] Post in the Slack thread when the incident has been resolved.
+- [ ] Retain any relevant materials.
+
+### Medium/High incidents
+
+- [ ] Provide updates to [#benefits-general][benefits-general] every 30 minutes.
+- [ ] [Release hotfixes](https://docs.calitp.org/benefits/deployment/release/) as necessary.
+- [ ] Notify [#benefits-general][benefits-general] when the incident has been resolved.
+
+## Follow-up
+
+- [ ] For Medium/High incidents, write an incident report. [Past examples.](https://drive.google.com/drive/search?q=parent:1f_UhA3958lrRQ7IVf0mGSpt7A9rSoUQm%20title:incident)
+  1. [ ] Write a draft.
+     - Link to relevant Slack messages, etc.
+  1. [ ] Get thumbs-up from those involved in the incident.
+  1. [ ] Share with relevant stakeholders.
+- [ ] Create issues for follow-up tasks, such as:
+  - Adding monitoring
+  - Updating documentation
+  - Having the system fail more gracefully
+  - Scheduling a retrospective/post-mortem
+
+[benefits-general]: https://cal-itp.slack.com/archives/c013w8ruamu

--- a/.github/ISSUE_TEMPLATE/incident-response.md
+++ b/.github/ISSUE_TEMPLATE/incident-response.md
@@ -22,7 +22,7 @@ _**Do not put sensitive information in this issue or Slack.** Use a file on Goog
 - [ ] Assign the severity above:
   - **High:** Possible/confirmed breach of sensitive information, such as production system credentials or personally-identifiable information (PII)
   - **Medium:** Full Benefits downtime for more than 30 minutes
-  - **Low:** Partial service degredation
+  - **Low:** Partial service degredation, zero-day vulnerabilities, data loss
 
 ### Medium/High incidents
 
@@ -32,7 +32,7 @@ _**Do not put sensitive information in this issue or Slack.** Use a file on Goog
 
 ## Remediate
 
-- [ ] Take notes in the Slack thread.
+- [ ] Delegate someone to take notes in the Slack thread.
 - [ ] Check the [troubleshooting documentation](https://docs.calitp.org/benefits/deployment/troubleshooting/) for relevant information.
 - [ ] Post in the Slack thread when the incident has been resolved.
 - [ ] Retain any relevant materials.
@@ -45,7 +45,7 @@ _**Do not put sensitive information in this issue or Slack.** Use a file on Goog
 
 ## Follow-up
 
-- [ ] For Medium/High incidents, write an incident report. [Past examples.](https://drive.google.com/drive/search?q=parent:1f_UhA3958lrRQ7IVf0mGSpt7A9rSoUQm%20title:incident)
+- [ ] For Medium/High incidents, write an incident report. [Past examples.](https://drive.google.com/drive/folders/1MVixX2jFioaSiM3xtGB15rKyU99fScqH)
   1. [ ] Write a draft.
      - Link to relevant Slack messages, etc.
   1. [ ] Get thumbs-up from those involved in the incident.
@@ -56,4 +56,4 @@ _**Do not put sensitive information in this issue or Slack.** Use a file on Goog
   - Having the system fail more gracefully
   - Scheduling a retrospective/post-mortem
 
-[benefits-general]: https://cal-itp.slack.com/archives/c013w8ruamu
+[benefits-general]: https://cal-itp.slack.com/archives/C013W8RUAMU


### PR DESCRIPTION
Closes #833.

I kept it somewhat minimal, leaving out formalities such as the [assigning of roles](https://handbook.login.gov/articles/secops-incident-response-guide.html#initiate). I also tried to keep instructions in the issue and short, rather than creating yet another page that needs to be read.