### PR TITLE
Docker: Revert platform change

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -8,7 +8,6 @@ services:
       dockerfile: appcontainer/Dockerfile
     image: benefits_client:latest
     env_file: .env
-    platform: linux/amd64
     ports:
       - "${DJANGO_LOCAL_PORT:-8000}:8000"
 
@@ -22,7 +21,6 @@ services:
     entrypoint: sleep infinity
     depends_on:
       - server
-    platform: linux/amd64
     ports:
       - "${DJANGO_LOCAL_PORT:-8000}:8000"
     volumes:
@@ -32,7 +30,6 @@ services:
     image: benefits_client:dev
     entrypoint: mkdocs
     command: serve --dev-addr "0.0.0.0:8001"
-    platform: linux/amd64
     ports:
       - "8001"
     volumes:


### PR DESCRIPTION
closes #1730 

When I run `docker compose run --entrypoint bash client` on my machine now, with this PR, I'm able to get to bash properly.