### PR TITLE
Fix/docker m1

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM benefits_client:latest
+FROM --platform=linux/amd64 benefits_client:latest
 
 # install devcontainer requirements
 COPY .devcontainer/requirements.txt .devcontainer/requirements.txt

--- a/appcontainer/Dockerfile
+++ b/appcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/cal-itp/docker-python-web:main
+FROM --platform=linux/amd64 ghcr.io/cal-itp/docker-python-web:main
 
 # install python dependencies
 COPY appcontainer/requirements.txt requirements.txt

--- a/compose.yml
+++ b/compose.yml
@@ -38,6 +38,7 @@ services:
   server:
     image: ghcr.io/cal-itp/eligibility-server:dev
     env_file: .devcontainer/server/.env.server
+    platform: linux/amd64
     ports:
       - "8000"
     volumes:

--- a/docs/use-cases/college.md
+++ b/docs/use-cases/college.md
@@ -1,4 +1,4 @@
-# College discount
+# College Discount
 
 We have another potential transit discount use case, which is for students/faculty/staff from the Monterey-Salinas Transit (MST) area. We will be taking [the existing program](https://mst.org/fares/overview/) where students from certain schools ride free, expanding it to faculty and staff in some cases, and allowing those riders to enroll their contactless bank (credit/debit) cards for half-price (50%) discounts during fall and winter breaks.
 

--- a/docs/use-cases/college.md
+++ b/docs/use-cases/college.md
@@ -1,4 +1,4 @@
-# College Discount
+# College discount
 
 We have another potential transit discount use case, which is for students/faculty/staff from the Monterey-Salinas Transit (MST) area. We will be taking [the existing program](https://mst.org/fares/overview/) where students from certain schools ride free, expanding it to faculty and staff in some cases, and allowing those riders to enroll their contactless bank (credit/debit) cards for half-price (50%) discounts during fall and winter breaks.
 


### PR DESCRIPTION
Using this PR to test and log issues.

## Prepping my machine
- Updated to latest Mac OS and X Code
- Updated to latest Docker: `Docker version 20.10.24, build 297e128`
- Updated to latest Docker Compose: Docker Compose version v2.17.2
- Docker settings: Docker Compose V2 is turned on.
- Pruned everything from Docker
- Reset Docker to factory settings
- Restarted computer multiple times
- Deleted all branches from `benefits`
- Ensured I am on `dev`, _not_ `main` 🙃 
- Re-created MobiMart from scratch, MobiMart devcontainer works fine!
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/230528976-6b180271-2249-468a-ae14-b94852a8f931.png">


## How I arrived here
### Eligibility Server
- Running `bin/build.sh` fails at the Server step b/c of https://github.com/cal-itp/eligibility-server/issues/247
- Added this line https://github.com/cal-itp/benefits/pull/1353/files#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588R41
- Re-ran `docker compose build --no-cache client` successfully

### Benefits dev container installation
- https://compilerla.slack.com/archives/C02GQ7AJXQE/p1664913246444999
- https://github.com/cal-itp/benefits/issues/989
- https://github.com/cal-itp/benefits/pull/1027 fix no longer working.
- Open VS Code. Then tried to open Dev Container (no cache mode). Fails quickly, with this error at the benefits_client step:
`bash
failed to solve: rpc error: code = Unknown desc = failed to solve with frontend dockerfile.v0: failed to create LLB definition: pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed
`

- https://github.com/moby/moby/issues/42893
- https://github.com/docker/cli/issues/3286
- https://forums.docker.com/t/not-finding-local-unprefixed-docker-image-in-the-local-cache/113297/2
- Making this change https://github.com/cal-itp/benefits/pull/1353/commits/4ef33da6423c1e35c0ffd8ddb0597582f61f55c4, then running `docker compose build --no-cache client`, then Re-open in Container without Cache, worked.

### Benefits dev container usage
- Installs somewhat slowly
- Took forever to get all the VS Code extensions downloaded
- Tried to open Debugger, but it said I need to reload VS Code to get Pylance to run correctly.
- Restarted VS Code.
- Tried Debugger.
- Works. App works. I can edit files. I can commit and get pre-commit running.
- The main terminal panel did not allow me to Git push on first try.
- Using the Git sidebar extension _did_ work though - - that's how I got this branch up here.
- After that, creating second terminal window also worked...

#### Does not work

<img width="1479" alt="image" src="https://user-images.githubusercontent.com/3673236/230527385-c3a137cf-212b-48bc-8063-d8ecf52be997.png">

```bash
calitp@5f89e5e89bfe:~/app$ git push --set-upstream origin fix/docker-m1
Unable to connect to VS Code Dev Containers extension.
Error in request Error: connect ENOENT /tmp/vscode-remote-containers-ipc-76f3bf70-254c-4d77-a692-0ae1d6caecdc.sock
    at PipeConnectWrap.afterConnect [as oncomplete] (node:net:1157:16) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'connect',
  address: '/tmp/vscode-remote-containers-ipc-76f3bf70-254c-4d77-a692-0ae1d6caecdc.sock'
}
Unable to connect to VS Code Dev Containers extension.
Error in request Error: connect ENOENT /tmp/vscode-remote-containers-ipc-76f3bf70-254c-4d77-a692-0ae1d6caecdc.sock
    at PipeConnectWrap.afterConnect [as oncomplete] (node:net:1157:16) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'connect',
  address: '/tmp/vscode-remote-containers-ipc-76f3bf70-254c-4d77-a692-0ae1d6caecdc.sock'
}
/vscode/vscode-server/bin/linux-arm64/b7886d7461186a5eac768481578c1d7ca80e2d21/extensions/git/dist/askpass.sh: 3: /vscode/vscode-server/bin/linux-arm64/b7886d7461186a5eac768481578c1d7ca80e2d21/node: not found
/vscode/vscode-server/bin/linux-arm64/b7886d7461186a5eac768481578c1d7ca80e2d21/extensions/git/dist/askpass.sh: 3: /vscode/vscode-server/bin/linux-arm64/b7886d7461186a5eac768481578c1d7ca80e2d21/node: not found
Unable to connect to VS Code Dev Containers extension.
Error in request Error: connect ENOENT /tmp/vscode-remote-containers-ipc-76f3bf70-254c-4d77-a692-0ae1d6caecdc.sock
    at PipeConnectWrap.afterConnect [as oncomplete] (node:net:1157:16) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'connect',
  address: '/tmp/vscode-remote-containers-ipc-76f3bf70-254c-4d77-a692-0ae1d6caecdc.sock'
}
Unable to connect to VS Code Dev Containers extension.
Error in request Error: connect ENOENT /tmp/vscode-remote-containers-ipc-76f3bf70-254c-4d77-a692-0ae1d6caecdc.sock
    at PipeConnectWrap.afterConnect [as oncomplete] (node:net:1157:16) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'connect',
  address: '/tmp/vscode-remote-containers-ipc-76f3bf70-254c-4d77-a692-0ae1d6caecdc.sock'
}
remote: No anonymous write access.
fatal: Authentication failed for 'https://github.com/cal-itp/benefits/'
calitp@5f89e5e89bfe:~/app$ git push -u origin fix/docker-m1
Unable to connect to VS Code Dev Containers extension.
Error in request Error: connect ENOENT /tmp/vscode-remote-containers-ipc-76f3bf70-254c-4d77-a692-0ae1d6caecdc.sock
    at PipeConnectWrap.afterConnect [as oncomplete] (node:net:1157:16) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'connect',
  address: '/tmp/vscode-remote-containers-ipc-76f3bf70-254c-4d77-a692-0ae1d6caecdc.sock'
}
Unable to connect to VS Code Dev Containers extension.
Error in request Error: connect ENOENT /tmp/vscode-remote-containers-ipc-76f3bf70-254c-4d77-a692-0ae1d6caecdc.sock
    at PipeConnectWrap.afterConnect [as oncomplete] (node:net:1157:16) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'connect',
  address: '/tmp/vscode-remote-containers-ipc-76f3bf70-254c-4d77-a692-0ae1d6caecdc.sock'
}
/vscode/vscode-server/bin/linux-arm64/b7886d7461186a5eac768481578c1d7ca80e2d21/extensions/git/dist/askpass.sh: 3: /vscode/vscode-server/bin/linux-arm64/b7886d7461186a5eac768481578c1d7ca80e2d21/node: not found
/vscode/vscode-server/bin/linux-arm64/b7886d7461186a5eac768481578c1d7ca80e2d21/extensions/git/dist/askpass.sh: 3: /vscode/vscode-server/bin/linux-arm64/b7886d7461186a5eac768481578c1d7ca80e2d21/node: not found
Unable to connect to VS Code Dev Containers extension.
Error in request Error: connect ENOENT /tmp/vscode-remote-containers-ipc-76f3bf70-254c-4d77-a692-0ae1d6caecdc.sock
    at PipeConnectWrap.afterConnect [as oncomplete] (node:net:1157:16) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'connect',
  address: '/tmp/vscode-remote-containers-ipc-76f3bf70-254c-4d77-a692-0ae1d6caecdc.sock'
}
Unable to connect to VS Code Dev Containers extension.
Error in request Error: connect ENOENT /tmp/vscode-remote-containers-ipc-76f3bf70-254c-4d77-a692-0ae1d6caecdc.sock
    at PipeConnectWrap.afterConnect [as oncomplete] (node:net:1157:16) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'connect',
  address: '/tmp/vscode-remote-containers-ipc-76f3bf70-254c-4d77-a692-0ae1d6caecdc.sock'
}
remote: No anonymous write access.
fatal: Authentication failed for 'https://github.com/cal-itp/benefits/'
```

#### Does work
<img width="762" alt="image" src="https://user-images.githubusercontent.com/3673236/230527438-cf39ef2a-94cd-4cea-abc0-951798666e56.png">

#### Tested
- [x] `git pull`
- [x] `git commit`, pre-commit
- [x] `bin/makemessages.sh`
- [x] `bin/makemigrations.sh`
- [x] `tests/pytest.run.sh`