### PR TITLE
Chore: regenerate .po files

### DIFF
--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2023-07-07 02:33+0000\n"
+"POT-Creation-Date: 2023-07-10 20:47+0000\n"
 "Language: English\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -15,15 +15,6 @@ msgstr ""
 
 msgid "eligibility.buttons.senior.signout"
 msgstr "Sign out of Login.gov"
-
-msgid "eligibility.pages.index.login_gov.label"
-msgstr "I am 65 years of age or older"
-
-msgid "eligibility.pages.index.login_gov.description"
-msgstr ""
-"You must be 65 years or older. This benefit does not expire, but you may "
-"need to renew. Using this benefit means your new transit fare is half of the "
-"standard fare."
 
 msgid "eligibility.pages.unverified.title"
 msgstr "Eligibility Error"
@@ -52,32 +43,12 @@ msgstr ""
 "You will need to reapply if you choose to change the bank card you use to "
 "pay for transit service."
 
-msgid "eligibility.pages.index.veteran.label"
-msgstr "US Veteran"
-
-msgid "eligibility.pages.index.veteran.description"
-msgstr ""
-"This option is for people who have served in the active military, naval, or "
-"air service, and who were discharged or released therefrom under conditions "
-"other than dishonorable. You will need to <a href='https://www.va.gov/"
-"resources/verifying-your-identity-on-vagov/' target=\"_blank\" "
-"rel=\"noopener noreferrer\">verify your identity through VA.gov</a>"
-
 msgid "enrollment.pages.success.veteran.confirm_item.details"
 msgstr ""
 "You were not charged anything today. When boarding transit, pay with this "
 "same physical card and you will automatically receive your new reduced fare. "
 "You will need to reapply if you choose to change the bank card you use to "
 "pay for transit service."
-
-msgid "eligibility.pages.index.mst_cc.label"
-msgstr "I have an MST Courtesy Card"
-
-msgid "eligibility.pages.index.mst_cc.description"
-msgstr ""
-"This option is for people who have a current Courtesy Card or an MST RIDES "
-"Eligibility card. This benefit may need to be renewed in the future. Using "
-"this benefit means your new transit fare is half of the standard fare."
 
 msgid "eligibility.pages.confirm.mst_cc.title"
 msgstr "Confirm your Courtesy Card"
@@ -323,6 +294,9 @@ msgstr "Please choose your transit provider:"
 msgid "core.pages.index.agency_selector%(agency_short_name)s"
 msgstr "%(agency_short_name)s logo"
 
+msgid "core.buttons.previous_page"
+msgstr "Previous Page"
+
 msgid "core.includes.nocookies.brand"
 msgstr "Cookies are disabled"
 
@@ -342,6 +316,35 @@ msgstr ""
 "To function properly, this website requires a browser that supports "
 "JavaScript. Please enable JavaScript for this website and"
 
+msgid "eligibility.pages.index.login_gov.label"
+msgstr "I am 65 years of age or older"
+
+msgid "eligibility.pages.index.login_gov.description"
+msgstr ""
+"You must be 65 years or older. This benefit does not expire, but you may "
+"need to renew. Using this benefit means your new transit fare is half of the "
+"standard fare."
+
+msgid "eligibility.pages.index.mst_cc.label"
+msgstr "I have an MST Courtesy Card"
+
+msgid "eligibility.pages.index.mst_cc.description"
+msgstr ""
+"This option is for people who have a current Courtesy Card or an MST RIDES "
+"Eligibility card. This benefit may need to be renewed in the future. Using "
+"this benefit means your new transit fare is half of the standard fare."
+
+msgid "eligibility.pages.index.veteran.label"
+msgstr "US Veteran"
+
+msgid "eligibility.pages.index.veteran.description"
+msgstr ""
+"This option is for people who have served in the active military, naval, or "
+"air service, and who were discharged or released therefrom under conditions "
+"other than dishonorable. You will need to <a href='https://www.va.gov/"
+"resources/verifying-your-identity-on-vagov/' target=\"_blank\" rel="
+"\"noopener noreferrer\">verify your identity through VA.gov</a>"
+
 msgid "core.pages.landing.h2"
 msgstr ""
 "Cal-ITP Benefits connects your transit benefit to your contactless card"
