### PR TITLE
Feat: helper script to read KeyVault secrets

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,11 @@
 FROM benefits_client:latest
 
+# install Azure CLI
+# https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt
+USER root
+RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+USER $USER
+
 # install devcontainer requirements
 RUN pip install -e .[dev,test]
 

--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,1 @@
+testsecret=Hello from the local environment!

--- a/benefits/secrets.py
+++ b/benefits/secrets.py
@@ -1,17 +1,27 @@
 import sys
 
+from django.conf import settings
+
 from azure.identity import DefaultAzureCredential
 from azure.keyvault.secrets import SecretClient
 
 
+KEY_VAULT_URL = "https://kv-cdt-pub-calitp-{env}-001.vault.azure.net/"
+
+
 if __name__ == "__main__":
     args = sys.argv[1:]
-    if len(args) < 2:
-        print("Provide the Key Vault URL and the name of the secret to read")
+    if len(args) < 1:
+        print("Provide the name of the secret to read")
         exit(1)
 
-    vault_url = args[0]
-    secret_name = args[1]
+    # construct the KeyVault URL from the runtime environment
+    # see https://docs.calitp.org/benefits/deployment/infrastructure/#environments
+    # and https://github.com/cal-itp/benefits/blob/dev/terraform/key_vault.tf
+    runtime_env = settings.RUNTIME_ENVIRONMENT()
+    vault_url = KEY_VAULT_URL.format(env=runtime_env[0])
+
+    secret_name = args[0]
 
     credential = DefaultAzureCredential()
     client = SecretClient(vault_url=vault_url, credential=credential)

--- a/benefits/secrets.py
+++ b/benefits/secrets.py
@@ -1,0 +1,22 @@
+import sys
+
+from azure.identity import DefaultAzureCredential
+from azure.keyvault.secrets import SecretClient
+
+
+if __name__ == "__main__":
+    args = sys.argv[1:]
+    if len(args) < 2:
+        print("Provide the Key Vault URL and the name of the secret to read")
+        exit(1)
+
+    vault_url = args[0]
+    secret_name = args[1]
+
+    credential = DefaultAzureCredential()
+    client = SecretClient(vault_url=vault_url, credential=credential)
+    secret = client.get_secret(secret_name)
+
+    print(f"Reading {secret_name} from {vault_url}")
+    print(f"Value: {secret.value}")
+    exit(0)

--- a/benefits/secrets.py
+++ b/benefits/secrets.py
@@ -9,24 +9,29 @@ from azure.keyvault.secrets import SecretClient
 KEY_VAULT_URL = "https://kv-cdt-pub-calitp-{env}-001.vault.azure.net/"
 
 
+def get_secret_by_name(secret_name, client=None):
+    if client is None:
+        # construct the KeyVault URL from the runtime environment
+        # see https://docs.calitp.org/benefits/deployment/infrastructure/#environments
+        # and https://github.com/cal-itp/benefits/blob/dev/terraform/key_vault.tf
+        runtime_env = settings.RUNTIME_ENVIRONMENT()
+        vault_url = KEY_VAULT_URL.format(env=runtime_env[0])
+
+        credential = DefaultAzureCredential()
+        client = SecretClient(vault_url=vault_url, credential=credential)
+
+    secret = client.get_secret(secret_name)
+    return secret.value
+
+
 if __name__ == "__main__":
     args = sys.argv[1:]
     if len(args) < 1:
         print("Provide the name of the secret to read")
         exit(1)
 
-    # construct the KeyVault URL from the runtime environment
-    # see https://docs.calitp.org/benefits/deployment/infrastructure/#environments
-    # and https://github.com/cal-itp/benefits/blob/dev/terraform/key_vault.tf
-    runtime_env = settings.RUNTIME_ENVIRONMENT()
-    vault_url = KEY_VAULT_URL.format(env=runtime_env[0])
-
     secret_name = args[0]
+    secret_value = get_secret_by_name(secret_name)
 
