### PR TITLE
Fix: make active flags False by default

### DIFF
--- a/benefits/core/migrations/0002_data.py
+++ b/benefits/core/migrations/0002_data.py
@@ -288,7 +288,7 @@ PEM DATA
         merchant_id=sample_agency["merchant_id"],
         info_url=sample_agency["info_url"],
         phone=sample_agency["phone"],
-        active=True,
+        active=os.environ.get("MST_AGENCY_ACTIVE", "True").lower() == "true",
         private_key=client_private_key,
         public_key=client_public_key,
         jws_signing_alg=os.environ.get("MST_AGENCY_JWS_SIGNING_ALG", "RS256"),

--- a/benefits/core/migrations/0002_data.py
+++ b/benefits/core/migrations/0002_data.py
@@ -178,7 +178,7 @@ PEM DATA
 
     mst_veteran_verifier = EligibilityVerifier.objects.create(
         name=os.environ.get("MST_VETERAN_VERIFIER_NAME", "VA.gov - Veteran (MST)"),
-        active=os.environ.get("MST_VETERAN_VERIFIER_ACTIVE", "True").lower() == "true",
+        active=os.environ.get("MST_VETERAN_VERIFIER_ACTIVE", "False").lower() == "true",
         eligibility_type=mst_veteran_type,
         auth_provider=veteran_auth_provider,
         selection_label_template="eligibility/includes/selection-label--veteran.html",
@@ -309,7 +309,7 @@ PEM DATA
         merchant_id=os.environ.get("SACRT_AGENCY_MERCHANT_ID", "sacrt"),
         info_url="https://sacrt.com/",
         phone="916-321-2877",
-        active=os.environ.get("SACRT_AGENCY_ACTIVE", "True").lower() == "true",
+        active=os.environ.get("SACRT_AGENCY_ACTIVE", "False").lower() == "true",
         private_key=client_private_key,
         public_key=client_public_key,
         jws_signing_alg=os.environ.get("SACRT_AGENCY_JWS_SIGNING_ALG", "RS256"),
@@ -329,7 +329,7 @@ PEM DATA
         merchant_id=os.environ.get("SBMTD_AGENCY_MERCHANT_ID", "sbmtd"),
         info_url="https://sbmtd.gov/taptoride/",
         phone="805-963-3366",
-        active=os.environ.get("SBMTD_AGENCY_ACTIVE", "True").lower() == "true",
+        active=os.environ.get("SBMTD_AGENCY_ACTIVE", "False").lower() == "true",
         private_key=client_private_key,
         public_key=client_public_key,
         jws_signing_alg=os.environ.get("SBMTD_AGENCY_JWS_SIGNING_ALG", "RS256"),

--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -151,6 +151,7 @@ resource "azurerm_linux_web_app" "main" {
     "SBMTD_PAYMENT_PROCESSOR_CARD_TOKENIZE_ENV"            = "${local.secret_prefix}sbmtd-payment-processor-card-tokenize-env)"
     "MST_AGENCY_SHORT_NAME"                                = "${local.secret_prefix}mst-agency-short-name)"
     "MST_AGENCY_LONG_NAME"                                 = "${local.secret_prefix}mst-agency-long-name)"
+    "MST_AGENCY_ACTIVE"                                    = "${local.secret_prefix}mst-agency-active)"
     "MST_AGENCY_JWS_SIGNING_ALG"                           = "${local.secret_prefix}mst-agency-jws-signing-alg)"
     "SACRT_AGENCY_SHORT_NAME"                              = "${local.secret_prefix}sacrt-agency-short-name)"
     "SACRT_AGENCY_LONG_NAME"                               = "${local.secret_prefix}sacrt-agency-long-name)"


### PR DESCRIPTION
Closes #1742 

Moves the hard-coded MST active flag into settings so it is like the others (even though we are live with them already!)