@@ -351,9 +354,6 @@ msgstr "You have successfully logged out."
 
 msgid "core.pages.logged_out.headline[1]"
 msgstr "Thank you for using Cal-ITP Benefits!"
-
-msgid "core.buttons.previous_page"
-msgstr "Previous Page"
 
 msgid "eligibility.pages.index.label"
 msgstr "Select the option that best applies to you:"
@@ -447,14 +447,16 @@ msgstr "Check your input. The format looks wrong."
 msgid "eligibility.forms.confirm.errors.missing"
 msgstr "This field is required."
 
-msgid "eligibility.pages.start.sub_headline"
-msgstr "You will need a few items to connect your benefit:"
+msgctxt "image alt text"
+msgid "core.icons.bankcardcheck"
+msgstr "Bank card icon with contactless symbol and checkmark"
 
-msgid "eligibility.pages.start.login_gov.title"
-msgstr "Older Adult benefit information"
+msgid "eligibility.pages.start.bankcard.title"
+msgstr "Your bank card details"
 
-msgid "eligibility.pages.start.login_gov.headline"
-msgstr "You selected an Older Adult benefit."
+msgid "eligibility.pages.start.bankcard.text"
+msgstr ""
+"Your card must be a contactless debit or credit card by Visa or Mastercard."
 
 msgctxt "image alt text"
 msgid "core.icons.idcardcheck"
@@ -479,21 +481,6 @@ msgstr "Your Social Security number"
 msgid "eligibility.pages.start.login_gov.required_items[2]"
 msgstr "A phone number with a phone plan associated with your name"
 
-msgid "eligibility.pages.start.help_text"
-msgstr "Questions about the items above? Please visit our"
-
-msgid "eligibility.pages.start.help_link_text"
-msgstr "Help Page"
-
-msgid "eligibility.buttons.senior.signin"
-msgstr "Get started with"
-
-msgid "eligibility.pages.start.mst_cc.title"
-msgstr "Courtesy Card information"
-
-msgid "eligibility.pages.start.mst_cc.headline"
-msgstr "You selected a Courtesy Card benefit."
-
 msgid "eligibility.pages.start.mst_cc.start_item.heading"
 msgstr "Your current Courtesy Card number"
 
@@ -501,15 +488,6 @@ msgid "eligibility.pages.start.mst_cc.start_item.details"
 msgstr ""
 "You do not need to have your physical card, but you will need to know the "
 "number. The number starts with a number sign (#) followed by five digits."
-
-msgid "eligibility.buttons.continue"
-msgstr "Continue"
-
-msgid "eligibility.pages.start.veteran.title"
-msgstr "Veteran benefit information"
-
-msgid "eligibility.pages.start.veteran.headline"
-msgstr "You selected a Veteran transit benefit."
 
 msgid "eligibility.pages.start.veteran.start_item.heading"
 msgstr "Access to your preferred VA related account"
@@ -536,19 +514,41 @@ msgstr ""
 "If you do not have an account with any of these services, you will need to "
 "create one. We recommend using Login.gov."
 
+msgid "eligibility.pages.start.sub_headline"
+msgstr "You will need a few items to connect your benefit:"
+
+msgid "eligibility.pages.start.login_gov.title"
+msgstr "Older Adult benefit information"
+
+msgid "eligibility.pages.start.login_gov.headline"
+msgstr "You selected an Older Adult benefit."
+
+msgid "eligibility.pages.start.help_text"
+msgstr "Questions about the items above? Please visit our"
+
+msgid "eligibility.pages.start.help_link_text"
+msgstr "Help Page"
+
+msgid "eligibility.buttons.senior.signin"
+msgstr "Get started with"
+
+msgid "eligibility.pages.start.mst_cc.title"
+msgstr "Courtesy Card information"
+
+msgid "eligibility.pages.start.mst_cc.headline"
+msgstr "You selected a Courtesy Card benefit."
+
+msgid "eligibility.buttons.continue"
+msgstr "Continue"
+
+msgid "eligibility.pages.start.veteran.title"
+msgstr "Veteran benefit information"
+
+msgid "eligibility.pages.start.veteran.headline"
+msgstr "You selected a Veteran transit benefit."
+
 msgid "eligibility.buttons.veteran.signin"
 msgstr "Continue to VA.gov"
