### PR TITLE
Refactor: agency links

### DIFF
--- a/benefits/core/context_processors.py
+++ b/benefits/core/context_processors.py
@@ -4,7 +4,33 @@ The core application: context processors for enriching request context data.
 from django.conf import settings
 from django.urls import reverse
 
-from . import session
+from . import models, session
+
+
+def _agency_context(agency):
+    return {
+        "long_name": agency.long_name,
+        "short_name": agency.short_name,
+        "info_url": agency.info_url,
+        "phone": agency.phone,
+    }
+
+
+def agency(request):
+    """Context processor adds some information about the active agency to the request context."""
+    agency = session.agency(request)
+
+    if agency is None:
+        return {}
+
+    return {"agency": _agency_context(agency)}
+
+
+def active_agencies(request):
+    """Context processor adds some information about all active agencies to the request context."""
+    agencies = models.TransitAgency.all_active()
+
+    return {"active_agencies": [_agency_context(agency) for agency in agencies]}
 
 
 def analytics(request):

--- a/benefits/core/templates/core/help.html
+++ b/benefits/core/templates/core/help.html
@@ -24,7 +24,7 @@
                width="40"
                height="50"
                src="{% static 'img/icon/contactless.svg' %}"
-               alt="{% translate "core.icons.contactless" context "image alt text" %}"/>
+               alt="{% translate "core.icons.contactless" context "image alt text" %}" />
         </p>
 
         <p class="pt-4">{% translate "core.pages.help.payment_options.p[1]" %}</p>
@@ -60,11 +60,17 @@
       </div>
     </div>
 
-    {% if agency_links %}
     <div class="row justify-content-center">
-      <div class="col-10">{% include "core/includes/agency-links.html" with buttons=agency_links %}</div>
+      <div class="col-10">
+        {% if agency %}
+          {% include "core/includes/agency-links.html" %}
+        {% else %}
+          {% for agency in active_agencies %}
+            {% include "core/includes/agency-links.html" with agency_name=agency.long_name phone=agency.phone info_url=agency.info_url %}
+          {% endfor %}
+        {% endif %}
+      </div>
     </div>
-    {% endif %}
 
     <div class="row pt-8">
       <div class="col-lg-3 offset-lg-8 col-8 offset-2">

--- a/benefits/core/templates/core/includes/agency-links.html
+++ b/benefits/core/templates/core/includes/agency-links.html
@@ -1,9 +1,3 @@
-{% for agency_button in buttons %}
-  {% if agency_button.label %}<label class="mt-4 d-block fs-base ls-base">{{ agency_button.label }}</label>{% endif %}
-  <a class="d-table fs-base ls-base"
-      {% if agency_button.target %}target="{{ agency_button.target }}"{% endif %}
-      {% if agency_button.rel %}rel="{{ agency_button.rel }}"{% endif %}
-      href="{{ agency_button.url }}">
-    {{ agency_button.text }}
-  </a>
-{% endfor %}
+<label class="mt-4 d-block fs-base ls-base">{{ agency_name | default:agency.long_name }}</label>
+<a class="d-table fs-base ls-base" href="tel:{{ phone | default:agency.phone }}">{{ phone | default:agency.phone }}</a>
+<a class="d-table fs-base ls-base" href="{{ info_url | default:agency.info_url }}" target="_blank" rel="noopener noreferrer">{{ info_url | default:agency.info_url }}</a>

--- a/benefits/core/viewmodels.py
+++ b/benefits/core/viewmodels.py
@@ -36,22 +36,6 @@ class Button:
         self.rel = kwargs.get("rel")
 
     @staticmethod
-    def agency_contact_links(agency):
-        """Create link buttons for agency contact information."""
-        return [
-            Button.link(label=agency.long_name, text=agency.phone, url=f"tel:{agency.phone}"),
-            Button.link(text=agency.info_url, url=agency.info_url, target="_blank", rel="noopener noreferrer"),
-        ]
-
-    @staticmethod
-    def link(**kwargs):
-        classes = kwargs.pop("classes", [])
-        if isinstance(classes, str):
-            classes = classes.split(" ")
-        classes.insert(0, "btn-link")
-        return Button(classes=classes, **kwargs)
-
-    @staticmethod
     def primary(**kwargs):
         classes = kwargs.pop("classes", [])
         if isinstance(classes, str):

--- a/benefits/core/views.py
+++ b/benefits/core/views.py
@@ -64,20 +64,12 @@ def agency_public_key(request, agency):
 @pageview_decorator
 def help(request):
     """View handler for the help page."""
-    if session.active_agency(request):
-        agency = session.agency(request)
-        agency_links = viewmodels.Button.agency_contact_links(agency)
-    else:
-        agency_links = [btn for a in models.TransitAgency.all_active() for btn in viewmodels.Button.agency_contact_links(a)]
-
     page = viewmodels.Page(
         title=_("core.buttons.help"),
         headline=_("core.buttons.help"),
     )
 
     ctx = page.context_dict()
