### PR TITLE
fix(url): fix broken link in docs

### DIFF
--- a/docs/use-cases/courtesy-cards.md
+++ b/docs/use-cases/courtesy-cards.md
@@ -33,7 +33,7 @@ flowchart LR
 Notes:
 
 - [Eligibility Server documentation](https://docs.calitp.org/eligibility-server/)
-- [More details about the Benefits architecture](../deployment/infrastructure/#architecture)
+- [More details about the Benefits architecture](../../deployment/infrastructure/#architecture)
 - Velocity is the system MST uses to manage Courtesy Cards
 
 ## Process


### PR DESCRIPTION
I noticed the internal link to the Deployment: Infrastructure page is broken on the Courtesy Card use case page https://docs.calitp.org/benefits/use-cases/courtesy-cards/

<img width="1495" alt="image" src="https://user-images.githubusercontent.com/3673236/230496561-d59819e7-1a44-499c-ac7a-bfefbb3fe092.png">

Link should go tohttps://docs.calitp.org/benefits/deployment/infrastructure/#architecture instead of https://docs.calitp.org/benefits/use-cases/deployment/infrastructure/#architecture


