### PR TITLE
Refactor: home button

### DIFF
--- a/benefits/core/context_processors.py
+++ b/benefits/core/context_processors.py
@@ -36,3 +36,13 @@ def authentication(request):
 def debug(request):
     """Context processor adds debug information to request context."""
     return {"debug": session.context_dict(request)}
+
+
+def origin(request):
+    """Context processor adds session.origin to request context."""
+    origin = session.origin(request)
+
+    if origin:
+        return {"origin": origin}
+    else:
+        return {}

--- a/benefits/core/middleware.py
+++ b/benefits/core/middleware.py
@@ -20,8 +20,7 @@ TEMPLATE_USER_ERROR = "200_user_error.html"
 
 
 def user_error(request):
-    home = viewmodels.Button.home(request)
-    page = viewmodels.ErrorPage.user_error(button=home)
+    page = viewmodels.ErrorPage.user_error()
 
     return TemplateResponse(request, TEMPLATE_USER_ERROR, page.context_dict())
 

--- a/benefits/core/templates/core/help.html
+++ b/benefits/core/templates/core/help.html
@@ -66,13 +66,12 @@
     </div>
     {% endif %}
 
-    {% if back_button %}
     <div class="row pt-8">
       <div class="col-lg-3 offset-lg-8 col-8 offset-2">
-        {% include "core/includes/button.html" with button=back_button %}
+        {% translate "core.buttons.back" as button_text %}
+        {% include "core/includes/button--home.html" with button_text=button_text %}
       </div>
     </div>
-    {% endif %}
 
     <div class="row justify-content-center">
       <div class="col-8 col-lg-10 mt-4">

--- a/benefits/core/templates/core/includes/button--home.html
+++ b/benefits/core/templates/core/includes/button--home.html
@@ -1,0 +1,5 @@
+{% load i18n %}
+
+{% translate "core.buttons.return_home" as default_button_text %}
+
+<a href="{{ origin }}" class="btn btn-lg btn-primary">{{ button_text | default:default_button_text }}</a>

--- a/benefits/core/viewmodels.py
+++ b/benefits/core/viewmodels.py
@@ -6,8 +6,6 @@ from django.urls import reverse
 
 from benefits.core import models
 
-from . import session
-
 
 class Button:
     """
@@ -44,14 +42,6 @@ class Button:
             Button.link(label=agency.long_name, text=agency.phone, url=f"tel:{agency.phone}"),
             Button.link(text=agency.info_url, url=agency.info_url, target="_blank", rel="noopener noreferrer"),
         ]
-
-    @staticmethod
-    def home(request, text=None):
-        """Create a button back to this session's origin."""
-        if text is None:
-            text = _("core.buttons.return_home")
-
-        return Button.primary(text=text, url=session.origin(request))
 
     @staticmethod
     def link(**kwargs):

--- a/benefits/core/views.py
+++ b/benefits/core/views.py
@@ -70,8 +70,6 @@ def help(request):
     else:
         agency_links = [btn for a in models.TransitAgency.all_active() for btn in viewmodels.Button.agency_contact_links(a)]
 
