### PR TITLE
Fix: Add alt text to index, agency index background image

### DIFF
--- a/benefits/core/templates/core/landing.html
+++ b/benefits/core/templates/core/landing.html
@@ -11,6 +11,7 @@
         <div class="box px-4 py-3">
           <h1 class="text-left p-0">{{ page.headline }}</h1>
           <h2 class="p-sm pb-lg-8 pt-1 pt-lg-4 pb-4">{% translate "core.pages.landing.h2" %}</h2>
+          <span role="img" aria-label="{% translate "core.pages.index.alt" %}"></span>
           {% block call-to-action %}
           {% endblock call-to-action %}
         </div>

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -278,6 +278,10 @@ msgstr "Choose Provider"
 msgid "core.pages.index.headline"
 msgstr "Get reduced fare on public transportation when you tap to ride"
 
+msgid "core.pages.index.alt"
+msgstr ""
+"A person holds a contactless debit card next to a card reader on a bus."
+
 msgid "core.pages.agency_index.title"
 msgstr "Introduction"
 

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -282,6 +282,11 @@ msgid "core.pages.index.headline"
 msgstr ""
 "Obtenga una tarifa reducida en el transporte público cuando toque para viajar"
 
+msgid "core.pages.index.alt"
+msgstr ""
+"Una persona sostiene una tarjeta de débito junto a un lector de tarjetas en "
+"un autobús."
+
 msgid "core.pages.agency_index.title"
 msgstr "Introducción"
 

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -759,9 +759,6 @@ a.card:focus-visible {
   --landing-box-background: var(--bs-white);
   --landing-box-border: 12px solid var(--primary-color);
   --landing-text-color: var(--text-primary-color);
-  --agency-index-box-background: var(--bs-white);
-  --agency-index-box-border: 12px solid var(--primary-color);
-  --agency-index-text-color: var(--text-primary-color);
   --landing-page-x-margin: auto;
 }
 


### PR DESCRIPTION
fixes #1418 

This PR takes a different approach from the previous PR - and avoids a lot of complications in new HTML, changing the debug bar, changing templates, etc.

Instead of changing the CSS structure, this PR simply adds an empty `span` tag with `role="img"` and `aria-label` with the alt tag, as suggested here: https://www.davidmacd.com/blog/alternate-text-for-css-background-images.html

<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/c11bdd2a-e9ef-40ba-9247-ab2d209ca67f">
