### PR TITLE
Chore: block Sqlite scraper patterns

### DIFF
--- a/appcontainer/nginx.conf
+++ b/appcontainer/nginx.conf
@@ -52,7 +52,7 @@ http {
 
     # 404 known scraping file targets
     # case-insensitive regex matches the given file extension anywhere in the request path
-    location ~* /.*\.(ash|asp|axd|cgi|com|env|json|php|ping|xml|ya?ml) {
+    location ~* /.*\.(ash|asp|axd|cgi|com|db|env|json|php|ping|sqlite|xml|ya?ml) {
         access_log off;
         log_not_found off;
         return 404;


### PR DESCRIPTION
See recent Sentry errors, e.g. https://sentry.calitp.org/organizations/sentry/issues/73065/?project=3

The database file cannot be served anyway, but this just rejects the request earlier in the chain to avoid hitting the application layer at all.