### PR TITLE
Refactor Cypress helper

### DIFF
--- a/tests/cypress/plugins/helpers.js
+++ b/tests/cypress/plugins/helpers.js
@@ -25,8 +25,7 @@ export const selectAgency = () => {
 export const selectCourtesyCard = () => {
   cy.location("pathname").should("eq", `/eligibility/${agency.slug}`);
 
-  // TODO find a more robust way to do this
-  cy.get('#form-verifier-selection [type="radio"]').check("3");
-  cy.get("#form-verifier-selection button[type='submit']").click();
+  cy.contains("MST Courtesy Card").click();
+  cy.contains("Choose this Benefit").click();
   cy.contains("Continue").click();
 };


### PR DESCRIPTION
closes #1443 

This code, a `selectCourtesyCard` test helper method, was previously quite brittle, and would break if any new Eligibility Verifiers were added - b/c the code was going by order of verifiers -- which can change -- and not actually looking for the radio input label that says "Courtesy Cards." This method broke when we added the Veterans verifier: https://github.com/cal-itp/benefits/pull/1436/files#diff-d8c366d9dffb4c84efb0c81d20aae1435d1a10f57a019a62d8131839878b194e

This PR refactors this method by having Cypress actually look for elements to click by copy, so it will not break when we add new verifiers.