-    ctx["agency_links"] = agency_links
-
     return TemplateResponse(request, TEMPLATE_HELP, ctx)
 
 

--- a/benefits/eligibility/templates/eligibility/unverified.html
+++ b/benefits/eligibility/templates/eligibility/unverified.html
@@ -12,11 +12,9 @@
       </div>
     </div>
 
-    {% if agency_links %}
-      <div class="row justify-content-center">
-        <div class="col-lg-8">{% include "core/includes/agency-links.html" with buttons=agency_links %}</div>
-      </div>
-    {% endif %}
+    <div class="row justify-content-center">
+      <div class="col-lg-8">{% include "core/includes/agency-links.html" %}</div>
+    </div>
 
     <div class="row pt-8 justify-content-center">
       <div class="col-lg-3 col-8">{% include "core/includes/button--home.html" %}</div>

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -181,8 +181,6 @@ def unverified(request):
 
     analytics.returned_fail(request, types_to_verify)
 
-    agency_links = viewmodels.Button.agency_contact_links(agency)
-
     page = viewmodels.Page(
         title=_(verifier.unverified_title),
         headline=_("eligibility.pages.unverified.headline"),
@@ -191,6 +189,4 @@ def unverified(request):
     )
 
     ctx = page.context_dict()
-    ctx["agency_links"] = agency_links
-
     return TemplateResponse(request, TEMPLATE_UNVERIFIED, ctx)

--- a/benefits/enrollment/templates/enrollment/retry.html
+++ b/benefits/enrollment/templates/enrollment/retry.html
@@ -12,16 +12,14 @@
       </div>
     </div>
 
-    {% if agency_links %}
     <div class="row justify-content-center">
-      <div class="col-lg-8">{% include "core/includes/agency-links.html" with buttons=agency_links %}</div>
+      <div class="col-lg-8">{% include "core/includes/agency-links.html" %}</div>
     </div>
-    {% endif %}
 
     {% if retry_button %}
-    <div class="row pt-8 justify-content-center">
-      <div class="col-lg-3 col-8">{% include "core/includes/button.html" with button=retry_button %}</div>
-    </div>
+      <div class="row pt-8 justify-content-center">
+        <div class="col-lg-3 col-8">{% include "core/includes/button.html" with button=retry_button %}</div>
+      </div>
     {% endif %}
 
   </div>

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -96,7 +96,6 @@ def retry(request):
         analytics.returned_retry(request)
         form = forms.CardTokenizeFailForm(request.POST)
         if form.is_valid():
-            agency = session.agency(request)
             page = viewmodels.Page(
                 title=_("enrollment.pages.retry.title"),
                 icon=viewmodels.Icon("bankcardquestion", pgettext("image alt text", "core.icons.bankcardquestion")),
@@ -105,7 +104,6 @@ def retry(request):
             )
 
             ctx = page.context_dict()
-            ctx["agency_links"] = viewmodels.Button.agency_contact_links(agency)
             ctx["retry_button"] = viewmodels.Button.primary(text=_("core.buttons.retry"), url=session.origin(request))
 
             return TemplateResponse(request, TEMPLATE_RETRY, ctx)

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -111,6 +111,8 @@ ROOT_URLCONF = "benefits.urls"
 template_ctx_processors = [
     "django.template.context_processors.request",
     "django.contrib.messages.context_processors.messages",
+    "benefits.core.context_processors.agency",
+    "benefits.core.context_processors.active_agencies",
     "benefits.core.context_processors.analytics",
     "benefits.core.context_processors.authentication",
     "benefits.core.context_processors.origin",

--- a/tests/pytest/core/test_views.py
+++ b/tests/pytest/core/test_views.py
@@ -113,15 +113,12 @@ def test_help(client):
 
 
 @pytest.mark.django_db
-def test_help_with_session_agency(mocked_session_agency, client):
+@pytest.mark.usefixtures("mocked_session_agency")
+def test_help_with_session_agency(client):
     path = reverse(ROUTE_HELP)
     response = client.get(path)
 
     assert response.status_code == 200
-    # mocked_session_agency is Mocked version of the session.agency() function
-    # call it (with a None request) to return the sample agency
-    agency = mocked_session_agency(None)
-    assert agency.long_name in str(response.content)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Part of #1520

The `eligibility:unverified` view uses the _agency links_ construct. They also show up in two other views: 
* `core:help`
* `enrollment:retry`

In `eligibility` and `enrollment`, we assume an agency has been selected by the user. 

For `core:help`, the user may navigate there before selecting an agency, so we show all "agency links" for active agencies.

This PR moves the variation and content to a new template field: `TransitAgency.links_template`, referencing an `includes` file specific for the agency. The include is used explicitly where it is needed in templates.

This PR removes unused `TransitAgency` fields as well as deleting the `Button.agency_contact_links()` viewmodel helper.