### PR TITLE
Styles: New body text color

### DIFF
--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -4,7 +4,7 @@
   --bs-blue: var(--primary-color);
   --bs-primary: var(--primary-color);
   --bs-primary-rgb: var(--primary-color-rgb);
-  --text-primary-color: #000000;
+  --text-primary-color: #212121;
   --bs-body-color: var(--text-primary-color);
   --bs-body-text-align: left;
   --bs-body-font-weight: 400;
@@ -59,6 +59,7 @@
 
 body {
   font-size: 100%;
+  color: var(--text-primary-color);
 }
 
 h1,


### PR DESCRIPTION
closes #1616 

## What this PR does
- Update value for `--text-primary-color` from `#000000` to `#212121`
- Add color declaration to `body` class to override the CA State Web Template default of `#111111`
- All text, footer background color, text-colored buttons (like Previous Page button) are now `#212121`. Radio button remains `--standout-color`.