### PR TITLE
Fix: Login.gov button width on Tablet

### DIFF
--- a/benefits/eligibility/templates/eligibility/start--mst-courtesy-card.html
+++ b/benefits/eligibility/templates/eligibility/start--mst-courtesy-card.html
@@ -16,7 +16,7 @@
 {% endblock media-item %}
 
 {% block call-to-action %}
-  <div class="row d-flex flex-column-reverse justify-content-lg-end flex-lg-row">
+  <div class="row d-flex justify-content-lg-end">
     <div class="col-lg-3 offset-2 offset-sm-2 offset-lg-0 col-sm-8 col-8">
       {% url "eligibility:confirm" as button_url %}
       <a href="{{ button_url }}" class="btn btn-lg btn-primary" role="button">{% translate "eligibility.buttons.continue" %}</a>

--- a/benefits/eligibility/templates/eligibility/start--mst-courtesy-card.html
+++ b/benefits/eligibility/templates/eligibility/start--mst-courtesy-card.html
@@ -15,7 +15,11 @@
   {% include "eligibility/includes/media-item--idcardcheck--start--mst-courtesy-card.html" %}
 {% endblock media-item %}
 
-{% block call-to-action-button %}
-  {% url "eligibility:confirm" as button_url %}
-  <a href="{{ button_url }}" class="btn btn-lg btn-primary" role="button">{% translate "eligibility.buttons.continue" %}</a>
-{% endblock call-to-action-button %}
+{% block call-to-action %}
+  <div class="row d-flex flex-column-reverse justify-content-lg-end flex-lg-row">
+    <div class="col-lg-3 offset-2 offset-sm-2 offset-lg-0 col-sm-8 col-8">
+      {% url "eligibility:confirm" as button_url %}
+      <a href="{{ button_url }}" class="btn btn-lg btn-primary" role="button">{% translate "eligibility.buttons.continue" %}</a>
+    </div>
+  </div>
+{% endblock call-to-action %}

--- a/benefits/eligibility/templates/eligibility/start--senior.html
+++ b/benefits/eligibility/templates/eligibility/start--senior.html
@@ -15,10 +15,14 @@
   {% include "eligibility/includes/media-item--idcardcheck--start--senior.html" %}
 {% endblock media-item %}
 
-{% block call-to-action-button %}
-  {% url "oauth:login" as button_url %}
-  {% translate "eligibility.buttons.senior.signin" as button_text %}
-  <a href="{{ button_url }}" class="btn btn-lg btn-primary" id="login">
-    {{ button_text }} <span class="fallback-text white-logo">Login.gov</span>
-  </a>
-{% endblock call-to-action-button %}
+{% block call-to-action %}
+  <div class="row d-flex flex-column-reverse justify-content-lg-end flex-lg-row">
+    <div class="col-lg-4 offset-2 offset-lg-0 col-sm-8 col-8 d-flex justify-content-lg-end justify-content-center">
+      {% url "oauth:login" as button_url %}
+      {% translate "eligibility.buttons.senior.signin" as button_text %}
+      <a href="{{ button_url }}" class="btn btn-lg btn-primary" id="login">
+        {{ button_text }} <span class="fallback-text white-logo">Login.gov</span>
+      </a>
+    </div>
+  </div>
+{% endblock call-to-action %}

--- a/benefits/eligibility/templates/eligibility/start--senior.html
+++ b/benefits/eligibility/templates/eligibility/start--senior.html
@@ -16,7 +16,7 @@
 {% endblock media-item %}
 
 {% block call-to-action %}
-  <div class="row d-flex flex-column-reverse justify-content-lg-end flex-lg-row">
+  <div class="row d-flex justify-content-lg-end">
     <div class="col-lg-4 offset-2 offset-lg-0 col-sm-8 col-8 d-flex justify-content-lg-end justify-content-center">
       {% url "oauth:login" as button_url %}
       {% translate "eligibility.buttons.senior.signin" as button_text %}

--- a/benefits/eligibility/templates/eligibility/start--veteran.html
+++ b/benefits/eligibility/templates/eligibility/start--veteran.html
@@ -15,8 +15,12 @@
   {% include "eligibility/includes/media-item--idcardcheck--start--veteran.html" %}
 {% endblock media-item %}
 
