### PR TITLE
Fix: Configurable traces sampling rate for Sentry

### DIFF
--- a/benefits/sentry.py
+++ b/benefits/sentry.py
@@ -63,10 +63,12 @@ def get_denylist():
 
 
 def get_traces_sample_rate():
-    rate = float(os.environ.get("SENTRY_TRACES_SAMPLE_RATE", "0.0"))
-
-    if rate < 0.0 or rate > 1.0:
-        raise ValueError("SENTRY_TRACES_SAMPLE_RATE must be a float in [0.0, 1.0]")
+    try:
+        rate = float(os.environ.get("SENTRY_TRACES_SAMPLE_RATE", "0.0"))
+        if rate < 0.0 or rate > 1.0:
+            rate = 0.0
+    except ValueError:
+        rate = 0.0
 
     return rate
 

--- a/benefits/sentry.py
+++ b/benefits/sentry.py
@@ -62,6 +62,15 @@ def get_denylist():
     return denylist
 
 
+def get_traces_sample_rate():
+    rate = float(os.environ.get("SENTRY_TRACES_SAMPLE_RATE", "0.0"))
+
+    if rate < 0.0 or rate > 1.0:
+        raise ValueError("SENTRY_TRACES_SAMPLE_RATE must be a float in [0.0, 1.0]")
+
+    return rate
+
+
 def configure():
     SENTRY_DSN = os.environ.get("SENTRY_DSN")
     if SENTRY_DSN:
@@ -74,7 +83,7 @@ def configure():
             integrations=[
                 DjangoIntegration(),
             ],
-            traces_sample_rate=1.0,
+            traces_sample_rate=get_traces_sample_rate(),
             environment=SENTRY_ENVIRONMENT,
             release=release,
             in_app_include=["benefits"],

--- a/benefits/sentry.py
+++ b/benefits/sentry.py
@@ -1,3 +1,4 @@
+import logging
 import shutil
 import os
 import subprocess
@@ -8,6 +9,7 @@ from sentry_sdk.scrubber import EventScrubber, DEFAULT_DENYLIST
 
 from benefits import VERSION
 
+logger = logging.getLogger(__name__)
 
 SENTRY_ENVIRONMENT = os.environ.get("SENTRY_ENVIRONMENT", "local")
 SENTRY_CSP_REPORT_URI = None
@@ -66,8 +68,12 @@ def get_traces_sample_rate():
     try:
         rate = float(os.environ.get("SENTRY_TRACES_SAMPLE_RATE", "0.0"))
         if rate < 0.0 or rate > 1.0:
+            logger.warn("SENTRY_TRACES_SAMPLE_RATE was not in the range [0.0, 1.0], defaulting to 0.0")
             rate = 0.0
+        else:
+            logger.info(f"SENTRY_TRACES_SAMPLE_RATE set to: {rate}")
     except ValueError:
+        logger.warn("SENTRY_TRACES_SAMPLE_RATE did not parse to float, defaulting to 0.0")
         rate = 0.0
 
     return rate
@@ -77,7 +83,7 @@ def configure():
     SENTRY_DSN = os.environ.get("SENTRY_DSN")
     if SENTRY_DSN:
         release = get_release()
