### PR TITLE
Fix: remove duplicate dependabot pip check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,15 +14,6 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
-  - package-ecosystem: "pip"
-    directory: "/docs" # requirements.txt
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-    labels:
-      - "dependencies"
   - package-ecosystem: "github-actions"
     # Workflow files stored in the
     # default location of `.github/workflows`


### PR DESCRIPTION
It seems like the top-level check also handles our `docs/requirements.txt`

e.g. we got duplicate PRs for a docs update #1932 and #1933