### PR TITLE
Buttons: Use copy for button capitalization, not CSS

### DIFF
--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2023-06-29 00:40+0000\n"
+"POT-Creation-Date: 2023-07-07 02:33+0000\n"
 "Language: English\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -381,7 +381,7 @@ msgstr ""
 "Please enable cookies for this website and"
 
 msgid "core.buttons.return_home"
-msgstr "Return home"
+msgstr "Return Home"
 
 msgid "core.includes.noscript.brand"
 msgstr "JavaScript is disabled"
@@ -456,10 +456,10 @@ msgid "core.pages.index.headline"
 msgstr "Connect your transit benefit to your contactless card"
 
 msgid "core.pages.index.button"
-msgstr "Choose Your Provider"
+msgstr "Choose your Provider"
 
 msgid "core.pages.index.continue"
-msgstr "Get started"
+msgstr "Get Started"
 
 msgid "core.pages.agency_index.title"
 msgstr "Introduction"
@@ -471,7 +471,7 @@ msgstr ""
 "contactless card"
 
 msgid "core.buttons.back"
-msgstr "Go back"
+msgstr "Go Back"
 
 msgid "core.pages.logged_out.title"
 msgstr "Logged out"
@@ -596,7 +596,7 @@ msgid "enrollment.pages.index.headline"
 msgstr "Your eligibility is confirmed! You’re nearly there."
 
 msgid "enrollment.buttons.payment_partner"
-msgstr "Connect Your Card"
+msgstr "Connect your Card"
 
 msgid "enrollment.pages.retry.title"
 msgstr "We couldn’t connect your bank card"

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2023-06-29 00:40+0000\n"
+"POT-Creation-Date: 2023-07-07 02:33+0000\n"
 "Language: Español\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -396,7 +396,7 @@ msgstr ""
 "admita cookies. Por favor, active cookies por este sitio web y"
 
 msgid "core.buttons.return_home"
-msgstr "Regresar a la página principal"
+msgstr "Regresar a la Página Principal"
 
 msgid "core.includes.noscript.brand"
 msgstr "JavaScript está inactivo"
@@ -471,7 +471,7 @@ msgid "core.pages.index.headline"
 msgstr "Conecte su beneficio del transporte a su tarjeta de sin contacto"
 
 msgid "core.pages.index.button"
-msgstr "Elija Su Proveedor"
+msgstr "Elija su Proveedor"
 
 msgid "core.pages.index.continue"
 msgstr "Empezar"
@@ -486,7 +486,7 @@ msgstr ""
 "tarjeta de sin contacto"
 
 msgid "core.buttons.back"
-msgstr "Regresar a la página principal"
+msgstr "Regresar a la Página Principal"
 
 msgid "core.pages.logged_out.title"
 msgstr "Cierre sesión"
@@ -496,7 +496,7 @@ msgid "core.icons.happybus"
 msgstr "Icono de autobús con cara sonriente"
 
 msgid "eligibility.buttons.choose"
-msgstr "Elija Este Beneficio"
+msgstr "Elija este Beneficio"
 
 msgid "eligibility.forms.confirm.submit"
 msgstr "Verificación de estatus"

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -290,7 +290,6 @@ footer .footer-links li a:visited {
 
 .btn.btn-lg.btn-primary {
   border-width: 2px;
-  text-transform: capitalize;
   letter-spacing: 0.02em;
   font-weight: var(--medium-font-weight);
   font-size: calc(20rem / 16);

--- a/tests/cypress/plugins/helpers.js
+++ b/tests/cypress/plugins/helpers.js
@@ -14,7 +14,7 @@ export const rateLimitWait = () => {
 export const selectAgency = () => {
   cy.location("pathname").should("eq", "/");
 
-  cy.contains("Choose Your Provider").click();
+  cy.contains("Choose your Provider").click();
   cy.contains(agency.long_name).click();
 
   cy.location("pathname").should("eq", `/eligibility/${agency.slug}`);

--- a/tests/cypress/specs/help.cy.js
+++ b/tests/cypress/specs/help.cy.js
@@ -6,7 +6,7 @@ describe("Help page spec", () => {
   it("Allows user to go back", () => {
     cy.contains("Help").click();
 
-    cy.contains("Go back").click();
+    cy.contains("Go Back").click();
 
     cy.location("pathname").should("eq", "/");
   });


### PR DESCRIPTION
#1483 

There have been app-wide changes to how buttons are capitalized or not. This PR intends to make all those changes in 1 PR (but no wording changes).

## What this PR does
- Removes CSS logic for button text capitalization. The capitalization must be correct in the `django.po` file. The reason for this is because _some_ buttons are capitalized, but not all. So there is no 1 style that can be applied to all buttons.
- Updates `django.po` file with all new capitalization in English and Spanish.

## What changed

### These are all capitalized
- `Return Home`|| `Regresar a la Página Principal` for 404, 400, 500 pages 
- `Get Started` (`Empezar`, stays the same for Es) for Agency Index page
- `Go Back` || `Regresar a la Página Principal` for Help page

### These have mixed casing
- `Choose your Provider` `Elija su Proveedor` for Index page
- `Choose this Benefit` `Elija este Beneficio` for Elig Index page
- `Connect your Card` for Enrollment page

### What didn't need to be updated but now looks different b/c of CSS
- `Check status` || `Verificación de estatus` now has mixed casing (But will have the last word changed from `status` to `eligibility` in the copy changes to come