### PR TITLE
Fix: Veterans - Enrollment Success: Add msgid for Veterans copy

### DIFF
--- a/benefits/core/migrations/0002_data.py
+++ b/benefits/core/migrations/0002_data.py
@@ -185,9 +185,7 @@ PEM DATA
         start_item_secondary_details=_("eligibility.pages.start.veteran.start_item.secondary_details"),
         unverified_title=_("eligibility.pages.unverified.title"),
         unverified_blurb=_("eligibility.pages.unverified.p[0]"),
-        enrollment_success_confirm_item_details=_(
-            "enrollment.pages.index.login_gov.eligibility_confirmed_item.details%(transit_agency_short_name)s"
-        ),
+        enrollment_success_confirm_item_details=_("enrollment.pages.success.veteran.confirm_item.details"),
         enrollment_success_expiry_item_heading=None,
         enrollment_success_expiry_item_details=None,
     )

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -107,6 +107,13 @@ msgstr ""
 "If you do not have an account with any of these services, you will need to "
 "create one. We recommend using Login.gov."
 
+msgid "enrollment.pages.success.veteran.confirm_item.details"
+msgstr ""
+"You were not charged anything today. When boarding transit, pay with this "
+"same physical card and you will automatically receive your new reduced fare. "
+"You will need to reapply if you choose to change the bank card you use to "
+"pay for transit service."
+
 msgid "eligibility.pages.index.mst_cc.label"
 msgstr "I have an MST Courtesy Card"
 

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2023-06-26 21:25+0000\n"
+"POT-Creation-Date: 2023-06-28 22:08+0000\n"
 "Language: English\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2023-06-26 21:25+0000\n"
+"POT-Creation-Date: 2023-06-28 22:08+0000\n"
 "Language: Español\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -107,6 +107,13 @@ msgstr ""
 "TODO: If you do not have an account with any of these services, you will "
 "need to create one. We recommend using Login.gov."
 
+msgid "enrollment.pages.success.veteran.confirm_item.details"
+msgstr ""
+"No se le ha cobrado nada hoy. Al abordar al el tránsito, pague con esta "
+"misma tarjeta física y automáticamente recibirá su nueva tarifa reducida. "
+"Deberá volver a presenter la solicitud si elige cambiar la tarjeta bancaria "
+"que utiliza para pagar el servicio de transito."
+
 msgid "eligibility.pages.index.mst_cc.label"
 msgstr "Tengo una Tarjeta de Cortesía de MST"
 


### PR DESCRIPTION
fix #1463 

- Corrects the `enrollment_success_confirm_item_details` value for Veteran's EligibilityVerifier
- Uses Enrollment Success copy _from what is on Production and already translated - ***not*** what is on Figma currently_ for the time being. Updating the Enrollment Success copy with the new variables is not part of this ticket. 


<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/7a9f6a92-907e-4193-87d5-ae2aa78f4fc7">
