### PR TITLE
Docs: Various small fixes

### DIFF
--- a/docs/product-and-design/.pages
+++ b/docs/product-and-design/.pages
@@ -1,5 +1,6 @@
 nav:
 
+- use-cases
 - analytics.md
 - copy-delivery.md
 - Design style guide: https://www.figma.com/proto/SeSd3LaLd6WkbEYhmtKpO3/Benefits-(IAL2-Login.gov)?node-id=4942%3A17385&scaling=scale-down&page-id=4890%3A17182

--- a/docs/product-and-design/use-cases/enrollment-use-cases.md
+++ b/docs/product-and-design/use-cases/enrollment-use-cases.md
@@ -23,8 +23,9 @@ The use cases documented on this page focus on how the system is supposed to wor
 **Alternate flows**:
 
 - 3a. Payment processor returns with one of the following errors: card verification failed, token is invalid, or general server error
-    - 3a1. Transit rider chooses to retry, starting back at initiating the enrollment phase
-    - 3b1. Transit rider leaves the Benefits app
+
+  - 3a1. Transit rider chooses to retry, starting back at initiating the enrollment phase
+  - 3b1. Transit rider leaves the Benefits app
 
 **Postconditions**:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,9 +38,7 @@ plugins:
         "deployment/azure.md": "deployment/infrastructure.md"
         "getting-started/development.md": "development/README.md"
         "getting-started/docker-dynamic-ports.md": "development/docker-dynamic-ports.md"
-        "students.md": "use-cases/college.md"
-        "use-cases/courtesy-cards.md": "use-cases/agency-cards.md"
-        "use-cases/students.md": "use-cases/college.md"
+        "use-cases/courtesy-cards.md": "enrollment-pathways/agency-cards.md"
 
 extra_css:
   - https://use.fontawesome.com/releases/v5.13.0/css/all.css


### PR DESCRIPTION
- Add Use Cases back to the sidebar: Renames the page to `Enrollment use cases` so it fits better in the hierarchy
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/8a77013e-1c6a-41a1-adbf-80bf1cb7f2d2">

- Fixes Alternate flows bullet bug:
<img width="1512" alt="image" src="https://github.com/cal-itp/benefits/assets/3673236/9526ec55-52cf-4272-ad0d-d1c5993de9cc">

- Updates redirect to go to the proper URL, removes College redirect (page is now deleted)