### PR TITLE
Feat: parameterize Django database path/deletion

### DIFF
--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -2,6 +2,7 @@
 Django settings for benefits project.
 """
 import os
+
 from benefits import sentry
 
 
@@ -147,10 +148,11 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "benefits.wsgi.application"
 
+DATABASE_DIR = os.environ.get("DJANGO_DB_DIR", BASE_DIR)
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
-        "NAME": "django.db",
+        "NAME": os.path.join(DATABASE_DIR, "django.db"),
     }
 }
 

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
 set -eux
 
-# construct the path to the database file from environment or default
-
-DB_DIR="${DJANGO_DB_DIR:-.}"
-DB_FILE="${DB_DIR}/django.db"
-
 # remove existing (old) database file
-# -f forces the delete (and avoids an error when the file doesn't exist)
 
-rm -f "${DB_FILE}"
+if [[ ${DJANGO_DB_RESET:-true} = true ]]; then
+    # construct the path to the database file from environment or default
+    DB_DIR="${DJANGO_DB_DIR:-.}"
+    DB_FILE="${DB_DIR}/django.db"
+
+    # -f forces the delete (and avoids an error when the file doesn't exist)
+    rm -f "${DB_FILE}"
+fi
 
 # run database migrations
 

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
 set -eux
 
+# construct the path to the database file from environment or default
+
+DB_DIR="${DJANGO_DB_DIR:-.}"
+DB_FILE="${DB_DIR}/django.db"
+
 # remove existing (old) database file
 # -f forces the delete (and avoids an error when the file doesn't exist)
 
-rm -f django.db
+rm -f "${DB_FILE}"
 
 # run database migrations
 

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -6,20 +6,6 @@ The sections below outline in more detail the application environment variables 
 
 See other topic pages in this section for more specific environment variable configurations.
 
-## Docker
-
-### `COMPOSE_PROJECT_NAME`
-
-!!! info "Local configuration"
-
-    This setting only affects the app running on localhost
-
-!!! tldr "Docker docs"
-
-    Read more at <https://docs.docker.com/compose/reference/envvars/#compose_project_name>
-
-Name that Docker Compose prefixes to the project for container runs.
-
 ## Amplitude
 
 !!! tldr "Amplitude API docs"
@@ -56,6 +42,17 @@ Boolean:
     [Settings: `ALLOWS_HOSTS`](https://docs.djangoproject.com/en/4.0/ref/settings/#allowed-hosts)
 
 A list of strings representing the host/domain names that this Django site can serve.
+
+### `DJANGO_DB_DIR`
+
+!!! warning "Deployment configuration"
+
+    You may change this setting when deploying the app to a non-localhost domain
+
+The directory where Django creates its Sqlite database file. _Must exist and be
+writable by the Django process._
+
+By default, the base project directory (i.e. the root of the repository).
 
 ### `DJANGO_DEBUG`
 

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -54,6 +54,17 @@ writable by the Django process._
 
 By default, the base project directory (i.e. the root of the repository).
 
+### `DJANGO_DB_RESET`
+
+!!! warning "Deployment configuration"
+
+    You may change this setting when deploying the app to a non-localhost domain
+
+Boolean:
+
+- `True` (default): deletes the existing database file and runs fresh Django migrations.
+- `False`: Django uses the existing database file.
+
 ### `DJANGO_DEBUG`
 
 !!! warning "Deployment configuration"

--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -64,6 +64,8 @@ resource "azurerm_linux_web_app" "main" {
     # Django settings
     "DJANGO_ADMIN"         = (local.is_prod || local.is_test) ? null : "${local.secret_prefix}django-admin)",
     "DJANGO_ALLOWED_HOSTS" = "${local.secret_prefix}django-allowed-hosts)",
+    "DJANGO_DB_DIR"        = "${local.secret_prefix}django-db-dir)",
+    "DJANGO_DB_RESET"      = "${local.secret_prefix}django-db-reset)",
     "DJANGO_DEBUG"         = local.is_prod ? null : "${local.secret_prefix}django-debug)",
     "DJANGO_LOG_LEVEL"     = "${local.secret_prefix}django-log-level)",
 


### PR DESCRIPTION
Closes #1763 

## Testing / review

In your local `.env` file, try different values for the environment variables.

_Note the `DJANGO_DB_DIR` must already exist!_ 

E.g. to create the database file in a local (to your repo) directory called `db`:

```bash
# make sure the directory exists!
mkdir db
```

Then set the environment variable and reload your devcontainer:

```env
DJANGO_DB_DIR=./db
```

Verify `bin/init.sh` output:

```console
$ DJANGO_DB_DIR=./db bin/init.sh 
+ [[ true = true ]]
+ DB_DIR=./db
+ DB_FILE=./db/django.db
+ rm -f ./db/django.db
+ python manage.py migrate
Operations to perform:
  Apply all migrations: core, sessions
Running migrations:
  Applying core.0001_initial... OK
  Applying core.0002_data... OK
  Applying sessions.0001_initial... OK
```

Set `DJANGO_DB_RESET` to `false` to keep the database between restarts/reinits:

```env
DJANGO_DB_RESET=false
```

Verify `bin/init.sh` output:

```console
$ DJANGO_DB_RESET=false bin/init.sh 
+ [[ false = true ]]
+ python manage.py migrate
Operations to perform:
  Apply all migrations: core, sessions
Running migrations:
  No migrations to apply.
```

## Before merge

- [x] Create `django-db-dir` secret in Key Vault (x3), set to `/home/site/wwwroot`
- [x] Create `django-db-reset` secret in Key Vault (x3), set to `true`

## After merge

You shouldn't have to make any changes to your local setup, unless you want to per the above settings.