-{% block call-to-action-button %}
-  {% url "oauth:login" as button_url %}
-  {% translate "eligibility.buttons.veteran.signin" as button_text %}
-  <a href="{{ button_url }}" class="btn btn-lg btn-primary" role="button">{{ button_text }}</a>
-{% endblock call-to-action-button %}
+{% block call-to-action %}
+  <div class="row d-flex flex-column-reverse justify-content-lg-end flex-lg-row">
+    <div class="col-lg-3 offset-2 offset-sm-2 offset-lg-0 col-sm-8 col-8">
+      {% url "oauth:login" as button_url %}
+      {% translate "eligibility.buttons.veteran.signin" as button_text %}
+      <a href="{{ button_url }}" class="btn btn-lg btn-primary" role="button">{{ button_text }}</a>
+    </div>
+  </div>
+{% endblock call-to-action %}

--- a/benefits/eligibility/templates/eligibility/start--veteran.html
+++ b/benefits/eligibility/templates/eligibility/start--veteran.html
@@ -16,7 +16,7 @@
 {% endblock media-item %}
 
 {% block call-to-action %}
-  <div class="row d-flex flex-column-reverse justify-content-lg-end flex-lg-row">
+  <div class="row d-flex justify-content-lg-end">
     <div class="col-lg-3 offset-2 offset-sm-2 offset-lg-0 col-sm-8 col-8">
       {% url "oauth:login" as button_url %}
       {% translate "eligibility.buttons.veteran.signin" as button_text %}

--- a/benefits/eligibility/templates/eligibility/start.html
+++ b/benefits/eligibility/templates/eligibility/start.html
@@ -21,5 +21,8 @@
   </div>
 {% endblock inner-content %}
 
+{% block call-to-action %}
+{% endblock call-to-action %}
+
 {% block call-to-action-button %}
 {% endblock call-to-action-button %}

--- a/benefits/eligibility/templates/eligibility/start.html
+++ b/benefits/eligibility/templates/eligibility/start.html
@@ -23,6 +23,3 @@
 
 {% block call-to-action %}
 {% endblock call-to-action %}
