### PR TITLE
Chore: version management

### DIFF
--- a/benefits/__init__.py
+++ b/benefits/__init__.py
@@ -1,3 +1,10 @@
-__version__ = "2023.09.1"
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("benefits")
+except PackageNotFoundError:
+    # package is not installed
+    pass
+
 
 VERSION = __version__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,11 @@
-[build-system]
-requires = ["setuptools>=65", "wheel"]
-build-backend = "setuptools.build_meta"
-
 [project]
-classifiers = ["Programming Language :: Python :: 3 :: Only"]
+name = "benefits"
+version = "2023.09.1"
 description = "Cal-ITP Benefits is an application that enables automated eligibility verification and enrollment for transit benefits onto customers’ existing contactless bank (credit/debit) cards."
+readme = "README.md"
+license = { file = "LICENSE" }
+classifiers = ["Programming Language :: Python :: 3 :: Only"]
+requires-python = ">=3.9"
 dependencies = [
     "Authlib==1.2.1",
     "Django==4.2.5",
@@ -14,12 +15,6 @@ dependencies = [
     "sentry-sdk==1.31.0",
     "six==1.16.0",
 ]
-version = "2023.09.1"
-keywords = ["django"]
-license = { file = "LICENSE" }
-name = "benefits"
-readme = "README.md"
-requires-python = ">=3.9"
 
 [project.optional-dependencies]
 dev = [
@@ -41,13 +36,20 @@ Code = "https://github.com/cal-itp/benefits"
 Documentation = "https://docs.calitp.org/benefits"
 Issues = "https://github.com/cal-itp/benefits/issues"
 
-# Configuration for black
+[build-system]
+requires = ["setuptools>=65", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [tool.black]
 line-length = 127
 target-version = ['py310']
 include = '\.pyi?$'
 
-# Configuration for djlint
+[tool.coverage.run]
+omit = [
+    "benefits/core/migrations/*"
+]
+
 [tool.djlint]
 ignore = "H017,H031"
 indent = 2
@@ -57,11 +59,8 @@ profile = "django"
 preserve_blank_lines = true
 use_gitignore = true
 
-# Configuration for pytest
-[tool.coverage.run]
-omit = [
-    "benefits/core/migrations/*"
-]
+[tool.pyright]
+include = ["benefits", "tests/pytest"]
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "benefits.settings"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64", "wheel"]
+requires = ["setuptools>=65", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -14,7 +14,7 @@ dependencies = [
     "sentry-sdk==1.31.0",
     "six==1.16.0",
 ]
-dynamic = ["version"]
+version = "2023.09.1"
 keywords = ["django"]
 license = { file = "LICENSE" }
 name = "benefits"

--- a/tests/pytest/test_version.py
+++ b/tests/pytest/test_version.py
@@ -1,0 +1,9 @@
+import re
+
+
+def test_version():
+    from benefits import __version__, VERSION
+
+    assert __version__ is not None
+    assert __version__ == VERSION
+    assert re.match(r"\d{4}\.\d{1,2}\.\d+", __version__)


### PR DESCRIPTION
Standardizing on managing the version string in the `pyproject.toml` across Benefits projects.

See also cal-itp/eligibility-server#325

## How to review

1. Checkout this branch
2. Rebuild app and devcontainer without caching `docker compose build --no-cache client` then the same for `dev`
3. Run `docker compose run --entrypoint bash client` to attach to a client container
4. Confirm `pip freeze` shows output similar to (look for the line mentioning `benefits`):
```console
$ docker compose run --entrypoint bash client
calitp@afef4102469a:~/app$ pip freeze
asgiref==3.7.2
Authlib==1.2.1
# Editable install with no version control (benefits==2023.9.1)
-e /home/calitp/app
certifi==2023.7.22
cffi==1.15.1
...
```
5. Launch devcontainer
6. Confirm all tests pass
