### PR TITLE
Landing Pages: Fix text padding

### DIFF
--- a/benefits/core/templates/core/landing.html
+++ b/benefits/core/templates/core/landing.html
@@ -19,7 +19,7 @@
             {% block headline %}
             {% endblock headline %}
           </h1>
-          <h2 class="p-sm pb-lg-8 pt-1 pt-lg-5 pb-4">{% translate "core.pages.landing.h2" %}</h2>
+          <h2 class="p-sm pt-1 pt-lg-5 pb-4 pb-lg-5 mb-lg-2">{% translate "core.pages.landing.h2" %}</h2>
           <span role="img" aria-label="{% translate "core.pages.index.alt" %}"></span>
           {% block call-to-action %}
           {% endblock call-to-action %}

--- a/benefits/core/templates/core/landing.html
+++ b/benefits/core/templates/core/landing.html
@@ -19,7 +19,7 @@
             {% block headline %}
             {% endblock headline %}
           </h1>
-          <h2 class="p-sm pb-lg-8 pt-1 pt-lg-4 pb-4">{% translate "core.pages.landing.h2" %}</h2>
+          <h2 class="p-sm pb-lg-8 pt-1 pt-lg-5 pb-4">{% translate "core.pages.landing.h2" %}</h2>
           <span role="img" aria-label="{% translate "core.pages.index.alt" %}"></span>
           {% block call-to-action %}
           {% endblock call-to-action %}

--- a/benefits/core/templates/core/landing.html
+++ b/benefits/core/templates/core/landing.html
@@ -14,8 +14,8 @@
   <div class="container">
     <div class="row align-items-end align-items-lg-center">
       <div class="col-lg-5">
-        <div class="box py-3">
-          <h1 class="text-left p-0">
+        <div class="box py-3 px-lg-0 px-3">
+          <h1 class="text-left p-0 ">
             {% block headline %}
             {% endblock headline %}
           </h1>

--- a/benefits/core/templates/core/landing.html
+++ b/benefits/core/templates/core/landing.html
@@ -14,7 +14,7 @@
   <div class="container">
     <div class="row align-items-end align-items-lg-center">
       <div class="col-lg-5">
-        <div class="box px-4 py-3">
+        <div class="box py-3">
           <h1 class="text-left p-0">
             {% block headline %}
             {% endblock headline %}


### PR DESCRIPTION
fix #1580 

Fixes small padding issue on Landing Pages (Index and Agency Index):
- Desktop: H1 and H2 are flush with the container (vertically aligned with Cal-ITP logo)
- Desktop: Distance between H1 and H2 increased to 48px

### Screenshots
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/7ec59bac-a8b3-4dc5-988b-08b7de1001a7">
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/9c21b3a7-f6a5-4566-804e-f6ae560d862e">
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/72a7c4e7-c015-4e08-8474-36a57646977d">

