### PR TITLE
Docs: configuration data uses env vars/secrets

### DIFF
--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -13,6 +13,8 @@ startup.
 
 The model objects defined in the data migration file are also loaded into and seed Django's database at application startup time.
 
+ See the [Setting secrets](../deployment/secrets) section for how to set secret values for a deployment.
+
 ## Django settings
 
 !!! example "Settings file"


### PR DESCRIPTION
Closes #1245 

This PR adds a line to the Configuration README so that the link between secrets and configuration is more obvious.

Not much change was needed here because the documentation updates from #1294 and #1311 cover the new workflow thoroughly.

Let me know though if there is anything that we want more documentation on.