### PR TITLE
Fix: Eligibility Index - Radio button alignment 

### DIFF
--- a/benefits/core/templates/core/widgets/verifier-radio-select.html
+++ b/benefits/core/templates/core/widgets/verifier-radio-select.html
@@ -4,7 +4,7 @@
 
   <label for="{{ id }}" class="pb-4 h2">{% translate "eligibility.pages.index.label" %}</label>
 
-  <div {% if id %}id="{{ id }}"{% endif %} class="radio-container">
+  <div {% if id %}id="{{ id }}"{% endif %} class="ps-3 ps-md-0 ps-lg-0 offset-md-1 offset-lg-1 radio-container">
     {% for group, options, index in widget.optgroups %}
       {% if group %}
         <div>


### PR DESCRIPTION
closes #1545 

The alignment logic:
- Desktop and Tablet: The radio buttons have a 1 column offset (`offset-lg-1`)
- Mobile: The radio buttons have a padding-left of 16px (`ps-3`), and no offset.

## Desktop
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/16fe0fd9-c6e9-4291-96ff-c0793b2fe406">

## Tablet
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/65c411c3-3689-4731-a1d7-719f0bed8f37">
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/3f818d96-ea1a-428d-9b7c-1adef5935022">


## Mobile
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/7f3d7176-2e2a-4b15-bd3e-a811ee96c4fb">
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/72198133-1c8b-45f0-a078-f59052e94bb4">
