### PR TITLE
Fix: return home button

### DIFF
--- a/benefits/core/templates/core/includes/button--index.html
+++ b/benefits/core/templates/core/includes/button--index.html
@@ -1,0 +1,6 @@
+{% load i18n %}
+
+{% url "core:index" as href %}
+{% translate "Return Home" as text %}
+
+<a href="{{ href }}" class="btn btn-lg btn-primary">{{ text }}</a>

--- a/benefits/core/templates/core/includes/button--index.html
+++ b/benefits/core/templates/core/includes/button--index.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 
 {% url "core:index" as href %}
-{% translate "Return Home" as text %}
+{% translate "Return Home" as default_button_text %}
 
-<a href="{{ href }}" class="btn btn-lg btn-primary">{{ text }}</a>
+<a href="{{ href }}" class="btn btn-lg btn-primary">{{ button_text | default:default_button_text }}</a>

--- a/benefits/eligibility/templates/eligibility/unverified.html
+++ b/benefits/eligibility/templates/eligibility/unverified.html
@@ -33,7 +33,7 @@
     </div>
 
     <div class="row pt-8 justify-content-center">
-      <div class="col-lg-3 col-8">{% include "core/includes/button--origin.html" %}</div>
+      <div class="col-lg-3 col-8">{% include "core/includes/button--index.html" %}</div>
     </div>
 
   </div>

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2023-08-15 05:58+0000\n"
+"POT-Creation-Date: 2023-08-15 06:04+0000\n"
 "Language: English\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -573,7 +573,7 @@ msgstr ""
 msgid "Start Here"
 msgstr ""
 
-msgid "Service is down."
+msgid "Service is down"
 msgstr ""
 
 msgid "Sorry! Service for this site is down."

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2023-08-14 21:37+0000\n"
+"POT-Creation-Date: 2023-08-15 05:58+0000\n"
 "Language: English\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -568,6 +568,9 @@ msgstr ""
 msgid ""
 "To get started with Cal-ITP Benefits please click the button below, and you "
 "will be directed to the beginning of the enrollment process."
+msgstr ""
+
+msgid "Start Here"
 msgstr ""
 
 msgid "Service is down."

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2023-08-15 05:58+0000\n"
+"POT-Creation-Date: 2023-08-15 06:04+0000\n"
 "Language: Español\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -702,7 +702,7 @@ msgstr ""
 msgid "Start Here"
 msgstr "Comenzar aquí"
 
-msgid "Service is down."
+msgid "Service is down"
 msgstr "El servicio está inactivo"
 
 msgid "Sorry! Service for this site is down."

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2023-08-14 21:37+0000\n"
+"POT-Creation-Date: 2023-08-15 05:58+0000\n"
 "Language: Español\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -698,6 +698,9 @@ msgid ""
 msgstr ""
 "Para comenzar con Cal-ITP Benefits haga clic en el botón de abajo y será "
 "dirigido al comienzo del proceso de inscripción."
+
+msgid "Start Here"
+msgstr "Comenzar aquí"
 
 msgid "Service is down."
 msgstr "El servicio está inactivo"

--- a/benefits/templates/200-user-error.html
+++ b/benefits/templates/200-user-error.html
@@ -14,3 +14,8 @@
     {% translate "To get started with Cal-ITP Benefits please click the button below, and you will be directed to the beginning of the enrollment process." %}
   </p>
 {% endblock paragraphs %}
+
+{% block button %}
+  {% translate "Start Here" as button_text %}
+  {% include "core/includes/button--index.html" with button_text=button_text %}
+{% endblock button %}

--- a/benefits/templates/400.html
+++ b/benefits/templates/400.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% block title %}
-  {% translate "Service is down." %}
+  {% translate "Service is down" %}
 {% endblock title %}
 
 {% block headline %}

--- a/benefits/templates/500.html
+++ b/benefits/templates/500.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% block title %}
-  {% translate "Service is down." %}
+  {% translate "Service is down" %}
 {% endblock title %}
 
 {% block headline %}

--- a/benefits/templates/error.html
+++ b/benefits/templates/error.html
@@ -25,7 +25,11 @@
     </div>
 
     <div class="row pt-8 justify-content-center">
-      <div class="col-lg-3 col-8">{% include "core/includes/button--origin.html" %}</div>
+      <div class="col-lg-3 col-8">
+        {% block button %}
+          {% include "core/includes/button--origin.html" %}
+        {% endblock button %}
+      </div>
     </div>
   </div>
 {% endblock main-content %}


### PR DESCRIPTION
Closes #1650 

This PR makes the `Return Home` button on Eligibility Unverified (and `Start Here` on 200 User Error) take the user back to the index page, allowing for a correction of Transit Agency and/or Eligibility Type.

Also fixed a small typo in a few error page titles.