### PR TITLE
Fix: path to coverage report

### DIFF
--- a/docs/tests/automated-tests.md
+++ b/docs/tests/automated-tests.md
@@ -77,4 +77,4 @@ The report files include a local `.gitignore` file, so the entire directory is h
 
 ### Latest coverage report
 
-We also make the latest (from `dev`) coverage report available online here: [Coverage report](./coverage)
+We also make the latest (from `dev`) coverage report available online here: [Coverage report](../coverage)


### PR DESCRIPTION
Fixing a 404 I noticed on our docs site:
<img src="https://github.com/cal-itp/benefits/assets/25497886/0cbed89a-f23e-42e0-b1a2-7ace09705dd4" width="450">

<img src="https://github.com/cal-itp/benefits/assets/25497886/4dc00d2d-ebac-4e6d-9482-8be059692e5e" width="450">



The `mkdocs.yml` GitHub workflow publishes the coverage report at [`docs/tests/coverage`](https://github.com/cal-itp/benefits/blob/2024.03.3/.github/workflows/mkdocs.yml#L100).

The link to the coverage report was on a page that got moved under `docs/tests/automated-tests` in https://github.com/cal-itp/benefits/commit/a5c63c54228209d94124f0725468ef79820da1f3, and we forgot to update the link.