### PR TITLE
Feat: Unattended superuser creation

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -20,7 +20,7 @@ python manage.py migrate
 # check DJANGO_ADMIN = true, default to false if empty or unset
 
 if [[ ${DJANGO_ADMIN:-false} = true ]]; then
-    python manage.py createsuperuser
+    python manage.py createsuperuser --no-input
 else
     echo "superuser: Django not configured for Admin access"
 fi

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -120,6 +120,42 @@ By default the application sends logs to `stdout`.
 
 Django's primary secret, keep this safe!
 
+### `DJANGO_SUPERUSER_EMAIL`
+
+!!! warning "Deployment configuration"
+
+    You may change this setting when deploying the app to a non-localhost domain
+
+!!! danger "Required configuration"
+
+    This setting is required when `DJANGO_ADMIN` is `true`
+
+The email address of the Django Admin superuser created during initialization.
+
+### `DJANGO_SUPERUSER_PASSWORD`
+
+!!! warning "Deployment configuration"
+
+    You may change this setting when deploying the app to a non-localhost domain
+
+!!! danger "Required configuration"
+
+    This setting is required when `DJANGO_ADMIN` is `true`
+
+The password of the Django Admin superuser created during initialization.
+
+### `DJANGO_SUPERUSER_USERNAME`
+
+!!! warning "Deployment configuration"
+
+    You may change this setting when deploying the app to a non-localhost domain
+
+!!! danger "Required configuration"
+
+    This setting is required when `DJANGO_ADMIN` is `true`
+
+The username of the Django Admin superuser created during initialization.
+
 ### `DJANGO_TRUSTED_ORIGINS`
 
 !!! warning "Deployment configuration"

--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -66,12 +66,15 @@ resource "azurerm_linux_web_app" "main" {
     "REQUESTS_READ_TIMEOUT"    = "${local.secret_prefix}requests-read-timeout)",
 
     # Django settings
-    "DJANGO_ADMIN"         = (local.is_prod || local.is_test) ? null : "${local.secret_prefix}django-admin)",
-    "DJANGO_ALLOWED_HOSTS" = "${local.secret_prefix}django-allowed-hosts)",
-    "DJANGO_DB_DIR"        = "${local.secret_prefix}django-db-dir)",
-    "DJANGO_DB_RESET"      = "${local.secret_prefix}django-db-reset)",
-    "DJANGO_DEBUG"         = local.is_prod ? null : "${local.secret_prefix}django-debug)",
-    "DJANGO_LOG_LEVEL"     = "${local.secret_prefix}django-log-level)",
+    "DJANGO_ADMIN"              = "${local.secret_prefix}django-admin)",
+    "DJANGO_ALLOWED_HOSTS"      = "${local.secret_prefix}django-allowed-hosts)",
+    "DJANGO_DB_DIR"             = "${local.secret_prefix}django-db-dir)",
+    "DJANGO_DB_RESET"           = "${local.secret_prefix}django-db-reset)",
+    "DJANGO_DEBUG"              = local.is_prod ? null : "${local.secret_prefix}django-debug)",
+    "DJANGO_LOG_LEVEL"          = "${local.secret_prefix}django-log-level)",
+    "DJANGO_SUPERUSER_EMAIL"    = "${local.secret_prefix}django-superuser-email)",
+    "DJANGO_SUPERUSER_PASSWORD" = "${local.secret_prefix}django-superuser-password)",
+    "DJANGO_SUPERUSER_USERNAME" = "${local.secret_prefix}django-superuser-username)",
 
     "DJANGO_RECAPTCHA_SECRET_KEY" = local.is_dev ? null : "${local.secret_prefix}django-recaptcha-secret-key)",
     "DJANGO_RECAPTCHA_SITE_KEY"   = local.is_dev ? null : "${local.secret_prefix}django-recaptcha-site-key)",


### PR DESCRIPTION
Closes #1776 

## Reviewing 

In your `.env` file, add the new environment variables:

```env
DJANGO_SUPERUSER_EMAIL=you@example.com
DJANGO_SUPERUSER_PASSWORD=password
DJANGO_SUPERUSER_USERNAME=username

# also make sure DJANGO_ADMIN is true to enable the admin:
DJANGO_ADMIN=true
```

Rebuild and reopen the devcontainer.

Confirm in the init output that the admin/user migrations are run and superuser is created.

Launch the app with `F5`, and visit `localhost:PORT/admin` in your browser. Confirm you can login with the username/password above.