### PR TITLE
Fix: Agency Selector h4 bug 

### DIFF
--- a/benefits/core/templates/core/includes/modal--agency-selector.html
+++ b/benefits/core/templates/core/includes/modal--agency-selector.html
@@ -22,7 +22,7 @@
                                  width="148"
                                  height="72"
                                  alt="{% blocktranslate with agency=agency.short_name %}{{ agency }} logo{% endblocktranslate %}">
-                            <h4 class="card-title mt-lg-3 mb-0 mb-lg-3">{{ agency.long_name }}</h4>
+                            <h4 class="mt-lg-3 mb-0 mb-lg-3">{{ agency.long_name }}</h4>
                         </div>
                     </a>
                 </div>

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -739,11 +739,6 @@ a.card:focus-visible {
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25) !important;
 }
 
-.card .card-title {
-  font-size: var(--card-title-font-size);
-  letter-spacing: var(--card-title-letter-spacing);
-}
-
 .card .card-body {
   padding: 0 var(--card-body-x-padding) !important;
 }


### PR DESCRIPTION
fix #1648 

I think this came out of a bad merge conflict resolve. Not sure.

## What this PR does
- Remove unneeded class
- Use H4 from base element style instead

## Screenshots
Compare with what's on dev:
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/b5373ffd-e886-4817-acb5-91d79954af34">
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/f8624ee7-47d4-42b3-a65f-9a875b5dbf9b">
