### PR TITLE
Refactor: Add alt tags to the landing pages

### DIFF
--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -3,7 +3,7 @@
 {% load static %}
 {% get_current_language as LANGUAGE_CODE %}
 <!DOCTYPE html>
-<html lang="{{ LANGUAGE_CODE }}" class="{% block classes %}{% endblock classes %}">
+<html lang="{{ LANGUAGE_CODE }}" class="{% block classes %}{% endblock classes %}{% if debug %}debug{% endif %}">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
@@ -51,7 +51,7 @@
         {% include "core/includes/noscript.html" %}
       </noscript>
 
-      <div id="header-container" class="navbar navbar-expand-sm navbar-dark bg-primary justify-content-between">
+      <div id="header-container" class="navbar navbar-expand-sm navbar-dark bg-primary justify-content-between position-static">
         <div class="container">
           <span class="navbar-brand p-0">
             <img class="sm d-lg-none" src="{% static "img/logo-sm.svg" %}" width="90" height="51.3" alt="{% translate "core.logos.small" context "image alt text" %}" />

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -35,9 +35,6 @@
     {% include "core/includes/analytics.html" with api_key=analytics.api_key uid=analytics.uid did=analytics.did %}
   </head>
   <body>
-    {% if debug %}
-      {% include "core/includes/debug.html" %}
-    {% endif %}
     <header role="banner" id="header">
       <div id="skip-to-content">
         <a href="#main-content">{% translate "core.buttons.skip" %}</a>
@@ -113,6 +110,10 @@
         </ul>
       </div>
     </footer>
+
+    {% if debug %}
+      {% include "core/includes/debug.html" %}
+    {% endif %}
 
     {% comment %}
       CA State Template v6.0.7 comes with Bootstrap v5.1.3

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -98,7 +98,7 @@
       {% endblock main-content %}
     </main>
 
-    <footer id="footer">
+    <footer id="footer" class="position-relative">
       <div class="container">
         <ul class="footer-links m-0 p-0 list-unstyled d-lg-flex gap-lg-4">
           <li>

--- a/benefits/core/templates/core/index.html
+++ b/benefits/core/templates/core/index.html
@@ -1,9 +1,25 @@
 {% extends "core/landing.html" %}
 
 {% load i18n %}
+{% load static %}
 
