### PR TITLE
Add new primary color, hover color, footer hover color, footer visited color

### DIFF
--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -1,6 +1,6 @@
 :root {
-  --primary-color: #046b99;
-  --primary-color-rgb: 4, 107, 153;
+  --primary-color: #045b86;
+  --primary-color-rgb: 4, 91, 134;
   --bs-blue: var(--primary-color);
   --bs-primary: var(--primary-color);
   --bs-primary-rgb: var(--primary-color-rgb);
@@ -17,7 +17,7 @@
   --bs-body-line-height: 1.5;
   --body-letter-spacing: 0.05em;
   --dark-color: #212121;
-  --hover-color: #2f4c65;
+  --hover-color: #044869;
   --error-color: #ea1010;
   --selected-color: #562b97;
   --error-color-rgb: 234, 16, 16;
@@ -222,7 +222,8 @@ main {
   --footer-background-color: var(--dark-color);
   --footer-link-color: #73b3e7;
   --footer-link-width: 100%;
-  --footer-link-hover-color: #9b74d7;
+  --footer-link-hover-color: #0062ff;
+  --footer-link-visited-color: #9b74d7;
   --footer-link-font-weight: var(--bold-font-weight);
   --footer-mobile-underline-color: var(--bs-white);
   --main-content-min-height: calc(100vh - 246px);
@@ -255,11 +256,13 @@ footer .footer-links li a {
   line-height: 50px;
 }
 
-footer .footer-links li a:hover,
-footer .footer-links li a:focus,
+footer .footer-links li a:hover {
+  color: var(--footer-link-hover-color);
+}
+
 footer .footer-links li a:active,
 footer .footer-links li a:visited {
-  color: var(--footer-link-hover-color);
+  color: var(--footer-link-visited-color);
 }
 
 /* Custom non-mobile-first code to */


### PR DESCRIPTION
fix #1577 

- Design instructions are coming from here and reflected in Figma Style Guide: https://github.com/cal-itp/benefits/issues/1423#issuecomment-1601567969
- 4 updated colors: `primary`, `hover`, `footer-link-hover`, `footer-link-visited`


## Where to notice these color changes

### Footer Link Hover

Used to be purple. Now it's a different shade of dark blue (`#0062ff`)

<img width="300" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/8e73abd1-42f6-4c88-8ea1-d08936e2398e">

### Footer Link Visited

The color for :hover and :visited used to be the same. Now, only the visited is purple.

<img width="295" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/d00297a0-59c1-49b4-85b3-cdcca300f783">

### Hover

<img width="488" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/111831d0-f5b8-4d43-9fb7-6a61f9a86d8b">

Regular link hover is slightly darker.

### Primary

Primary color is now darker. It's most noticable in the nav:

<img width="781" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/9913430f-0da8-48d4-9db8-09b510f4a942">


