### PR TITLE
Fix: Button uses primary-color for background

### DIFF
--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -373,6 +373,8 @@ footer .footer-links li a.footer-link:visited {
 }
 
 .btn.btn-lg.btn-primary {
+  background-color: var(--primary-color);
+  border-color: var(--primary-color);
   border-width: 2px;
   font-weight: var(--medium-font-weight);
   font-size: var(--font-size-20px);

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -383,6 +383,11 @@ footer .footer-links li a.footer-link:visited {
   padding: var(--primary-button-padding);
 }
 
+.btn.btn-lg.btn-primary:hover {
+  background-color: var(--hover-color);
+  border-color: var(--hover-color);
+}
+
 .btn.btn-lg.btn-primary:focus,
 .btn.btn-lg.btn-primary:focus-visible,
 .btn-outline-dark:focus,


### PR DESCRIPTION
fix #1635 

This fix came from @srhhnry's #1582 

## What this PR does
- Previously, button background color (and 2px border color of the same color) was coming from CA State Web Template. Now we're overriding the CA State Web Template and declaring it in the CSS itself.
- Add the hover color to button as well

<img width="1392" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/42ac5d36-8eec-452b-b51a-1d048ab21d75">

## Buttons affected
- All CTAs with blue background
- Doesn't affect the button in `disabled` state