### PR TITLE
Modals: Mobile - Get alignment right

### DIFF
--- a/benefits/core/templates/core/includes/modal-info.html
+++ b/benefits/core/templates/core/includes/modal-info.html
@@ -6,7 +6,7 @@
                 <div class="modal-header border-0 p-md-2 p-3">
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
-                <div class="modal-body pb-md-3 my-md-3 py-0 pt-0">
+                <div class="modal-body pb-md-3 mb-md-3 mx-md-3 py-0 pt-0">
                     {% block modal-content %}
                     {% endblock modal-content %}
                 </div>

--- a/benefits/core/templates/core/includes/modal-info.html
+++ b/benefits/core/templates/core/includes/modal-info.html
@@ -1,6 +1,6 @@
 <!-- Modal -->
 {% with id|add:"-modal-label" as aria_labelledby_id %}
-    <div class="modal fade" id="{{ id }}" tabindex="-1" aria-labelledby="{{ aria_labelledby_id }}" aria-hidden="true">
+    <div class="modal fade modal-info" id="{{ id }}" tabindex="-1" aria-labelledby="{{ aria_labelledby_id }}" aria-hidden="true">
         <div class="modal-dialog {{ size }} modal-dialog-centered modal-dialog-scrollable">
             <div class="modal-content">
                 <div class="modal-header border-0 p-md-2 p-3">

--- a/benefits/core/templates/core/includes/modal-info.html
+++ b/benefits/core/templates/core/includes/modal-info.html
@@ -3,10 +3,10 @@
     <div class="modal fade" id="{{ id }}" tabindex="-1" aria-labelledby="{{ aria_labelledby_id }}" aria-hidden="true">
         <div class="modal-dialog {{ size }} modal-dialog-centered modal-dialog-scrollable">
             <div class="modal-content">
-                <div class="modal-header border-0 p-2">
+                <div class="modal-header border-0 p-md-2 p-3">
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
-                <div class="modal-body pt-0 mt-0 p-4 m-2">
+                <div class="modal-body pb-md-3 my-md-3 py-0 pt-0">
                     {% block modal-content %}
                     {% endblock modal-content %}
                 </div>

--- a/benefits/eligibility/templates/eligibility/includes/modal--contactless.html
+++ b/benefits/eligibility/templates/eligibility/includes/modal--contactless.html
@@ -3,7 +3,7 @@
 {% load static %}
 
 {% block modal-content %}
-    <h2 id="contactless-modal">{% translate "eligibility.pages.start.modal.title" %}</h2>
+    <h2 id="contactless-modal" class="me-4 me-md-0">{% translate "eligibility.pages.start.modal.title" %}</h2>
     <div class="row">
         <p class="pt-3">{% translate "eligibility.pages.start.modal.p[0]" %}</p>
         <p class="pt-4">{% translate "eligibility.pages.start.modal.p[1]" %}</p>

--- a/benefits/eligibility/templates/eligibility/includes/modal--senior-help.html
+++ b/benefits/eligibility/templates/eligibility/includes/modal--senior-help.html
@@ -3,7 +3,7 @@
 {% load static %}
 
 {% block modal-content %}
-    <h2>
+    <h2 class="me-4 me-md-0">
         {% translate "eligibility.pages.index.senior.help.headline" %}
         <img class="icon" width="197" height="26" src="{% static "img/login-gov-logo.svg" %}" alt="{% translate "core.logos.login_gov" context "image alt text" %}" />
     </h2>

--- a/benefits/eligibility/templates/eligibility/includes/modal--senior-start-help.html
+++ b/benefits/eligibility/templates/eligibility/includes/modal--senior-start-help.html
@@ -3,7 +3,7 @@
 {% load static %}
 
 {% block modal-content %}
-    <h2>
+    <h2 class="me-4 me-md-0">
         {% translate "eligibility.pages.start.senior.help.headline" %}
         <img class="icon" width="197" height="26" src="{% static "img/login-gov-logo.svg" %}" alt="{% translate "core.logos.login_gov" context "image alt text" %}" />
     </h2>

--- a/benefits/enrollment/templates/enrollment/includes/modal--littlepay.html
+++ b/benefits/enrollment/templates/enrollment/includes/modal--littlepay.html
@@ -3,7 +3,7 @@
 {% load static %}
 
 {% block modal-content %}
