### PR TITLE
Fix: correct Google SSO secret names

### DIFF
--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -81,12 +81,12 @@ resource "azurerm_linux_web_app" "main" {
 
     # Google SSO for Admin
 
-    "GOOGLE_SSO_CLIENT_ID"         = "${local.secret_prefix}google-sso-client-id",
-    "GOOGLE_SSO_PROJECT_ID"        = "${local.secret_prefix}google-sso-project-id",
-    "GOOGLE_SSO_CLIENT_SECRET"     = "${local.secret_prefix}google-sso-client-secret",
-    "GOOGLE_SSO_ALLOWABLE_DOMAINS" = "${local.secret_prefix}google-sso-allowable-domains",
-    "GOOGLE_SSO_STAFF_LIST"        = "${local.secret_prefix}google-sso-staff-list",
-    "GOOGLE_SSO_SUPERUSER_LIST"    = "${local.secret_prefix}google-sso-superuser-list"
+    "GOOGLE_SSO_CLIENT_ID"         = "${local.secret_prefix}google-sso-client-id)",
+    "GOOGLE_SSO_PROJECT_ID"        = "${local.secret_prefix}google-sso-project-id)",
+    "GOOGLE_SSO_CLIENT_SECRET"     = "${local.secret_prefix}google-sso-client-secret)",
+    "GOOGLE_SSO_ALLOWABLE_DOMAINS" = "${local.secret_prefix}google-sso-allowable-domains)",
+    "GOOGLE_SSO_STAFF_LIST"        = "${local.secret_prefix}google-sso-staff-list)",
+    "GOOGLE_SSO_SUPERUSER_LIST"    = "${local.secret_prefix}google-sso-superuser-list)"
 
     # Sentry
     "SENTRY_DSN"                = "${local.secret_prefix}sentry-dsn)",


### PR DESCRIPTION
Quick follow-up to #1855 that was missed in review