-    credential = DefaultAzureCredential()
-    client = SecretClient(vault_url=vault_url, credential=credential)
-    secret = client.get_secret(secret_name)
-
-    print(f"Reading {secret_name} from {vault_url}")
-    print(f"Value: {secret.value}")
+    print(f"[{settings.RUNTIME_ENVIRONMENT()}] {secret_name}: {secret_value}")
     exit(0)

--- a/benefits/secrets.py
+++ b/benefits/secrets.py
@@ -1,21 +1,35 @@
+import logging
+import os
 import sys
-
-from django.conf import settings
 
 from azure.identity import DefaultAzureCredential
 from azure.keyvault.secrets import SecretClient
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
 
 
 KEY_VAULT_URL = "https://kv-cdt-pub-calitp-{env}-001.vault.azure.net/"
 
 
 def get_secret_by_name(secret_name, client=None):
-    if client is None:
+    """Read a value from the secret store, currently Azure KeyVault.
+
+    When `settings.RUNTIME_ENVIRONMENT() == "local"`, reads from the environment instead.
+    """
+
+    runtime_env = settings.RUNTIME_ENVIRONMENT()
+
+    if runtime_env == "local":
+        logger.debug("Runtime environment is local, reading from environment instead of Azure KeyVault.")
+        return os.environ.get(secret_name)
+
+    elif client is None:
         # construct the KeyVault URL from the runtime environment
         # see https://docs.calitp.org/benefits/deployment/infrastructure/#environments
         # and https://github.com/cal-itp/benefits/blob/dev/terraform/key_vault.tf
-        runtime_env = settings.RUNTIME_ENVIRONMENT()
         vault_url = KEY_VAULT_URL.format(env=runtime_env[0])
+        logger.debug(f"Configuring Azure KeyVault secrets client for: {vault_url}")
 
         credential = DefaultAzureCredential()
         client = SecretClient(vault_url=vault_url, credential=credential)

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -32,8 +32,10 @@ def RUNTIME_ENVIRONMENT():
 
     # usage of django.conf.settings.ALLOWED_HOSTS here (rather than the module variable directly)
     # is to ensure dynamic calculation, e.g. for unit tests and elsewhere this setting is needed
-    env = "dev"
-    if "test-benefits.calitp.org" in settings.ALLOWED_HOSTS:
+    env = "local"
+    if "dev-benefits.calitp.org" in settings.ALLOWED_HOSTS:
+        env = "dev"
+    elif "test-benefits.calitp.org" in settings.ALLOWED_HOSTS:
         env = "test"
     elif "benefits.calitp.org" in settings.ALLOWED_HOSTS:
         env = "prod"

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -4,6 +4,8 @@ Django settings for benefits project.
 
 import os
 
+from django.conf import settings
+
 from benefits import sentry
 
 
@@ -23,6 +25,20 @@ DEBUG = os.environ.get("DJANGO_DEBUG", "False").lower() == "true"
 ADMIN = os.environ.get("DJANGO_ADMIN", "False").lower() == "true"
 
 ALLOWED_HOSTS = _filter_empty(os.environ.get("DJANGO_ALLOWED_HOSTS", "localhost,127.0.0.1").split(","))
+
+
+def RUNTIME_ENVIRONMENT():
+    """Helper calculates the current runtime environment from ALLOWED_HOSTS."""
+
+    # usage of django.conf.settings.ALLOWED_HOSTS here (rather than the module variable directly)
+    # is to ensure dynamic calculation, e.g. for unit tests and elsewhere this setting is needed
+    env = "dev"
+    if "test-benefits.calitp.org" in settings.ALLOWED_HOSTS:
+        env = "test"
+    elif "benefits.calitp.org" in settings.ALLOWED_HOSTS:
+        env = "prod"
+    return env
+
 
 # Application definition
 

--- a/benefits/urls.py
+++ b/benefits/urls.py
@@ -8,6 +8,7 @@ The `urlpatterns` list routes URLs to views. For more information please see:
 import logging
 
 from django.conf import settings
+from django.http import HttpResponse
 from django.urls import include, path
 
 logger = logging.getLogger(__name__)
@@ -33,6 +34,18 @@ if settings.DEBUG:
         raise RuntimeError("Test error")
 
     urlpatterns.append(path("error/", trigger_error))
