### PR TITLE
Fix: Remove alt tag from decorative icons

### DIFF
--- a/benefits/core/templates/core/includes/icon.html
+++ b/benefits/core/templates/core/includes/icon.html
@@ -1,9 +1,2 @@
-
-{% if not name %}
-  <p class="bg-grey-lightest color-standout">
-    Missing <strong><code>name</code></strong> argument
-  </p>
-{% else %}
-  {% load static %}
-  <img class="icon" width="150" height="150" src="{% get_static_prefix %}img/icon/{{ name }}.svg" alt="" />
-{% endif %}
+{% load static %}
+<img class="icon" width="150" height="150" src="{% get_static_prefix %}img/icon/{{ name }}.svg" alt="" />

--- a/benefits/core/templates/core/includes/icon.html
+++ b/benefits/core/templates/core/includes/icon.html
@@ -3,11 +3,7 @@
   <p class="bg-grey-lightest color-standout">
     Missing <strong><code>name</code></strong> argument
   </p>
-{% elif not alt %}
-  <p class="bg-grey-lightest color-standout">
-    Missing <strong><code>alt</code></strong> argument
-  </p>
 {% else %}
   {% load static %}
-  <img class="icon" width="150" height="150" src="{% get_static_prefix %}img/icon/{{ name }}.svg" alt="{{ alt }}" />
+  <img class="icon" width="150" height="150" src="{% get_static_prefix %}img/icon/{{ name }}.svg" alt="" />
 {% endif %}

--- a/benefits/core/templates/core/logged-out.html
+++ b/benefits/core/templates/core/logged-out.html
@@ -10,10 +10,7 @@
     <div class="row justify-content-lg-center">
       <div class="col-md-6">
         <h1 class="h2 text-center">
-          <span class="d-block pb-lg-8 pb-5">
-            {% translate "Bus icon with smiley face" context "image alt text" as alt_i18n %}
-            {% include "core/includes/icon.html" with name="happybus" alt=alt_i18n %}
-          </span>
+          <span class="d-block pb-lg-8 pb-5">{% include "core/includes/icon.html" with name="happybus" %}</span>
           {% translate "You have successfully logged out. Thank you for using Cal-ITP Benefits!" %}
         </h1>
       </div>

--- a/benefits/eligibility/templates/eligibility/includes/media-item--bankcardcheck--start.html
+++ b/benefits/eligibility/templates/eligibility/includes/media-item--bankcardcheck--start.html
@@ -2,8 +2,7 @@
 {% load i18n %}
 
 {% block icon %}
-    {% translate "Bank card icon with contactless symbol and checkmark" context "image alt text" as icon_alt %}
-    {% include "core/includes/icon.html" with name="bankcardcheck" alt=icon_alt %}
+    {% include "core/includes/icon.html" with name="bankcardcheck" %}
 {% endblock icon %}
 
 {% block heading %}

--- a/benefits/eligibility/templates/eligibility/includes/media-item--idcardcheck.html
+++ b/benefits/eligibility/templates/eligibility/includes/media-item--idcardcheck.html
@@ -3,6 +3,5 @@
 {% load i18n %}
 
 {% block icon %}
-    {% translate "Identification card icon with checkmark" context "image alt text" as icon_alt %}
-    {% include "core/includes/icon.html" with name="idcardcheck" alt=icon_alt %}
+    {% include "core/includes/icon.html" with name="idcardcheck" %}
 {% endblock icon %}

--- a/benefits/eligibility/templates/eligibility/includes/modal--contactless.html
+++ b/benefits/eligibility/templates/eligibility/includes/modal--contactless.html
@@ -13,7 +13,7 @@
     </p>
     <p class="pt-4">{% translate "The contactless symbol is four curved lines, like this:" %}</p>
     <p class="contactless-symbol pt-3">
-      <img class="icon mx-auto d-block" width="30" height="37.5" src="{% static 'img/icon/contactless.svg' %}" alt="" />
+      <img class="icon mx-auto d-block" width="30" height="37.5" src="{% static 'img/icon/contactless.svg' %}" alt="{% translate "Four curved lines on contactless-enabled cards" context "image alt text" %}" />
     </p>
     <p class="pt-4">{% translate "Your card must include a Visa or Mastercard logo." %}</p>
     <p class="pt-4">

