### PR TITLE
Fix: Focus ring on Card on Google Chrome

### DIFF
--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -719,6 +719,7 @@ a.card:focus-visible {
 .card:focus,
 .card:focus-visible {
   outline: 3px solid var(--focus-color) !important; /* override CA State Web Template */
+  outline-offset: 0 !important;
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25) !important;
 }
 


### PR DESCRIPTION
fixes #1659 

## What this PR does
- Explicitly set the `.card`'s focus ring's `outline-offset` to 0, to override Chrome's default browser CSS
- `.card`'s focus ring should be flush against the card, without any space in between:

<img width="214" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/c00bba05-e368-4587-9ab8-9a01a4535429">vs. on Chrome dev right now:
<img width="219" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/91d4bf42-2ede-4a2b-bd32-d299313df9e1">


## What accounts for the cross-browser differences?

Chrome's browser adds this CSS to all websites:

```css
a:-webkit-any-link:focus-visible {
    outline-offset: 1px;
}
```

<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/11f6068b-d7bd-4372-b504-03c53548e655">

Firefox and Safari do not set an `outline-offset` at all, so it defaults to `initial`, which is 0. I had only tested in Firefox and Safari, so I didn't notice that Chrome _does_ add an 1px offset.

This PR takes care of that browser difference.
