### PR TITLE
Refactor: Footer - Re-do mobile footer alignment

### DIFF
--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -127,7 +127,7 @@
       <div class="d-block d-lg-none container">
         <ul class="col-12 footer-links ps-0 mb-0">
           <li>
-            <a href="https://cdt.ca.gov/privacy-policy/" target="_blank" rel="noopener noreferrer" class="">Privacy Policy</a>
+            <a href="https://cdt.ca.gov/privacy-policy/" target="_blank" rel="noopener noreferrer" class="">{% translate "Privacy Policy" %}</a>
           </li>
         </ul>
       </div>

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -102,8 +102,8 @@
       {% endblock main-content %}
     </main>
 
-    <footer id="footer">
-      <div class="container">
+    <footer id="footer" class="navbar py-0">
+      <div class="container d-none d-lg-block">
         <ul class="footer-links m-0 p-0 list-unstyled d-lg-flex gap-lg-4">
           <li>
             <a class="footer-link m-0 ms-5 ps-lg-0" href="{% url "core:help" %}">{% translate "Help" %}</a>
@@ -113,6 +113,25 @@
           </li>
         </ul>
       </div>
+
+      <div class="d-block d-lg-none container">
+        <ul class="col-12 footer-links ps-0 mb-0">
+          <li>
+            <a href="{% url "core:help" %}">{% translate "Help" %}</a>
+          </li>
+        </ul>
+      </div>
+      <div class="d-block d-lg-none container-fluid p-0">
+        <hr class="border border-white border-1 p-0 m-0 w-100 opacity-100">
+      </div>
+      <div class="d-block d-lg-none container">
+        <ul class="col-12 footer-links ps-0 mb-0">
+          <li>
+            <a href="https://cdt.ca.gov/privacy-policy/" target="_blank" rel="noopener noreferrer" class="">Privacy Policy</a>
+          </li>
+        </ul>
+      </div>
+
     </footer>
 
     {% comment %}

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -106,10 +106,10 @@
       <div class="container d-none d-lg-block">
         <ul class="footer-links m-0 p-0 list-unstyled d-lg-flex gap-lg-4">
           <li>
-            <a class="footer-link m-0 ms-5 ps-lg-0" href="{% url "core:help" %}">{% translate "Help" %}</a>
+            <a class="footer-link m-0 p-0" href="{% url "core:help" %}">{% translate "Help" %}</a>
           </li>
           <li>
-            <a class="footer-link m-0 ms-5 ps-lg-0" href="https://cdt.ca.gov/privacy-policy/" target="_blank" rel="noopener noreferrer">{% translate "Privacy Policy" %}</a>
+            <a class="footer-link m-0 p-0" href="https://cdt.ca.gov/privacy-policy/" target="_blank" rel="noopener noreferrer">{% translate "Privacy Policy" %}</a>
           </li>
         </ul>
       </div>
@@ -117,7 +117,7 @@
       <div class="d-block d-lg-none container">
         <ul class="col-12 footer-links ps-0 mb-0">
           <li>
-            <a href="{% url "core:help" %}">{% translate "Help" %}</a>
+            <a class="footer-link" href="{% url "core:help" %}">{% translate "Help" %}</a>
           </li>
         </ul>
       </div>
@@ -127,7 +127,7 @@
       <div class="d-block d-lg-none container">
         <ul class="col-12 footer-links ps-0 mb-0">
           <li>
-            <a href="https://cdt.ca.gov/privacy-policy/" target="_blank" rel="noopener noreferrer" class="">{% translate "Privacy Policy" %}</a>
+            <a class="footer-link" href="https://cdt.ca.gov/privacy-policy/" target="_blank" rel="noopener noreferrer">{% translate "Privacy Policy" %}</a>
           </li>
         </ul>
       </div>

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -257,6 +257,17 @@ h4 {
   line-height: var(--h4-line-height);
 }
 
