### PR TITLE
Refactor: delete now unneeded Azure file mount

### DIFF
--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -44,15 +44,6 @@ resource "azurerm_linux_web_app" "main" {
     }
   }
 
-  storage_account {
-    access_key   = azurerm_storage_account.main.primary_access_key
-    account_name = azurerm_storage_account.main.name
-    name         = "benefits-config"
-    type         = "AzureBlob"
-    share_name   = azurerm_storage_container.config.name
-    mount_path   = "/home/calitp/app/config"
-  }
-
   app_settings = {
     # app setting used solely for refreshing secrets - see https://github.com/MicrosoftDocs/azure-docs/issues/79855#issuecomment-1265664801
     "change_me_to_refresh_secrets" = "change me in the portal to refresh all secrets",


### PR DESCRIPTION
Part of #1244 

This PR removes the file mount path from the App Service.

I checked over documentation, and it does not contain any mention of the blob container or file mount path anywhere.