### PR TITLE
Letter-spacing

### DIFF
--- a/benefits/core/templates/core/includes/modal--agency-selector.html
+++ b/benefits/core/templates/core/includes/modal--agency-selector.html
@@ -4,7 +4,9 @@
 
 {% block modal-content %}
     <div class="container text-center">
-        <h3 id="{{ aria_labelledby_id }}" class="modal-title">{% translate "Please choose your transit provider:" %}</h3>
+        <h3 id="{{ aria_labelledby_id }}" class="modal-title h1 p-0 text-center">
+            {% translate "Please choose your transit provider:" %}
+        </h3>
         <div class="row gx-lg-5 mx-lg-1 d-flex flex-column flex-lg-row text-start text-lg-center">
             {% for agency in active_agencies %}
                 <div class="col">

--- a/benefits/core/templates/core/landing.html
+++ b/benefits/core/templates/core/landing.html
@@ -19,7 +19,7 @@
             {% block headline %}
             {% endblock headline %}
           </h1>
-          <h2 class="p-sm pt-1 pt-lg-5 pb-4 pb-lg-5 mb-lg-2">
+          <h2 class="h2-sm pt-1 pt-lg-5 pb-4 pb-lg-5 mb-lg-2">
             {% translate "Cal-ITP Benefits connects your transit benefit to your contactless card" %}
           </h2>
           <span role="img" aria-label="{% translate "A person holds a contactless debit card next to a card reader on a bus." %}"></span>

--- a/benefits/core/templates/core/landing.html
+++ b/benefits/core/templates/core/landing.html
@@ -19,15 +19,10 @@
             {% block headline %}
             {% endblock headline %}
           </h1>
-<<<<<<< HEAD
-          <h2 class="h2-sm pt-1 pt-lg-5 pb-4 pb-lg-5 mb-lg-2">
+          <h2 class="h2-sm-p pt-1 pt-lg-5 pb-4 pb-lg-5 mb-lg-2">
             {% translate "Cal-ITP Benefits connects your transit benefit to your contactless card" %}
           </h2>
           <span role="img" aria-label="{% translate "A person holds a contactless debit card next to a card reader on a bus." %}"></span>
-=======
-          <h2 class="h2-sm-p pt-1 pt-lg-5 pb-4 pb-lg-5 mb-lg-2">{% translate "core.pages.landing.h2" %}</h2>
-          <span role="img" aria-label="{% translate "core.pages.index.alt" %}"></span>
->>>>>>> 26fe9477 (fix(css): replace p-sm with h2-sm, renamed class)
           {% block call-to-action %}
           {% endblock call-to-action %}
         </div>

--- a/benefits/core/templates/core/landing.html
+++ b/benefits/core/templates/core/landing.html
@@ -19,10 +19,15 @@
             {% block headline %}
             {% endblock headline %}
           </h1>
+<<<<<<< HEAD
           <h2 class="h2-sm pt-1 pt-lg-5 pb-4 pb-lg-5 mb-lg-2">
             {% translate "Cal-ITP Benefits connects your transit benefit to your contactless card" %}
           </h2>
           <span role="img" aria-label="{% translate "A person holds a contactless debit card next to a card reader on a bus." %}"></span>
+=======
+          <h2 class="h2-sm-p pt-1 pt-lg-5 pb-4 pb-lg-5 mb-lg-2">{% translate "core.pages.landing.h2" %}</h2>
+          <span role="img" aria-label="{% translate "core.pages.index.alt" %}"></span>
+>>>>>>> 26fe9477 (fix(css): replace p-sm with h2-sm, renamed class)
           {% block call-to-action %}
           {% endblock call-to-action %}
         </div>

--- a/benefits/eligibility/templates/eligibility/start.html
+++ b/benefits/eligibility/templates/eligibility/start.html
@@ -12,7 +12,7 @@
 
 {% block inner-content %}
   <div class="col-12 col-sm-12 col-lg-8">
-    <h2 class="media-title p-sm">{% translate "You will need a few items to continue:" %}</h2>
+    <h2 class="media-title h2-sm">{% translate "You will need a few items to continue:" %}</h2>
     <ul class="media-list mx-0 px-0 d-flex justify-content-center flex-column">
       {% block media-item %}
       {% endblock media-item %}