+/* Header */
+#header-container {
+  height: 80px;
+}
+
+/* Language button */
+#header-container .btn-outline-light {
+  font-size: var(--bs-body-font-size);
+  padding: 3.5px 29.01px; /* 126 x 38px, all screen sizes  */
+}
+
 /* Main */
 /* The minimum height is calculated by 100 viewport height minus Header and Footer height */
 main {
@@ -264,42 +275,20 @@ main {
 }
 
 /* Footer */
-/* Footer has same font styles on all screen widths */
-/* Mobile first: One link per row, each link is 50px height */
-/* Screen width above 992px - Footer is 50px height */
-/* Total footer height is 50px on Desktop */
-/* And 102 on Mobile */
-/* Footer breakpoint set to 992px */
-/* Note: Not all Footer styles are written in mobile-first */
-/* to style the full-width line on mobile */
-/* and the desktop container-width sizing */
-
 :root {
   --footer-background-color: var(--dark-color);
   --footer-link-color: #73b3e7;
-  --footer-link-width: 100%;
   --footer-link-hover-color: #0062ff;
   --footer-link-visited-color: #9b74d7;
   --footer-link-font-weight: var(--bold-font-weight);
-  --footer-mobile-underline-color: var(--bs-white);
   --main-content-min-height: calc(100vh - 246px);
   /* 246px = Header Height (80px) + (Footer Link (50px) * Number of Links (2)) + Underline Height (2px) + Footer Margin Top (64px) */
 }
 
 @media (min-width: 992px) {
   :root {
-    --footer-link-width: auto;
     --main-content-min-height: calc(100vh - 194px);
     /* 194px = Header Height (80px) + Footer Height (50px) + Footer Margin Top (64px) */
-  }
-}
-
-/* Custom non-mobile-first code to */
-/* allow the mobile footer to have a */
-/* full-width line beyond container-fluid width */
-@media (max-width: 992px) {
-  footer {
-    margin-top: 64px;
   }
 }
 
@@ -334,18 +323,6 @@ footer .footer-links li a.footer-link:focus-visible {
 footer .footer-links li a.footer-link:active,
 footer .footer-links li a.footer-link:visited {
   color: var(--footer-link-visited-color);
-}
-
-/* Header */
-
-#header-container {
-  height: 80px;
-}
-
-/* Language button */
-#header-container .btn-outline-light {
-  font-size: var(--bs-body-font-size);
-  padding: 3.5px 29.01px; /* 126 x 38px, all screen sizes  */
 }
 
 /* Buttons */

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -297,10 +297,6 @@ footer {
   margin-top: 64px;
 }
 
-/* footer .footer-links li {
-  width: var(--footer-link-width);
-} */
-
 footer .footer-links li a.footer-link {
   color: var(--footer-link-color);
   font-weight: var(--footer-link-font-weight);

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -294,14 +294,23 @@ main {
   }
 }
 
+/* Custom non-mobile-first code to */
+/* allow the mobile footer to have a */
+/* full-width line beyond container-fluid width */
+@media (max-width: 992px) {
+  footer {
+    margin-top: 64px;
+  }
+}
+
 footer {
   background: var(--footer-background-color);
   margin-top: 64px;
 }
 
-footer .footer-links li {
+/* footer .footer-links li {
   width: var(--footer-link-width);
-}
+} */
 
 footer .footer-links li a.footer-link {
   color: var(--footer-link-color);
@@ -325,24 +334,6 @@ footer .footer-links li a.footer-link:focus-visible {
 footer .footer-links li a.footer-link:active,
 footer .footer-links li a.footer-link:visited {
   color: var(--footer-link-visited-color);
-}
-
-/* Custom non-mobile-first code to */
-/* allow the mobile footer to have a */
-/* full-width line beyond container-fluid width */
-@media (max-width: 992px) {
-  footer {
-    margin-top: 64px;
-  }
-
-  footer .container {
-    max-width: 100%;
-    padding: 0;
-  }
-
-  footer .footer-links li:not(:last-child) {
-    border-bottom: 2px solid var(--footer-mobile-underline-color);
-  }
 }
 
 /* Header */


### PR DESCRIPTION
fixes #1636 


## What this PR does
- Creates an entirely separate mobile-only footer
- Toggle footer display at mobile/desktop width
- Ensure no Desktop regressions

## Mobile footer specs
- 3 different divs. Cannot be encapsulated into 1 parent div... doesn't work. The parent div has to be the `<footer class="navbar"` (which acts like a `row`, and is what the `<header>` uses). We want the footer link widths to be the same as that of the `<header>`. 
- 2 divs with the 2 different links are `container` width, to get that `container` scaling
- 1 div is `container-fluid` width with `p-0`, so that the horizontal white line can be 100% width of the desktop
- Removes all manual padding/margin that was previously positioning the mobile footer link, so the focus ring looks correct.

## Screenshots

I temporarily hid the `main` container from this view, so it's easy to see the Header/Footer alignment. 

![Kapture 2023-08-10 at 14 50 50](https://user-images.githubusercontent.com/3673236/259882532-d7777ec0-0a62-47e1-bc1b-6458eb475136.gif)
Click [here](https://user-images.githubusercontent.com/3673236/259882532-d7777ec0-0a62-47e1-bc1b-6458eb475136.gif) to view gif again


<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/bc606f57-9cde-48a2-adae-c46c0318d4f6">

