### PR TITLE
Refactor: agency links context

### DIFF
--- a/benefits/core/templates/core/help.html
+++ b/benefits/core/templates/core/help.html
@@ -66,15 +66,13 @@
     </div>
     {% endif %}
 
-    {% for back_button in page.buttons %}
-      {% if "btn-primary" in back_button.classes %}
-        <div class="row pt-8">
-          <div class="col-lg-3 offset-lg-8 col-8 offset-2">
-            {% include "core/includes/button.html" with button=back_button %}
-          </div>
-        </div>
-      {% endif %}
-    {% endfor %}
+    {% if back_button %}
+    <div class="row pt-8">
+      <div class="col-lg-3 offset-lg-8 col-8 offset-2">
+        {% include "core/includes/button.html" with button=back_button %}
+      </div>
+    </div>
+    {% endif %}
 
     <div class="row justify-content-center">
       <div class="col-8 col-lg-10 mt-4">

--- a/benefits/core/templates/core/help.html
+++ b/benefits/core/templates/core/help.html
@@ -60,9 +60,11 @@
       </div>
     </div>
 
+    {% if agency_links %}
     <div class="row justify-content-center">
-      <div class="col-10">{% include "core/includes/agency-links.html" with buttons=page.buttons %}</div>
+      <div class="col-10">{% include "core/includes/agency-links.html" with buttons=agency_links %}</div>
     </div>
+    {% endif %}
 
     {% for back_button in page.buttons %}
       {% if "btn-primary" in back_button.classes %}

--- a/benefits/core/templates/core/includes/agency-links.html
+++ b/benefits/core/templates/core/includes/agency-links.html
@@ -1,11 +1,9 @@
 {% for agency_button in buttons %}
-  {% if "agency" in agency_button.classes %}
-    {% if agency_button.label %}<label class="mt-4 d-block fs-base ls-base">{{ agency_button.label }}</label>{% endif %}
-    <a class="d-table fs-base ls-base"
-       {% if agency_button.target %}target="{{ agency_button.target }}"{% endif %}
-       {% if agency_button.rel %}rel="{{ agency_button.rel }}"{% endif %}
-       href="{{ agency_button.url }}">
-      {{ agency_button.text }}
-    </a>
-  {% endif %}
+  {% if agency_button.label %}<label class="mt-4 d-block fs-base ls-base">{{ agency_button.label }}</label>{% endif %}
+  <a class="d-table fs-base ls-base"
+      {% if agency_button.target %}target="{{ agency_button.target }}"{% endif %}
+      {% if agency_button.rel %}rel="{{ agency_button.rel }}"{% endif %}
+      href="{{ agency_button.url }}">
+    {{ agency_button.text }}
+  </a>
 {% endfor %}

--- a/benefits/core/viewmodels.py
+++ b/benefits/core/viewmodels.py
@@ -41,10 +41,8 @@ class Button:
     def agency_contact_links(agency):
         """Create link buttons for agency contact information."""
         return [
-            Button.link(classes="agency", label=agency.long_name, text=agency.phone, url=f"tel:{agency.phone}"),
-            Button.link(
-                classes="agency", text=agency.info_url, url=agency.info_url, target="_blank", rel="noopener noreferrer"
-            ),
+            Button.link(label=agency.long_name, text=agency.phone, url=f"tel:{agency.phone}"),
+            Button.link(text=agency.info_url, url=agency.info_url, target="_blank", rel="noopener noreferrer"),
         ]
 
     @staticmethod

--- a/benefits/core/views.py
+++ b/benefits/core/views.py
@@ -72,16 +72,16 @@ def help(request):
     else:
         agency_links = [btn for a in models.TransitAgency.all_active() for btn in viewmodels.Button.agency_contact_links(a)]
 
-    buttons = viewmodels.Button.home(request, _("core.buttons.back"))
+    back_button = viewmodels.Button.home(request, _("core.buttons.back"))
 
     page = viewmodels.Page(
         title=_("core.buttons.help"),
         headline=_("core.buttons.help"),
-        buttons=buttons,
     )
 
     ctx = page.context_dict()
     ctx["agency_links"] = agency_links
+    ctx["back_button"] = back_button
 
     return TemplateResponse(request, TEMPLATE_HELP, ctx)
 

