### PR TITLE
Help: Mobile - Type fixes

### DIFF
--- a/benefits/core/templates/core/help.html
+++ b/benefits/core/templates/core/help.html
@@ -16,11 +16,11 @@
 
     <div class="row justify-content-center">
       <div class="col-md-8 col-10">
-        <h2 class="pt-8" id="what-is-cal-itp">{% translate "core.pages.help.about" %}</h2>
+        <h2 class="h3-sm pt-8" id="what-is-cal-itp">{% translate "core.pages.help.about" %}</h2>
         <p class="pt-4">{% translate "core.pages.help.about.p[0]" %}</p>
         <p class="pt-4">{% translate "core.pages.help.about.p[1]" %}</p>
 
-        <h2 class="pt-8" id="payment-options">{% translate "core.pages.help.payment_options" %}</h2>
+        <h2 class="h3-sm pt-8" id="payment-options">{% translate "core.pages.help.payment_options" %}</h2>
         <p class="pt-4">{% translate "eligibility.pages.start.modal.p[0]" %}</p>
         <p class="pt-4">{% translate "eligibility.pages.start.modal.p[1]" %}</p>
         <p class="contactless-symbol pt-3">
@@ -38,14 +38,14 @@
           </p>
         {% endif %}
 
-        <h2 class="pt-8" id="login-gov">{% translate "eligibility.pages.index.senior.help.sub_headline[0]" %}</h2>
+        <h2 class="h3-sm pt-8" id="login-gov">{% translate "eligibility.pages.index.senior.help.sub_headline[0]" %}</h2>
         <p class="pt-4">{% translate "eligibility.pages.index.senior.help.p[0]" %}</p>
         <p class="pt-4">{% translate "eligibility.pages.index.senior.help.p[2]" %}</p>
 
-        <h2 class="pt-8" id="why-login-gov">{% translate "eligibility.pages.index.senior.help.sub_headline[1]" %}</h2>
+        <h2 class="h3-sm pt-8" id="why-login-gov">{% translate "eligibility.pages.index.senior.help.sub_headline[1]" %}</h2>
         <p class="pt-4">{% translate "eligibility.pages.index.senior.help.p[1]" %}</p>
 
-        <h2 class="pt-8" id="login-gov-verify">{% translate "core.pages.help.login_gov_verify" %}</h2>
+        <h2 class="h3-sm pt-8" id="login-gov-verify">{% translate "core.pages.help.login_gov_verify" %}</h2>
         <p class="pt-4">{% translate "eligibility.pages.start.senior.help.p[0]" %}</p>
         <p class="pt-4">{% translate "eligibility.pages.start.senior.help.p[1]" %}</p>
         <p class="pt-4">{% translate "eligibility.pages.start.senior.help.p[2]" %}</p>
@@ -56,11 +56,11 @@
           {% include agency.help_template %}
         {% endif %}
 
-        <h2 class="pt-8" id="littlepay">{% translate "core.pages.help.littlepay" %}</h2>
+        <h2 class="h3-sm pt-8" id="littlepay">{% translate "core.pages.help.littlepay" %}</h2>
         <p class="pt-4">{% translate "enrollment.pages.index.modal.p[0]" %}</p>
         <p class="pt-4">{% translate "enrollment.pages.index.modal.p[1]" %}</p>
 
-        <h2 class="pt-8" id="questions">{% translate "core.pages.help.questions" %}</h2>
+        <h2 class="h3-sm pt-8" id="questions">{% translate "core.pages.help.questions" %}</h2>
         <p class="pt-4">{% translate "core.pages.help.questions.p[0]" %}</p>
       </div>
     </div>

--- a/benefits/core/templates/core/help.html
+++ b/benefits/core/templates/core/help.html
@@ -10,7 +10,7 @@
   <div class="container">
     <div class="row justify-content-center">
       <div class="col-md-8 col-10">
-        <h1>{% translate "core.buttons.help" %}</h1>
+        <h1 class="text-center">{% translate "core.buttons.help" %}</h1>
       </div>
     </div>
 