-
-msgctxt "image alt text"
-msgid "core.icons.bankcardcheck"
-msgstr "Bank card icon with contactless symbol and checkmark"
-
-msgid "eligibility.pages.start.bankcard.title"
-msgstr "Your bank card details"
-
-msgid "eligibility.pages.start.bankcard.text"
-msgstr ""
-"Your card must be a contactless debit or credit card by Visa or Mastercard."
 
 #, python-format
 msgid "eligibility.pages.index.p[0]%(info_link)s"
@@ -568,8 +568,8 @@ msgstr ""
 #, python-format
 msgid "eligibility.pages.index.help_text%(help_link)s"
 msgstr ""
-"Not sure which option is right for you? Please visit our <a "
-"href=\"%(help_link)s\">Help Page</a>."
+"Not sure which option is right for you? Please visit our <a href="
+"\"%(help_link)s\">Help Page</a>."
 
 msgid "eligibility.pages.unverified.headline"
 msgstr "Your eligibility could not be verified."

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2023-07-07 02:33+0000\n"
+"POT-Creation-Date: 2023-07-10 20:47+0000\n"
 "Language: Español\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -15,15 +15,6 @@ msgstr ""
 
 msgid "eligibility.buttons.senior.signout"
 msgstr "Cierre sesión de Login.gov"
-
-msgid "eligibility.pages.index.login_gov.label"
-msgstr "Tengo 65 años de edad o más"
-
-msgid "eligibility.pages.index.login_gov.description"
-msgstr ""
-"Usted debe de tener 65 años o más. Este beneficio no caduca, pero es posible "
-"que deba renovarlo. Usando este beneficio significa que su nueva tarifa de "
-"tránsito es la mitad de la tarifa estándar."
 
 msgid "eligibility.pages.unverified.title"
 msgstr "Error de elegibilidad"
@@ -52,33 +43,12 @@ msgstr ""
 "Deberá volver a presenter la solicitud si elige cambiar la tarjeta bancaria "
 "que utiliza para pagar el servicio de transito."
 
-msgid "eligibility.pages.index.veteran.label"
-msgstr "TODO: US Veteran"
-
-msgid "eligibility.pages.index.veteran.description"
-msgstr ""
-"TODO: This option is for people who have served in the active military, "
-"naval, or air service, and who were discharged or released therefrom under "
-"conditions other than dishonorable. You will need to <a href='https://www.va."
-"gov/resources/verifying-your-identity-on-vagov/' target=\"_blank\" "
-"rel=\"noopener noreferrer\">verify your identity through VA.gov</a>"
-
 msgid "enrollment.pages.success.veteran.confirm_item.details"
 msgstr ""
 "No se le ha cobrado nada hoy. Al abordar al el tránsito, pague con esta "
 "misma tarjeta física y automáticamente recibirá su nueva tarifa reducida. "
 "Deberá volver a presenter la solicitud si elige cambiar la tarjeta bancaria "
 "que utiliza para pagar el servicio de transito."
-
-msgid "eligibility.pages.index.mst_cc.label"
-msgstr "Tengo una Tarjeta de Cortesía de MST"
-
-msgid "eligibility.pages.index.mst_cc.description"
-msgstr ""
-"Esta opción es para personas que tienen una Tarjeta de Cortesía actual o una "
-"tarjeta de elegibilidad de Paratránsito de MST RIDES. Es posible que este "
-"beneficio deba renovarse en el futuro. Usar este beneficio significa que su "
-"nueva tarifa de tránsito es la mitad de la tarifa estándar."
 
 msgid "eligibility.pages.confirm.mst_cc.title"
 msgstr "Confirmar su eligibilidad"
@@ -338,6 +308,9 @@ msgstr "Por favor, elija su proveedor de transporte:"
 msgid "core.pages.index.agency_selector%(agency_short_name)s"
 msgstr "%(agency_short_name)s logo"
 
+msgid "core.buttons.previous_page"
+msgstr "Página Anterior"
+
 msgid "core.includes.nocookies.brand"
 msgstr "Cookies están inactivos"
 
