### PR TITLE
Enrollment Success: Desktop - Bring text/img closer together

### DIFF
--- a/benefits/enrollment/templates/enrollment/success.html
+++ b/benefits/enrollment/templates/enrollment/success.html
@@ -20,7 +20,7 @@
 {% block inner-content %}
   <div class="col-12 col-sm-12 col-lg-9">
     <div class="row flex-column-reverse flex-lg-row">
-      <div class="col-12 col-lg-6">
+      <div class="col-12 col-lg-7">
         <p class="pt-lg-4 mt-lg-3">
           {% block success-message %}
           {% endblock success-message %}

--- a/benefits/enrollment/templates/enrollment/success.html
+++ b/benefits/enrollment/templates/enrollment/success.html
@@ -27,7 +27,7 @@
         </p>
         <p class="pt-4">{% translate "Thank you for using Cal-ITP Benefits!" %}</p>
       </div>
-      <div class="col-12 offset-lg-1 col-lg-5">
+      <div class="col-12 col-lg-5">
         <img width="180"
              height="155.1"
              class="illo d-block mx-auto mb-4 mb-lg-0"


### PR DESCRIPTION
fix #1638 

## What this PR does
- Remove `offset-lg-1`
- Change `col-lg-6` to `col-lg-7`
- No changes to mobile

## Screenshot
<img width="1254" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/2f269f7c-b333-4795-94b5-6ac90d814572">
