### PR TITLE
Fix: Skip Nav - Remove skip nav page jank

### DIFF
--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -52,6 +52,10 @@
   /* prettier-ignore */
 }
 
+html {
+  scroll-padding-top: 120px;
+}
+
 body {
   font-size: 100%;
   color: var(--text-primary-color);

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -53,7 +53,7 @@
 }
 
 html {
-  scroll-padding-top: 120px;
+  scroll-padding-top: 101px; /* Header Height (80px) + Skip Nav Height (21px) = 101px */
 }
 
 body {


### PR DESCRIPTION
closes #1661 

This was bothering me a lot 😓 and I finally looked up a solid, easy solution w/o any drawbacks. Currently, when using the Skip Nav to get to `#main-content` and then continuing to use the keyboard for navigation, the site will scroll you back _up_ the page when you go from `#main-content` to `Previous Page`. It creates a jarring user experience, where the page goes down, and then back up. This PR fixes it by adding a `scroll-padding-top` that's greater than the height of the nav (80px), so the screen doesn't move back up. This solution also doesn't affect anything else (like the footer position, main container height, etc).

| Before     | After     |
| --------  | -------- |
|  ![broken](https://github.com/cal-itp/benefits/assets/3673236/1e52e757-1675-4c9c-9d53-328a933cd704)|  ![fixed](https://github.com/cal-itp/benefits/assets/3673236/63179341-3d26-4824-8e22-4add37f00f14) |

- Uses `scroll-padding-top` from this: https://css-tricks.com/fixed-headers-on-page-links-and-overlapping-content-oh-my/
- Note: You have to test it with the DEBUG bar hidden. Doesn't work with the DEBUG bar on.
