### PR TITLE
Agency Selector Modal: Fix padding regression

### DIFF
--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -835,18 +835,18 @@ a.card:focus-visible {
 
 /* Agency Selector */
 
-#agency-selector .modal-body {
+#modal--agency-selector .modal-body {
   padding: 0;
 }
 
-#agency-selector .card img {
+#modal--agency-selector .card img {
   margin-right: -1px;
 }
 
-#agency-selector .col:first-child .card {
+#modal--agency-selector .col:first-child .card {
   margin-top: 2rem;
 }
 
-#agency-selector .col:last-child .card {
+#modal--agency-selector .col:last-child .card {
   margin-bottom: 2rem;
 }


### PR DESCRIPTION
fix #1618 


## What this PR does
- `#agency-selector` ID doesn't exist anymore
- replace with new ID, `#modal--agency-selector`

## Screenshot
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/4ee1fddb-9ca6-4a86-aa12-4122c5ca276a">
