### PR TITLE
Fix: enrollment expiry session

### DIFF
--- a/benefits/core/session.py
+++ b/benefits/core/session.py
@@ -180,6 +180,7 @@ def reset(request):
     request.session[_AGENCY] = None
     request.session[_ELIGIBILITY] = None
     request.session[_ORIGIN] = reverse("core:index")
+    request.session[_ENROLLMENT_EXP] = None
     request.session[_ENROLLMENT_TOKEN] = None
     request.session[_ENROLLMENT_TOKEN_EXP] = None
     request.session[_OAUTH_TOKEN] = None

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -139,6 +139,7 @@ template_ctx_processors = [
     "benefits.core.context_processors.active_agencies",
     "benefits.core.context_processors.analytics",
     "benefits.core.context_processors.authentication",
+    "benefits.core.context_processors.enrollment",
     "benefits.core.context_processors.origin",
 ]
 

--- a/tests/pytest/core/test_session.py
+++ b/tests/pytest/core/test_session.py
@@ -260,11 +260,14 @@ def test_reset_eligibility(app_request):
 
 @pytest.mark.django_db
 def test_reset_enrollment(app_request):
+    app_request.session[session._ENROLLMENT_EXP] = "1234567890"
     app_request.session[session._ENROLLMENT_TOKEN] = "enrollmenttoken123"
     app_request.session[session._ENROLLMENT_TOKEN_EXP] = "1234567890"
 
     session.reset(app_request)
 
+    assert session.enrollment_expiry(app_request) is None
+    assert session.enrollment_reenrollment(app_request) is None
     assert session.enrollment_token(app_request) is None
     assert session.enrollment_token_expiry(app_request) is None
     assert not session.enrollment_token_valid(app_request)


### PR DESCRIPTION
Quick follow-up to #1985 

* Forgot to activate the new context processor in `settings.py`
* Forgot to clear the enrollment expiry in `session.reset()`