--- a/benefits/core/views.py
+++ b/benefits/core/views.py
@@ -68,11 +68,11 @@ def help(request):
     """View handler for the help page."""
     if session.active_agency(request):
         agency = session.agency(request)
-        buttons = viewmodels.Button.agency_contact_links(agency)
+        agency_links = viewmodels.Button.agency_contact_links(agency)
     else:
-        buttons = [btn for a in models.TransitAgency.all_active() for btn in viewmodels.Button.agency_contact_links(a)]
+        agency_links = [btn for a in models.TransitAgency.all_active() for btn in viewmodels.Button.agency_contact_links(a)]
 
-    buttons.append(viewmodels.Button.home(request, _("core.buttons.back")))
+    buttons = viewmodels.Button.home(request, _("core.buttons.back"))
 
     page = viewmodels.Page(
         title=_("core.buttons.help"),
@@ -80,7 +80,10 @@ def help(request):
         buttons=buttons,
     )
 
-    return TemplateResponse(request, TEMPLATE_HELP, page.context_dict())
+    ctx = page.context_dict()
+    ctx["agency_links"] = agency_links
+
+    return TemplateResponse(request, TEMPLATE_HELP, ctx)
 
 
 @pageview_decorator

--- a/benefits/eligibility/templates/eligibility/unverified.html
+++ b/benefits/eligibility/templates/eligibility/unverified.html
@@ -18,13 +18,11 @@
     </div>
     {% endif %}
 
-    {% for back_button in page.buttons %}
-      {% if "btn-primary" in back_button.classes %}
-        <div class="row pt-8 justify-content-center">
-          <div class="col-lg-3 col-8">{% include "core/includes/button.html" with button=back_button %}</div>
-        </div>
-      {% endif %}
-    {% endfor %}
+    {% if back_button %}
+    <div class="row pt-8 justify-content-center">
+      <div class="col-lg-3 col-8">{% include "core/includes/button.html" with button=back_button %}</div>
+    </div>
+    {% endif %}
 
   </div>
 {% endblock main_content %}

--- a/benefits/eligibility/templates/eligibility/unverified.html
+++ b/benefits/eligibility/templates/eligibility/unverified.html
@@ -12,9 +12,11 @@
       </div>
     </div>
 
+    {% if agency_links %}
     <div class="row justify-content-center">
-      <div class="col-lg-8">{% include "core/includes/agency-links.html" with buttons=page.buttons %}</div>
+      <div class="col-lg-8">{% include "core/includes/agency-links.html" with buttons=agency_links %}</div>
     </div>
+    {% endif %}
 
     {% for back_button in page.buttons %}
       {% if "btn-primary" in back_button.classes %}

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -247,17 +247,17 @@ def unverified(request):
     analytics.returned_fail(request, types_to_verify)
 
     agency_links = viewmodels.Button.agency_contact_links(agency)
-    buttons = viewmodels.Button.home(request)
+    back_button = viewmodels.Button.home(request)
 
     page = viewmodels.Page(
         title=_(verifier.unverified_title),
         headline=_("eligibility.pages.unverified.headline"),
         icon=viewmodels.Icon("idcardquestion", pgettext("image alt text", "core.icons.idcardquestion")),
         paragraphs=[_(verifier.unverified_blurb)],
-        buttons=buttons,
     )
 
     ctx = page.context_dict()
     ctx["agency_links"] = agency_links
+    ctx["back_button"] = back_button
 
     return TemplateResponse(request, TEMPLATE_UNVERIFIED, ctx)

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -246,9 +246,8 @@ def unverified(request):
 
     analytics.returned_fail(request, types_to_verify)
 
-    # tel: link to agency phone number
-    buttons = viewmodels.Button.agency_contact_links(agency)
-    buttons.append(viewmodels.Button.home(request))
+    agency_links = viewmodels.Button.agency_contact_links(agency)
+    buttons = viewmodels.Button.home(request)
 
     page = viewmodels.Page(
         title=_(verifier.unverified_title),
@@ -258,4 +257,7 @@ def unverified(request):
         buttons=buttons,
     )
 
-    return TemplateResponse(request, TEMPLATE_UNVERIFIED, page.context_dict())
+    ctx = page.context_dict()
+    ctx["agency_links"] = agency_links
+
+    return TemplateResponse(request, TEMPLATE_UNVERIFIED, ctx)