--- a/benefits/core/templates/core/help.html
+++ b/benefits/core/templates/core/help.html
@@ -16,11 +16,11 @@
 
     <div class="row justify-content-center">
       <div class="col-md-8 col-10">
-        <h2 class="h3-sm pt-8" id="what-is-cal-itp">{% translate "core.pages.help.about" %}</h2>
+        <h2 class="h3-sm pt-4 pt-lg-8" id="what-is-cal-itp">{% translate "core.pages.help.about" %}</h2>
         <p class="pt-4">{% translate "core.pages.help.about.p[0]" %}</p>
         <p class="pt-4">{% translate "core.pages.help.about.p[1]" %}</p>
 
-        <h2 class="h3-sm pt-8" id="payment-options">{% translate "core.pages.help.payment_options" %}</h2>
+        <h2 class="h3-sm pt-4 pt-lg-8" id="payment-options">{% translate "core.pages.help.payment_options" %}</h2>
         <p class="pt-4">{% translate "eligibility.pages.start.modal.p[0]" %}</p>
         <p class="pt-4">{% translate "eligibility.pages.start.modal.p[1]" %}</p>
         <p class="contactless-symbol pt-3">
@@ -38,14 +38,14 @@
           </p>
         {% endif %}
 
-        <h2 class="h3-sm pt-8" id="login-gov">{% translate "eligibility.pages.index.senior.help.sub_headline[0]" %}</h2>
+        <h2 class="h3-sm pt-4 pt-lg-8" id="login-gov">{% translate "eligibility.pages.index.senior.help.sub_headline[0]" %}</h2>
         <p class="pt-4">{% translate "eligibility.pages.index.senior.help.p[0]" %}</p>
         <p class="pt-4">{% translate "eligibility.pages.index.senior.help.p[2]" %}</p>
 
-        <h2 class="h3-sm pt-8" id="why-login-gov">{% translate "eligibility.pages.index.senior.help.sub_headline[1]" %}</h2>
+        <h2 class="h3-sm pt-4 pt-lg-8" id="why-login-gov">{% translate "eligibility.pages.index.senior.help.sub_headline[1]" %}</h2>
         <p class="pt-4">{% translate "eligibility.pages.index.senior.help.p[1]" %}</p>
 
-        <h2 class="h3-sm pt-8" id="login-gov-verify">{% translate "core.pages.help.login_gov_verify" %}</h2>
+        <h2 class="h3-sm pt-4 pt-lg-8" id="login-gov-verify">{% translate "core.pages.help.login_gov_verify" %}</h2>
         <p class="pt-4">{% translate "eligibility.pages.start.senior.help.p[0]" %}</p>
         <p class="pt-4">{% translate "eligibility.pages.start.senior.help.p[1]" %}</p>
         <p class="pt-4">{% translate "eligibility.pages.start.senior.help.p[2]" %}</p>
@@ -56,11 +56,11 @@
           {% include agency.help_template %}
         {% endif %}
 
-        <h2 class="h3-sm pt-8" id="littlepay">{% translate "core.pages.help.littlepay" %}</h2>
+        <h2 class="h3-sm pt-4 pt-lg-8" id="littlepay">{% translate "core.pages.help.littlepay" %}</h2>
         <p class="pt-4">{% translate "enrollment.pages.index.modal.p[0]" %}</p>
         <p class="pt-4">{% translate "enrollment.pages.index.modal.p[1]" %}</p>
 
-        <h2 class="h3-sm pt-8" id="questions">{% translate "core.pages.help.questions" %}</h2>
+        <h2 class="h3-sm pt-4 pt-lg-8" id="questions">{% translate "core.pages.help.questions" %}</h2>
         <p class="pt-4">{% translate "core.pages.help.questions.p[0]" %}</p>
       </div>
     </div>
@@ -77,7 +77,7 @@
       </div>
     </div>
 
-    <div class="row pt-8">
+    <div class="row pt-4 pt-lg-8">
       <div class="col-lg-2 offset-lg-10 col-8 offset-2">
         {% translate "core.buttons.back" as button_text %}
         {% include "core/includes/button--origin.html" with button_text=button_text %}