-        print(f"Enabling Sentry for environment '{SENTRY_ENVIRONMENT}', release '{release}'...")
+        logger.info(f"Enabling Sentry for environment '{SENTRY_ENVIRONMENT}', release '{release}'...")
 
         # https://docs.sentry.io/platforms/python/configuration/
         sentry_sdk.init(
@@ -99,4 +105,4 @@ def configure():
         global SENTRY_CSP_REPORT_URI
         SENTRY_CSP_REPORT_URI = os.environ.get("SENTRY_REPORT_URI", "")
     else:
-        print("SENTRY_DSN not set, so won't send events")
+        logger.info("SENTRY_DSN not set, so won't send events")

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -187,5 +187,15 @@ Collect information on Content-Security-Policy (CSP) violations. Read more about
 
 To enable report collection, set this env var to the authenticated Sentry endpoint.
 
+### `SENTRY_TRACES_SAMPLE_RATE`
+
+!!! tldr "Sentry docs"
+
+    [`traces_sample_rate`](https://docs.sentry.io/platforms/python/configuration/sampling/#configuring-the-transaction-sample-rate)
+
+Control the volume of transactions sent to Sentry. Value must be a float in the range `[0.0, 1.0]`.
+
+The default is `0.0` (i.e. no transactions are tracked).
+
 [app-service-config]: https://docs.microsoft.com/en-us/azure/app-service/configure-common?tabs=portal
 [getting-started_create-env]: ../getting-started/README.md#create-an-environment-file

--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -76,9 +76,10 @@ resource "azurerm_linux_web_app" "main" {
     "HEALTHCHECK_USER_AGENTS" = local.is_dev ? null : "${local.secret_prefix}healthcheck-user-agents)",
 
     # Sentry
-    "SENTRY_DSN"         = "${local.secret_prefix}sentry-dsn)",
-    "SENTRY_ENVIRONMENT" = local.env_name,
-    "SENTRY_REPORT_URI"  = "${local.secret_prefix}sentry-report-uri)",
+    "SENTRY_DSN"                = "${local.secret_prefix}sentry-dsn)",
+    "SENTRY_ENVIRONMENT"        = local.env_name,
+    "SENTRY_REPORT_URI"         = "${local.secret_prefix}sentry-report-uri)",
+    "SENTRY_TRACES_SAMPLE_RATE" = "${local.secret_prefix}sentry-traces-sample-rate)",
 
     # Environment variables for data migration
     "MST_SENIOR_GROUP_ID"                                  = "${local.secret_prefix}mst-senior-group-id)",

--- a/tests/pytest/test_sentry.py
+++ b/tests/pytest/test_sentry.py
@@ -69,3 +69,11 @@ def test_traces_sample_rate_invalid_range(mocker, env_rate):
 
     with pytest.raises(ValueError, match=r"SENTRY_TRACES_SAMPLE_RATE"):
         get_traces_sample_rate()
+
+
+@pytest.mark.parametrize("env_rate", ["zero", "one", "huh?"])
+def test_traces_sample_rate_float(mocker, env_rate):
+    mocker.patch("benefits.sentry.os.environ.get", return_value=env_rate)
+
+    with pytest.raises(ValueError, match=r"could not convert string to float"):
+        get_traces_sample_rate()

--- a/tests/pytest/test_sentry.py
+++ b/tests/pytest/test_sentry.py
@@ -1,7 +1,10 @@
-from benefits import VERSION
-from benefits.sentry import get_release
 import os
 from tempfile import NamedTemporaryFile
+
+import pytest
+
+from benefits import VERSION
+from benefits.sentry import get_release, get_traces_sample_rate
 
 
 def test_git(mocker):
@@ -45,3 +48,24 @@ def test_git_no_repo(mocker):
     mocker.patch("benefits.sentry.get_sha_file_path", return_value=file_path)
 
     assert get_release() == VERSION
+
+
+def test_traces_sample_rate_default():
+    rate = get_traces_sample_rate()
+    assert rate == 0.0
+
+
+@pytest.mark.parametrize("env_rate", ["0.0", "0.25", "0.99", "1.0"])
+def test_traces_sample_rate_valid_range(mocker, env_rate):
+    mocker.patch("benefits.sentry.os.environ.get", return_value=env_rate)
+
+    rate = get_traces_sample_rate()
+    assert rate == float(env_rate)
+
+
+@pytest.mark.parametrize("env_rate", ["-1.0", "-0.1", "1.01", "2.0"])
+def test_traces_sample_rate_invalid_range(mocker, env_rate):
+    mocker.patch("benefits.sentry.os.environ.get", return_value=env_rate)
+
+    with pytest.raises(ValueError, match=r"SENTRY_TRACES_SAMPLE_RATE"):
+        get_traces_sample_rate()

--- a/tests/pytest/test_sentry.py
+++ b/tests/pytest/test_sentry.py
@@ -67,13 +67,13 @@ def test_traces_sample_rate_valid_range(mocker, env_rate):
 def test_traces_sample_rate_invalid_range(mocker, env_rate):
     mocker.patch("benefits.sentry.os.environ.get", return_value=env_rate)
 
-    with pytest.raises(ValueError, match=r"SENTRY_TRACES_SAMPLE_RATE"):
-        get_traces_sample_rate()
+    rate = get_traces_sample_rate()
+    assert rate == 0.0
 
 
 @pytest.mark.parametrize("env_rate", ["zero", "one", "huh?"])
-def test_traces_sample_rate_float(mocker, env_rate):
+def test_traces_sample_rate_not_float(mocker, env_rate):
     mocker.patch("benefits.sentry.os.environ.get", return_value=env_rate)
 
-    with pytest.raises(ValueError, match=r"could not convert string to float"):
-        get_traces_sample_rate()
+    rate = get_traces_sample_rate()
+    assert rate == 0.0


### PR DESCRIPTION
Related to #1359 and this [Slack thread](https://cal-itp.slack.com/archives/C044UUY78TB/p1681423801273219), more work to reduce unnecessary traffic we send to Sentry.

This PR introduces an environment-specific configuration for the Sentry [`traces_sample_rate`](https://docs.sentry.io/platforms/python/configuration/sampling/#configuring-the-transaction-sample-rate) setting using our standard environment variable / key vault pattern.

The new default is `0.0`, so this has to be turned on explicitly. Before we were hard-coding to `1.0` (i.e. send 100% of transactions) in all environments.

This is temporarily on top of #1358 because that PR also introduced a new Sentry config, though otherwise unrelated.