### PR TITLE
Fix: Question mark and color Login.gov sizing alignment

### DIFF
--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -718,7 +718,6 @@ a.card:focus-visible {
   display: inline-block;
   width: 22px;
   height: 22px;
-  margin-left: 2px;
   vertical-align: text-bottom;
 }
 

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -384,8 +384,6 @@ footer .footer-links li a:visited {
   display: block;
   margin: 8px auto 0 auto;
   position: relative;
-  width: 132px;
-  height: 18px;
   padding-top: 1px;
   color: transparent;
   font-size: var(--font-size-16px);
@@ -399,10 +397,14 @@ footer .footer-links li a:visited {
 
 #login .fallback-text.white-logo {
   background-image: url("/static/img/login-gov-logo-rev.svg");
+  width: 132px;
+  height: 18px;
 }
 
 #login .fallback-text.color-logo {
   background-image: url("/static/img/login-gov-logo.svg");
+  width: 120px;
+  height: 16px;
 }
 
 @media (min-width: 992px) {
@@ -714,8 +716,8 @@ a.card:focus-visible {
   background-image: url("/static/img/modal-trigger.svg");
   background-size: contain;
   display: inline-block;
-  width: 24px;
-  height: 24px;
+  width: 22px;
+  height: 22px;
   margin-left: 2px;
   vertical-align: text-bottom;
 }


### PR DESCRIPTION
fixes #1553 

This PR only deals with the _color_ Login.gov icon (on Elig Index and Enrollment Success), and the question mark next to the Login.gov icon on Elig Index

The issues:
- Sizing - ? should be 22x22, on both Desktop and Mobile
- Sizing - the color Login.gov is a bit smaller than the white one, at 120x16.
- There doesn't need to be the margin of 2px between the Login.gov button and the question mark (and any text).

<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/2b065150-e7e3-47c8-8b7f-670dbacbb20c">
<img width="962" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/7550fb01-67b1-4af3-84b5-210be27dabdd">