--- a/benefits/core/templates/core/help.html
+++ b/benefits/core/templates/core/help.html
@@ -17,12 +17,12 @@
     <div class="row justify-content-center">
       <div class="col-md-8 col-10">
         <h2 class="h3-sm pt-4 pt-lg-8" id="what-is-cal-itp">{% translate "core.pages.help.about" %}</h2>
-        <p class="pt-4">{% translate "core.pages.help.about.p[0]" %}</p>
-        <p class="pt-4">{% translate "core.pages.help.about.p[1]" %}</p>
+        <p class="pt-2 pt-lg-4">{% translate "core.pages.help.about.p[0]" %}</p>
+        <p class="pt-3 pt-lg-4">{% translate "core.pages.help.about.p[1]" %}</p>
 
         <h2 class="h3-sm pt-4 pt-lg-8" id="payment-options">{% translate "core.pages.help.payment_options" %}</h2>
-        <p class="pt-4">{% translate "eligibility.pages.start.modal.p[0]" %}</p>
-        <p class="pt-4">{% translate "eligibility.pages.start.modal.p[1]" %}</p>
+        <p class="pt-2 pt-lg-4">{% translate "eligibility.pages.start.modal.p[0]" %}</p>
+        <p class="pt-3 pt-lg-4">{% translate "eligibility.pages.start.modal.p[1]" %}</p>
         <p class="contactless-symbol pt-3">
           <img class="icon mx-auto d-block"
                width="40"
@@ -30,38 +30,38 @@
                src="{% static 'img/icon/contactless.svg' %}"
                alt="{% translate "core.icons.contactless" context "image alt text" %}" />
         </p>
-        <p class="pt-4">{% translate "eligibility.pages.start.modal.p[2]" %}</p>
-        <p class="pt-4">{% translate "eligibility.pages.start.modal.p[3]" %}</p>
+        <p class="pt-3 pt-lg-4">{% translate "eligibility.pages.start.modal.p[2]" %}</p>
+        <p class="pt-3 pt-lg-4">{% translate "eligibility.pages.start.modal.p[3]" %}</p>
         {% if agency %}
-          <p class="pt-4">
+          <p class="pt-3 pt-lg-4">
             {% blocktranslate with short_name=agency.short_name website=agency.info_url %}eligibility.pages.start.modal.p[4]{{ short_name }}{{ website }}{% endblocktranslate %}
           </p>
         {% endif %}
 
         <h2 class="h3-sm pt-4 pt-lg-8" id="login-gov">{% translate "eligibility.pages.index.senior.help.sub_headline[0]" %}</h2>
-        <p class="pt-4">{% translate "eligibility.pages.index.senior.help.p[0]" %}</p>
-        <p class="pt-4">{% translate "eligibility.pages.index.senior.help.p[2]" %}</p>
+        <p class="pt-2 pt-lg-4">{% translate "eligibility.pages.index.senior.help.p[0]" %}</p>
+        <p class="pt-3 pt-lg-4">{% translate "eligibility.pages.index.senior.help.p[2]" %}</p>
 
         <h2 class="h3-sm pt-4 pt-lg-8" id="why-login-gov">{% translate "eligibility.pages.index.senior.help.sub_headline[1]" %}</h2>
-        <p class="pt-4">{% translate "eligibility.pages.index.senior.help.p[1]" %}</p>
+        <p class="pt-2 pt-lg-4">{% translate "eligibility.pages.index.senior.help.p[1]" %}</p>
 
         <h2 class="h3-sm pt-4 pt-lg-8" id="login-gov-verify">{% translate "core.pages.help.login_gov_verify" %}</h2>