--- a/benefits/eligibility/templates/eligibility/includes/modal--contactless.html
+++ b/benefits/eligibility/templates/eligibility/includes/modal--contactless.html
@@ -13,7 +13,11 @@
     </p>
     <p class="pt-4">{% translate "The contactless symbol is four curved lines, like this:" %}</p>
     <p class="contactless-symbol pt-3">
-      <img class="icon mx-auto d-block" width="30" height="37.5" src="{% static 'img/icon/contactless.svg' %}" alt="{% translate "Four curved lines on contactless-enabled cards" context "image alt text" %}" />
+      <img class="icon mx-auto d-block"
+           width="30"
+           height="37.5"
+           src="{% static 'img/icon/contactless.svg' %}"
+           alt="{% translate "Four curved lines on contactless-enabled cards" context "image alt text" %}" />
     </p>
     <p class="pt-4">{% translate "Your card must include a Visa or Mastercard logo." %}</p>
     <p class="pt-4">

--- a/benefits/eligibility/templates/eligibility/includes/modal--contactless.html
+++ b/benefits/eligibility/templates/eligibility/includes/modal--contactless.html
@@ -13,11 +13,7 @@
     </p>
     <p class="pt-4">{% translate "The contactless symbol is four curved lines, like this:" %}</p>
     <p class="contactless-symbol pt-3">
-      <img class="icon mx-auto d-block"
-           width="30"
-           height="37.5"
-           src="{% static 'img/icon/contactless.svg' %}"
-           alt="{% translate "Four curved lines on contactless-enabled cards" context "image alt text" %}" />
+      <img class="icon mx-auto d-block" width="30" height="37.5" src="{% static 'img/icon/contactless.svg' %}" alt="" />
     </p>
     <p class="pt-4">{% translate "Your card must include a Visa or Mastercard logo." %}</p>
     <p class="pt-4">

--- a/benefits/eligibility/templates/eligibility/unverified.html
+++ b/benefits/eligibility/templates/eligibility/unverified.html
@@ -13,8 +13,7 @@
   <div class="container">
     <h1 class="h2 text-center">
       <span class="icon d-block pb-5">
-        {% translate "Identification card icon with question mark" context "image alt text" as alt_i18n %}
-        {% include "core/includes/icon.html" with name="idcardquestion" alt=alt_i18n %}
+        {% include "core/includes/icon.html" with name="idcardquestion" %}
       </span>
       {% translate "Your eligibility could not be verified." %}
     </h1>

--- a/benefits/enrollment/templates/enrollment/includes/media-item--bankcardcheck--index.html
+++ b/benefits/enrollment/templates/enrollment/includes/media-item--bankcardcheck--index.html
@@ -2,8 +2,7 @@
 {% load i18n %}
 
 {% block icon %}
-    {% translate "Bank card icon with contactless symbol and checkmark" context "image alt text" as icon_alt %}
-    {% include "core/includes/icon.html" with name="bankcardcheck" alt=icon_alt %}
+    {% include "core/includes/icon.html" with name="bankcardcheck" %}
 {% endblock icon %}
 
 {% block heading %}

--- a/benefits/enrollment/templates/enrollment/retry.html
+++ b/benefits/enrollment/templates/enrollment/retry.html
@@ -12,8 +12,7 @@
 
   <div class="container">
     <h1 class="h2 text-center">
-      {% translate "Bank card icon with contactless symbol and question mark" context "image alt text" as alt_i18n %}
-      <span class="icon d-block pb-5">{% include "core/includes/icon.html" with name="bankcardquestion" alt=alt_i18n %}</span>
+      <span class="icon d-block pb-5">{% include "core/includes/icon.html" with name="bankcardquestion" %}</span>
       {% translate "We couldn’t connect your card" %}
     </h1>
 

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -270,10 +270,6 @@ msgstr ""
 msgid "Logged out"
 msgstr ""
 
-msgctxt "image alt text"
-msgid "Bus icon with smiley face"
-msgstr ""
-
 msgid "You have successfully logged out. Thank you for using Cal-ITP Benefits!"
 msgstr ""
 
@@ -293,10 +289,6 @@ msgid "Check your input. The format looks wrong."
 msgstr ""
 
 msgid "This field is required."
-msgstr ""
-
-msgctxt "image alt text"
-msgid "Bank card icon with contactless symbol and checkmark"
 msgstr ""
 
 msgid "Your contactless card details"
@@ -363,10 +355,6 @@ msgstr ""
 msgid ""
 "If you do not have an account with any of these services, you will need to "
 "create one. We recommend using Login.gov."
