### PR TITLE
Show retry button on enrollment/retry page

### DIFF
--- a/benefits/enrollment/templates/enrollment/retry.html
+++ b/benefits/enrollment/templates/enrollment/retry.html
@@ -26,14 +26,12 @@
       <div class="col-lg-8">{% include "core/includes/agency-links.html" %}</div>
     </div>
 
-    {% if retry_button %}
-      <div class="row pt-8 justify-content-center">
-        <div class="col-lg-3 col-8">
-          {% translate "Try again" as button_text %}
-          {% include "core/includes/button--origin.html" with button_text=button_text %}
-        </div>
+    <div class="row pt-8 justify-content-center">
+      <div class="col-lg-3 col-8">
+        {% translate "Try again" as button_text %}
+        {% include "core/includes/button--origin.html" with button_text=button_text %}
       </div>
-    {% endif %}
+    </div>
 
   </div>
 {% endblock main-content %}

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -99,7 +99,10 @@ def retry(request):
         analytics.returned_retry(request)
         form = forms.CardTokenizeFailForm(request.POST)
         if form.is_valid():
-            return TemplateResponse(request, TEMPLATE_RETRY)
+            context = {
+                "retry_button": True,
+            }
+            return TemplateResponse(request, TEMPLATE_RETRY, context)
         else:
             analytics.returned_error(request, "Invalid retry submission.")
             raise Exception("Invalid retry submission.")

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -99,10 +99,7 @@ def retry(request):
         analytics.returned_retry(request)
         form = forms.CardTokenizeFailForm(request.POST)
         if form.is_valid():
-            context = {
-                "retry_button": True,
-            }
-            return TemplateResponse(request, TEMPLATE_RETRY, context)
+            return TemplateResponse(request, TEMPLATE_RETRY)
         else:
             analytics.returned_error(request, "Invalid retry submission.")
             raise Exception("Invalid retry submission.")


### PR DESCRIPTION
fix #1755 

## What this PR does
- Pass `retry_button` as `True` to the `enrollment/retry` page, so that the button appears