### PR TITLE
Fix: Remove extra asterisks

### DIFF
--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2023-07-11 17:23+0000\n"
+"POT-Creation-Date: 2023-07-11 16:05+0000\n"
 "Language: English\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -42,7 +42,7 @@ msgid "eligibility.forms.confirm.mst_cc.fields.sub.help_text"
 msgstr "[qualifier]"
 
 msgid "eligibility.forms.confirm.mst_cc.fields.name"
-msgstr "[Identity-Marker] (as it appears on [Agency-Card])*"
+msgstr "[Identity-Marker] (as it appears on [Agency-Card])"
 
 msgid "eligibility.forms.confirm.mst_cc.fields.name.help_text"
 msgstr "We use this to help confirm your [Agency-Card]."

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2023-07-11 17:23+0000\n"
+"POT-Creation-Date: 2023-07-11 16:05+0000\n"
 "Language: Español\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -42,7 +42,7 @@ msgid "eligibility.forms.confirm.mst_cc.fields.sub.help_text"
 msgstr "[qualifier]"
 
 msgid "eligibility.forms.confirm.mst_cc.fields.name"
-msgstr "[Identity-Marker] (as it appears on [Agency-Card])*"
+msgstr "[Identity-Marker] (as it appears on [Agency-Card])"
 
 msgid "eligibility.forms.confirm.mst_cc.fields.name.help_text"
 msgstr "Usamos esto para ayudar a confirmar su [Agency-Card]."


### PR DESCRIPTION
noticed this bug on dev:
<img width="1292" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/0fa5120d-0d40-466a-bac0-6ce824ba7f01">


the fix:
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/224beaf4-b4c8-4f0a-bbe6-32c0e202d0ae">
