### PR TITLE
Feat: configure Azure file share backup

### DIFF
--- a/docs/deployment/infrastructure.md
+++ b/docs/deployment/infrastructure.md
@@ -131,6 +131,7 @@ Terraform is [`plan`](https://www.terraform.io/cli/commands/plan)'d when code is
    ./init.sh <env>
    ```
 
+1. Create a local `terraform.tfvars` file (ignored by git) from the sample; fill in the `*_OBJECT_ID` variables with values from the Azure Pipeline definition.
 1. Make changes to Terraform files.
 1. Preview the changes, as necessary.
 

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.37.0"
   constraints = "~> 3.0"
   hashes = [
+    "h1:83XTgyPKUKt706IjTLHo9HL0KN5m+DwmSKuVQv6dNb4=",
     "h1:tD9TmGFgYV/oxZQu0pXuA46H+ML9nALCDwFqoaETjGg=",
     "h1:yBkhudX4uTCZAUU85SVr10C40bVlK6kAVGU6IiTUWSU=",
     "zh:2a7bda0b7679d1c791c762103a22f333b544b6e6776c4177f33bafc9cc28c919",

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -23,6 +23,45 @@ resource "azurerm_storage_account" "main" {
   }
 }
 
+resource "azurerm_recovery_services_vault" "main" {
+  name                = "rsvcdtcalitp${lower(local.env_letter)}001"
+  location            = data.azurerm_resource_group.main.location
+  resource_group_name = data.azurerm_resource_group.main.name
+  sku                 = "Standard"
+  soft_delete_enabled = true
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+
+resource "azurerm_backup_container_storage_account" "main" {
+  resource_group_name = data.azurerm_resource_group.main.name
+  recovery_vault_name = azurerm_recovery_services_vault.main.name
+  storage_account_id  = azurerm_storage_account.main.id
+}
+
+resource "azurerm_backup_policy_file_share" "policy" {
+  name                = "${azurerm_storage_account.main.name}-backup-policy"
+  resource_group_name = data.azurerm_resource_group.main.name
+  recovery_vault_name = azurerm_recovery_services_vault.main.name
+  timezone            = "UTC"
+
+  backup {
+    frequency = "Daily"
+    time      = "14:00"
+  }
+
+  retention_daily {
+    count = 1
+  }
+
+  retention_weekly {
+    count    = 5
+    weekdays = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]
+  }
+}
+
 resource "azurerm_storage_share" "data" {
   name                 = "benefits-data"
   storage_account_name = azurerm_storage_account.main.name

--- a/terraform/terraform.tfvars.sample
+++ b/terraform/terraform.tfvars.sample
@@ -1,0 +1,2 @@
+DEVSECOPS_OBJECT_ID         = "object-id"
+ENGINEERING_GROUP_OBJECT_ID = "object-id"


### PR DESCRIPTION
Closes #1816 

## What this PR does

1. Defines an Azure Recovery Services Vault; this is where snapshots are stored. The default Geo-redundant storage is configured, so that backups are stored across various Azure geographic regions for maximum availability in case of e.g. a data center outage. The cost difference for our level of transactions and storage is mostly irrelevant at this point.
2. Links the existing Storage Account, containing the file(s) to be backed up, to this new Recovery Services Vault.
3. Creates an Azure File Share backup and retention policy: a daily snapshot taken at 14:00 UTC (roughly 6-7am Pacific), keeping 1 backup per day and 5 per week (1 for each weekday). The thinking here is we likely make changes throughout the day, so the snapshot will be at the beginning of a new day, capturing the end-state of any previous day's changes.

I also added a quick update to our Terraform docs for getting setup with a local `terraform.tfvars` file, which is required to run e.g. `terraform plan` locally.

## Relevant Azure docs

* [About Azure file share backup](https://learn.microsoft.com/en-us/azure/backup/azure-file-share-backup-overview)
* [Overview of share snapshots for Azure Files](https://learn.microsoft.com/en-us/azure/storage/files/storage-snapshots-files)
* [Manage Azure file share backups](https://learn.microsoft.com/en-us/azure/backup/manage-afs-backup)
* [Azure Storage redundancy](https://learn.microsoft.com/en-us/azure/storage/common/storage-redundancy)
* [Azure Files pricing](https://azure.microsoft.com/en-us/pricing/details/storage/files/)

## Relevant Terraform docs

* [`azurerm_recovery_services_vault`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/recovery_services_vault)
* [`azurerm_backup_container_storage_account`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/backup_container_storage_account)
* [`azurerm_backup_policy_file_share`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/backup_policy_file_share)