-    back_button = viewmodels.Button.home(request, _("core.buttons.back"))
-
     page = viewmodels.Page(
         title=_("core.buttons.help"),
         headline=_("core.buttons.help"),
@@ -79,7 +77,6 @@ def help(request):
 
     ctx = page.context_dict()
     ctx["agency_links"] = agency_links
-    ctx["back_button"] = back_button
 
     return TemplateResponse(request, TEMPLATE_HELP, ctx)
 
@@ -92,8 +89,7 @@ def bad_request(request, exception, template_name="400.html"):
     else:
         session.update(request, origin=reverse(ROUTE_INDEX))
 
-    home = viewmodels.Button.home(request)
-    page = viewmodels.ErrorPage.server_error(button=home)
+    page = viewmodels.ErrorPage.server_error()
     t = loader.get_template(template_name)
 
     return HttpResponseBadRequest(t.render(page.context_dict()))
@@ -109,8 +105,7 @@ def csrf_failure(request, reason):
     else:
         session.update(request, origin=reverse(ROUTE_INDEX))
 
-    home = viewmodels.Button.home(request)
-    page = viewmodels.ErrorPage.not_found(button=home, path=request.path)
+    page = viewmodels.ErrorPage.not_found(path=request.path)
     t = loader.get_template("400.html")
 
     return HttpResponseNotFound(t.render(page.context_dict()))
@@ -124,9 +119,8 @@ def page_not_found(request, exception, template_name="404.html"):
     else:
         session.update(request, origin=reverse(ROUTE_INDEX))
 
-    home = viewmodels.Button.home(request)
     # show a more user-friendly message instead of not_found
-    page = viewmodels.ErrorPage.user_error(button=home, path=request.path)
+    page = viewmodels.ErrorPage.user_error(path=request.path)
     t = loader.get_template(template_name)
 
     return HttpResponseNotFound(t.render(page.context_dict()))
@@ -140,8 +134,7 @@ def server_error(request, template_name="500.html"):
     else:
         session.update(request, origin=reverse(ROUTE_INDEX))
 
-    home = viewmodels.Button.home(request)
-    page = viewmodels.ErrorPage.server_error(button=home)
+    page = viewmodels.ErrorPage.server_error()
     t = loader.get_template(template_name)
 
     return HttpResponseServerError(t.render(page.context_dict()))

--- a/benefits/eligibility/templates/eligibility/unverified.html
+++ b/benefits/eligibility/templates/eligibility/unverified.html
@@ -13,16 +13,14 @@
     </div>
 
     {% if agency_links %}
-    <div class="row justify-content-center">
-      <div class="col-lg-8">{% include "core/includes/agency-links.html" with buttons=agency_links %}</div>
-    </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-8">{% include "core/includes/agency-links.html" with buttons=agency_links %}</div>
+      </div>
     {% endif %}
 
-    {% if back_button %}
     <div class="row pt-8 justify-content-center">
-      <div class="col-lg-3 col-8">{% include "core/includes/button.html" with button=back_button %}</div>
+      <div class="col-lg-3 col-8">{% include "core/includes/button--home.html" %}</div>
     </div>
-    {% endif %}
 
   </div>
 {% endblock main_content %}

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -35,8 +35,7 @@ def index(request, agency=None):
         # see if session has an agency
         agency = session.agency(request)
         if agency is None:
-            home = viewmodels.Button.home(request)
-            page = viewmodels.ErrorPage.user_error(button=home, path=request.path)
+            page = viewmodels.ErrorPage.user_error(path=request.path)
             return TemplateResponse(request, "200_user_error.html", page.context_dict())
         else:
             session.update(request, eligibility_types=[], origin=agency.index_url)
@@ -183,7 +182,6 @@ def unverified(request):
     analytics.returned_fail(request, types_to_verify)
 
     agency_links = viewmodels.Button.agency_contact_links(agency)
-    back_button = viewmodels.Button.home(request)
 
     page = viewmodels.Page(
         title=_(verifier.unverified_title),
@@ -194,6 +192,5 @@ def unverified(request):
 
     ctx = page.context_dict()
     ctx["agency_links"] = agency_links
-    ctx["back_button"] = back_button
 
     return TemplateResponse(request, TEMPLATE_UNVERIFIED, ctx)

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -227,6 +227,9 @@ msgstr ""
 "If you need assistance with this website, please reach out to the customer "
 "service team for your local transit provider."
 
+msgid "core.buttons.back"
+msgstr "Go Back"
+
 msgid "core.pages.help.foss.text"
 msgstr ""
 "This application is Free and Open Source Software. You may obtain the source "
@@ -234,6 +237,9 @@ msgstr ""
 
 msgid "core.pages.help.foss.link"
 msgstr "GitHub"
+
+msgid "core.buttons.return_home"
+msgstr "Return Home"
 
 msgid "core.buttons.previous_page"
 msgstr "Previous Page"
@@ -252,9 +258,6 @@ msgid "core.includes.nocookies.text"
 msgstr ""
 "To function properly, this website requires a browser that supports cookies. "
 "Please enable cookies for this website and"
-
-msgid "core.buttons.return_home"
-msgstr "Return Home"
 
 msgid "core.includes.noscript.brand"
 msgstr "JavaScript is disabled"
@@ -337,9 +340,6 @@ msgid "core.pages.agency_index.headline%(transit_agency_short_name_and_type)s"
 msgstr ""
 "Get reduced fare on %(transit_agency_short_name_and_type)s when you tap to "
 "ride"
-
-msgid "core.buttons.back"
-msgstr "Go Back"
 
 msgid "core.pages.logged_out.title"
 msgstr "Logged out"

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -235,6 +235,9 @@ msgstr ""
 "Si necesita ayuda con este sitio web, póngase en contacto con el equipo de "
 "servicio al cliente de su proveedor de transito local."
 
+msgid "core.buttons.back"
+msgstr "Regresar a la Página Principal"
+
 msgid "core.pages.help.foss.text"
 msgstr ""
 "Esta aplicación es un software libre y de código abierto. Puede obtener el "
@@ -242,6 +245,9 @@ msgstr ""
 
 msgid "core.pages.help.foss.link"
 msgstr "GitHub"
+
+msgid "core.buttons.return_home"
+msgstr "Regresar a la Página Principal"
 
 msgid "core.buttons.previous_page"
 msgstr "Página Anterior"
@@ -260,9 +266,6 @@ msgid "core.includes.nocookies.text"
 msgstr ""
 "Para funcionar correctamente, este sitio web requiere un navegador que "
 "admita cookies. Por favor, active cookies por este sitio web y"
-
-msgid "core.buttons.return_home"
-msgstr "Regresar a la Página Principal"
 
 msgid "core.includes.noscript.brand"
 msgstr "JavaScript está inactivo"
@@ -345,9 +348,6 @@ msgid "core.pages.agency_index.headline%(transit_agency_short_name_and_type)s"
 msgstr ""
 "Obtenga una tarifa reducida en el transporte público "
 "%(transit_agency_short_name_and_type)s a cuando toque para viajar"
-
-msgid "core.buttons.back"
-msgstr "Regresar a la Página Principal"
 
 msgid "core.pages.logged_out.title"
 msgstr "Cierre sesión"

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -113,6 +113,7 @@ template_ctx_processors = [
     "django.contrib.messages.context_processors.messages",
     "benefits.core.context_processors.analytics",
     "benefits.core.context_processors.authentication",
+    "benefits.core.context_processors.origin",
 ]
 
 if DEBUG:

--- a/benefits/templates/200_user_error.html
+++ b/benefits/templates/200_user_error.html
@@ -11,9 +11,7 @@
     </div>
 
     <div class="row pt-8 justify-content-center">
-      {% for b in page.buttons %}
-        <div class="col-lg-3 col-8">{% include "core/includes/button.html" with button=b %}</div>
-      {% endfor %}
+      <div class="col-lg-3 col-8">{% include "core/includes/button--home.html" %}</div>
     </div>
   </div>
 {% endblock main_content %}

--- a/benefits/templates/400.html
+++ b/benefits/templates/400.html
@@ -11,9 +11,7 @@
     </div>
 
     <div class="row pt-8 justify-content-center">
-      {% for b in page.buttons %}
-        <div class="col-lg-3 col-8">{% include "core/includes/button.html" with button=b %}</div>
-      {% endfor %}
+      <div class="col-lg-3 col-8">{% include "core/includes/button--home.html" %}</div>
     </div>
   </div>
 {% endblock main_content %}

--- a/benefits/templates/404.html
+++ b/benefits/templates/404.html
@@ -11,9 +11,7 @@
     </div>
 
     <div class="row pt-8 justify-content-center">
-      {% for b in page.buttons %}
-        <div class="col-lg-3 col-8">{% include "core/includes/button.html" with button=b %}</div>
-      {% endfor %}
+      <div class="col-lg-3 col-8">{% include "core/includes/button--home.html" %}</div>
     </div>
   </div>
 {% endblock main_content %}

--- a/benefits/templates/500.html
+++ b/benefits/templates/500.html
@@ -11,9 +11,7 @@
     </div>
 
     <div class="row pt-8 justify-content-center">
-      {% for b in page.buttons %}
-        <div class="col-lg-3 col-8">{% include "core/includes/button.html" with button=b %}</div>
-      {% endfor %}
+      <div class="col-lg-3 col-8">{% include "core/includes/button--home.html" %}</div>
     </div>
   </div>
 {% endblock main_content %}


### PR DESCRIPTION
Part of #1520

The `eligibility:unverified` view uses the _home button_ construct. This also shows up in the `core:help` view as well as in most error pages in `core`.

This PR moves the content to an include, with some added context for the user's current `session.origin` via a new `context_processor`. 

The include is used explicitly where it is needed in templates, removing the need for the `Button.home()` viewmodel helper.