-    <h2 id="littlepay-modal">{% translate "enrollment.pages.index.modal.title" %}</h2>
+    <h2 id="littlepay-modal" class="me-4 me-md-0">{% translate "enrollment.pages.index.modal.title" %}</h2>
     <div class="row">
         <p class="pt-3">{% translate "enrollment.pages.index.modal.p[0]" %}</p>
         <p class="pt-4">{% translate "enrollment.pages.index.modal.p[1]" %}</p>

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -664,12 +664,14 @@ a.card:focus-visible {
 :root {
   --modal-title-font-size: var(--font-size-24px);
   --modal-border-radius: 8px;
+  --modal-body-top: -36px;
 }
 
 @media (min-width: 992px) {
   :root {
     --modal-title-font-size: var(--font-size-35px);
     --modal-border-radius: 4px;
+    --modal-body-top: 0;
   }
 }
 
@@ -712,14 +714,8 @@ a.card:focus-visible {
 }
 
 .modal-body {
-  top: -36px;
+  top: var(--modal-body-top);
   z-index: 1056;
-}
-
-@media (min-width: 992px) {
-  .modal-body {
-    top: 0;
-  }
 }
 
 /* Modal Trigger */

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -38,10 +38,6 @@
   --border-radius: calc(3rem / 16);
 }
 
-.bg-danger {
-  display: none;
-}
-
 @media (min-width: 992px) {
   :root {
     --h1-font-size: var(--font-size-35px);

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -707,6 +707,21 @@ a.card:focus-visible {
   font-size: var(--modal-title-font-size);
 }
 
+.modal-header {
+  z-index: 1057;
+}
+
+.modal-body {
+  top: -36px;
+  z-index: 1056;
+}
+
+@media (min-width: 992px) {
+  .modal-body {
+    top: 0;
+  }
+}
+
 /* Modal Trigger */
 /* All links/image buttons that open modals have a question mark icon after them */
 /* Buttons that open modals (like the Agency Selector) do not have the icon */

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -38,6 +38,10 @@
   --border-radius: calc(3rem / 16);
 }
 
+.bg-danger {
+  display: none;
+}
+
 @media (min-width: 992px) {
   :root {
     --h1-font-size: var(--font-size-35px);
@@ -667,11 +671,16 @@ a.card:focus-visible {
   --modal-body-top: -36px;
 }
 
+@media (min-width: 768px) {
+  :root {
+    --modal-body-top: 0;
+  }
+}
+
 @media (min-width: 992px) {
   :root {
     --modal-title-font-size: var(--font-size-35px);
     --modal-border-radius: 4px;
-    --modal-body-top: 0;
   }
 }
 
@@ -709,11 +718,11 @@ a.card:focus-visible {
   font-size: var(--modal-title-font-size);
 }
 
-.modal-header {
+.modal-info .modal-header {
   z-index: 1057;
 }
 
-.modal-body {
+.modal-info .modal-body {
   top: var(--modal-body-top);
   z-index: 1056;
 }


### PR DESCRIPTION
fix #1593 


## What this PR does
- The informational modals have too much margin-top and margin-left and margin-right. This PR brings the text up by 36px so it's aligned with the X, and makes adjustments necessary for that.
- The overall effect of getting all the margins right is that modals on mobile fit more text on the screen, and theoretically, are shorter now.

## How to test this PR
- Run thru the app in mobile and open _every_ informational modal (2 login.gov, 1 contactless pay, 1 littlepay)

## Docs: Informational Modals, specs

I wrote these out to help me get the alignment right.

### Desktop
- The height of the entire header section: 36px
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/ae321e10-0647-49c0-bb87-1a3fa5cdeb3f">

- Space between the edge and the begining of the text: 32px
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/ad3aba58-57e6-42e5-aef0-0d0d76e672cd">


### Mobile
- The distance between the edge and the top of the X/the begining of header text: 16px
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/ee2c9230-b232-482a-878b-f0ea8bb10877">

- Space between the edge and the begining of the text: 16px
<img width="1502" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/eb293712-5843-4792-acd0-39684b3bf792">

- I added the `z-index` declarations (and a `margin-right`) so that the X always comes on _top_ of the header and the header never overlaps with the X. Now that the header is getting pushed up 36px _into_ the header div, we need this z-index to ensure the clickability of the X.
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/f556049c-f945-40f3-bdce-fdc9e804f20b">
