### PR TITLE
Fix: sample env and reset_db helper

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -7,7 +7,6 @@ DJANGO_DB_DIR=.
 DJANGO_DB_FILE=django.db
 DJANGO_DB_FIXTURES="benefits/core/migrations/local_fixtures.json"
 
-testsecret=Hello from the local environment!
 auth_provider_client_id=benefits-oauth-client-id
 courtesy_card_verifier_api_auth_key=server-auth-token
 mobility_pass_verifier_api_auth_key=server-auth-token
@@ -22,3 +21,5 @@ sacrt_payment_processor_client_cert_root_ca='-----BEGIN CERTIFICATE-----\nPEM DA
 sbmtd_payment_processor_client_cert='-----BEGIN CERTIFICATE-----\nPEM DATA\n-----END CERTIFICATE-----'
 sbmtd_payment_processor_client_cert_private_key='-----BEGIN RSA PRIVATE KEY-----\nPEM DATA\n-----END RSA PRIVATE KEY-----'
 sbmtd_payment_processor_client_cert_root_ca='-----BEGIN CERTIFICATE-----\nPEM DATA\n-----END CERTIFICATE-----'
+
+testsecret="Hello from the local environment!"

--- a/bin/reset_db.sh
+++ b/bin/reset_db.sh
@@ -3,8 +3,6 @@ set -ex
 
 # whether to reset database file, defaults to true
 DB_RESET="${DJANGO_DB_RESET:-true}"
-# optional fixtures to import
-FIXTURES="${DJANGO_DB_FIXTURES}"
 
 if [[ $DB_RESET = true ]]; then
     # construct the path to the database file from environment or default
@@ -25,11 +23,11 @@ else
     echo "DB_RESET is false, skipping"
 fi
 
-valid_fixtures=$( echo $FIXTURES | grep -e fixtures\.json$ )
+valid_fixtures=$(echo "$DJANGO_DB_FIXTURES" | grep -e fixtures\.json$)
 
 if [[ -n "$valid_fixtures" ]]; then
     # load data fixtures
-    python manage.py loaddata "$FIXTURES"
+    python manage.py loaddata "$DJANGO_DB_FIXTURES"
 else
     echo "No JSON fixtures to load"
 fi


### PR DESCRIPTION
* wraps the sample secret value in quotes in `.env.sample` because bash can choke on the spaces
* fix an apparent syntax error in `bin/reset_db.sh` that was causing evaluation of the fixtures file to fail