### PR TITLE
Feat: external link icon

### DIFF
--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -108,7 +108,7 @@
             <a class="m-0 ps-5 ps-lg-0" href="{% url "core:help" %}">{% translate "core.buttons.help" %}</a>
           </li>
           <li>
-            <a class="m-0 ps-5 ps-lg-0" href="https://cdt.ca.gov/privacy-policy/" target="_blank" rel="noopener noreferrer">{% translate "core.buttons.privacy" %}</a>
+            <a class="m-0 ps-5 ps-lg-0 external-link" href="https://cdt.ca.gov/privacy-policy/" target="_blank" rel="noopener noreferrer">{% translate "core.buttons.privacy" %}</a>
           </li>
         </ul>
       </div>

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -108,7 +108,7 @@
             <a class="m-0 ps-5 ps-lg-0" href="{% url "core:help" %}">{% translate "core.buttons.help" %}</a>
           </li>
           <li>
-            <a class="m-0 ps-5 ps-lg-0 external-link" href="https://cdt.ca.gov/privacy-policy/" target="_blank" rel="noopener noreferrer">{% translate "core.buttons.privacy" %}</a>
+            <a class="m-0 ps-5 ps-lg-0" href="https://cdt.ca.gov/privacy-policy/" target="_blank" rel="noopener noreferrer">{% translate "core.buttons.privacy" %}</a>
           </li>
         </ul>
       </div>

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -199,7 +199,7 @@ msgstr ""
 "tool to support the Courtesy Card program. This benefit may need to be "
 "renewed in the future based on the expiration date of the Courtesy Card. "
 "Learn more at the <a href='https://mst.org/riders-guide/how-to-ride/courtesy-"
-"card/' target =\"blank\" rel=\"noopener noreferrer\">MST Riders Guide</a>."
+"card/' target=\"_blank\" rel=\"noopener noreferrer\">MST Riders Guide</a>."
 
 msgid "core.pages.help.littlepay"
 msgstr "What is Littlepay?"

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -207,7 +207,7 @@ msgstr ""
 "Tarjeta de Cortesía. Es posible que este beneficio deba renovarse en el "
 "futuro según la fecha de vencimiento de la Tarjeta de Cortesía. Obtenga más "
 "información <a href='https://mst.org/riders-guide/how-to-ride/courtesy-"
-"card/' target =\"blank\" rel=\"noopener noreferrer\">MST Riders Guide</a>."
+"card/' target=\"_blank\" rel=\"noopener noreferrer\">MST Riders Guide</a>."
 
 msgid "core.pages.help.littlepay"
 msgstr "¿Qué es Littlepay?"

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -142,7 +142,7 @@ a:visited:not(.btn) {
   color: var(--selected-color);
 }
 
-.external-link::after {
+[target="_blank"]::after {
   content: " ";
   background-color: currentColor;
 

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -142,6 +142,25 @@ a:visited:not(.btn) {
   color: var(--selected-color);
 }
 
+.external-link::after {
+  content: " ";
+  background-color: currentColor;
+
+  mask-image: url("/static/img/external-link.svg"),
+    linear-gradient(transparent, transparent);
+  mask-position: center center;
+  -webkit-mask-image: url("/static/img/external-link.svg"),
+    linear-gradient(transparent, transparent);
+  -webkit-mask-position: center center;
+
+  display: inline-block;
+  position: relative;
+  width: 24px;
+  height: 24px;
+  margin-left: 2px;
+  vertical-align: text-bottom;
+}
+
 /* Headlines */
 /* All headlines */
 /* All headlines share font-weight, letter-spacing, line-height and margin */

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -142,7 +142,7 @@ a:visited:not(.btn) {
   color: var(--selected-color);
 }
 
-[target="_blank"]::after {
+a[target="_blank"]::after {
   content: " ";
   background-color: currentColor;
 

--- a/benefits/static/img/external-link.svg
+++ b/benefits/static/img/external-link.svg
@@ -1,0 +1,11 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="icon">
+<g id="USWDS Components">
+<g id="Icons">
+<g id="Fill">
+<path id="Vector" fill-rule="evenodd" clip-rule="evenodd" d="M19 19H5V5H12V3H5C3.89 3 3 3.9 3 5V19C3 20.1 3.89 21 5 21H19C20.1 21 21 20.1 21 19V12H19V19ZM14 3V5H17.59L7.76 14.83L9.17 16.24L19 6.41V10H21V3H14Z" fill="#045B86"/>
+</g>
+</g>
+</g>
+</g>
+</svg>


### PR DESCRIPTION
Closes #1471 

Also closes #1478 , closes #1484 

This PR assumes that all external links have an attribute of `target="_blank"` and adds an icon after the link.

### Footer links

![image](https://github.com/cal-itp/benefits/assets/25497886/77cd9a3f-fa6a-4a25-98e2-e07eb7cd95fa)

<img src="https://github.com/cal-itp/benefits/assets/25497886/5fedbdfd-bfb8-466a-bef8-2ab0b7055736" width="500">

### Eligibility index
![image](https://github.com/cal-itp/benefits/assets/25497886/c0e77b7d-1da5-47fa-9f55-40841d521d7e)

<img src="https://github.com/cal-itp/benefits/assets/25497886/1e11887c-4836-4c7b-8e56-e2e0c1e13d36" width="500">

### Help page
![image](https://github.com/cal-itp/benefits/assets/25497886/16f01af4-0b31-4236-bcfa-177238623054)

<img src="https://github.com/cal-itp/benefits/assets/25497886/5f8d9f17-0658-4e14-bcd3-88231a7bb1e0" width="500">





