### PR TITLE
Fixes: CSS column alignment

### DIFF
--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -72,11 +72,11 @@
         <div class="container main-row">
           <div class="row justify-content-center">
             {% block headline %}
-              <div class="col-lg-10">
+              <div class="col-lg-8">
                 <h1>{{ page.headline }}</h1>
               </div>
             {% endblock headline %}
-            <div class="col-lg-10">
+            <div class="col-lg-8">
               {% block explanatory-text %}
               {% endblock explanatory-text %}
             </div>

--- a/benefits/core/templates/core/includes/form.html
+++ b/benefits/core/templates/core/includes/form.html
@@ -6,7 +6,7 @@
   <form id="{{ form.id }}" action="{{ form_action }}" method="{{ form.method | default:"post" | upper }}" role="form">
     {% csrf_token %}
 
-    <div class="row form-container">
+    <div class="row form-container justify-content-center">
       <div class="{{ form.classes }}">
         {% for field in form %}
           <div class="row form-group mb-0">

--- a/benefits/eligibility/forms.py
+++ b/benefits/eligibility/forms.py
@@ -27,7 +27,7 @@ class EligibilityVerifierSelectionForm(forms.Form):
         super().__init__(*args, **kwargs)
         verifiers = agency.eligibility_verifiers.all()
 
-        self.classes = "offset-lg-1 col-lg-9"
+        self.classes = "col-lg-8"
         # second element is not used since we render the whole label using selection_label_template,
         # therefore set to None
         self.fields["verifier"].choices = [(v.id, None) for v in verifiers]
