### PR TITLE
Eligibility Start: Show Veteran-flow specific bullet copy

### DIFF
--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -110,12 +110,14 @@ def start(request):
     )
 
     if verifier.is_auth_required:
-        if verifier.uses_auth_verification:
+        if verifier.name == "OAuth claims via Login.gov (MST)" or "OAuth claims via Login.gov (SacRT)":
             identity_item.bullets = [
                 _("eligibility.pages.start.login_gov.required_items[0]"),
                 _("eligibility.pages.start.login_gov.required_items[1]"),
                 _("eligibility.pages.start.login_gov.required_items[2]"),
             ]
+        if verifier.name == "VA.gov - Veteran (MST)":
+            identity_item.bullets = ["Login.gov", "ID.me", "DS Logon", "My HealtheVet"]
 
         if not session.logged_in(request):
             button = viewmodels.Button.login(

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -117,7 +117,12 @@ def start(request):
                 _("eligibility.pages.start.login_gov.required_items[2]"),
             ]
         if verifier.name == "VA.gov - Veteran (MST)":
-            identity_item.bullets = ["Login.gov", "ID.me", "DS Logon", "My HealtheVet"]
+            identity_item.bullets = [
+                _("eligibility.pages.start.veteran.required_items[0]"),
+                _("eligibility.pages.start.veteran.required_items[1]"),
+                _("eligibility.pages.start.veteran.required_items[2]"),
+                _("eligibility.pages.start.veteran.required_items[3]"),
+            ]
 
         if not session.logged_in(request):
             button = viewmodels.Button.login(

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -5,7 +5,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Report-Msgid-Bugs-To: \n"
+"Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
 "POT-Creation-Date: 2023-06-21 23:17+0000\n"
 "Language: English\n"
 "MIME-Version: 1.0\n"
@@ -527,6 +527,18 @@ msgstr "Your Social Security number"
 
 msgid "eligibility.pages.start.login_gov.required_items[2]"
 msgstr "A phone number with a phone plan associated with your name"
+
+msgid "eligibility.pages.start.veteran.required_items[0]"
+msgstr "Login.gov"
+
+msgid "eligibility.pages.start.veteran.required_items[1]"
+msgstr "ID.me"
+
+msgid "eligibility.pages.start.veteran.required_items[2]"
+msgstr "DS Logon"
+
+msgid "eligibility.pages.start.veteran.required_items[3]"
+msgstr "My HealtheVet"
 
 msgctxt "image alt text"
 msgid "core.icons.bankcardcheck"

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -5,8 +5,8 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-21 23:17+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
+"POT-Creation-Date: 2023-06-27 20:52+0000\n"
 "Language: Español\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"


### PR DESCRIPTION
closes #1441 

This PR does not change any CSS. It looks like some indentation has changed on this screen.

## What this PR does
- [x] Add English and Spanish copy for bullets
- [x] STUB OUT logic for deciding between Senior or Veteran (Waiting on #1439 to be merged into `main`)
- [ ] Change `uses_auth_verification` to optionally take a claim (`"senior"` or `"veteran"`) to determine which copy to return to context

## Screenshots
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/9bd6ccd3-a876-436b-a00c-c7eef6539a8a">