@@ -357,6 +330,36 @@ msgstr ""
 "Para funcionar correctamente, este sitio web requiere un navegador que "
 "admita JavaScript. Por favor, active JavaScript por este sitio web y"
 
+msgid "eligibility.pages.index.login_gov.label"
+msgstr "Tengo 65 años de edad o más"
+
+msgid "eligibility.pages.index.login_gov.description"
+msgstr ""
+"Usted debe de tener 65 años o más. Este beneficio no caduca, pero es posible "
+"que deba renovarlo. Usando este beneficio significa que su nueva tarifa de "
+"tránsito es la mitad de la tarifa estándar."
+
+msgid "eligibility.pages.index.mst_cc.label"
+msgstr "Tengo una Tarjeta de Cortesía de MST"
+
+msgid "eligibility.pages.index.mst_cc.description"
+msgstr ""
+"Esta opción es para personas que tienen una Tarjeta de Cortesía actual o una "
+"tarjeta de elegibilidad de Paratránsito de MST RIDES. Es posible que este "
+"beneficio deba renovarse en el futuro. Usar este beneficio significa que su "
+"nueva tarifa de tránsito es la mitad de la tarifa estándar."
+
+msgid "eligibility.pages.index.veteran.label"
+msgstr "TODO: US Veteran"
+
+msgid "eligibility.pages.index.veteran.description"
+msgstr ""
+"TODO: This option is for people who have served in the active military, "
+"naval, or air service, and who were discharged or released therefrom under "
+"conditions other than dishonorable. You will need to <a href='https://www.va."
+"gov/resources/verifying-your-identity-on-vagov/' target=\"_blank\" rel="
+"\"noopener noreferrer\">verify your identity through VA.gov</a>"
+
 msgid "core.pages.landing.h2"
 msgstr "Su beneficio se aplicará cada vez que acerque su tarjeta para viajar"
 
@@ -365,9 +368,6 @@ msgstr "Ha cerrado la sesión correctamente."
 
 msgid "core.pages.logged_out.headline[1]"
 msgstr "¡Gracias por usar los Beneficios de Cal-ITP!"
-
-msgid "core.buttons.previous_page"
-msgstr "Página Anterior"
 
 msgid "eligibility.pages.index.label"
 msgstr "Seleccione la opción que mejor se adapte a usted:"
@@ -462,14 +462,18 @@ msgstr "Verifique su entrada. El formato parece incorrecto."
 msgid "eligibility.forms.confirm.errors.missing"
 msgstr "Este campo es requerido."
 
-msgid "eligibility.pages.start.sub_headline"
-msgstr "Necesitará algunos artículos para conectar su beneficio:"
+msgctxt "image alt text"
+msgid "core.icons.bankcardcheck"
+msgstr ""
+"Icono de tarjeta bancaria con símbolo sin contacto y marca de verificación"
 
-msgid "eligibility.pages.start.login_gov.title"
-msgstr "Información sobre beneficios para Adultos Mayores"
+msgid "eligibility.pages.start.bankcard.title"
+msgstr "Los datos de su tarjeta bancaria"
 
-msgid "eligibility.pages.start.login_gov.headline"
-msgstr "Usted seleccionó un beneficio para Adultos Mayores"
+msgid "eligibility.pages.start.bankcard.text"
+msgstr ""
+"Su tarjeta debe ser una tarjeta de débito o crédito sin contacto de Visa o "
+"Mastercard."
 
 msgctxt "image alt text"
 msgid "core.icons.idcardcheck"
@@ -494,21 +498,6 @@ msgstr "Su número de Seguro Social"
 msgid "eligibility.pages.start.login_gov.required_items[2]"
 msgstr "Un número de teléfono con un plan de teléfono asociado con su nombre"
 
-msgid "eligibility.pages.start.help_text"
-msgstr "¿Preguntas sobre los artículos anteriores? Visite nuestro"
-
-msgid "eligibility.pages.start.help_link_text"
-msgstr "Página de Ayuda"
-
-msgid "eligibility.buttons.senior.signin"
-msgstr "Comencemos con"
-
-msgid "eligibility.pages.start.mst_cc.title"
-msgstr "Información de la Tarjeta de Cortesía"
-
-msgid "eligibility.pages.start.mst_cc.headline"
-msgstr "Usted a seleccionado un Beneficio de la Tarjeta de Cortesía."
-
 msgid "eligibility.pages.start.mst_cc.start_item.heading"
 msgstr "Su número actual de Tarjeta de Cortesía"
 