@@ -56,7 +56,7 @@ class EligibilityVerificationForm(forms.Form):
     def __init__(self, verifier: models.EligibilityVerifier, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.classes = "offset-lg-3 col-lg-6"
+        self.classes = "col-lg-6"
         sub_widget = widgets.FormControlTextInput(placeholder=verifier.form_sub_placeholder)
         if verifier.form_sub_pattern:
             sub_widget.attrs.update({"pattern": verifier.form_sub_pattern})

--- a/benefits/eligibility/templates/eligibility/index.html
+++ b/benefits/eligibility/templates/eligibility/index.html
@@ -15,7 +15,7 @@
 {% endblock nav-buttons %}
 
 {% block headline %}
-  <div class="col-lg-10">
+  <div class="col-lg-8">
     <h1>{% translate "eligibility.pages.index.headline" %}</h1>
   </div>
 {% endblock headline %}
@@ -24,7 +24,5 @@
 {% endblock explanatory-text %}
 
 {% block inner-content %}
-  <div class="container">
-    <div class="row">{% include "core/includes/form.html" with form=form %}</div>
-  </div>
+  {% include "core/includes/form.html" with form=form %}
 {% endblock inner-content %}

--- a/benefits/eligibility/templates/eligibility/start--mst-courtesy-card.html
+++ b/benefits/eligibility/templates/eligibility/start--mst-courtesy-card.html
@@ -6,7 +6,7 @@
 {% endblock page-title %}
 
 {% block headline %}
-  <div class="col-lg-10">
+  <div class="col-lg-8">
     <h1>{% translate "eligibility.pages.start.mst_courtesy_card.headline" %}</h1>
   </div>
 {% endblock headline %}

--- a/benefits/eligibility/templates/eligibility/start--senior.html
+++ b/benefits/eligibility/templates/eligibility/start--senior.html
@@ -6,7 +6,7 @@
 {% endblock page-title %}
 
 {% block headline %}
-  <div class="col-lg-10">
+  <div class="col-lg-8">
     <h1>{% translate "eligibility.pages.start.senior.headline" %}</h1>
   </div>
 {% endblock headline %}

--- a/benefits/eligibility/templates/eligibility/start--veteran.html
+++ b/benefits/eligibility/templates/eligibility/start--veteran.html
@@ -6,7 +6,7 @@
 {% endblock page-title %}
 
 {% block headline %}
-  <div class="col-lg-10">
+  <div class="col-lg-8">
     <h1>{% translate "eligibility.pages.start.veteran.headline" %}</h1>
   </div>
 {% endblock headline %}

--- a/benefits/eligibility/templates/eligibility/start.html
+++ b/benefits/eligibility/templates/eligibility/start.html
@@ -11,7 +11,7 @@
 {% endblock nav-buttons %}
 
 {% block inner-content %}
-  <div class="col-12 col-sm-12 col-lg-10">
+  <div class="col-12 col-sm-12 col-lg-8">
     <h2 class="media-title p-sm">{% translate "eligibility.pages.start.sub_headline" %}</h2>
     <ul class="media-list mx-0 px-0 d-flex justify-content-center flex-column">
       {% block media-item %}

--- a/benefits/enrollment/templates/enrollment/index.html
+++ b/benefits/enrollment/templates/enrollment/index.html
@@ -18,7 +18,7 @@
 {% endblock headline %}
 
 {% block inner-content %}
-  <div class="col-12 col-sm-12 col-lg-10">
+  <div class="col-12 col-sm-12 col-lg-8">
     <ul class="media-list mx-0 px-0 d-flex justify-content-center flex-column">
       {% include "enrollment/includes/media-item--bankcardcheck--index.html" %}
     </ul>

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -561,7 +561,7 @@ footer .footer-links li a:visited {
 @media (min-width: 992px) {
   :root {
     --media-item-icon-size: calc(90rem / 16);
-    --media-item-gap: calc(62rem / 16);
+    --media-item-gap: calc(24rem / 16);
     --media-item-icon-margin: calc(32rem / 16);
     --media-title-margin-top: calc(32rem / 16);
   }
@@ -580,7 +580,7 @@ h1 + .media-list, /* A .media-list immediately following the h1: Enrollment Succ
 
 .media-list {
   gap: var(--media-item-gap);
-  margin-bottom: calc(64rem / 16);
+  margin-bottom: calc(55rem / 16);
 }
 
 .media-list .media .media-line .icon {

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -580,7 +580,7 @@ h1 + .media-list, /* A .media-list immediately following the h1: Enrollment Succ
 
 .media-list {
   gap: var(--media-item-gap);
-  margin-bottom: calc(55rem / 16);
+  margin-bottom: calc(64rem / 16);
 }
 
 .media-list .media .media-line .icon {

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -562,8 +562,8 @@ footer .footer-links li a:visited {
   :root {
     --media-item-icon-size: calc(90rem / 16);
     --media-item-gap: calc(24rem / 16);
-    --media-item-icon-margin: calc(64rem / 16);
-    --media-title-margin-top: calc(32rem / 16);
+    --media-item-icon-margin: calc(32rem / 16);
+    --media-title-margin-top: calc(64rem / 16);
   }
 }
 

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -563,7 +563,7 @@ footer .footer-links li a:visited {
     --media-item-icon-size: calc(90rem / 16);
     --media-item-gap: calc(62rem / 16);
     --media-item-icon-margin: calc(32rem / 16);
-    --media-title-margin-top: calc(64rem / 16);
+    --media-title-margin-top: calc(32rem / 16);
   }
 }
 

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -562,7 +562,7 @@ footer .footer-links li a:visited {
   :root {
     --media-item-icon-size: calc(90rem / 16);
     --media-item-gap: calc(24rem / 16);
-    --media-item-icon-margin: calc(32rem / 16);
+    --media-item-icon-margin: calc(64rem / 16);
     --media-title-margin-top: calc(32rem / 16);
   }
 }


### PR DESCRIPTION
closes #1548 

- Desktop: Container width for most* pages is now `col-lg-8`, not `col-lg-10`. Index page, Agency Index page and Enrollment Success is an outlier and is not part of this. No changes necessary for 404/400/500 pages. Also one page has a `col-lg-6` H1 wrapper container instead. Because some pages _are_ actually different from others, I recommend *not* codifying the `col-lg-8` width into the `base.html` itself.
- Desktop: Media Item grid gap is now lower to 24px. 
- Mobile: Should have no changes

### Screenshots

<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/f13cd83d-5a54-4b90-b02e-9101dc39480b">
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/0495389f-d970-4a08-9c0f-564c42d191d9">
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/7178895b-6901-4c08-8cf2-07bd33114e39">
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/00a8deaa-1ba9-4efd-9e70-b9fb21d5b93e">

<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/4511ab75-1c0e-4031-8725-dfdfeaacacd4">
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/421e76ce-dfa2-49d0-9da6-1de3770e9981">
