### PR TITLE
Chore: add pip metadata file to app container

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: actions/setup-python@v4
+        with:
+          python-version-file: .github/workflows/.python-version
+          cache: pip
+          cache-dependency-path: "**/pyproject.toml"
+
+      - name: Write python packages to file
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install -e .
+          pip freeze
+          pip freeze >> benefits/static/requirements.txt
+
       - name: Write commit SHA to file
         run: echo "${{ github.sha }}" >> benefits/static/sha.txt
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,9 +32,10 @@ jobs:
         run: |
           python -m venv .venv
           source .venv/bin/activate
+          pip install pipdeptree
           pip install -e .
-          pip freeze
-          pip freeze >> benefits/static/requirements.txt
+          pipdeptree
+          pipdeptree >> benefits/static/requirements.txt
 
       - name: Write commit SHA to file
         run: echo "${{ github.sha }}" >> benefits/static/sha.txt


### PR DESCRIPTION
Runs ~`pip freeze`~ `pipdeptree` and puts the results in `benefits/static/requirements.txt` before building and publishing the app image.

Similar to having the `sha.txt`, this will help confirm changes and debug issues with Python package updates.

## Reviewing this PR

I [ran the Deploy Action manually](https://github.com/cal-itp/benefits/actions/runs/6241134138/job/16942713064#step:4:6) for this branch to produce an image using the updated workflow, you can see in the logs the results of the updates.

That image is here: https://github.com/cal-itp/benefits/pkgs/container/benefits/129491917?tag=pip-freeze

To test that this works, pull the image locally:

```console
$ docker pull ghcr.io/cal-itp/benefits:pip-freeze
pip-freeze: Pulling from cal-itp/benefits
Digest: sha256:79741236bcd586bf56e052af6c38ad92cce138d47d28a0fe55d032e1d597a0af
Status: Image is up to date for ghcr.io/cal-itp/benefits:pip-freeze
ghcr.io/cal-itp/benefits:pip-freeze
```

Then run a container based on that image, using the `-P` flag to ensure the port is bound for traffic from your host --> container:

```console
$ docker run -P ghcr.io/cal-itp/benefits:pip-freeze
+ bin/init.sh
+ rm -f django.db
+ python manage.py migrate
# ... etc benefits startup
```

Now visit `localhost:PORT/static/requirements.txt` for the dynamic port that Docker assigned, and you should see the list of requirements. Take note that the version specified for `benefits` is tied to the commit SHA (which is the same as the HEAD from this PR): `0a961c2e0d59befb1d5195eb7a5d3a1310c81a5b`