### PR TITLE
Refactor: use cal-itp/littlepay to check API access

### DIFF
--- a/.github/workflows/check-api.yml
+++ b/.github/workflows/check-api.yml
@@ -2,81 +2,39 @@ name: Check access to API
 
 on:
   workflow_dispatch:
-    inputs:
-      environment:
-        type: choice
-        description: Select the API environment
-        options: [all, prod, qa]
   schedule:
     - cron: "0 12 * * *"
 
 jobs:
   check-api:
     runs-on: ubuntu-latest
-    env:
-      SHOULD_RUN: |
-        ${{ github.event_name == 'schedule'
-        || github.event.inputs.environment == 'all'
-        || github.event.inputs.environment == matrix.name
-        }}
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - name: prod
-            cert: API_CHECK_PROD_CERT
-            key: API_CHECK_PROD_KEY
-            ca-cert: API_CHECK_PROD_CA_CERT
-            url: API_CHECK_PROD_URL
-            data: API_CHECK_PROD_DATA
-
-          - name: qa
-            cert: API_CHECK_QA_CERT
-            key: API_CHECK_QA_KEY
-            ca-cert: API_CHECK_QA_CA_CERT
-            url: API_CHECK_QA_URL
-            data: API_CHECK_QA_DATA
-
-    name: Check API endpoint (${{ matrix.name }})
+        participant: [mst, sacrt, sbmtd]
+        env: [qa, prod]
     steps:
-      - name: Echo workflow run information
+      - uses: actions/checkout@v4
+        with:
+          repository: "cal-itp/littlepay"
+
+      - name: Install the littlepay library
         run: |
-          echo "Triggering event name: ${{ github.event_name }}, \
-          APIs to check: ${{ github.event.inputs.environment }}"
+          python3 -m pip install --upgrade pip
+          pip install -e .
 
-      - name: Decode cert files
-        if: contains(env.SHOULD_RUN, 'true')
+      - name: Create config file and set config
         run: |
-          mkdir $RUNNER_TEMP/${{ matrix.name }}
-          temp_dir=$RUNNER_TEMP/${{ matrix.name }}
-
-          cat > $temp_dir/cert.pem <<- EOM
-          ${{ secrets[matrix.cert] }}
+          cat > config.yaml <<- EOM
+          ${{ secrets.API_CHECK_CONFIG }}
           EOM
+          littlepay config config.yaml
 
-          cat > $temp_dir/key.pem <<- EOM
-          ${{ secrets[matrix.key] }}
-          EOM
-
-          cat > $temp_dir/cacert.ca <<- EOM
-          ${{ secrets[matrix.ca-cert] }}
-          EOM
-
-      - name: Call API endpoint
-        if: contains(env.SHOULD_RUN, 'true')
+      - name: Run littlepay to get access token
         run: |
-          temp_dir=$RUNNER_TEMP/${{ matrix.name }}
-          curl -i --url ${{ secrets[matrix.url] }} \
-          --header 'Accept: application/json' \
-          --header 'Content-type: application/json' \
-          --data '${{ secrets[matrix.data] }}' \
-          --cert $temp_dir/cert.pem \
-          --key $temp_dir/key.pem \
-          --cacert $temp_dir/cacert.ca > $temp_dir/payload.txt
+          littlepay switch env ${{ matrix.env }}
+          littlepay switch participant ${{ matrix.participant }}
 
-          test $(head -n 1 $temp_dir/payload.txt | grep -o 201)
-
-      # https://www.ravsam.in/blog/send-slack-notification-when-github-actions-fails/#using-notify-slack-action
       - name: Report failure to Slack
         if: always()
         uses: ravsamhq/notify-slack-action@v2


### PR DESCRIPTION
Closes #1814 

This PR refactors the `check-api` workflow to use [cal-itp/littlepay](https://github.com/cal-itp/littlepay) instead. 

Like the previous implementation, this approach checks if it can get an access token for the QA and prod environments. Additionally it does those checks for each participant, as defined in the job matrix.

### Before merging
- [x] Copy contents of `config.yaml` for this API from LastPass, and add as a repository secret named `API_CHECK_CONFIG`

### Secrets cleanup to do
- [ ] Delete the old secrets used in the previous implementation