--- a/benefits/enrollment/templates/enrollment/retry.html
+++ b/benefits/enrollment/templates/enrollment/retry.html
@@ -18,13 +18,11 @@
     </div>
     {% endif %}
 
-    {% for back_button in page.buttons %}
-      {% if "btn-primary" in back_button.classes %}
-        <div class="row pt-8 justify-content-center">
-          <div class="col-lg-3 col-8">{% include "core/includes/button.html" with button=back_button %}</div>
-        </div>
-      {% endif %}
-    {% endfor %}
+    {% if retry_button %}
+    <div class="row pt-8 justify-content-center">
+      <div class="col-lg-3 col-8">{% include "core/includes/button.html" with button=retry_button %}</div>
+    </div>
+    {% endif %}
 
   </div>
 {% endblock main_content %}

--- a/benefits/enrollment/templates/enrollment/retry.html
+++ b/benefits/enrollment/templates/enrollment/retry.html
@@ -12,9 +12,11 @@
       </div>
     </div>
 
+    {% if agency_links %}
     <div class="row justify-content-center">
-      <div class="col-lg-8">{% include "core/includes/agency-links.html" with buttons=page.buttons %}</div>
+      <div class="col-lg-8">{% include "core/includes/agency-links.html" with buttons=agency_links %}</div>
     </div>
+    {% endif %}
 
     {% for back_button in page.buttons %}
       {% if "btn-primary" in back_button.classes %}

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -153,10 +153,14 @@ def retry(request):
                 icon=viewmodels.Icon("bankcardquestion", pgettext("image alt text", "core.icons.bankcardquestion")),
                 headline=_("enrollment.pages.retry.title"),
                 paragraphs=[_("enrollment.pages.retry.p[0]")],
-                buttons=viewmodels.Button.agency_contact_links(agency),
+                buttons=[],
             )
             page.buttons.append(viewmodels.Button.primary(text=_("core.buttons.retry"), url=session.origin(request)))
-            return TemplateResponse(request, TEMPLATE_RETRY, page.context_dict())
+
+            ctx = page.context_dict()
+            ctx["agency_links"] = viewmodels.Button.agency_contact_links(agency)
+
+            return TemplateResponse(request, TEMPLATE_RETRY, ctx)
         else:
             analytics.returned_error(request, "Invalid retry submission.")
             raise Exception("Invalid retry submission.")

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -153,12 +153,11 @@ def retry(request):
                 icon=viewmodels.Icon("bankcardquestion", pgettext("image alt text", "core.icons.bankcardquestion")),
                 headline=_("enrollment.pages.retry.title"),
                 paragraphs=[_("enrollment.pages.retry.p[0]")],
-                buttons=[],
             )
-            page.buttons.append(viewmodels.Button.primary(text=_("core.buttons.retry"), url=session.origin(request)))
 
             ctx = page.context_dict()
             ctx["agency_links"] = viewmodels.Button.agency_contact_links(agency)
+            ctx["retry_button"] = viewmodels.Button.primary(text=_("core.buttons.retry"), url=session.origin(request))
 
             return TemplateResponse(request, TEMPLATE_RETRY, ctx)
         else:


### PR DESCRIPTION
Closes #1054 

This PR implements the proposed solution on the ticket so that for the three pages that show agency links (help, unverified, and retry):
- we remove the [`{% if "agency" in agency_button.classes %}`](https://github.com/cal-itp/benefits/pull/1042/files#diff-1a4430de237c046c679071ef0d2a5b267007651b8fa1c42e755f0a1cea4d469cR2) check
- we remove the [`{% if "btn-primary" in back_button.classes %}`](https://github.com/cal-itp/benefits/pull/1042/files#diff-32d0e53bd73778cc6c0437f522dd3269a366d343d321f0d9eee21d3ec3d4d166R20) check

### Testing locally
`/help` and `/unverified` are easy to test by going through the flow (use Courtesy Card with ineligible user credentials).

To test the `/enrollment/retry` view, you can modify the code as follows. Then, make sure to populate an agency in your session (either through the agency selector modal or going directly to an agency's slug) so that you can go directly to the endpoint and see that agency's contact links.
```diff
-@decorator_from_middleware(EligibleSessionRequired)
+# @decorator_from_middleware(EligibleSessionRequired)
    """View handler for a recoverable failure condition."""
-    if request.method == "POST":
+    if request.method == "GET":
```