### PR TITLE
fix(docs): clean up front-matter

### DIFF
--- a/docs/enrollment-pathways/README.md
+++ b/docs/enrollment-pathways/README.md
@@ -19,7 +19,7 @@ See our Product Roadmap for more information on planned feature development and 
 ```mermaid
 timeline
 ---
-title Cal-ITP Benefits Product Roadmap
+title: Cal-ITP Benefits Product Roadmap
 ----
 %% Cal-ITP Benefits Epics (2024)
           section 2024


### PR DESCRIPTION
Front-matter should be in the form of

```yaml
---
key: value
---
```

This adds the colon to the title key