### PR TITLE
Fix: migrations formatting

### DIFF
--- a/bin/makemigrations.sh
+++ b/bin/makemigrations.sh
@@ -24,4 +24,4 @@ rm -rf benefits/core/old_migrations
 
 # reformat with black
 
-python -m black benefits/core/migrations/*
+python -m black benefits/core/migrations/*.py


### PR DESCRIPTION
Closes #1437 

Modifies the formatting command so that it only applies to Python files.