-        <p class="pt-4">{% translate "eligibility.pages.start.senior.help.p[0]" %}</p>
-        <p class="pt-4">{% translate "eligibility.pages.start.senior.help.p[1]" %}</p>
-        <p class="pt-4">{% translate "eligibility.pages.start.senior.help.p[2]" %}</p>
-        <p class="pt-4">{% translate "eligibility.pages.start.senior.help.p[3]" %}</p>
-        <p class="pt-4">{% translate "eligibility.pages.start.senior.help.p[4]" %}</p>
+        <p class="pt-2 pt-lg-4">{% translate "eligibility.pages.start.senior.help.p[0]" %}</p>
+        <p class="pt-3 pt-lg-4">{% translate "eligibility.pages.start.senior.help.p[1]" %}</p>
+        <p class="pt-3 pt-lg-4">{% translate "eligibility.pages.start.senior.help.p[2]" %}</p>
+        <p class="pt-3 pt-lg-4">{% translate "eligibility.pages.start.senior.help.p[3]" %}</p>
+        <p class="pt-3 pt-lg-4">{% translate "eligibility.pages.start.senior.help.p[4]" %}</p>
 
         {% if agency and agency.help_template %}
           {% include agency.help_template %}
         {% endif %}
 
         <h2 class="h3-sm pt-4 pt-lg-8" id="littlepay">{% translate "core.pages.help.littlepay" %}</h2>
-        <p class="pt-4">{% translate "enrollment.pages.index.modal.p[0]" %}</p>
-        <p class="pt-4">{% translate "enrollment.pages.index.modal.p[1]" %}</p>
+        <p class="pt-2 pt-lg-4">{% translate "enrollment.pages.index.modal.p[0]" %}</p>
+        <p class="pt-3 pt-lg-4">{% translate "enrollment.pages.index.modal.p[1]" %}</p>
 
         <h2 class="h3-sm pt-4 pt-lg-8" id="questions">{% translate "core.pages.help.questions" %}</h2>
-        <p class="pt-4">{% translate "core.pages.help.questions.p[0]" %}</p>
+        <p class="pt-2 pt-lg-4">{% translate "core.pages.help.questions.p[0]" %}</p>
       </div>
     </div>
 
@@ -86,7 +86,7 @@
 
     <div class="row justify-content-center">
       <div class="col-md-8 col-10 mt-4">
-        <p class="pt-4">
+        <p class="pt-3 pt-lg-4">
           {% translate "core.pages.help.foss.text" %}
           <a href="https://www.github.com/cal-itp/benefits" target="_blank" rel="noopener noreferrer">{% translate "core.pages.help.foss.link" %}</a>.
         </p>

--- a/benefits/core/templates/core/help.html
+++ b/benefits/core/templates/core/help.html
@@ -16,11 +16,11 @@
 
     <div class="row justify-content-center">
       <div class="col-md-8 col-10">
-        <h2 class="h3-sm pt-4 pt-lg-8" id="what-is-cal-itp">{% translate "core.pages.help.about" %}</h2>
+        <h2 class="h2-sm pt-4 pt-lg-8" id="what-is-cal-itp">{% translate "core.pages.help.about" %}</h2>
         <p class="pt-2 pt-lg-4">{% translate "core.pages.help.about.p[0]" %}</p>
         <p class="pt-3 pt-lg-4">{% translate "core.pages.help.about.p[1]" %}</p>
 
-        <h2 class="h3-sm pt-4 pt-lg-8" id="payment-options">{% translate "core.pages.help.payment_options" %}</h2>
+        <h2 class="h2-sm pt-4 pt-lg-8" id="payment-options">{% translate "core.pages.help.payment_options" %}</h2>
         <p class="pt-2 pt-lg-4">{% translate "eligibility.pages.start.modal.p[0]" %}</p>
         <p class="pt-3 pt-lg-4">{% translate "eligibility.pages.start.modal.p[1]" %}</p>
         <p class="contactless-symbol pt-3">
@@ -38,14 +38,14 @@
           </p>
         {% endif %}
 
-        <h2 class="h3-sm pt-4 pt-lg-8" id="login-gov">{% translate "eligibility.pages.index.senior.help.sub_headline[0]" %}</h2>
+        <h2 class="h2-sm pt-4 pt-lg-8" id="login-gov">{% translate "eligibility.pages.index.senior.help.sub_headline[0]" %}</h2>
         <p class="pt-2 pt-lg-4">{% translate "eligibility.pages.index.senior.help.p[0]" %}</p>
         <p class="pt-3 pt-lg-4">{% translate "eligibility.pages.index.senior.help.p[2]" %}</p>
 
