### PR TITLE
Fix: typo in info_url for SBMTD

### DIFF
--- a/benefits/core/migrations/0002_data.py
+++ b/benefits/core/migrations/0002_data.py
@@ -333,7 +333,7 @@ PEM DATA
         long_name=os.environ.get("SBMTD_AGENCY_LONG_NAME", "Santa Barbara MTD (sample)"),
         agency_id="sbmtd",
         merchant_id=os.environ.get("SBMTD_AGENCY_MERCHANT_ID", "sbmtd"),
-        info_url="https://sbmtd.gov/taptopride/",
+        info_url="https://sbmtd.gov/taptoride/",
         phone="805-963-3366",
         active=os.environ.get("SBMTD_AGENCY_ACTIVE", "True").lower() == "true",
         private_key=client_private_key,


### PR DESCRIPTION
Part of #1588 

Typo was from #1631 