+
+    # simple route to read a pre-defined "secret"
+    # this "secret" does not contain sensitive information
+    # and is only configured in the dev environment for testing/debugging
+
+    def test_secret(request):
+        from benefits.secrets import get_secret_by_name
+
+        return HttpResponse(get_secret_by_name("testsecret"))
+
+    urlpatterns.append(path("testsecret/", test_secret))
+
 
 if settings.ADMIN:
     from django.contrib import admin

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -219,7 +219,9 @@ Enables [sending events to Sentry](../../deployment/troubleshooting/#error-monit
 
     [`environment` config value](https://docs.sentry.io/platforms/python/configuration/options/#environment)
 
-Segments errors by which deployment they occur in. This defaults to `local`, and can be set to match one of the [environment names](../../deployment/infrastructure/#environments).
+Segments errors by which deployment they occur in. This defaults to `dev`, and can be set to match one of the [environment names](../../deployment/infrastructure/#environments).
+
+`local` may also be used for local testing of the Sentry integration.
 
 ### `SENTRY_REPORT_URI`
 

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -12,10 +12,10 @@ git clone https://github.com/cal-itp/benefits
 
 ## Create an environment file
 
-The application is configured with defaults to run locally, but an `.env` file is required to run with Docker Compose. This file can be empty, or environment overrides can be added as needed:
+The application is configured with defaults to run locally, but an `.env` file is required to run with Docker Compose. Start from the existing sample:
 
 ```bash
-touch .env
+cp .env.sample .env
 ```
 
 E.g. to change the localhost port from the default `8000` to `9000`, add the following line to your `.env` file:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,8 @@ classifiers = ["Programming Language :: Python :: 3 :: Only"]
 requires-python = ">=3.9"
 dependencies = [
     "Authlib==1.3.0",
+    "azure-keyvault-secrets==4.7.0",
+    "azure-identity==1.15.0",
     "Django==5.0.1",
     "django-csp==3.7",
     "eligibility-api==2023.9.1",

--- a/tests/pytest/test_secrets.py
+++ b/tests/pytest/test_secrets.py
@@ -1,0 +1,45 @@
+import pytest
+
+from benefits.secrets import KEY_VAULT_URL, get_secret_by_name
+
+
+@pytest.fixture(autouse=True)
+def mock_DefaultAzureCredential(mocker):
+    # patching the class to ensure new instances always return the same mock
+    credential_cls = mocker.patch("benefits.secrets.DefaultAzureCredential")
+    credential_cls.return_value = mocker.Mock()
+    return credential_cls
+
+
+def test_get_secret_by_name__with_client__returns_value(mocker):
+    secret_name = "the secret name"
+    secret_value = "the secret value"
+    client = mocker.patch("benefits.secrets.SecretClient")
+    client.get_secret.return_value = mocker.Mock(value=secret_value)
+
+    actual_value = get_secret_by_name(secret_name, client)
+
+    client.get_secret.assert_called_once_with(secret_name)
+    assert actual_value == secret_value
+
+
+def test_get_secret_by_name__None_client__returns_value(mocker, settings, mock_DefaultAzureCredential):
+    secret_name = "the secret name"
+    secret_value = "the secret value"
+
+    # override runtime to dev
+    settings.RUNTIME_ENVIRONMENT = lambda: "dev"
+    expected_keyvault_url = KEY_VAULT_URL.format(env="d")
+
+    # set up the mock client class and expected return values
+    # this test does not pass in a known client, instead checking that a client is constructed as expected
+    mock_credential = mock_DefaultAzureCredential.return_value
+    client_cls = mocker.patch("benefits.secrets.SecretClient")
+    client = client_cls.return_value
+    client.get_secret.return_value = mocker.Mock(value=secret_value)
+
+    actual_value = get_secret_by_name(secret_name)
+
+    client_cls.assert_called_once_with(vault_url=expected_keyvault_url, credential=mock_credential)
+    client.get_secret.assert_called_once_with(secret_name)
+    assert actual_value == secret_value

--- a/tests/pytest/test_settings.py
+++ b/tests/pytest/test_settings.py
@@ -1,5 +1,5 @@
 def test_runtime_environment__default(settings):
-    assert settings.RUNTIME_ENVIRONMENT() == "dev"
+    assert settings.RUNTIME_ENVIRONMENT() == "local"
 
 
 def test_runtime_environment__dev(settings):
@@ -7,15 +7,27 @@ def test_runtime_environment__dev(settings):
     assert settings.RUNTIME_ENVIRONMENT() == "dev"
 
 
+def test_runtime_environment__dev_and_test(settings):
+    # if both dev and test are specified (edge case/error in configuration), assume dev
+    settings.ALLOWED_HOSTS = ["test-benefits.calitp.org", "dev-benefits.calitp.org"]
+    assert settings.RUNTIME_ENVIRONMENT() == "dev"
+
+
+def test_runtime_environment__dev_and_test_and_prod(settings):
+    # if all 3 of dev and test and prod are specified (edge case/error in configuration), assume dev
+    settings.ALLOWED_HOSTS = ["benefits.calitp.org", "test-benefits.calitp.org", "dev-benefits.calitp.org"]
+    assert settings.RUNTIME_ENVIRONMENT() == "dev"
+
+
 def test_runtime_environment__local(settings):
     settings.ALLOWED_HOSTS = ["localhost", "127.0.0.1"]
-    assert settings.RUNTIME_ENVIRONMENT() == "dev"
+    assert settings.RUNTIME_ENVIRONMENT() == "local"
 
 
 def test_runtime_environment__nonmatching(settings):
-    # with only nonmatching hosts, return dev
+    # with only nonmatching hosts, return local
     settings.ALLOWED_HOSTS = ["example.com", "example2.org"]
-    assert settings.RUNTIME_ENVIRONMENT() == "dev"
+    assert settings.RUNTIME_ENVIRONMENT() == "local"
 
 
 def test_runtime_environment__test(settings):

--- a/tests/pytest/test_settings.py
+++ b/tests/pytest/test_settings.py
@@ -1,0 +1,46 @@
+def test_runtime_environment__default(settings):
+    assert settings.RUNTIME_ENVIRONMENT() == "dev"
+
+
+def test_runtime_environment__dev(settings):
+    settings.ALLOWED_HOSTS = ["dev-benefits.calitp.org"]
+    assert settings.RUNTIME_ENVIRONMENT() == "dev"
+
+
+def test_runtime_environment__local(settings):
+    settings.ALLOWED_HOSTS = ["localhost", "127.0.0.1"]
+    assert settings.RUNTIME_ENVIRONMENT() == "dev"
+
+
+def test_runtime_environment__nonmatching(settings):
+    # with only nonmatching hosts, return dev
+    settings.ALLOWED_HOSTS = ["example.com", "example2.org"]
+    assert settings.RUNTIME_ENVIRONMENT() == "dev"
+
+
+def test_runtime_environment__test(settings):
+    settings.ALLOWED_HOSTS = ["test-benefits.calitp.org"]
+    assert settings.RUNTIME_ENVIRONMENT() == "test"
+
+
+def test_runtime_environment__test_and_nonmatching(settings):
+    # when test is specified with other nonmatching hosts, assume test
+    settings.ALLOWED_HOSTS = ["test-benefits.calitp.org", "example.com"]
+    assert settings.RUNTIME_ENVIRONMENT() == "test"
+
+
+def test_runtime_environment__test_and_prod(settings):
+    # if both test and prod are specified (edge case/error in configuration), assume test
+    settings.ALLOWED_HOSTS = ["benefits.calitp.org", "test-benefits.calitp.org"]
+    assert settings.RUNTIME_ENVIRONMENT() == "test"
+
+
+def test_runtime_environment__prod(settings):
+    settings.ALLOWED_HOSTS = ["benefits.calitp.org"]
+    assert settings.RUNTIME_ENVIRONMENT() == "prod"
+
+
+def test_runtime_environment__prod_and_nonmatching(settings):
+    # when prod is specified with other nonmatching hosts, assume prod
+    settings.ALLOWED_HOSTS = ["benefits.calitp.org", "https://example.com"]
+    assert settings.RUNTIME_ENVIRONMENT() == "prod"


### PR DESCRIPTION
Part of #1847 

## What this PR does

* Defines a new setting `RUNTIME_ENVIRONMENT()` to dynamically calculate one of `local`, `dev`, `test`, or `prod` based on the values in `ALLOWED_HOSTS`
* Uses [`azure-keyvault-secrets`](https://pypi.org/project/azure-keyvault-secrets/) and [`azure-identity`](https://pypi.org/project/azure-identity/) based on [Getting Started with Azure Key Vault Secrets client library for Python](https://learn.microsoft.com/en-us/python/api/overview/azure/keyvault-secrets-readme?view=azure-python&source=recommendations#getting-started)
* Installs the Azure CLI into the devcontainer, to make debugging and testing of this functionality possible within the same environment we use for daily development.
* For `local` runtime environment, falls back to reading from environment variables

## Todo

- [x] Figure out how (ideally via Terraform) to create a [Managed identity for App Services](https://learn.microsoft.com/en-us/azure/app-service/overview-managed-identity?tabs=portal%2Cpython) so this code can run in Azure (non-local) environments. See also https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/identity/azure-identity#managed-identity-support

### Done

The existing Terraform [`app_service` definition](https://github.com/cal-itp/benefits/blob/dev/terraform/app_service.tf#L36) includes a [system-defined managed identity](https://learn.microsoft.com/en-us/azure/app-service/overview-managed-identity?tabs=portal%2Cpython).

Further, this managed identity should be able to GET secrets via an existing [policy definition](https://github.com/cal-itp/benefits/blob/dev/terraform/key_vault.tf#L77).

[According to the Python package docs](https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/identity/azure-identity#defaultazurecredential), `DefaultCredential` will check for access via this system-defined managed identity when running in Azure. This PR adds a `DEBUG`-only route `/testsecret` to help verify access from within Azure.

## How to verify the POC

1. Update your local `.env` file to add a new variable

        testsecret=Hello from the local environment!

1. Rebuild and Reopen the devcontainer

1. Call the helper script, setting the `DJANGO_SETTINGS_MODULE` env var and passing the name of the secret to read

        DJANGO_SETTINGS_MODULE=benefits.settings \
        python benefits/secrets.py testsecret

1. Verify output:
 
        [local] testsecret: Hello from the local environment!

1. From the devcontainer terminal, login to the Azure CLI with the `--use-device-code` flag, following instructions printed in the terminal. You may need to login to Azure on the website first, if you receive an error related to 2FA, to trigger that flow. Then run:
        
        az login --use-device-code

1. Call the helper script again configuring `DJANGO_ALLOWED_HOSTS` for the `dev` environment:

        DJANGO_ALLOWED_HOSTS=dev-benefits.calitp.org \
        DJANGO_SETTINGS_MODULE=benefits.settings \
        python benefits/secrets.py testsecret
        
1. Verify output:
 
        [dev] testsecret: Hello from the dev KeyVault!

1. Launch the local app with `F5` and visit the `/testsecret` endpoint, verify output in the browser:

        Hello from the local environment!

1. Override `DJANGO_ALLOWED_HOSTS` in `.vscode/launch.json` to point to `dev`. Be sure to include `localhost` so you can launch the app!

        "env": {
          ...
          "DJANGO_ALLOWED_HOSTS": "dev-benefits.calitp.org,localhost",
        }

1.  Launch the local app with `F5` and visit the `/testsecret` endpoint, verify output in the browser:

        Hello from the dev KeyVault!

1. Try another call against e.g. the `test` environment:

        DJANGO_ALLOWED_HOSTS=test-benefits.calitp.org \
        DJANGO_SETTINGS_MODULE=benefits.settings \
        python benefits/secrets.py <another secret name>

1. And verify the expected output:

        [test] <secret name>: <secret value from test>

## Post-merge verification steps

After this PR is merged and deployed to `dev`, visit the `/testsecret` route, which should print the value of the test secret in the browser (shown in `localhost` below):

![image](https://github.com/cal-itp/benefits/assets/1783439/61e43de1-e95c-4575-8bd4-1f47181b0db8)
