### PR TITLE
Docs: add extension to make nested lists work

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+mdx_truly_sane_lists
 mkdocs
 mkdocs-awesome-pages-plugin
 mkdocs-macros-plugin

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ markdown_extensions:
   - attr_list
   - codehilite:
       linenums: true
+  - mdx_truly_sane_lists
   - pymdownx.emoji:
       emoji_index: !!python/name:materialx.emoji.twemoji
       emoji_generator: !!python/name:materialx.emoji.to_svg


### PR DESCRIPTION
Useful for #1762 

This PR adds the `mdx_truly_sane_lists` extension to our Mkdocs configuration, which makes it so indenting a list item with 2 spaces in Markdown will make a nested list.

Without the extension, Mkdocs's default is to expect 4 spaces; this behavior is due to [Mkdocs's usage of Python-Markdown](https://github.com/mkdocs/mkdocs/issues/545). Prettier, our configured formatter, re-formats 4-space indents into 2-space indents.

So in our current docs site, we have lists like:

![image](https://github.com/cal-itp/benefits/assets/25497886/a1fd759d-cb38-42b3-a973-f0c64c267e59)

![image](https://github.com/cal-itp/benefits/assets/25497886/88f38ae1-bd5c-4f2e-a8e6-537f22e0d23d)

With this extension added, they are nested:

![image](https://github.com/cal-itp/benefits/assets/25497886/65ac4009-7ea6-4568-8871-f6db1f9357f1)

![image](https://github.com/cal-itp/benefits/assets/25497886/489ba75b-6fd8-4d30-90db-cb7272e10e9b)
