### PR TITLE
Fix: ignore line that causes prettier bug

### DIFF
--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -50,9 +50,9 @@
   font-family: "Public Sans";
   font-weight: var(--bold-font-weight);
   font-style: normal;
-  src:
-    local("PublicSans"),
-    url("../fonts/PublicSans-Bold.woff") format("woff");
+  /* prettier-ignore */
+  src: local("PublicSans"), url("../fonts/PublicSans-Bold.woff") format("woff");
+  /* prettier-ignore */
 }
 
 body {


### PR DESCRIPTION
Currently, there's a version mismatch between the `prettier` in VSCode and the one in pre-commit. The latest version of `prettier` has a new rule, that gets tripped up on 1 line of CSS. This PR ignores that line until the 2 versions match.