@@ -516,15 +505,6 @@ msgid "eligibility.pages.start.mst_cc.start_item.details"
 msgstr ""
 "No necesitas tener su tarjeta física, pero necesitará saber el número. El "
 "número comienza con un signo de número (#) seguido de cinco dígitos."
-
-msgid "eligibility.buttons.continue"
-msgstr "Continuar"
-
-msgid "eligibility.pages.start.veteran.title"
-msgstr "TODO: Veteran benefit information"
-
-msgid "eligibility.pages.start.veteran.headline"
-msgstr "TODO: You selected a Veteran transit benefit."
 
 msgid "eligibility.pages.start.veteran.start_item.heading"
 msgstr "TODO: Access to your preferred VA related account"
@@ -551,21 +531,41 @@ msgstr ""
 "TODO: If you do not have an account with any of these services, you will "
 "need to create one. We recommend using Login.gov."
 
+msgid "eligibility.pages.start.sub_headline"
+msgstr "Necesitará algunos artículos para conectar su beneficio:"
+
+msgid "eligibility.pages.start.login_gov.title"
+msgstr "Información sobre beneficios para Adultos Mayores"
+
+msgid "eligibility.pages.start.login_gov.headline"
+msgstr "Usted seleccionó un beneficio para Adultos Mayores"
+
+msgid "eligibility.pages.start.help_text"
+msgstr "¿Preguntas sobre los artículos anteriores? Visite nuestro"
+
+msgid "eligibility.pages.start.help_link_text"
+msgstr "Página de Ayuda"
+
+msgid "eligibility.buttons.senior.signin"
+msgstr "Comencemos con"
+
+msgid "eligibility.pages.start.mst_cc.title"
+msgstr "Información de la Tarjeta de Cortesía"
+
+msgid "eligibility.pages.start.mst_cc.headline"
+msgstr "Usted a seleccionado un Beneficio de la Tarjeta de Cortesía."
+
+msgid "eligibility.buttons.continue"
+msgstr "Continuar"
+
+msgid "eligibility.pages.start.veteran.title"
+msgstr "TODO: Veteran benefit information"
+
+msgid "eligibility.pages.start.veteran.headline"
+msgstr "TODO: You selected a Veteran transit benefit."
+
 msgid "eligibility.buttons.veteran.signin"
 msgstr "TODO: Continue with VA.gov"
-
-msgctxt "image alt text"
-msgid "core.icons.bankcardcheck"
-msgstr ""
-"Icono de tarjeta bancaria con símbolo sin contacto y marca de verificación"
-
-msgid "eligibility.pages.start.bankcard.title"
-msgstr "Los datos de su tarjeta bancaria"
-
-msgid "eligibility.pages.start.bankcard.text"
-msgstr ""
-"Su tarjeta debe ser una tarjeta de débito o crédito sin contacto de Visa o "
-"Mastercard."
 
 #, python-format
 msgid "eligibility.pages.index.p[0]%(info_link)s"
@@ -608,9 +608,8 @@ msgstr "El siguiente paso es vincular su tarjeta bancaria"
 msgid "enrollment.pages.index.link_card_item.p[0]%(link)s"
 msgstr ""
 "Ahora que se ha verificado su elegibilidad, vincularemos su descuento de "
-"tránsito a su tarjeta a través de nuestro socio de pago, <a "
-"href=\"%(link)s\">Littlepay</a>. No almacenamos su información y no se te "
-"cobrará."
+"tránsito a su tarjeta a través de nuestro socio de pago, <a href=\"%(link)s"
+"\">Littlepay</a>. No almacenamos su información y no se te cobrará."
 
 msgid "enrollment.pages.index.link_card_item.p[1]"
 msgstr ""


### PR DESCRIPTION
With all the changes from #1489 and #1498, we've somehow gotten `dev` into a state where the ordering in our PO files is not the same as it is after running the `./bin/makemessages.sh` script. This is causing other PRs to include reordering in their changes.

This PR merges in just the re-ordering so that other PRs only update the entries relevant to their changes.