### PR TITLE
Feat: check for existing superuser

### DIFF
--- a/benefits/superuser.py
+++ b/benefits/superuser.py
@@ -1,0 +1,20 @@
+import os
+import logging
+
+from django.contrib.auth import get_user_model
+
+logger = logging.getLogger(__name__)
+
+User = get_user_model()  # get the currently active user model
+
+username = os.environ.get("DJANGO_SUPERUSER_USERNAME")
+user = User.objects.filter(username=username)
+
+if user.exists():
+    logger.debug("Skipping superuser creation since it already exists")
+else:
+    email = os.environ.get("DJANGO_SUPERUSER_EMAIL")
+    password = os.environ.get("DJANGO_SUPERUSER_PASSWORD")
+
+    logger.debug("Creating superuser")
+    User.objects.create_superuser(username, email, password)

--- a/benefits/superuser.py
+++ b/benefits/superuser.py
@@ -11,7 +11,10 @@ username = os.environ.get("DJANGO_SUPERUSER_USERNAME")
 user = User.objects.filter(username=username)
 
 if user.exists():
-    logger.debug("Skipping superuser creation since it already exists")
+    if user.first().is_superuser:
+        logger.debug("Skipping superuser creation since it already exists")
+    else:
+        raise RuntimeError("A user already exists with DJANGO_SUPERUSER_NAME as the username")
 else:
     email = os.environ.get("DJANGO_SUPERUSER_EMAIL")
     password = os.environ.get("DJANGO_SUPERUSER_PASSWORD")

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -23,7 +23,7 @@ python manage.py migrate
 # check DJANGO_ADMIN = true, default to false if empty or unset
 
 if [[ ${DJANGO_ADMIN:-false} = true ]]; then
-    python manage.py createsuperuser --no-input
+    cat benefits/superuser.py | python manage.py shell
 else
     echo "superuser: Django not configured for Admin access"
 fi


### PR DESCRIPTION
If `./bin/init.sh` has already been run and then is run again with `DB_RESET` set to `false`, it runs into an error related to the superuser:

<details><summary>Log snippet</summary>

```
2024-01-08T23:46:28.287623934Z + bin/init.sh
2024-01-08T23:46:28.471919157Z + DB_DIR=./data
2024-01-08T23:46:28.471943758Z + DB_FILE=./data/django.db
2024-01-08T23:46:28.471947658Z + DB_RESET=false
2024-01-08T23:46:28.471950858Z + [[ false = true ]]
2024-01-08T23:46:28.471954158Z + python manage.py migrate
2024-01-08T23:46:35.050203435Z [08/Jan/2024 23:46:34] INFO benefits.oauth.client:51 Registering OAuth clients
2024-01-08T23:46:35.050323336Z /home/calitp/.local/lib/python3.11/site-packages/django/db/backends/utils.py:98: RuntimeWarning: Accessing the database during app initialization is discouraged. To fix this warning, avoid executing queries in AppConfig.ready() or when your app modules are imported.
2024-01-08T23:46:35.050333936Z   warnings.warn(self.APPS_NOT_READY_WARNING_MSG, category=RuntimeWarning)
2024-01-08T23:46:35.050337836Z [08/Jan/2024 23:46:34] DEBUG benefits.oauth.client:56 Registering OAuth client: cdt-logingov-ial2
2024-01-08T23:46:35.050341436Z [08/Jan/2024 23:46:34] DEBUG benefits.oauth.client:56 Registering OAuth client: cdt-vagov
2024-01-08T23:46:35.050345036Z [08/Jan/2024 23:46:34] DEBUG benefits.core.admin:21 Register EligibilityType
2024-01-08T23:46:35.050359536Z [08/Jan/2024 23:46:34] DEBUG benefits.core.admin:21 Register EligibilityVerifier
2024-01-08T23:46:35.050363636Z [08/Jan/2024 23:46:34] DEBUG benefits.core.admin:21 Register PaymentProcessor
2024-01-08T23:46:35.050367236Z [08/Jan/2024 23:46:34] DEBUG benefits.core.admin:21 Register PemData
2024-01-08T23:46:35.050370936Z [08/Jan/2024 23:46:34] DEBUG benefits.core.admin:21 Register TransitAgency
2024-01-08T23:46:35.081545016Z [08/Jan/2024 23:46:35] DEBUG benefits.core.analytics:111 Initialize Client for https://api2.amplitude.com/2/httpapi
2024-01-08T23:46:35.099570579Z [08/Jan/2024 23:46:35] DEBUG benefits.core.urls:41 Register path converter: TransitAgencyPathConverter
2024-01-08T23:46:35.235399800Z [08/Jan/2024 23:46:35] DEBUG benefits.urls:39 Register admin urls
2024-01-08T23:46:35.387978272Z Operations to perform:
2024-01-08T23:46:35.456002284Z   Apply all migrations: admin, auth, contenttypes, core, sessions
2024-01-08T23:46:35.456107285Z Running migrations:
2024-01-08T23:46:35.456122585Z   No migrations to apply.
2024-01-08T23:46:36.173646737Z + [[ true = true ]]
2024-01-08T23:46:36.173686937Z + python manage.py createsuperuser --no-input
2024-01-08T23:46:40.238376879Z [08/Jan/2024 23:46:40] INFO benefits.oauth.client:51 Registering OAuth clients
2024-01-08T23:46:40.265089419Z /home/calitp/.local/lib/python3.11/site-packages/django/db/backends/utils.py:98: RuntimeWarning: Accessing the database during app initialization is discouraged. To fix this warning, avoid executing queries in AppConfig.ready() or when your app modules are imported.
2024-01-08T23:46:40.265196120Z   warnings.warn(self.APPS_NOT_READY_WARNING_MSG, category=RuntimeWarning)
2024-01-08T23:46:40.273719496Z [08/Jan/2024 23:46:40] DEBUG benefits.oauth.client:56 Registering OAuth client: cdt-logingov-ial2
2024-01-08T23:46:40.276376020Z [08/Jan/2024 23:46:40] DEBUG benefits.oauth.client:56 Registering OAuth client: cdt-vagov
2024-01-08T23:46:40.278285437Z [08/Jan/2024 23:46:40] DEBUG benefits.core.admin:21 Register EligibilityType
2024-01-08T23:46:40.279116645Z [08/Jan/2024 23:46:40] DEBUG benefits.core.admin:21 Register EligibilityVerifier
2024-01-08T23:46:40.285648603Z [08/Jan/2024 23:46:40] DEBUG benefits.core.admin:21 Register PaymentProcessor
2024-01-08T23:46:40.286111908Z [08/Jan/2024 23:46:40] DEBUG benefits.core.admin:21 Register PemData
2024-01-08T23:46:40.307941404Z [08/Jan/2024 23:46:40] DEBUG benefits.core.admin:21 Register TransitAgency
2024-01-08T23:46:40.383256781Z [08/Jan/2024 23:46:40] DEBUG benefits.core.analytics:111 Initialize Client for https://api2.amplitude.com/2/httpapi
2024-01-08T23:46:40.385759203Z [08/Jan/2024 23:46:40] DEBUG benefits.core.urls:41 Register path converter: TransitAgencyPathConverter
2024-01-08T23:46:40.522614133Z [08/Jan/2024 23:46:40] DEBUG benefits.urls:39 Register admin urls
2024-01-08T23:46:40.720922115Z CommandError: Error: That username is already taken.
```
</details>

This PR checks if the superuser already exists and if not, creates it using [`User.create_superuser`](https://docs.djangoproject.com/en/5.0/ref/contrib/auth/#django.contrib.auth.models.UserManager.create_superuser).