### PR TITLE
Feat: CalFresh enrollment success with expiration

### DIFF
--- a/benefits/enrollment/templates/enrollment/success.html
+++ b/benefits/enrollment/templates/enrollment/success.html
@@ -21,10 +21,17 @@
   <div class="col-12 col-sm-12 col-lg-9">
     <div class="row flex-column-reverse flex-lg-row">
       <div class="col-12 col-lg-7">
-        <p class="pt-lg-4 mt-lg-3">
-          {% block success-message %}
-          {% endblock success-message %}
-        </p>
+        {# djlint:off #}
+        {% if enrollment.supports_expiration %}
+          <h2 class="h3 mb-1">{% translate "Your benefit will expire on" %} {{ enrollment.expires|date }}.</h2>
+          <p>
+        {% else %}
+          <p class="pt-lg-4 mt-lg-3">
+        {% endif %}
+            {% block success-message %}
+            {% endblock success-message %}
+          </p>
+        {# djlint:on #}
         <p class="pt-4">{% translate "Thank you for using Cal-ITP Benefits!" %}</p>
       </div>
       <div class="col-12 col-lg-5">

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -204,7 +204,11 @@ LOCALE_PATHS = [os.path.join(BASE_DIR, "benefits", "locale")]
 
 USE_I18N = True
 
-TIME_ZONE = "UTC"
+# See https://docs.djangoproject.com/en/5.0/ref/settings/#std-setting-TIME_ZONE
+# > Note that this isn’t necessarily the time zone of the server.
+# > When USE_TZ is True, this is the default time zone that Django will use to display datetimes in templates
+# > and to interpret datetimes entered in forms.
+TIME_ZONE = "America/Los_Angeles"
 USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)


### PR DESCRIPTION
Closes #1919 

## How to test

1. Temporarily change the [`context_processors.enrollment()`](https://github.com/cal-itp/benefits/blob/dev/benefits/core/context_processors.py#L75) to force a datetime for `expires`:

```diff
+ from datetime import datetime, timezone
...
- expiry = session.enrollment_expiry(request)
+ expiry = session.enrollment_expiry(request) or datetime.now(tz=timezone.utc)
```

2. In the Admin, update a flow that you can pass eligibility for to support expiration, e.g. MST Courtesy Cards
3. In the Admin, update the corresponding agency's PaymentProcessor to connect to the QA environment
4. Pass eligibility
5. Enroll a test credit card
6. See the new success page

## Screenshot - English

![image](https://github.com/cal-itp/benefits/assets/1783439/023c33a4-ab85-4f6d-a917-c546b0d892a9)

## Screenshot - Spanish

![image](https://github.com/cal-itp/benefits/assets/1783439/3254abc2-d3b6-46d3-bf28-4918e4f8f27f)
