### PR TITLE
docs(analytics): add table for default user props

### DIFF
--- a/docs/product-and-design/analytics.md
+++ b/docs/product-and-design/analytics.md
@@ -1,6 +1,6 @@
 # Analytics
 
-The [Cal-ITP Benefits application](https://benefits.calitp.org/) uses [Amplitude](https://amplitude.com/) to collect specific user and event data properties to analyze application usage.
+The Cal-ITP Benefits application, currently live at `https://benefits.calitp.org/`, uses [Amplitude](https://amplitude.com/) to collect specific user and event data properties to analyze application usage.
 
 ## Information not collected
 
@@ -13,24 +13,26 @@ See the [Amplitude analytics code on GitHub](https://github.com/cal-itp/benefits
 
 ## User information collected
 
-A combination of default and application-specific custom user properties are collected for each user who visits the [Cal-ITP Benefits](https://benefits.calitp.org/) application.
+A combination of default and application-specific custom user properties are collected for each user who visits the Benefits web application.
 
 ### Default Amplitude user properties collected
 
 The following attributes are collected from the browser of every user who visits the application, provided the browser does not block the tracking library:
 
-- Platform
-- Device type
-- Device family
-- Country
-- City
-- Region
-- Start version
-- Version
-- Carrier
-- OS: Operating system name and version
-- Language
-- Library
+User property | Description | Example value(s)
+-- | -- | --
+**Carrier** | The device's carrier. | `Verizon`
+**Country** | Country of the event. This is pulled using GeoIP. | `United States`
+**City** | City of the event. This is pulled using GeoIP. | `San Francisco`
+**Device family** | Family of the device. | `Apple iPhone, Samsung Galaxy Tablet, Windows`
+**Device type** | Specific type of device. | `Apple iPhone 6, Samsung Galaxy Note 4, Windows`
+**Language** | Language of the device. | `English`
+**Library** | Library used to send the event. | `Amplitude-iOS/3.2.1, HTTP/1.0`
+**OS** | Operating system is the name of the user's mobile operating system or browser. Operating system version is the version of the users' mobile operating system or browser. | `iOS 9.1, Chrome 46`
+**Platform** | Platform of the product. | `Web`
+**Region** | Region (e.g. state, province, county) of the event. This is pulled using GeoIP. | `California`
+**Start version** | First version of the application identified for the user. | `1.0.0`
+**Version** | Current verison of the application identified for the user | `1.0.0`
 
 Read more about each property on the [Amplitude documentation](https://help.amplitude.com/hc/en-us/articles/215562387-Appendix-Amplitude-User-Property-Definitions).
 
@@ -38,11 +40,11 @@ Read more about each property on the [Amplitude documentation](https://help.ampl
 
 The following custom user attributes are collected when the user performs specific actions on the application, like selecing an eligibility type or transit agency:
 
-| Custom user property   | Description                        | Example value                                                                                                     |
+| User property          | Description                        | Example value(s)                                                                                                  |
 | ---------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `eligibility_types`    | Eligibility type chosen by user    | `[veteran]`                                                                                                       |
 | `eligibility_verifier` | Eligibility verifier used by user  | `VA.gov - Veteran (MST)`                                                                                          |
-| `referrer`             | URL that the event came from       | [https://benefits.calitp.org/eligibility/start](https://benefits.calitp.org/eligibility/start)                                                                     |
+| `referrer`             | URL that the event came from       | `https://benefits.calitp.org/help/`                                                                               |
 | `referring_domain`     | Domain that the event came from    | `benefits.calitp.org`                                                                                             |
 | `transit_agency`       | Agency chosen by the user          | `Monterey-Salinas Transit`                                                                                        |
 | `user_agent`           | User's browser agent               | `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36` |
@@ -87,9 +89,9 @@ Read more on each of these events on the [Amplitude event documentation for Bene
 
 These events track the progress of a user who has successfully verified their eligibility and is enrolling their payment card with the system.
 
-- closed payment connection (e.g. Littlepay)
+- closed payment connection
 - returned enrollment
-- started payment connection (e.g. Littlepay)
+- started payment connection
 
 Read more on each of these events on the [Amplitude event documentation for Benefits, filtered by Enrollment](https://data.amplitude.com/public-doc/hdhfmlby2e?categories=id%3D1702329910563%26group%3Dcategories%26type%3DString%26operator%3Dis%26values%255B0%255D%3Denrollment%26dateValue%255Btype%255D%3DSINCE).
 


### PR DESCRIPTION
closes #1841 

## What this PR does
- Adds a table for default user props, with definitions from https://help.amplitude.com/hc/en-us/articles/215562387-Appendix-Amplitude-User-Property-Definitions
- Removes explicit reference to Littlepay. People can see if it they click through to the Amplitude docs.
- Reaching a compromise with regard to linking to the Benefits application or not:

1. On first reference, the app is now referred to like this: For people who might think "app" means a mobile application, I use the phrase `currently live at https://....`. But, I do *not* link the actual link - because we are trying to discourage "drive-by clicks" that artificially inflate our click-through numbers. (Though remember, if we want to filter out People Who Came To Benefits via the Documentation or any Calitp.org website/social media, we can do that too -- so it's not a huge porblem.) 

I thought about linking back to the documentation front page - especially because it has the visual screenshot example, but I thought that would confuse the confused people even more. So I settled on showing a text link without it hyperlinked. If someone is TRULY confused about what the site they are reading documentation about, they can copy and paste that link and go there themselves.

![image](https://github.com/cal-itp/benefits/assets/3673236/0036eec5-4f1f-4afe-b242-3698e3e0c2f4)

On second and further references, I remove links entirely. 
![image](https://github.com/cal-itp/benefits/assets/3673236/40579652-c245-45fd-a50f-8179922e9c3d)

And lastly, for user property example values - again - I do NOT link to the app itself. 
![image](https://github.com/cal-itp/benefits/assets/3673236/c43159b6-a84f-46ca-922c-77517fa0eb36)

The point here isn't for someone to go to the Help page. It's to serve as an example for someone who wants to know what a "URL that the event came from" could like.


cc @thekaveman @indexing - Check it out live on the _preview_ site here: https://benefits-1846--cal-itp-previews.netlify.app/product-and-design/analytics/