### PR TITLE
Fix: Add one S

### DIFF
--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2023-09-06 23:20+0000\n"
+"POT-Creation-Date: 2023-09-07 20:33+0000\n"
 "Language: English\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2023-09-06 23:20+0000\n"
+"POT-Creation-Date: 2023-09-07 20:33+0000\n"
 "Language: Español\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -552,7 +552,7 @@ msgstr ""
 "tránsito"
 
 msgid "You will be directed to our payment partner, "
-msgstr "Será dirigido a nuestro socio de pago, "
+msgstr "Será dirigido a nuestro socio de pagos, "
 
 msgid "We don’t store your information, and you won’t be charged."
 msgstr "No almacenamos su información y no se le cobrará."


### PR DESCRIPTION
closes #1710 

Payment partner in Spanish is `socio de pagos`, not `socio de pago`.