### PR TITLE
Feat: Skip Nav

### DIFF
--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -43,9 +43,9 @@
       {% include "core/includes/debug.html" %}
     {% endif %}
     <header role="banner" id="header">
-      <div id="skip-to-content">
-        <a href="#main-content">{% translate "Skip to Main Content" %}</a>
-      </div>
+      <a id="skip-to-content"  href="#main-content" class="d-block w-100">
+        <div class="container">{% translate "Skip to Main Content" %}</div>
+      </a>
       {% if messages %}
         {% for message in messages %}
           {% include "core/includes/alert.html" with message=message %}

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -276,13 +276,10 @@ main {
 }
 
 #skip-to-content {
-  background: var(--focus-color);
-  text-align: inherit;
-  position: initial !important;
-  clip: initial;
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
+  left: unset !important;
+  transform: none;
   overflow: hidden;
+  background: var(--focus-color);
   font-size: var(--font-size-15px);
   line-height: var(--bs-body-line-height);
   letter-spacing: calc(var(--font-size-15px) * var(--letter-spacing-5));
@@ -294,13 +291,6 @@ main {
   box-shadow: none;
 }
 
-#skip-to-content {
-  width: unset;
-  height: 0;
-  left: unset !important;
-  transform: none;
-  overflow: hidden;
-}
 /* Footer */
 :root {
   --footer-background-color: var(--dark-color);

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -35,6 +35,7 @@
   --font-size-24px: calc(24rem / 16);
   --font-size-20px: calc(20rem / 16);
   --font-size-18px: calc(18rem / 16);
+  --font-size-15px: calc(15rem / 16);
   --font-size-16px: calc(16rem / 16);
   --font-size-14px: calc(14rem / 16);
   --font-size-12px: calc(12rem / 16);
@@ -129,8 +130,8 @@ a:hover:not(.btn) {
   text-decoration: underline;
 }
 
-a:focus:not(.btn):not(.card):not(.footer-link),
-a:focus-visible:not(.btn):not(.card):not(.footer-link) {
+a:focus:not(.btn):not(.card):not(.footer-link):not(#skip-to-content),
+a:focus-visible:not(.btn):not(.card):not(.footer-link):not(#skip-to-content) {
   outline: 3px solid var(--focus-color) !important;
   outline-offset: 2px !important;
 }
@@ -274,6 +275,32 @@ main {
   min-height: var(--main-content-min-height);
 }
 
+#skip-to-content {
+  background: var(--focus-color);
+  text-align: inherit;
+  position: initial !important;
+  clip: initial;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  overflow: hidden;
+  font-size: var(--font-size-15px);
+  line-height: var(--bs-body-line-height);
+  letter-spacing: calc(var(--font-size-15px) * var(--letter-spacing-5));
+}
+
+#skip-to-content:focus {
+  height: 21px !important;
+  outline: none !important;
+  box-shadow: none;
+}
+
+#skip-to-content {
+  width: unset;
+  height: 0;
+  left: unset !important;
+  transform: none;
+  overflow: hidden;
+}
 /* Footer */
 :root {
   --footer-background-color: var(--dark-color);


### PR DESCRIPTION
closes #1388 

requires #1387 and #1613 

## What this PR does
- Style the Skip Nav into a full-width div with yellow background
- Works like the Skip Nav here https://www.gov.uk/

## To test
- When testing, do not have the developer console tool window open. The focus won't work.
- On Desktop: Go to any page, like http://localhost:8000/mst
- Click <kbd>Tab</kbd> on keyboard
- Once the skip nav appears, click <kbd>Enter</kdb>
- Click  <kbd>Tab</kbd> again. You'll now be in the `#main-content` div and probably focused on a Call to Action button. You'll have skipped the `Español` button. You don't skip the `Previous Page` button though.
- Skip Navs are generally Desktop features b/c it's for users using a keyboard, but it works fine on Mobile too.
- Works _better_ if you hide the Dev Mode bar. Hide it by adding `d-none` in `base.html` or adding `.bg-danger { display: none;} ` to style.css

## Screenshots
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/3f454cac-cf71-4a82-a333-dc22dade47a7">
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/87554807-7a62-4d10-be64-6ea9f51621f2">

