### PR TITLE
Refactor: Remove unnecessary template code

### DIFF
--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -87,11 +87,7 @@
             {% endblock inner-content %}
           </div>
           {% block call-to-action %}
-            <div class="row d-flex flex-column-reverse justify-content-lg-end flex-lg-row">
-              <div class="col-lg-9 d-flex align-items-end flex-row-reverse col-sm-8 offset-sm-2 offset-lg-0 offset-2 col-8">
-                {% block call-to-action-text %}
-                {% endblock call-to-action-text %}
-              </div>
+            <div class="row d-flex justify-content-lg-end">
               <div class="col-lg-3 offset-2 offset-sm-2 offset-lg-0 col-sm-8 col-8">
                 {% block call-to-action-button %}
                 {% endblock call-to-action-button %}

--- a/benefits/core/templates/core/includes/form.html
+++ b/benefits/core/templates/core/includes/form.html
@@ -28,12 +28,7 @@
     </div>
 
     {% if form.submit_value %}
-      <div class="row d-flex flex-column-reverse justify-content-lg-end flex-lg-row pt-8">
-        {% if help_text %}
-          <div class="col-lg-9 d-flex align-items-end flex-row-reverse col-sm-8 offset-sm-2 offset-lg-0 offset-2 col-8">
-            <p class="pt-4 pt-lg-0">{{ help_text }}</p>
-          </div>
-        {% endif %}
+      <div class="row d-flex justify-content-lg-end pt-8">
         <div class="col-lg-3 offset-2 offset-sm-2 offset-lg-0 col-sm-8 col-8">
           <button class="btn btn-lg btn-primary spinner-hidden d-flex justify-content-center align-items-center"
                   data-action="submit"


### PR DESCRIPTION
closes #1672 

## What this PR does
The new Figma designs eliminated the text preceding CTAs on all pages of the site, like these:
<img width="1505" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/e418b17b-fc2f-490f-a48b-fdebe5535e7b">
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/de3070df-4133-4492-ba56-41eb46e77ea2">

This PR removes the `help_text` (used on the Eligibility form CTA, https://github.com/cal-itp/benefits/commit/a8a6c63a4d4025be561fd535d6f31d51633b9236) and the `call-to-action-text` (used on Eligibility Start) from the templates. It also removes the CSS classes that were necessary to get the mobile version to flip order from the Desktop mode.