### PR TITLE
Chore: update to latest eligibility-api

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "Authlib==1.2.0",
     "Django==4.2",
     "django-csp==3.7",
-    "eligibility-api==2023.01.1",
+    "eligibility-api==2023.6.1",
     "requests==2.31.0",
     "sentry-sdk==1.25.1",
     "six==1.16.0",


### PR DESCRIPTION
See https://github.com/cal-itp/eligibility-api/releases/tag/2023.06.01

Related to https://github.com/cal-itp/eligibility-server/pull/263