### PR TITLE
Fix: allow unsafe-inline for style-src

### DIFF
--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -315,6 +315,7 @@ if RECAPTCHA_ENABLED:
 
 CSP_STYLE_SRC = [
     "'self'",
+    "'unsafe-inline'",
     "https://california.azureedge.net/",
     "https://fonts.googleapis.com/css",
 ]


### PR DESCRIPTION
Accidentally removed as part of #1358, but this is needed for payment processor overlay window.

According to https://csp.withgoogle.com/, the more critical piece of strict CSP is `script-src`, which disallowed `unsafe-inline` as part of #1358.