--- a/benefits/eligibility/templates/eligibility/start.html
+++ b/benefits/eligibility/templates/eligibility/start.html
@@ -12,7 +12,11 @@
 
 {% block inner-content %}
   <div class="col-12 col-sm-12 col-lg-8">
+<<<<<<< HEAD
     <h2 class="media-title h2-sm">{% translate "You will need a few items to continue:" %}</h2>
+=======
+    <h2 class="media-title h2-sm-p">{% translate "eligibility.pages.start.sub_headline" %}</h2>
+>>>>>>> 26fe9477 (fix(css): replace p-sm with h2-sm, renamed class)
     <ul class="media-list mx-0 px-0 d-flex justify-content-center flex-column">
       {% block media-item %}
       {% endblock media-item %}

--- a/benefits/eligibility/templates/eligibility/start.html
+++ b/benefits/eligibility/templates/eligibility/start.html
@@ -12,11 +12,7 @@
 
 {% block inner-content %}
   <div class="col-12 col-sm-12 col-lg-8">
-<<<<<<< HEAD
-    <h2 class="media-title h2-sm">{% translate "You will need a few items to continue:" %}</h2>
-=======
-    <h2 class="media-title h2-sm-p">{% translate "eligibility.pages.start.sub_headline" %}</h2>
->>>>>>> 26fe9477 (fix(css): replace p-sm with h2-sm, renamed class)
+    <h2 class="media-title h2-sm-p">{% translate "You will need a few items to continue:" %}</h2>
     <ul class="media-list mx-0 px-0 d-flex justify-content-center flex-column">
       {% block media-item %}
       {% endblock media-item %}

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -671,7 +671,6 @@ h1 + .media-list, /* A .media-list immediately following the h1: Enrollment Succ
 /* Cards */
 
 :root {
-  --card-title-font-size: var(--font-size-18px);
   --card-x-padding: calc(10rem / 16);
   --card-body-x-padding: 0;
   --card-body-y-padding: 0.75rem;
@@ -682,7 +681,6 @@ h1 + .media-list, /* A .media-list immediately following the h1: Enrollment Succ
 
 @media (min-width: 992px) {
   :root {
-    --card-title-font-size: var(--font-size-20px);
     --card-x-padding: calc(35rem / 16);
     --card-body-x-padding: calc(40rem / 16);
     --card-body-y-padding: 0;

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -313,7 +313,7 @@ footer .footer-links li a {
   font-weight: var(--footer-link-font-weight);
   font-size: var(--bs-body-font-size);
   text-decoration: underline;
-  letter-spacing: var(--body-letter-spacing);
+  letter-spacing: calc(var(--bs-body-font-size) * var(--letter-spacing-5));
   line-height: 50px;
 }
 

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -57,6 +57,7 @@ body {
 }
 
 h1,
+.h1,
 h2,
 .h2,
 h3,
@@ -181,7 +182,6 @@ h4 {
 
 h1,
 .h1 {
-  font-family: var(--bs-font-sans-serif);
   font-size: var(--h1-font-size);
   text-align: var(--h1-text-align);
   padding-top: calc(70rem / 16);

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -191,23 +191,11 @@ h1,
 /* H2 */
 /* Same sizes for all screen widths: 24px (24rem/16 = 1.5rem) */
 /* Also has a class which can be applied to non-headline elements */
-:root {
-  --h2-letter-spacing-percent: var(--letter-spacing-5);
-}
-
-@media (min-width: 992px) {
-  :root {
-    --h2-letter-spacing-percent: var(--letter-spacing-3);
-  }
-}
-
 h2,
 .h2 {
   font-size: var(--font-size-24px);
   line-height: var(--heading-line-height);
-  letter-spacing: calc(
-    var(--font-size-24px) * var(--h2-letter-spacing-percent)
-  );
+  letter-spacing: calc(var(--font-size-24px) * var(--letter-spacing-3));
 }
 
 @media (max-width: 992px) {
@@ -216,16 +204,13 @@ h2,
   .h2-sm-p {
     font-size: var(--bs-body-font-size);
     font-weight: var(--bs-body-font-weight);
-    letter-spacing: calc(
-      var(--bs-body-font-size) * var(--h2-letter-spacing-percent)
-    );
+    letter-spacing: calc(var(--bs-body-font-size) * var(--letter-spacing-5));
     line-height: var(--heading-line-height);
     margin: 0;
   }
-}
 
-@media (max-width: 992px) {
   /* H2: 20px, up to Small width */
+  /* Only used on Help Pages */
   .h2-sm {
     font-size: var(--font-size-20px);
     line-height: var(--heading-line-height);

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -153,6 +153,7 @@ a[target="_blank"]::after {
 /* Headlines */
 /* All headlines */
 h1,
+.h1,
 h2,
 .h2,
 h3,
@@ -165,7 +166,6 @@ h4 {
 /* H1 */
 /* Mobile first: Screen width up to 992px - 24px (24rem/16 = 1.5rem) and left */
 /* Screen width above 992px - 35px (35rem/16 = 2.1875rem) and centered */
-/* Does not have a class. Do not apply to non-headline elements. */
 :root {
   --h1-letter-spacing-percent: var(--letter-spacing-3);
 }
@@ -179,7 +179,9 @@ h4 {
   }
 }
 
-h1 {
+h1,
+.h1 {
+  font-family: var(--bs-font-sans-serif);
   font-size: var(--h1-font-size);
   text-align: var(--h1-text-align);
   padding-top: calc(70rem / 16);
@@ -710,7 +712,6 @@ a.card:focus-visible {
 /* Modal Dialogs */
 
 :root {
-  --modal-title-font-size: var(--font-size-24px);
   --modal-border-radius: 8px;
   --modal-body-top: -36px;
 }
@@ -723,7 +724,6 @@ a.card:focus-visible {
 
 @media (min-width: 992px) {
   :root {
-    --modal-title-font-size: var(--font-size-35px);
     --modal-border-radius: 4px;
   }
 }
@@ -756,10 +756,6 @@ a.card:focus-visible {
 
 .btn-close {
   color: var(--text-primary-color);
-}
-
-.modal-title {
-  font-size: var(--modal-title-font-size);
 }
 
 .modal-info .modal-header {

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -208,8 +208,7 @@ h2,
 }
 
 @media (max-width: 992px) {
-  /* Paragraph: Body Text, up to Small width */
-  /* Used with an H2 */
+  /* H2 mobile sizing */
   /* Only used on Landing Pages */
   .h2-sm {
     font-size: var(--bs-body-font-size);

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -366,8 +366,6 @@ footer .footer-links li a:visited {
   padding: var(--primary-button-padding);
 }
 
-/* Unclear if this class is still necessary/different from .btn.btn-lg */
-/* Only used in Form */
 .btn-text {
   font-weight: var(--medium-font-weight);
   font-size: var(--font-size-20px);

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -239,11 +239,26 @@ h3,
 .h3 {
   font-size: var(--h3-font-size);
   line-height: var(--heading-line-height);
+  letter-spacing: calc(var(--h3-font-size) * var(--letter-spacing-5));
 }
 
 /* H4 */
-/* Desktop only: Used for Agency Selector card, agency name */
+/* Used for Agency Selector card, agency name */
+:root {
+  --h4-font-size: var(--font-size-18px);
+  --h4-letter-spacing-percent: var(--letter-spacing-5);
+}
+
+@media (min-width: 992px) {
+  :root {
+    --h4-font-size: var(--font-size-20px);
+    --h4-letter-spacing-percent: var(--letter-spacing-3);
+  }
+}
+
 h4 {
+  font-size: var(--h4-font-size);
+  letter-spacing: calc(var(--h4-font-size) * var(--h4-letter-spacing-percent));
   line-height: var(--h4-line-height);
 }
 

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -672,7 +672,6 @@ h1 + .media-list, /* A .media-list immediately following the h1: Enrollment Succ
 
 :root {
   --card-title-font-size: var(--font-size-18px);
-  /* --card-title-letter-spacing: 0.03em; */
   --card-x-padding: calc(10rem / 16);
   --card-body-x-padding: 0;
   --card-body-y-padding: 0.75rem;
@@ -684,7 +683,6 @@ h1 + .media-list, /* A .media-list immediately following the h1: Enrollment Succ
 @media (min-width: 992px) {
   :root {
     --card-title-font-size: var(--font-size-20px);
-    /* --card-title-letter-spacing: 0.05rem; */
     --card-x-padding: calc(35rem / 16);
     --card-body-x-padding: calc(40rem / 16);
     --card-body-y-padding: 0;
@@ -714,11 +712,6 @@ a.card:focus-visible {
 
 .card:hover {
   border-top: solid var(--card-border-width) var(--hover-color);
-}
-
-.card .card-title {
-  font-size: var(--card-title-font-size);
-  /* letter-spacing: var(--card-title-letter-spacing); */
 }
 
 .card .card-body {

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -17,10 +17,9 @@
   --bs-body-line-height: 1.5; /* Displayed as 150% on Figma */
   --heading-line-height: 1.3; /* Displayed as 130% on Figma */
   --h4-line-height: 1.2; /* Displayed as 120% on Figma */
-  --body-letter-spacing: 0.05em;
-  --letter-spacing-2: 0.02;
-  --letter-spacing-3: 0.03;
-  --letter-spacing-5: 0.05;
+  --letter-spacing-2: 0.02; /* Displayed as 2% on Figma */
+  --letter-spacing-3: 0.03; /* Displayed as 3% on Figma */
+  --letter-spacing-5: 0.05; /* Displayed as 5% on Figma */
   --dark-color: #212121;
   --hover-color: #044869;
   --error-color: #ea1010;
@@ -110,7 +109,7 @@ li {
 }
 
 .ls-base {
-  letter-spacing: var(--body-letter-spacing);
+  letter-spacing: calc(var(--bs-body-font-size) * var(--letter-spacing-5));
 }
 
 /* Links */
@@ -503,7 +502,7 @@ footer .footer-links li a:visited {
   padding: 2px 4px;
   border-radius: var(--border-radius);
   border: var(--border-width) solid var(--primary-color);
-  letter-spacing: 0.02em;
+  letter-spacing: calc(var(--bs-body-font-size) * var(--letter-spacing-2));
   font-weight: 500 !important;
   text-decoration: none !important;
 }
@@ -513,7 +512,7 @@ footer .footer-links li a:visited {
   .signout-link:visited {
     font-size: var(--font-size-12px);
     text-decoration: underline !important;
-    letter-spacing: var(--body-letter-spacing);
+    letter-spacing: calc(var(--font-size-12px) * var(--letter-spacing-5));
     border: none;
   }
 }
@@ -525,7 +524,7 @@ footer .footer-links li a:visited {
   color: var(--text-primary-color);
   font-weight: var(--medium-font-weight);
   font-size: var(--font-size-14px);
-  letter-spacing: var(--body-letter-spacing);
+  letter-spacing: calc(var(--font-size-14px) * var(--letter-spacing-5));
   padding: 3.5px 2.35px; /* button dimensions are 130 x 32 */
 }
 
@@ -562,7 +561,7 @@ footer .footer-links li a:visited {
 .form-container .form-control-label {
   font-size: var(--bs-body-font-size);
   font-weight: var(--medium-font-weight);
-  letter-spacing: var(--body-letter-spacing);
+  letter-spacing: calc(var(--bs-body-font-size) * var(--letter-spacing-5));
   padding-bottom: calc(12rem / 16);
 }
 

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -18,6 +18,7 @@
   --heading-line-height: 1.3; /* Displayed as 130% on Figma */
   --h4-line-height: 1.2; /* Displayed as 120% on Figma */
   --body-letter-spacing: 0.05em;
+  --letter-spacing-2: 0.02;
   --letter-spacing-3: 0.03;
   --letter-spacing-5: 0.05;
   --dark-color: #212121;
@@ -373,17 +374,19 @@ footer .footer-links li a:visited {
 
 .btn.btn-lg.btn-primary {
   border-width: 2px;
-  letter-spacing: 0.02em;
   font-weight: var(--medium-font-weight);
-  font-size: calc(20rem / 16);
+  font-size: var(--font-size-20px);
+  letter-spacing: calc(var(--font-size-20px) * var(--letter-spacing-2));
   width: 100%;
   padding: var(--primary-button-padding);
 }
 
+/* Unclear if this class is still necessary/different from .btn.btn-lg */
+/* Only used in Form */
 .btn-text {
-  letter-spacing: 0.02em;
   font-weight: var(--medium-font-weight);
-  font-size: calc(20rem / 16);
+  font-size: var(--font-size-20px);
+  letter-spacing: calc(var(--font-size-20px) * var(--letter-spacing-2));
 }
 
 /* A button that actually is a text link */

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -213,7 +213,7 @@ h2,
 @media (max-width: 992px) {
   /* H2 mobile sizing */
   /* Only used on Landing Pages */
-  .h2-sm {
+  .h2-sm-p {
     font-size: var(--bs-body-font-size);
     font-weight: var(--bs-body-font-weight);
     letter-spacing: calc(

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -18,6 +18,8 @@
   --heading-line-height: 1.3; /* Displayed as 130% on Figma */
   --h4-line-height: 1.2; /* Displayed as 120% on Figma */
   --body-letter-spacing: 0.05em;
+  --letter-spacing-3: 0.03;
+  --letter-spacing-5: 0.05;
   --dark-color: #212121;
   --hover-color: #044869;
   --error-color: #ea1010;
@@ -38,14 +40,6 @@
   --font-size-12px: calc(12rem / 16);
   --border-width: calc(2rem / 16);
   --border-radius: calc(3rem / 16);
-}
-
-@media (min-width: 992px) {
-  :root {
-    --h1-font-size: var(--font-size-35px);
-    --h1-text-align: center;
-    --font-size-35px: calc(35rem / 16);
-  }
 }
 
 @font-face {
@@ -176,7 +170,6 @@ h3,
 .h3,
 h4 {
   font-weight: var(--bold-font-weight);
-  letter-spacing: var(--body-letter-spacing);
   margin: 0;
 }
 
@@ -184,11 +177,25 @@ h4 {
 /* Mobile first: Screen width up to 992px - 24px (24rem/16 = 1.5rem) and left */
 /* Screen width above 992px - 35px (35rem/16 = 2.1875rem) and centered */
 /* Does not have a class. Do not apply to non-headline elements. */
+:root {
+  --h1-letter-spacing-percent: var(--letter-spacing-3);
+}
+
+@media (min-width: 992px) {
+  :root {
+    --h1-font-size: var(--font-size-35px);
+    --h1-text-align: center;
+    --h1-letter-spacing-percent: var(--letter-spacing-5);
+    --font-size-35px: 2.1875rem;
+  }
+}
+
 h1 {
   font-size: var(--h1-font-size);
   text-align: var(--h1-text-align);
   padding-top: calc(70rem / 16);
   line-height: var(--heading-line-height);
+  letter-spacing: calc(var(--h1-font-size) * var(--h1-letter-spacing-percent));
 }
 
 /* H2 */

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -28,9 +28,7 @@
   --bs-danger: var(--error-color);
   --bs-danger-rgb: var(--error-color-rgb);
   --standout-color: #323a45;
-  --h1-font-size: calc(24rem / 16);
   --h1-text-align: left;
-  --h2-font-size: calc(24rem / 16);
   --h3-font-size: calc(20rem / 16);
   --font-size-24px: calc(24rem / 16);
   --font-size-20px: calc(20rem / 16);
@@ -168,6 +166,7 @@ h4 {
 /* Mobile first: Screen width up to 992px - 24px (24rem/16 = 1.5rem) and left */
 /* Screen width above 992px - 35px (35rem/16 = 2.1875rem) and centered */
 :root {
+  --h1-font-size: var(--font-size-24px);
   --h1-letter-spacing-percent: var(--letter-spacing-3);
 }
 
@@ -193,11 +192,13 @@ h1,
 /* Same sizes for all screen widths: 24px (24rem/16 = 1.5rem) */
 /* Also has a class which can be applied to non-headline elements */
 :root {
+  --h2-font-size: var(--font-size-20px);
   --h2-letter-spacing-percent: var(--letter-spacing-5);
 }
 
 @media (min-width: 992px) {
   :root {
+    --h2-font-size: var(--font-size-24px);
     --h2-letter-spacing-percent: var(--letter-spacing-3);
   }
 }

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -199,21 +199,22 @@ h2,
 }
 
 @media (max-width: 992px) {
-  /* H2 mobile sizing */
-  /* Only used on Landing Pages */
-  .h2-sm-p {
-    font-size: var(--bs-body-font-size);
-    font-weight: var(--bs-body-font-weight);
-    letter-spacing: calc(var(--bs-body-font-size) * var(--letter-spacing-5));
-    line-height: var(--heading-line-height);
-    margin: 0;
-  }
-
   /* H2: 20px, up to Small width */
   /* Only used on Help Pages */
   .h2-sm {
     font-size: var(--font-size-20px);
     line-height: var(--heading-line-height);
+    letter-spacing: calc(var(--font-size-20px) * var(--letter-spacing-5));
+  }
+
+  /* H2: 18px, up to Small width */
+  /* Only used on Landing Page, Eligibility Start */
+  .h2-sm-p {
+    font-size: var(--bs-body-font-size);
+    font-weight: var(--bs-body-font-weight);
+    line-height: var(--heading-line-height);
+    letter-spacing: calc(var(--bs-body-font-size) * var(--letter-spacing-5));
+    margin: 0;
   }
 }
 

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -89,17 +89,6 @@ li {
   margin: 0;
 }
 
-@media (max-width: 992px) {
-  /* Paragraph: Body Text, up to Small width */
-  .p-sm {
-    font-size: var(--bs-body-font-size);
-    font-weight: var(--bs-body-font-weight);
-    letter-spacing: var(--body-letter-spacing);
-    line-height: var(--bs-body-line-height);
-    margin: 0;
-  }
-}
-
 @media (min-width: 992px) {
   /* Utility Class: Padding bottom 64px on Desktop */
   /* Pair with pb-4 on Form pages to get 24px on Mobile, 64px on Desktop */
@@ -201,10 +190,36 @@ h1 {
 /* H2 */
 /* Same sizes for all screen widths: 24px (24rem/16 = 1.5rem) */
 /* Also has a class which can be applied to non-headline elements */
+:root {
+  --h2-letter-spacing-percent: var(--letter-spacing-5);
+}
+
+@media (min-width: 992px) {
+  :root {
+    --h2-letter-spacing-percent: var(--letter-spacing-3);
+  }
+}
+
 h2,
 .h2 {
   font-size: var(--h2-font-size);
   line-height: var(--heading-line-height);
+  letter-spacing: calc(var(--h2-font-size) * var(--h2-letter-spacing-percent));
+}
+
+@media (max-width: 992px) {
+  /* Paragraph: Body Text, up to Small width */
+  /* Used with an H2 */
+  /* Only used on Landing Pages */
+  .h2-sm {
+    font-size: var(--bs-body-font-size);
+    font-weight: var(--bs-body-font-weight);
+    letter-spacing: calc(
+      var(--bs-body-font-size) * var(--h2-letter-spacing-percent)
+    );
+    line-height: var(--heading-line-height);
+    margin: 0;
+  }
 }
 
 @media (max-width: 992px) {

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -83,7 +83,7 @@ span,
 li {
   font-size: var(--bs-body-font-size);
   font-weight: var(--bs-body-font-weight);
-  letter-spacing: var(--body-letter-spacing);
+  letter-spacing: calc(var(--bs-body-font-size) * var(--letter-spacing-5));
   line-height: var(--bs-body-line-height);
   margin: 0;
 }

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -192,22 +192,22 @@ h1,
 /* Same sizes for all screen widths: 24px (24rem/16 = 1.5rem) */
 /* Also has a class which can be applied to non-headline elements */
 :root {
-  --h2-font-size: var(--font-size-20px);
   --h2-letter-spacing-percent: var(--letter-spacing-5);
 }
 
 @media (min-width: 992px) {
   :root {
-    --h2-font-size: var(--font-size-24px);
     --h2-letter-spacing-percent: var(--letter-spacing-3);
   }
 }
 
 h2,
 .h2 {
-  font-size: var(--h2-font-size);
+  font-size: var(--font-size-24px);
   line-height: var(--heading-line-height);
-  letter-spacing: calc(var(--h2-font-size) * var(--h2-letter-spacing-percent));
+  letter-spacing: calc(
+    var(--font-size-24px) * var(--h2-letter-spacing-percent)
+  );
 }
 
 @media (max-width: 992px) {

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -246,13 +246,13 @@ h3,
 /* Used for Agency Selector card, agency name */
 :root {
   --h4-font-size: var(--font-size-18px);
-  --h4-letter-spacing-percent: var(--letter-spacing-5);
+  --h4-letter-spacing-percent: var(--letter-spacing-3);
 }
 
 @media (min-width: 992px) {
   :root {
     --h4-font-size: var(--font-size-20px);
-    --h4-letter-spacing-percent: var(--letter-spacing-3);
+    --h4-letter-spacing-percent: var(--letter-spacing-5);
   }
 }
 
@@ -672,7 +672,7 @@ h1 + .media-list, /* A .media-list immediately following the h1: Enrollment Succ
 
 :root {
   --card-title-font-size: var(--font-size-18px);
-  --card-title-letter-spacing: 0.03em;
+  /* --card-title-letter-spacing: 0.03em; */
   --card-x-padding: calc(10rem / 16);
   --card-body-x-padding: 0;
   --card-body-y-padding: 0.75rem;
@@ -684,7 +684,7 @@ h1 + .media-list, /* A .media-list immediately following the h1: Enrollment Succ
 @media (min-width: 992px) {
   :root {
     --card-title-font-size: var(--font-size-20px);
-    --card-title-letter-spacing: 0.05rem;
+    /* --card-title-letter-spacing: 0.05rem; */
     --card-x-padding: calc(35rem / 16);
     --card-body-x-padding: calc(40rem / 16);
     --card-body-y-padding: 0;
@@ -718,7 +718,7 @@ a.card:focus-visible {
 
 .card .card-title {
   font-size: var(--card-title-font-size);
-  letter-spacing: var(--card-title-letter-spacing);
+  /* letter-spacing: var(--card-title-letter-spacing); */
 }
 
 .card .card-body {


### PR DESCRIPTION
closes #1600 

Status: Rebased and Ready for Review

## What this PR does
- Remove the old letter-spacing variable, and add letter-spacing percentage variables
- Use CSS calc to calculate letter-spacing: the font-size in rem * the letter-spacing percentage
- Use the type set by the most basic element (like `h1`, `h3`) - prefer to not add class or component-level overrides when the type is using the same styles as the already-styled basic elements.

## Testing

The browser developer tools shows letter-spacing in pixels. Make sure your Figma is in Dev Mode, with display set to Pixels, so you can compare the Figma's pixels to the browser's pixels.

### H1

**Desktop**|**Mobile**
:-----:|:-----:
 <img width="1510" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/ed7a9d68-f784-487b-9c8b-2dcef8cba64a">| <img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/06956864-c6e0-406c-8ee9-3fc5399e1081">
1.75px | 0.72px

### H2: There are 3 kinds of H2's on the app

#### A regular H2 where the size/letter-spacing don't change responsively, `h2, .h2`
**Desktop**|**Mobile**
:-----:|:-----: 
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/d016e845-a59a-437c-8add-c044e4992068">|<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/89e3b0a3-be5b-4c0e-9558-c9b191807fd6">
0.72px | 0.72px 

#### H2 that down-sizes to a P on Mobile, `.h2-sm-p`
**Desktop**|**Mobile**
:-----:|:-----:
 <img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/dfc771f6-8fa6-4d5c-bc68-27c1f10875da">|<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/3e9bee95-b095-4c71-b44c-1f4a0027d2e0"> 
0.72px | 0.9px

#### H2 that downsizes to font-size 20px on Mobile, `.h2-sm`
**Desktop**|**Mobile**
:-----:|:-----:
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/19140330-3c9a-4ae6-ac61-433ffc399d78">|<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/0779e99a-9261-477a-bf67-4186117b3a78">
0.72px| 1px

### H4 
**Desktop**|**Mobile**
:-----:|:-----:
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/bc25d706-7f4d-42b9-85a9-5432a133ede3">|<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/6a294d40-3272-4f41-b524-709abca5326b">
1px | 0.54px

### Body, Paragraph
**Desktop**|**Mobile**
:-----:|:-----:
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/ebd56e00-f2cf-4418-8b99-e01ead4dc333">|<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/33c8a726-6d42-4377-85b1-a2b43c3ac6d8">
0.9px | 0.9px

### Buttons
**Desktop**|**Mobile**
:-----:|:-----:
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/806b5727-c8dc-4cb6-92ad-edef7a75ecc5">|<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/c073e0a8-9b35-4a90-892a-d87829d3715c">
0.4px | 0.4px

### Previous Page
**Desktop**|**Mobile**
:-----:|:-----:
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/ef3a3430-51ac-4861-be5f-0169cca3f0d8">|<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/0e8484f0-12ed-49cc-8470-5cc179d801be">
0.7px | 0.7px
