### PR TITLE
Fix: Line-height across the app for H1, H2, H3, H4

### DIFF
--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -14,7 +14,9 @@
   --bs-font-sans-serif: Roboto, system-ui, -apple-system, "Segoe UI", sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --bs-body-font-family: var(--bs-font-sans-serif);
-  --bs-body-line-height: 1.5;
+  --bs-body-line-height: 1.5; /* Displayed as 150% on Figma */
+  --heading-line-height: 1.3; /* Displayed as 130% on Figma */
+  --h4-line-height: 1.2; /* Displayed as 120% on Figma */
   --body-letter-spacing: 0.05em;
   --dark-color: #212121;
   --hover-color: #044869;
@@ -162,7 +164,6 @@ a[target="_blank"]::after {
 
 /* Headlines */
 /* All headlines */
-/* All headlines share font-weight, letter-spacing, line-height and margin */
 h1,
 h2,
 .h2,
@@ -171,7 +172,6 @@ h3,
 h4 {
   font-weight: var(--bold-font-weight);
   letter-spacing: var(--body-letter-spacing);
-  line-height: var(--bs-body-line-height);
   margin: 0;
 }
 
@@ -183,6 +183,7 @@ h1 {
   font-size: var(--h1-font-size);
   text-align: var(--h1-text-align);
   padding-top: calc(70rem / 16);
+  line-height: var(--heading-line-height);
 }
 
 /* H2 */
@@ -191,6 +192,7 @@ h1 {
 h2,
 .h2 {
   font-size: var(--h2-font-size);
+  line-height: var(--heading-line-height);
 }
 
 /* H3 */
@@ -199,6 +201,13 @@ h2,
 h3,
 .h3 {
   font-size: var(--h3-font-size);
+  line-height: var(--heading-line-height);
+}
+
+/* H4 */
+/* Desktop only: Used for Agency Selector card, agency name */
+h4 {
+  line-height: var(--h4-line-height);
 }
 
 /* Main */

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -615,7 +615,6 @@ h1 + .media-list, /* A .media-list immediately following the h1: Enrollment Succ
 
 :root {
   --card-title-font-size: var(--font-size-18px);
-  --card-title-line-height: calc(21.6rem / 16);
   --card-title-letter-spacing: 0.03em;
   --card-x-padding: calc(10rem / 16);
   --card-body-x-padding: 0;
@@ -628,7 +627,6 @@ h1 + .media-list, /* A .media-list immediately following the h1: Enrollment Succ
 @media (min-width: 992px) {
   :root {
     --card-title-font-size: var(--font-size-20px);
-    --card-title-line-height: calc(24rem / 16);
     --card-title-letter-spacing: 0.05rem;
     --card-x-padding: calc(35rem / 16);
     --card-body-x-padding: calc(40rem / 16);
@@ -663,7 +661,6 @@ a.card:focus-visible {
 
 .card .card-title {
   font-size: var(--card-title-font-size);
-  line-height: var(--card-title-line-height);
   letter-spacing: var(--card-title-letter-spacing);
 }
 


### PR DESCRIPTION
fixes #1573 

Line-height should always be a unitless value. https://developer.mozilla.org/en-US/docs/Web/CSS/line-height#values Do not use rems, pixels for line-height.

## What this PR does
- Applies new line-height to h1, h2, h3, h4
- H1-H3 are 1.3
- H4 is 1.2
- These values are the same across Desktop and Mobile.

## Steps I took to run through this PR

1. Confirm on Figma that H1, H2, H3, H4 now have _different_ line-height values from the standard body line height.
2. Confirm that the `--bs-body-line-height` variable is correct, set at 1.5, and applied to all the places it should.
3. Create a new variable: `--heading-line-height` of value 1.3.
4. Create a new variable: `--h4-line-height` of value 1.2. H4 is only used in _one spot_ in the whole app, and that is for the Agency Selector modal, specifically, the name of the transit agency. The 1.2 value allows for the transit agency name to be tighter.
5. Apply the `--heading-line-height` to H1, H2, H3
6. Apply `--h4-line-height` outlier exception to H4.
7. Deleted the custom code setting `.card .card-title`'s line-height, which is an H4, to fall back and use the H4 line-height. 
8. Audit the CSS file for any other line-height declarations and make sure they're correct/appropriate.
9. Confirm local vs. dev site vs. Figma for desktop and mobile headlines 

## Is this even noticeable? Yes.

### Modal titles on Mobile
Side-by-side comparison of Figma, this PR and the Dev site for modal titles. Modal titles on Dev have a line-height of 1.5, and now, with this PR, they are tightened to 1.3.
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/db914460-1d5f-4a29-b1af-0b7752a9c03c">

### Index/Agency Index on Desktop
Total height of the H1 and H2 types are tighter now
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/e989a569-3613-4544-a7e9-6f3459fd6e6d">

### 2-line Headlines on Desktop
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/38d968e8-7ddf-4a40-8d23-8b24b3c140c8">

