### PR TITLE
Fix(server): remove unnecessary configuration of FLASK_APP

### DIFF
--- a/.devcontainer/server/.env.server
+++ b/.devcontainer/server/.env.server
@@ -1,2 +1,1 @@
 ELIGIBILITY_SERVER_SETTINGS=/.devcontainer/server/settings.py
-FLASK_APP=eligibility_server/app.py


### PR DESCRIPTION
I was finally able to reproduce the issue we've been seeing in our GitHub Actions Cypress test failures. That workflow [starts up `client` and `server` via Docker Compose](https://github.com/cal-itp/benefits/blob/cb8db9e62b024b49fb28d3ab9a67891c1154cf0a/.github/workflows/tests-cypress.yml#L19).

I had to delete all my containers and images to finally see the issue:
```
2023-12-20 12:35:09 + bin/init.sh
2023-12-20 12:35:09 + flask init-db
2023-12-20 12:35:09 Error: Could not import 'app'.
2023-12-20 12:35:09 
2023-12-20 12:35:09 Usage: flask [OPTIONS] COMMAND [ARGS]...
2023-12-20 12:35:09 Try 'flask --help' for help.
2023-12-20 12:35:09 
2023-12-20 12:35:09 Error: No such command 'init-db'.
```

I guess somewhere in some cached layer of a Docker image, there must've been something that made my `server` able to find the Flask app, and only by deleting everything was I able to get my Docker Compose `server` to break.

The reason that server was not starting up is because `FLASK_APP` needs to be to `eligibility_server.app:app` to match the change in https://github.com/cal-itp/eligibility-server/commit/60c8eb28179b1cc1a4ad2d0b35c29d436e1a56d8#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R16.

But actually, Benefits doesn't even need to set this environment variable since eligibility-server's Dockerfile already sets it.