### PR TITLE
Fix: allow custom media-item--heading tag

### DIFF
--- a/benefits/core/templates/core/includes/media-item.html
+++ b/benefits/core/templates/core/includes/media-item.html
@@ -4,10 +4,12 @@
         {% endblock icon %}
     </div>
     <div class="media-body">
-        <h3 class="media-body--heading">
+        {% block heading_wrapper %}
+            <{{ heading_tag|default:"h3" }} class="media-body--heading h3">
             {% block heading %}
             {% endblock heading %}
-        </h3>
+            </{{ heading_tag|default:"h3" }}>
+        {% endblock heading_wrapper %}
         {% block body %}
         {% endblock body %}
     </div>

--- a/benefits/enrollment/templates/enrollment/includes/media-item--bankcardcheck--index.html
+++ b/benefits/enrollment/templates/enrollment/includes/media-item--bankcardcheck--index.html
@@ -5,6 +5,10 @@
     {% include "core/includes/icon.html" with name="bankcardcheck" %}
 {% endblock icon %}
 
+{% block heading_wrapper %}
+    {% with heading_tag="h2" %}{{ block.super }}{% endwith %}
+{% endblock heading_wrapper %}
+
 {% block heading %}
     {% translate "The next step is to connect your contactless card to your transit benefit" %}
 {% endblock heading %}


### PR DESCRIPTION
Fixes #1975 

Previously `h3` was hard-coded as the heading tag for media items.

This caused a bug in `enrollment:index`, where heading levels skip from `h1` (the page title) to `h3` (the first media item).

In `eligibility:start` (the other place where media items are used), there is an intervening `h2` that keeps the order correct.

This change allows a child media item to override the heading tag, while maintaining the `h3` styling for all `.media-item--heading`, regardless of tag used.

The default tag remains `h3` if a child media item does not choose to override.

Found this answer on SO which showed that, with an extra wrapping `{% block %}`, context from the child can be passed up to the parent using `{% with %}`: https://stackoverflow.com/a/46581444 TIL!

## Before

### Eligibility start -- correct heading levels

![image](https://github.com/cal-itp/benefits/assets/1783439/11d01a4b-7f51-49d1-8f25-3888ff643856)

### Enrollment index -- `h2` is skipped

![image](https://github.com/cal-itp/benefits/assets/1783439/33945172-529d-4151-9661-2ec3d752e439)

## After

### Eligibility start -- correct heading levels

![image](https://github.com/cal-itp/benefits/assets/1783439/16d13abc-1fe0-45e4-9e92-46a22fe672cb)

### Enrollment index -- `.media-item--heading` is overridden to `h2`, styling remains the same

![image](https://github.com/cal-itp/benefits/assets/1783439/136e237f-7293-476c-be4e-3c6095cb8927)