-
-{% block call-to-action-button %}
-{% endblock call-to-action-button %}

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -358,7 +358,7 @@ footer .footer-links li a:visited {
 @media (min-width: 992px) {
   :root {
     --login-gov-button-font-size: var(--font-size-16px);
-    --login-gov-button-padding: 13px 0;
+    --login-gov-button-padding: 10px 0;
     --login-gov-button-max-width: 289px;
   }
 }

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -350,14 +350,16 @@ footer .footer-links li a:visited {
 /* Used on Eligibility Start */
 
 :root {
-  --login-gov-button-font-size: var(--h3-font-size);
-  --login-gov-button-padding: 11px 0;
+  --login-gov-button-font-size: var(--font-size-20px);
+  --login-gov-button-padding: 10px 0;
+  --login-gov-button-max-width: none;
 }
 
 @media (min-width: 992px) {
   :root {
     --login-gov-button-font-size: var(--font-size-16px);
-    --login-gov-button-padding: var(--primary-button-padding);
+    --login-gov-button-padding: 13px 0;
+    --login-gov-button-max-width: 289px;
   }
 }
 
@@ -368,6 +370,7 @@ footer .footer-links li a:visited {
   letter-spacing: 0;
   font-size: var(--login-gov-button-font-size);
   font-family: "Public Sans", Roboto, system-ui;
+  max-width: var(--login-gov-button-max-width);
   text-decoration: none;
 }
 
@@ -382,7 +385,7 @@ footer .footer-links li a:visited {
   background-size: contain;
   background-repeat: no-repeat;
   display: block;
-  margin: 8px auto 0 auto;
+  margin: 11px auto 0 auto;
   position: relative;
   padding-top: 1px;
   color: transparent;
@@ -397,9 +400,11 @@ footer .footer-links li a:visited {
 
 #login .fallback-text.white-logo {
   background-image: url("/static/img/login-gov-logo-rev.svg");
-  width: 132px;
-  height: 18px;
+  width: 130.9887px;
+  height: 17px;
 }
+
+/* Used on Eligibility Index for Modal */
 
 #login .fallback-text.color-logo {
   background-image: url("/static/img/login-gov-logo.svg");

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -352,7 +352,7 @@ footer .footer-links li a:visited {
 :root {
   --login-gov-button-font-size: var(--font-size-20px);
   --login-gov-button-padding: 10px 0;
-  --login-gov-button-max-width: none;
+  --login-gov-button-max-width: 310px;
 }
 
 @media (min-width: 992px) {

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -351,14 +351,12 @@ footer .footer-links li a:visited {
 
 :root {
   --login-gov-button-font-size: var(--font-size-20px);
-  --login-gov-button-padding: 10px 0;
   --login-gov-button-max-width: 310px;
 }
 
 @media (min-width: 992px) {
   :root {
     --login-gov-button-font-size: var(--font-size-16px);
-    --login-gov-button-padding: 10px 0;
     --login-gov-button-max-width: 289px;
   }
 }
@@ -372,10 +370,6 @@ footer .footer-links li a:visited {
   font-family: "Public Sans", Roboto, system-ui;
   max-width: var(--login-gov-button-max-width);
   text-decoration: none;
-}
-
-.eligibility-start #login {
-  padding: var(--login-gov-button-padding);
 }
 
 /* Sets the text `Login.gov` as transparent */
@@ -394,8 +388,18 @@ footer .footer-links li a:visited {
   line-height: 1;
 }
 
-.eligibility-index #login .fallback-text {
-  display: inline-block;
+@media (min-width: 992px) {
+  #login .fallback-text {
+    margin: 0 0 0 5px;
+    display: inline-block;
+    vertical-align: baseline;
+  }
+}
+
+/* Sign in with Login.gov (white logo) on Eligibility Start */
+
+.eligibility-start #login {
+  padding: 10px 0;
 }
 
 #login .fallback-text.white-logo {
@@ -404,7 +408,7 @@ footer .footer-links li a:visited {
   height: 17px;
 }
 
-/* Used on Eligibility Index for Modal */
+/* Login.gov modal button (color logo) on Eligibility Index */
 
 #login .fallback-text.color-logo {
   background-image: url("/static/img/login-gov-logo.svg");
@@ -412,12 +416,8 @@ footer .footer-links li a:visited {
   height: 16px;
 }
 
-@media (min-width: 992px) {
-  #login .fallback-text {
-    margin: 0 0 0 5px;
-    display: inline-block;
-    vertical-align: baseline;
-  }
+.eligibility-index #login .fallback-text {
+  display: inline-block;
 }
 
 /* Custom button: Sign Out */


### PR DESCRIPTION
fix #1574 

## What is the problem anyway?

At this specific range of widths (1279px - 992px), the Login.gov button breaks into 2 lines in a way that is not part of the design.

<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/45ebe148-630d-4780-aac6-b8c92bff7a99">
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/a27e2741-d217-4639-8cc8-fbb172efafab">

The button should only exist in 2 designs, as shown on Figma:

<img width="390" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/8d401fc2-8d15-4244-98c9-d149cc6c7a66">

## What this PR does
- Make sure the Login.gov button only shows up in those 2 ways
- Ensure the 2 Login.gov buttons are the correct dimensions
- Modify the `start.html` so that I can adjust the columns for the `start--seniors` includes only, but keep the rest the same.
- Widened the container from `col-3` to `col-4` to allow for the button to remain at width: 289px as the window scales down from 1279px to the maximum of 992px. Add flex-box classes and a max-width declaration so that the button stays at the proper width and also is right-aligned. This widening is a one-off for _this includes with the Login.gov button only_. Not to be done for anything else.

## How to test
- Get to Elig Start for Login.gov/Seniors and check the button in all possible screen widths
- Ensure no regressions on the rest of the Elig Starts (Veterans, Agency Card)
- Make sure button looks good in focus, hover modes

## Documentation: Sign into Login.gov button specs

### Desktop/Tablet
- Width: 289px
- Height: 41px
- Font size: 16px
- Space between top/bottom of the text and the edge: 12px (Add the 10px padding and 2 px border for total 12px)

<img width="1510" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/b313d50a-9f2b-45ed-b000-b0dd80749645">
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/bb9f31ce-fa53-4b70-89ad-70f394620385">
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/2a78469c-b529-4a3f-8cca-b32ad8bdad85">


### Mobile
- Width: 310px
- Height: 72px
- Font size: 20px
- Space between top/bottom of the text and the edge: 12px

<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/30c6fb94-17b2-40f6-bd12-8467ae4e25c6">
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/eb378ff5-9010-47cf-9fc7-f0188983d9f7">
