### PR TITLE
Fix: update GitHub branch for sample eligibility server config

### DIFF
--- a/.devcontainer/server/settings.py
+++ b/.devcontainer/server/settings.py
@@ -4,14 +4,14 @@ LOG_LEVEL = "DEBUG"
 
 # Eligibility Verification settings
 
-CLIENT_KEY_PATH = "https://raw.githubusercontent.com/cal-itp/eligibility-server/dev/keys/client.pub"
-SERVER_PRIVATE_KEY_PATH = "https://raw.githubusercontent.com/cal-itp/eligibility-server/dev/keys/server.key"
-SERVER_PUBLIC_KEY_PATH = "https://raw.githubusercontent.com/cal-itp/eligibility-server/dev/keys/server.pub"
+CLIENT_KEY_PATH = "https://raw.githubusercontent.com/cal-itp/eligibility-server/main/keys/client.pub"
+SERVER_PRIVATE_KEY_PATH = "https://raw.githubusercontent.com/cal-itp/eligibility-server/main/keys/server.key"
+SERVER_PUBLIC_KEY_PATH = "https://raw.githubusercontent.com/cal-itp/eligibility-server/main/keys/server.pub"
 SUB_FORMAT_REGEX = r".+"
 
 # Data settings
 
-IMPORT_FILE_PATH = "https://raw.githubusercontent.com/cal-itp/eligibility-server/dev/data/server.csv"
+IMPORT_FILE_PATH = "https://raw.githubusercontent.com/cal-itp/eligibility-server/main/data/server.csv"
 INPUT_HASH_ALGO = ""
 
 # CSV-specific settings

--- a/benefits/core/migrations/0002_data.py
+++ b/benefits/core/migrations/0002_data.py
@@ -40,14 +40,14 @@ def load_data(app, *args, **kwargs):
     mst_server_public_key = PemData.objects.create(
         label="Eligibility server public key",
         remote_url=os.environ.get(
-            "MST_SERVER_PUBLIC_KEY_URL", "https://raw.githubusercontent.com/cal-itp/eligibility-server/dev/keys/server.pub"
+            "MST_SERVER_PUBLIC_KEY_URL", "https://raw.githubusercontent.com/cal-itp/eligibility-server/main/keys/server.pub"
         ),
     )
 
     sbmtd_server_public_key = PemData.objects.create(
         label="Eligibility server public key",
         remote_url=os.environ.get(
-            "SBMTD_SERVER_PUBLIC_KEY_URL", "https://raw.githubusercontent.com/cal-itp/eligibility-server/dev/keys/server.pub"
+            "SBMTD_SERVER_PUBLIC_KEY_URL", "https://raw.githubusercontent.com/cal-itp/eligibility-server/main/keys/server.pub"
         ),
     )
 


### PR DESCRIPTION
After https://github.com/cal-itp/eligibility-server/pull/414 was merged and the `dev` branch was deleted over there, these URLs need to be updated to point to `main`.

Note these values are only used locally / in CI, not in production.

See e.g. [failing Cypress tests](https://github.com/cal-itp/benefits/actions/runs/7705421373/job/20999418005), related to WIP PR #1859