-        <h2 class="h3-sm pt-4 pt-lg-8" id="why-login-gov">{% translate "eligibility.pages.index.senior.help.sub_headline[1]" %}</h2>
+        <h2 class="h2-sm pt-4 pt-lg-8" id="why-login-gov">{% translate "eligibility.pages.index.senior.help.sub_headline[1]" %}</h2>
         <p class="pt-2 pt-lg-4">{% translate "eligibility.pages.index.senior.help.p[1]" %}</p>
 
-        <h2 class="h3-sm pt-4 pt-lg-8" id="login-gov-verify">{% translate "core.pages.help.login_gov_verify" %}</h2>
+        <h2 class="h2-sm pt-4 pt-lg-8" id="login-gov-verify">{% translate "core.pages.help.login_gov_verify" %}</h2>
         <p class="pt-2 pt-lg-4">{% translate "eligibility.pages.start.senior.help.p[0]" %}</p>
         <p class="pt-3 pt-lg-4">{% translate "eligibility.pages.start.senior.help.p[1]" %}</p>
         <p class="pt-3 pt-lg-4">{% translate "eligibility.pages.start.senior.help.p[2]" %}</p>
@@ -56,11 +56,11 @@
           {% include agency.help_template %}
         {% endif %}
 
-        <h2 class="h3-sm pt-4 pt-lg-8" id="littlepay">{% translate "core.pages.help.littlepay" %}</h2>
+        <h2 class="h2-sm pt-4 pt-lg-8" id="littlepay">{% translate "core.pages.help.littlepay" %}</h2>
         <p class="pt-2 pt-lg-4">{% translate "enrollment.pages.index.modal.p[0]" %}</p>
         <p class="pt-3 pt-lg-4">{% translate "enrollment.pages.index.modal.p[1]" %}</p>
 
-        <h2 class="h3-sm pt-4 pt-lg-8" id="questions">{% translate "core.pages.help.questions" %}</h2>
+        <h2 class="h2-sm pt-4 pt-lg-8" id="questions">{% translate "core.pages.help.questions" %}</h2>
         <p class="pt-2 pt-lg-4">{% translate "core.pages.help.questions.p[0]" %}</p>
       </div>
     </div>

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -204,6 +204,14 @@ h3,
   line-height: var(--heading-line-height);
 }
 
+@media (max-width: 992px) {
+  /* H3: H3, up to Small width */
+  .h3-sm {
+    font-size: var(--h3-font-size);
+    line-height: var(--heading-line-height);
+  }
+}
+
 /* H4 */
 /* Desktop only: Used for Agency Selector card, agency name */
 h4 {

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -111,6 +111,10 @@ li {
   .pb-lg-8 {
     padding-bottom: 64px !important;
   }
+
+  .pt-lg-8 {
+    padding-top: 64px !important;
+  }
 }
 
 .pt-8 {

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -199,6 +199,14 @@ h2,
   line-height: var(--heading-line-height);
 }
 
+@media (max-width: 992px) {
+  /* H2: 20px, up to Small width */
+  .h2-sm {
+    font-size: var(--font-size-20px);
+    line-height: var(--heading-line-height);
+  }
+}
+
 /* H3 */
 /* Same sizes for all screen widths: 20px (20rem/16 = 1.25rem) */
 /* Also has a class which can be applied to non-headline elements */
@@ -206,14 +214,6 @@ h3,
 .h3 {
   font-size: var(--h3-font-size);
   line-height: var(--heading-line-height);
-}
-
-@media (max-width: 992px) {
-  /* H3: H3, up to Small width */
-  .h3-sm {
-    font-size: var(--h3-font-size);
-    line-height: var(--heading-line-height);
-  }
 }
 
 /* H4 */


### PR DESCRIPTION
fix #1615 

## What this PR does
1. Headline: Center the headline on mobile
2. The questions are now 20px font size. Create and use a utility class for this.
3. Padding: Reduce padding between question and first graf. Reduce padding between grafs. Create and use a utility class for this. 
4. No changes for Desktop mode.

## Screenshots
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/48de26c8-bc61-4e78-8085-60c2373c045a">