-msgstr ""
-
-msgctxt "image alt text"
-msgid "Identification card icon with checkmark"
 msgstr ""
 
 msgid "Go back"
@@ -469,10 +457,6 @@ msgstr ""
 msgid "Unable to confirm eligibility"
 msgstr ""
 
-msgctxt "image alt text"
-msgid "Identification card icon with question mark"
-msgstr ""
-
 msgid "Your eligibility could not be verified."
 msgstr ""
 
@@ -512,10 +496,6 @@ msgid "Connect your Card"
 msgstr ""
 
 msgid "Unable to register card"
-msgstr ""
-
-msgctxt "image alt text"
-msgid "Bank card icon with contactless symbol and question mark"
 msgstr ""
 
 msgid "We couldn’t connect your card"
@@ -593,8 +573,4 @@ msgstr ""
 msgid ""
 "The page you are looking for might be somewhere else or may not exist "
 "anymore."
-msgstr ""
-
-msgctxt "image alt text"
-msgid "Bus icon with flat tire"
 msgstr ""

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -353,10 +353,6 @@ msgstr ""
 msgid "Logged out"
 msgstr "Cierre sesión"
 
-msgctxt "image alt text"
-msgid "Bus icon with smiley face"
-msgstr "Icono de autobús con cara sonriente"
-
 msgid "You have successfully logged out. Thank you for using Cal-ITP Benefits!"
 msgstr "Ha cerrado sesión correctamente. ¡Gracias por usar Cal-ITP Benefits!"
 
@@ -377,11 +373,6 @@ msgstr "Verifique su entrada. El formato parece incorrecto."
 
 msgid "This field is required."
 msgstr "Este campo es requerido."
-
-msgctxt "image alt text"
-msgid "Bank card icon with contactless symbol and checkmark"
-msgstr ""
-"Icono de tarjeta bancaria con símbolo sin contacto y marca de verificación"
 
 msgid "Your contactless card details"
 msgstr "Los datos de su tarjeta sin contacto"
@@ -460,10 +451,6 @@ msgid ""
 msgstr ""
 "Si no tiene una cuenta con ninguno de estos servicios, deberá crear una. "
 "Recomendamos utilizar Login.gov. "
-
-msgctxt "image alt text"
-msgid "Identification card icon with checkmark"
-msgstr "Icono de tarjeta de identificación con marca de verificación"
 
 msgid "Go back"
 msgstr "Volver"
@@ -580,10 +567,6 @@ msgstr "Necesitará algunos artículos para continuar:"
 msgid "Unable to confirm eligibility"
 msgstr "No se pudo confirmar la elegibilidad"
 
-msgctxt "image alt text"
-msgid "Identification card icon with question mark"
-msgstr "Icono de tarjeta de identificación con signo de interrogación"
-
 msgid "Your eligibility could not be verified."
 msgstr "No se pudo verificar su elegibilidad."
 
@@ -626,11 +609,6 @@ msgstr "Conecta tu tarjeta"
 
 msgid "Unable to register card"
 msgstr "No se pudo registrar la tarjeta"
-
-msgctxt "image alt text"
-msgid "Bank card icon with contactless symbol and question mark"
-msgstr ""
-"Icono de tarjeta bancaria con símbolo sin contacto y signo de interrogación"
 
 msgid "We couldn’t connect your card"
 msgstr "No pudimos conectar su tarjeta"
@@ -726,7 +704,3 @@ msgid ""
 msgstr ""
 "La página que está buscando puede estar en otro lugar o puede que ya no "
 "exista."
-
-msgctxt "image alt text"
-msgid "Bus icon with flat tire"
-msgstr "Icono de autobus con llanta ponchada"

--- a/benefits/templates/error.html
+++ b/benefits/templates/error.html
@@ -10,8 +10,7 @@
   <div class="container">
     <h1 class="icon-title h2 text-center">
       <span class="icon d-block pb-5">
-        {% translate "Bus icon with flat tire" context "image alt text" as alt_i18n %}
-        {% include "core/includes/icon.html" with name="sadbus" alt=alt_i18n %}
+        {% include "core/includes/icon.html" with name="sadbus" %}
       </span>
       {% block headline %}
       {% endblock headline %}


### PR DESCRIPTION
closes #1651 

## What this PR does
- Add `alt=""` to the `icon` includes. Remove alt validation
- Remove alt tag copy and call from happy bus, sad bus, contactless pay icons, id card icons