-{% block call-to-action %}
-    {% translate "core.pages.index.button" as trigger_text %}
-    {% include "core/includes/modal-trigger.html" with id="agency-selector" classes="btn btn-lg btn-primary" text=trigger_text %}
+{% block main-content %}
+    {# djlint:off #}
+    <img class="image w-100 d-none d-sm-none d-md-none d-lg-block" src="{% static "img/benefits-bg-desktop.jpg" %}" alt="{% translate "core.pages.index.alt" %}">
+    <img class="image w-100 d-sm-block d-md-block d-lg-none" src="{% static "img/benefits-bg-mobile.jpg" %}" alt="{% translate "core.pages.index.alt" %}">
+    {# djlint:on #}
+    <div class="container landing-container position-absolute start-0 end-0">
+        <div class="col-lg-5 col-12">
+            <div class="box px-4 py-3 px-lg-0 py-lg-0">
+                <h1 class="text-left p-0">{{ page.headline }}</h1>
+                <h2 class="p-sm pb-lg-8 pt-1 pt-lg-4 pb-4">{% translate "core.pages.landing.h2" %}</h2>
+                {% block call-to-action %}
+                    {% translate "core.pages.index.button" as trigger_text %}
+                    {% include "core/includes/modal-trigger.html" with id="agency-selector" classes="btn btn-lg btn-primary" text=trigger_text %}
+                {% endblock call-to-action %}
+            </div>
+        </div>
+    </div>
+
     {% include "core/includes/modal--agency-selector.html" with id="agency-selector" %}
-{% endblock call-to-action %}
+{% endblock main-content %}

--- a/benefits/core/templates/core/landing.html
+++ b/benefits/core/templates/core/landing.html
@@ -1,19 +1,22 @@
 {% extends "core/base.html" %}
 {% load i18n %}
+{% load static %}
 {% block classes %}
   {{ block.super |add:" landing" }}
 {% endblock classes %}
 
 {% block main-content %}
-  <div class="container">
-    <div class="row align-items-end align-items-lg-center">
-      <div class="col-lg-5">
-        <div class="box px-4 py-3">
-          <h1 class="text-left p-0">{{ page.headline }}</h1>
-          <h2 class="p-sm pb-lg-8 pt-1 pt-lg-4 pb-4">{% translate "core.pages.landing.h2" %}</h2>
-          {% block call-to-action %}
-          {% endblock call-to-action %}
-        </div>
+  {# djlint:off #}
+  <img class="image w-100 d-none d-sm-none d-md-none d-lg-block" src="{% static "img/benefits-bg-desktop.jpg" %}" alt="A person holds a contactless debit card next to a card reader on a bus.">
+  <img class="image w-100 d-sm-block d-md-block d-lg-none" src="{% static "img/benefits-bg-mobile.jpg" %}" alt="A person holds a contactless debit card next to a card reader on a bus.">
+  {# djlint:on #}
+  <div class="container landing-container">
+    <div class="col-lg-5 col-12">
+      <div class="box px-4 py-3 px-lg-0 py-lg-0">
+        <h1 class="text-left p-0">{{ page.headline }}</h1>
+        <h2 class="p-sm pb-lg-8 pt-1 pt-lg-4 pb-4">{% translate "core.pages.landing.h2" %}</h2>
+        {% block call-to-action %}
+        {% endblock call-to-action %}
       </div>
     </div>
   </div>

--- a/benefits/core/templates/core/landing.html
+++ b/benefits/core/templates/core/landing.html
@@ -10,7 +10,7 @@
   <img class="image w-100 d-none d-sm-none d-md-none d-lg-block" src="{% static "img/benefits-bg-desktop.jpg" %}" alt="{% translate "core.pages.index.alt" %}">
   <img class="image w-100 d-sm-block d-md-block d-lg-none" src="{% static "img/benefits-bg-mobile.jpg" %}" alt="{% translate "core.pages.index.alt" %}">
   {# djlint:on #}
-  <div class="container landing-container">
+  <div class="container landing-container position-absolute start-0 end-0">
     <div class="col-lg-5 col-12">
       <div class="box px-4 py-3 px-lg-0 py-lg-0">
         <h1 class="text-left p-0">{{ page.headline }}</h1>

--- a/benefits/core/templates/core/landing.html
+++ b/benefits/core/templates/core/landing.html
@@ -7,8 +7,8 @@
 
 {% block main-content %}
   {# djlint:off #}
-  <img class="image w-100 d-none d-sm-none d-md-none d-lg-block" src="{% static "img/benefits-bg-desktop.jpg" %}" alt="A person holds a contactless debit card next to a card reader on a bus.">
-  <img class="image w-100 d-sm-block d-md-block d-lg-none" src="{% static "img/benefits-bg-mobile.jpg" %}" alt="A person holds a contactless debit card next to a card reader on a bus.">
+  <img class="image w-100 d-none d-sm-none d-md-none d-lg-block" src="{% static "img/benefits-bg-desktop.jpg" %}" alt="{% translate "core.pages.index.alt" %}">
+  <img class="image w-100 d-sm-block d-md-block d-lg-none" src="{% static "img/benefits-bg-mobile.jpg" %}" alt="{% translate "core.pages.index.alt" %}">
   {# djlint:on #}
   <div class="container landing-container">
     <div class="col-lg-5 col-12">

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -2,11 +2,10 @@
 # Copyright (C) 2021 California Department of Transportation
 # This file is distributed under the same license as the benefits package.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2023-07-25 01:52+0000\n"
+"POT-Creation-Date: 2023-07-25 18:34+0000\n"
 "Language: English\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -682,8 +681,6 @@ msgstr ""
 "The page you are looking for might be somewhere else or may not exist "
 "anymore."
 
-#, fuzzy
-#| msgid "core.icons.sadbus"
 msgctxt "image alt text"
 msgid "core.icons.sadbus"
 msgstr "Bus icon with flat tire"

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2023-07-21 16:47+0000\n"
+"POT-Creation-Date: 2023-07-25 01:52+0000\n"
 "Language: English\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -254,6 +254,10 @@ msgstr "Sign out of Login.gov"
 msgid "core.pages.index.button"
 msgstr "Choose your Provider"
 
+msgid "core.pages.index.alt"
+msgstr ""
+"A person holds a contactless debit card next to a card reader on a bus."
+
 msgid "core.pages.landing.h2"
 msgstr ""
 "Cal-ITP Benefits connects your transit benefit to your contactless card"
@@ -263,6 +267,10 @@ msgstr "You have successfully logged out."
 
 msgid "core.pages.logged_out.headline[1]"
 msgstr "Thank you for using Cal-ITP Benefits!"
+
+msgctxt "image alt text"
+msgid "core.icons.happybus"
+msgstr "Bus icon with smiley face"
 
 msgid "eligibility.pages.index.label"
 msgstr "Which transit benefit would you like to enroll in?"
@@ -287,10 +295,6 @@ msgstr ""
 
 msgid "core.pages.logged_out.title"
 msgstr "Logged out"
-
-msgctxt "image alt text"
-msgid "core.icons.happybus"
-msgstr "Bus icon with smiley face"
 
 msgid "eligibility.buttons.choose"
 msgstr "Choose this Benefit"
@@ -560,6 +564,10 @@ msgstr "You will need a few items to continue:"
 msgid "eligibility.pages.unverified.title"
 msgstr "Eligibility Error"
 
+msgctxt "image alt text"
+msgid "core.icons.idcardquestion"
+msgstr "Identification card icon with question mark"
+
 msgid "eligibility.pages.unverified.headline"
 msgstr "Your eligibility could not be verified."
 
@@ -569,10 +577,6 @@ msgstr "That’s okay! You may still be eligible for our program."
 #, python-format
 msgid "eligibility.pages.unverified.p[0]s[1]%(short_name)s"
 msgstr "Please reach out to %(short_name)s for assistance."
-
-msgctxt "image alt text"
-msgid "core.icons.idcardquestion"
-msgstr "Identification card icon with question mark"
 
 msgid "enrollment.pages.index.link_card_item.heading"
 msgstr ""
@@ -614,6 +618,13 @@ msgstr "Please wait..."
 msgid "enrollment.buttons.payment_partner"
 msgstr "Connect your Card"
 
+msgctxt "image alt text"
+msgid "core.icons.bankcardquestion"
+msgstr "Bank card icon with contactless symbol and question mark"
+
+msgid "enrollment.pages.retry.title"
+msgstr "We couldn’t connect your bank card"
+
 msgid "enrollment.pages.success.title"
 msgstr "Success"
 
@@ -633,13 +644,6 @@ msgstr "Thank you for using Cal-ITP Benefits!"
 msgid "enrollment.pages.success.logout"
 msgstr ""
 "If you are on a public or shared computer, don’t forget to sign out of "
-
-msgid "enrollment.pages.retry.title"
-msgstr "We couldn’t connect your bank card"
-
-msgctxt "image alt text"
-msgid "core.icons.bankcardquestion"
-msgstr "Bank card icon with contactless symbol and question mark"
 
 msgid "enrollment.pages.retry.p[0]"
 msgstr ""
@@ -678,5 +682,8 @@ msgstr ""
 "The page you are looking for might be somewhere else or may not exist "
 "anymore."
 
+#, fuzzy
+#| msgid "core.icons.sadbus"
+msgctxt "image alt text"
 msgid "core.icons.sadbus"
 msgstr "Bus icon with flat tire"

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -2,11 +2,10 @@
 # Copyright (C) 2021 California Department of Transportation
 # This file is distributed under the same license as the benefits package.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2023-07-25 01:52+0000\n"
+"POT-Creation-Date: 2023-07-25 18:34+0000\n"
 "Language: Español\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -696,8 +695,6 @@ msgstr ""
 "La página que estás buscando puede estar en otro lugar o puede que ya no "
 "exista."
 
-#, fuzzy
-#| msgid "core.icons.sadbus"
 msgctxt "image alt text"
 msgid "core.icons.sadbus"
 msgstr "Icono de autobus con llanta ponchada"

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2023-07-21 16:47+0000\n"
+"POT-Creation-Date: 2023-07-25 01:52+0000\n"
 "Language: Español\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -261,6 +261,11 @@ msgstr "Cierre sesión de Login.gov"
 msgid "core.pages.index.button"
 msgstr "Elija su Proveedor"
 
+msgid "core.pages.index.alt"
+msgstr ""
+"Una persona sostiene una tarjeta de débito junto a un lector de tarjetas en "
+"un autobús."
+
 msgid "core.pages.landing.h2"
 msgstr "Su beneficio se aplicará cada vez que acerque su tarjeta para viajar"
 
@@ -269,6 +274,10 @@ msgstr "Ha cerrado la sesión correctamente."
 
 msgid "core.pages.logged_out.headline[1]"
 msgstr "¡Gracias por usar los Beneficios de Cal-ITP!"
+
+msgctxt "image alt text"
+msgid "core.icons.happybus"
+msgstr "Icono de autobús con cara sonriente"
 
 msgid "eligibility.pages.index.label"
 msgstr "TODO: Which transit benefit would you like to enroll in?"
@@ -294,10 +303,6 @@ msgstr ""
 
 msgid "core.pages.logged_out.title"
 msgstr "Cierre sesión"
-
-msgctxt "image alt text"
-msgid "core.icons.happybus"
-msgstr "Icono de autobús con cara sonriente"
 
 msgid "eligibility.buttons.choose"
 msgstr "Elija este Beneficio"
@@ -570,6 +575,10 @@ msgstr "TODO: Necesitará algunos artículos para conectar su beneficio:"
 msgid "eligibility.pages.unverified.title"
 msgstr "Error de elegibilidad"
 
+msgctxt "image alt text"
+msgid "core.icons.idcardquestion"
+msgstr "Icono de tarjeta de identificación con signo de interrogación"
+
 msgid "eligibility.pages.unverified.headline"
 msgstr "No se pudo verificar su elegibilidad."
 
@@ -579,10 +588,6 @@ msgstr "TODO: ¡Esta bien! Aún puede ser elegible para nuestro programa."
 #, python-format
 msgid "eligibility.pages.unverified.p[0]s[1]%(short_name)s"
 msgstr "TODO: Comuníquese con %(short_name)s para obtener asistencia."
-
-msgctxt "image alt text"
-msgid "core.icons.idcardquestion"
-msgstr "Icono de tarjeta de identificación con signo de interrogación"
 
 msgid "enrollment.pages.index.link_card_item.heading"
 msgstr ""
@@ -625,6 +630,14 @@ msgstr "Espere por favor..."
 msgid "enrollment.buttons.payment_partner"
 msgstr "Conecta tu tarjeta"
 
+msgctxt "image alt text"
+msgid "core.icons.bankcardquestion"
+msgstr ""
+"Icono de tarjeta bancaria con símbolo sin contacto y signo de interrogación"
+
+msgid "enrollment.pages.retry.title"
+msgstr "No pudimos conectar tú tarjeta bancaria"
+
 msgid "enrollment.pages.success.title"
 msgstr "Éxito"
 
@@ -644,14 +657,6 @@ msgstr "Gracias por usar los Beneficios de Cal-ITP."
 msgid "enrollment.pages.success.logout"
 msgstr ""
 "Si está en una computadora pública o compartida, no olvide cerrar sesión en "
-
-msgid "enrollment.pages.retry.title"
-msgstr "No pudimos conectar tú tarjeta bancaria"
-
-msgctxt "image alt text"
-msgid "core.icons.bankcardquestion"
-msgstr ""
-"Icono de tarjeta bancaria con símbolo sin contacto y signo de interrogación"
 
 msgid "enrollment.pages.retry.p[0]"
 msgstr ""
@@ -691,5 +696,8 @@ msgstr ""
 "La página que estás buscando puede estar en otro lugar o puede que ya no "
 "exista."
 
+#, fuzzy
+#| msgid "core.icons.sadbus"
+msgctxt "image alt text"
 msgid "core.icons.sadbus"
 msgstr "Icono de autobus con llanta ponchada"

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -765,12 +765,12 @@ a.card:focus-visible {
   :root {
     --landing-main-height: calc(
       100vh - 130px
-    ); /* 130px = Header Height (80px) + (Footer Link (50px) */
+    ); /* 130px = Header Height (80px) + Footer Link (50px) */
     --landing-box-background: transparent;
     --landing-box-border: none;
     --landing-text-color: var(--bs-white);
     --landing-page-x-margin: 0;
-    --landing-box-top: 215px;
+    --landing-box-top: 215px; /* 215px = Header Height (80px) + Margin (135px) */
   }
 }
 

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -754,15 +754,11 @@ a.card:focus-visible {
 
 :root {
   --landing-main-height: calc(100vh - 80px); /* Header Height (80px) */
-  --landing-background: url("/static/img/benefits-bg-mobile.jpg") no-repeat
-    var(--primary-color);
   --landing-box-background: var(--bs-white);
   --landing-box-border: 12px solid var(--primary-color);
   --landing-text-color: var(--text-primary-color);
-  --agency-index-box-background: var(--bs-white);
-  --agency-index-box-border: 12px solid var(--primary-color);
-  --agency-index-text-color: var(--text-primary-color);
   --landing-page-x-margin: auto;
+  --landing-box-top: inherit;
 }
 
 @media (min-width: 992px) {
@@ -770,21 +766,26 @@ a.card:focus-visible {
     --landing-main-height: calc(
       100vh - 130px
     ); /* 130px = Header Height (80px) + (Footer Link (50px) */
-    --landing-background: url("/static/img/benefits-bg-desktop.jpg") no-repeat;
     --landing-box-background: transparent;
     --landing-box-border: none;
     --landing-text-color: var(--bs-white);
     --landing-page-x-margin: 0;
+    --landing-box-top: 215px;
   }
 }
 
-.landing main#main-content {
-  background: var(--landing-background);
-  background-size: cover;
+.landing main#main-content .image {
+  height: var(--landing-main-height);
+  object-fit: cover;
+  object-position: top;
 }
 
-.landing main#main-content .container .row:first-child {
-  min-height: var(--landing-main-height);
+.landing-container {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: var(--landing-box-top);
 }
 
 .landing .box {

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -764,7 +764,8 @@ a.card:focus-visible {
   --landing-text-color: var(--text-primary-color);
   --landing-page-x-margin: auto;
   --landing-container-bottom: 0;
-  --landing-box-top: inherit;
+  --landing-container-top: inherit;
+  --landing-container-transform: inherit;
 }
 
 @media (min-width: 992px) {
@@ -777,7 +778,8 @@ a.card:focus-visible {
     --landing-text-color: var(--bs-white);
     --landing-page-x-margin: 0;
     --landing-container-bottom: 50px; /* Desktop Footer Height (50px) */
-    --landing-box-top: 215px; /* 215px = Header Height (80px) + Margin (135px) */
+    --landing-container-top: 50%;
+    --landing-container-transform: translate(0%, -50%);
   }
 }
 
@@ -789,7 +791,8 @@ a.card:focus-visible {
 
 .landing-container {
   bottom: var(--landing-container-bottom);
-  top: var(--landing-box-top);
+  top: var(--landing-container-top);
+  transform: var(--landing-container-transform);
 }
 
 .landing .box {

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -55,6 +55,11 @@
     url("../fonts/PublicSans-Bold.woff") format("woff");
 }
 
+html.debug {
+  outline: 5px solid var(--error-color);
+  outline-offset: -5px;
+}
+
 body {
   font-size: 100%;
 }

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -763,6 +763,7 @@ a.card:focus-visible {
   --landing-box-border: 12px solid var(--primary-color);
   --landing-text-color: var(--text-primary-color);
   --landing-page-x-margin: auto;
+  --landing-container-bottom: 0;
   --landing-box-top: inherit;
 }
 
@@ -775,6 +776,7 @@ a.card:focus-visible {
     --landing-box-border: none;
     --landing-text-color: var(--bs-white);
     --landing-page-x-margin: 0;
+    --landing-container-bottom: 50px; /* Desktop Footer Height (50px) */
     --landing-box-top: 215px; /* 215px = Header Height (80px) + Margin (135px) */
   }
 }
@@ -786,10 +788,7 @@ a.card:focus-visible {
 }
 
 .landing-container {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  bottom: var(--landing-container-bottom);
   top: var(--landing-box-top);
 }
 


### PR DESCRIPTION
fix #1418 

- This PR moves the debug bar to the bottom, adds an `outline` of 5px (with an `outline-offset` of -5px to ensure this outline doesn't affect any widths). This was necessary to have the CSS work for the way the now absolutely-positioned div's logic from the top is calculated.
- Replaces `background-image` with 2 responsive `img` tags.
- Absolutely positions the div with text to be 135px from the top on Desktop, and set to bottom: 0 for Mobile
- Adds alt tag content to django.po file

## How to test this PR
- Test the Index page - Desktop (in all sizes), tablet, mobile. Test the modal works. Test that the footer links work correctly.
- Test the Agency Index page - Desktop (in all sizes), tablet, mobile

## Screenshots

### Desktop
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/dfc6ce05-abdf-46f0-948f-8601415fadb1">
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/7f2f1b42-09c5-4c94-99ca-2752ccdc0636">
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/6ad83361-4cab-42ba-bbe2-cf666c150b09">
Observe that there are no height/width changes with the addition of the border

Short screens/weird width screens - Ensure the scaling/spacing/alignment is the same as Production
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/7e11d547-663e-42b6-81ee-b39014ee402a">
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/ab5dac4c-4e4b-4d23-a0bd-12a1c470d1a0">


### Tablet
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/a4d8f589-8b8f-4226-8cf2-70f88fa4a43e">

### Mobile
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/c3bc419a-15cb-4d6c-a425-d6936ddfe538">
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/d3955f62-47e1-4d61-afe9-c2b278959cce">


