### PR TITLE
Feat: enrollments can expire

### DIFF
--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -103,7 +103,10 @@ def index(request):
 
                 if not already_enrolled:
                     # enroll user with an expiration date, return success
-                    pass
+                    client.link_concession_group_funding_source(
+                        group_id=group_id, funding_source_id=funding_source.id, expiry_date=session.enrollment_expiry(request)
+                    )
+                    return _success(request, group_id)
                 else:
                     if has_no_expiration_date:
                         # update expiration of existing enrollment, return success

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -124,7 +124,12 @@ def index(request):
 
                         if is_expired or is_within_reenrollment_window:
                             # update expiration of existing enrollment, return success
-                            pass
+                            client.update_concession_group_funding_source_expiry(
+                                group_id=group_id,
+                                funding_source_id=funding_source.id,
+                                expiry_date=session.enrollment_expiry(request),
+                            )
+                            return _success(request, group_id)
                         else:
                             # re-enrollment error, return enrollment error with expiration and reenrollment_date
                             pass

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -92,12 +92,10 @@ def index(request):
             )
 
             already_enrolled = group_funding_source is not None
-            has_no_expiration_date = already_enrolled and group_funding_source.concession_expiry is None
-            has_expiration_date = already_enrolled and group_funding_source.concession_expiry is not None
 
             if eligibility.supports_expiration:
                 # set expiry on session
-                if has_expiration_date:
+                if already_enrolled and group_funding_source.concession_expiry is not None:
                     session.update(request, enrollment_expiry=group_funding_source.concession_expiry)
                 else:
                     session.update(request, enrollment_expiry=_calculate_expiry(eligibility.expiration_days))
@@ -108,8 +106,8 @@ def index(request):
                         group_id=group_id, funding_source_id=funding_source.id, expiry_date=session.enrollment_expiry(request)
                     )
                     return _success(request, group_id)
-                else:
-                    if has_no_expiration_date:
+                else:  # already_enrolled
+                    if group_funding_source.concession_expiry is None:
                         # update expiration of existing enrollment, return success
                         client.update_concession_group_funding_source_expiry(
                             group_id=group_id,
@@ -139,8 +137,8 @@ def index(request):
                     # enroll user with no expiration date, return success
                     client.link_concession_group_funding_source(group_id=group_id, funding_source_id=funding_source.id)
                     return _success(request, group_id)
-                else:
-                    if has_no_expiration_date:
+                else:  # already_enrolled
+                    if group_funding_source.concession_expiry is None:
                         # no action, return success
                         return _success(request, group_id)
                     else:

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -110,7 +110,12 @@ def index(request):
                 else:
                     if has_no_expiration_date:
                         # update expiration of existing enrollment, return success
-                        pass
+                        client.update_concession_group_funding_source_expiry(
+                            group_id=group_id,
+                            funding_source_id=funding_source.id,
+                            expiry_date=session.enrollment_expiry(request),
+                        )
+                        return _success(request, group_id)
                     else:
                         is_expired = _is_expired(group_funding_source.concession_expiry)
                         is_within_reenrollment_window = _is_within_reenrollment_window(

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -72,7 +72,6 @@ def index(request):
         if not form.is_valid():
             raise Exception("Invalid card token form")
 
-        logger.debug("Read tokenized card")
         card_token = form.cleaned_data.get("card_token")
 
         client = Client(

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -3,10 +3,12 @@ The enrollment application: view definitions for the benefits enrollment flow.
 """
 
 import logging
+from datetime import timedelta
 
 from django.http import JsonResponse
 from django.template.response import TemplateResponse
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.decorators import decorator_from_middleware
 from littlepay.api.client import Client
 from requests.exceptions import HTTPError
@@ -186,8 +188,13 @@ def _is_within_reenrollment_window(concession_expiry, enrollment_reenrollment_da
 
 
 def _calculate_expiry(expiration_days):
-    """Returns the expiry datetime."""
-    pass
+    """Returns the expiry datetime, which should be midnight in our configured timezone of the (N + 1)th day from now,
+    where N is expiration_days."""
+    default_time_zone = timezone.get_default_timezone()
+    expiry_date = timezone.localtime(timezone=default_time_zone) + timedelta(days=expiration_days + 1)
+    expiry_datetime = expiry_date.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    return expiry_datetime
 
 
 @decorator_from_middleware(EligibleSessionRequired)

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -144,7 +144,7 @@ def index(request):
                         return _success(request, group_id)
                     else:
                         # remove expiration date, return success
-                        pass
+                        raise NotImplementedError("Removing expiration date is currently not supported")
 
         except HTTPError as e:
             analytics.returned_error(request, str(e))

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -196,8 +196,8 @@ def _is_expired(concession_expiry):
 
 
 def _is_within_reenrollment_window(concession_expiry, enrollment_reenrollment_date):
-    """Returns whether the passed in datetime is within the reenrollment window."""
-    pass
+    """Returns if we are currently within the reenrollment window."""
+    return enrollment_reenrollment_date <= timezone.now() < concession_expiry
 
 
 def _calculate_expiry(expiration_days):

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -192,7 +192,7 @@ def _get_group_funding_source(client: Client, group_id, funding_source_id):
 
 def _is_expired(concession_expiry):
     """Returns whether the passed in datetime is expired or not."""
-    pass
+    return concession_expiry <= timezone.now()
 
 
 def _is_within_reenrollment_window(concession_expiry, enrollment_reenrollment_date):

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -28,6 +28,7 @@ ROUTE_RETRY = "enrollment:retry"
 ROUTE_SUCCESS = "enrollment:success"
 ROUTE_TOKEN = "enrollment:token"
 
+TEMPLATE_REENROLLMENT_ERROR = "enrollment/reenrollment-error.html"
 TEMPLATE_RETRY = "enrollment/retry.html"
 TEMPLATE_SUCCESS = "enrollment/success.html"
 
@@ -132,7 +133,7 @@ def index(request):
                             return _success(request, group_id)
                         else:
                             # re-enrollment error, return enrollment error with expiration and reenrollment_date
-                            pass
+                            return reenrollment_error(request)
             else:  # eligibility does not support expiration
                 if not already_enrolled:
                     # enroll user with no expiration date, return success
@@ -208,6 +209,12 @@ def _calculate_expiry(expiration_days):
     expiry_datetime = expiry_date.replace(hour=0, minute=0, second=0, microsecond=0)
 
     return expiry_datetime
+
+
+def reenrollment_error(request):
+    """View handler for a re-enrollment attempt that is not yet within the re-enrollment window."""
+    analytics.returned_error(request, "Re-enrollment error")
+    return TemplateResponse(request, TEMPLATE_REENROLLMENT_ERROR)
 
 
 @decorator_from_middleware(EligibleSessionRequired)

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -204,7 +204,11 @@ LOCALE_PATHS = [os.path.join(BASE_DIR, "benefits", "locale")]
 
 USE_I18N = True
 
-TIME_ZONE = "UTC"
+# See https://docs.djangoproject.com/en/5.0/ref/settings/#std-setting-TIME_ZONE
+# > Note that this isn’t necessarily the time zone of the server.
+# > When USE_TZ is True, this is the default time zone that Django will use to display datetimes in templates
+# > and to interpret datetimes entered in forms.
+TIME_ZONE = "America/Los_Angeles"
 USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)

--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -1,6 +1,7 @@
 from unittest.mock import create_autospec
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.middleware.locale import LocaleMiddleware
+from django.utils import timezone
 
 import pytest
 from pytest_socket import disable_socket
@@ -254,6 +255,15 @@ def mocked_session_eligibility(mocker, model_EligibilityType):
 @pytest.fixture
 def mocked_session_oauth_token(mocker):
     return mocker.patch("benefits.core.session.oauth_token", autospec=True, return_value="token")
+
+
+@pytest.fixture
+def mocked_session_enrollment_expiry(mocker):
+    return mocker.patch(
+        "benefits.core.session.enrollment_expiry",
+        autospec=True,
+        return_value=timezone.make_aware(timezone.datetime(2024, 1, 1), timezone=timezone.get_default_timezone()),
+    )
 
 
 @pytest.fixture

--- a/tests/pytest/enrollment/test_views.py
+++ b/tests/pytest/enrollment/test_views.py
@@ -273,6 +273,37 @@ def test_index_eligible_post_valid_form_success_supports_expiration(
 
 
 @pytest.mark.django_db
+@pytest.mark.usefixtures("mocked_session_agency", "mocked_session_verifier", "mocked_session_eligibility")
+def test_index_eligible_post_valid_form_success_supports_expiration_no_expiration(
+    mocker,
+    client,
+    card_tokenize_form_data,
+    mocked_analytics_module,
+    model_EligibilityType_supports_expiration,
+    mocked_funding_source,
+    mocked_group_funding_source_no_expiration,
+):
+    mock_client_cls = mocker.patch("benefits.enrollment.views.Client")
+    mock_client = mock_client_cls.return_value
+    mock_client.get_funding_source_by_token.return_value = mocked_funding_source
+
+    mocker.patch("benefits.enrollment.views._get_group_funding_source", return_value=mocked_group_funding_source_no_expiration)
+
+    path = reverse(ROUTE_INDEX)
+    response = client.post(path, card_tokenize_form_data)
+
+    mock_client.update_concession_group_funding_source_expiry.assert_called_once_with(
+        funding_source_id=mocked_funding_source.id,
+        group_id=model_EligibilityType_supports_expiration.group_id,
+        expiry_date=mocker.ANY,
+    )
+    assert response.status_code == 200
+    assert response.template_name == TEMPLATE_SUCCESS
+    mocked_analytics_module.returned_success.assert_called_once()
+    assert model_EligibilityType_supports_expiration.group_id in mocked_analytics_module.returned_success.call_args.args
+
+
+@pytest.mark.django_db
 def test_index_ineligible(client):
     path = reverse(ROUTE_INDEX)
 

--- a/tests/pytest/enrollment/test_views.py
+++ b/tests/pytest/enrollment/test_views.py
@@ -666,8 +666,8 @@ def test_success_no_verifier(client):
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("mocked_session_verifier_auth_required")
-def test_success_authentication_logged_in(mocker, client, model_TransitAgency):
+@pytest.mark.usefixtures("mocked_session_verifier_auth_required", "mocked_session_eligibility")
+def test_success_authentication_logged_in(mocker, client, model_TransitAgency, mocked_analytics_module):
     mock_session = mocker.patch("benefits.enrollment.views.session")
     mock_session.logged_in.return_value = True
     mock_session.agency.return_value = model_TransitAgency
@@ -678,11 +678,12 @@ def test_success_authentication_logged_in(mocker, client, model_TransitAgency):
     assert response.status_code == 200
     assert response.template_name == TEMPLATE_SUCCESS
     assert {"origin": reverse(ROUTE_LOGGED_OUT)} in mock_session.update.call_args
+    mocked_analytics_module.returned_success.assert_called_once()
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("mocked_session_verifier_auth_required")
-def test_success_authentication_not_logged_in(mocker, client, model_TransitAgency):
+@pytest.mark.usefixtures("mocked_session_verifier_auth_required", "mocked_session_eligibility")
+def test_success_authentication_not_logged_in(mocker, client, model_TransitAgency, mocked_analytics_module):
     mock_session = mocker.patch("benefits.enrollment.views.session")
     mock_session.logged_in.return_value = False
     mock_session.agency.return_value = model_TransitAgency
@@ -692,13 +693,15 @@ def test_success_authentication_not_logged_in(mocker, client, model_TransitAgenc
 
     assert response.status_code == 200
     assert response.template_name == TEMPLATE_SUCCESS
+    mocked_analytics_module.returned_success.assert_called_once()
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("mocked_session_agency", "mocked_session_verifier_auth_not_required")
-def test_success_no_authentication(client):
+@pytest.mark.usefixtures("mocked_session_agency", "mocked_session_verifier_auth_not_required", "mocked_session_eligibility")
+def test_success_no_authentication(client, mocked_analytics_module):
     path = reverse(ROUTE_SUCCESS)
     response = client.get(path)
 
     assert response.status_code == 200
     assert response.template_name == TEMPLATE_SUCCESS
+    mocked_analytics_module.returned_success.assert_called_once()

--- a/tests/pytest/enrollment/test_views.py
+++ b/tests/pytest/enrollment/test_views.py
@@ -292,6 +292,7 @@ def test_index_eligible_post_valid_form_success_supports_expiration(
     mocked_analytics_module,
     model_EligibilityType_supports_expiration,
     mocked_funding_source,
+    mocked_session_enrollment_expiry,
 ):
     mock_client_cls = mocker.patch("benefits.enrollment.views.Client")
     mock_client = mock_client_cls.return_value
@@ -303,7 +304,7 @@ def test_index_eligible_post_valid_form_success_supports_expiration(
     mock_client.link_concession_group_funding_source.assert_called_once_with(
         funding_source_id=mocked_funding_source.id,
         group_id=model_EligibilityType_supports_expiration.group_id,
-        expiry_date=mocker.ANY,
+        expiry_date=mocked_session_enrollment_expiry.return_value,
     )
     assert response.status_code == 200
     assert response.template_name == TEMPLATE_SUCCESS
@@ -321,6 +322,7 @@ def test_index_eligible_post_valid_form_success_supports_expiration_no_expiratio
     model_EligibilityType_supports_expiration,
     mocked_funding_source,
     mocked_group_funding_source_no_expiration,
+    mocked_session_enrollment_expiry,
 ):
     mock_client_cls = mocker.patch("benefits.enrollment.views.Client")
     mock_client = mock_client_cls.return_value
@@ -334,7 +336,7 @@ def test_index_eligible_post_valid_form_success_supports_expiration_no_expiratio
     mock_client.update_concession_group_funding_source_expiry.assert_called_once_with(
         funding_source_id=mocked_funding_source.id,
         group_id=model_EligibilityType_supports_expiration.group_id,
-        expiry_date=mocker.ANY,
+        expiry_date=mocked_session_enrollment_expiry.return_value,
     )
     assert response.status_code == 200
     assert response.template_name == TEMPLATE_SUCCESS
@@ -388,6 +390,7 @@ def test_index_eligible_post_valid_form_success_supports_expiration_is_expired(
     model_EligibilityType_supports_expiration,
     mocked_funding_source,
     mocked_group_funding_source_with_expiration,
+    mocked_session_enrollment_expiry,
 ):
     mock_client_cls = mocker.patch("benefits.enrollment.views.Client")
     mock_client = mock_client_cls.return_value
@@ -406,7 +409,7 @@ def test_index_eligible_post_valid_form_success_supports_expiration_is_expired(
     mock_client.update_concession_group_funding_source_expiry.assert_called_once_with(
         funding_source_id=mocked_funding_source.id,
         group_id=model_EligibilityType_supports_expiration.group_id,
-        expiry_date=mocker.ANY,
+        expiry_date=mocked_session_enrollment_expiry.return_value,
     )
     assert response.status_code == 200
     assert response.template_name == TEMPLATE_SUCCESS
@@ -499,6 +502,7 @@ def test_index_eligible_post_valid_form_success_supports_expiration_is_within_re
     model_EligibilityType_supports_expiration,
     mocked_funding_source,
     mocked_group_funding_source_with_expiration,
+    mocked_session_enrollment_expiry,
 ):
     mock_client_cls = mocker.patch("benefits.enrollment.views.Client")
     mock_client = mock_client_cls.return_value
@@ -517,7 +521,7 @@ def test_index_eligible_post_valid_form_success_supports_expiration_is_within_re
     mock_client.update_concession_group_funding_source_expiry.assert_called_once_with(
         funding_source_id=mocked_funding_source.id,
         group_id=model_EligibilityType_supports_expiration.group_id,
-        expiry_date=mocker.ANY,
+        expiry_date=mocked_session_enrollment_expiry.return_value,
     )
     assert response.status_code == 200
     assert response.template_name == TEMPLATE_SUCCESS

--- a/tests/pytest/enrollment/test_views.py
+++ b/tests/pytest/enrollment/test_views.py
@@ -60,7 +60,7 @@ def mocked_funding_source():
 
 
 @pytest.fixture
-def mocked_group_funding_source_no_expiration(mocked_funding_source):
+def mocked_group_funding_source_no_expiry(mocked_funding_source):
     return GroupFundingSourceResponse(
         id=mocked_funding_source.id,
         participant_id=mocked_funding_source.participant_id,
@@ -71,7 +71,7 @@ def mocked_group_funding_source_no_expiration(mocked_funding_source):
 
 
 @pytest.fixture
-def mocked_group_funding_source_with_expiration(mocked_funding_source):
+def mocked_group_funding_source_with_expiry(mocked_funding_source):
     return GroupFundingSourceResponse(
         id=mocked_funding_source.id,
         participant_id=mocked_funding_source.participant_id,
@@ -200,32 +200,32 @@ def test_get_group_funding_sources_funding_source_not_enrolled_yet(mocker, mocke
 @pytest.mark.django_db
 @pytest.mark.usefixtures("model_EligibilityType")
 def test_get_group_funding_sources_funding_source_already_enrolled(
-    mocker, mocked_funding_source, mocked_group_funding_source_no_expiration
+    mocker, mocked_funding_source, mocked_group_funding_source_no_expiry
 ):
     mock_client = mocker.Mock()
-    mock_client.get_concession_group_linked_funding_sources.return_value = [mocked_group_funding_source_no_expiration]
+    mock_client.get_concession_group_linked_funding_sources.return_value = [mocked_group_funding_source_no_expiry]
 
     matching_group_funding_source = _get_group_funding_source(mock_client, "group123", mocked_funding_source.id)
 
-    assert matching_group_funding_source == mocked_group_funding_source_no_expiration
+    assert matching_group_funding_source == mocked_group_funding_source_no_expiry
 
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_session_agency", "mocked_session_verifier", "mocked_session_eligibility")
-def test_index_eligible_post_valid_form_customer_already_enrolled(
+def test_index_eligible_post_valid_form_customer_already_enrolled_no_expiry(
     mocker,
     client,
     card_tokenize_form_data,
     mocked_analytics_module,
     model_EligibilityType,
     mocked_funding_source,
-    mocked_group_funding_source_no_expiration,
+    mocked_group_funding_source_no_expiry,
 ):
     mock_client_cls = mocker.patch("benefits.enrollment.views.Client")
     mock_client = mock_client_cls.return_value
     mock_client.get_funding_source_by_token.return_value = mocked_funding_source
 
-    mocker.patch("benefits.enrollment.views._get_group_funding_source", return_value=mocked_group_funding_source_no_expiration)
+    mocker.patch("benefits.enrollment.views._get_group_funding_source", return_value=mocked_group_funding_source_no_expiry)
 
     path = reverse(ROUTE_INDEX)
     response = client.post(path, card_tokenize_form_data)
@@ -238,7 +238,7 @@ def test_index_eligible_post_valid_form_customer_already_enrolled(
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_session_agency", "mocked_session_verifier", "mocked_session_eligibility")
-def test_index_eligible_post_valid_form_success(
+def test_index_eligible_post_valid_form_success_no_expiry(
     mocker, client, card_tokenize_form_data, mocked_analytics_module, model_EligibilityType, mocked_funding_source
 ):
     mock_client_cls = mocker.patch("benefits.enrollment.views.Client")
@@ -314,21 +314,21 @@ def test_index_eligible_post_valid_form_success_supports_expiration(
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_session_agency", "mocked_session_verifier", "mocked_session_eligibility")
-def test_index_eligible_post_valid_form_success_supports_expiration_no_expiration(
+def test_index_eligible_post_valid_form_success_supports_expiration_no_expiry(
     mocker,
     client,
     card_tokenize_form_data,
     mocked_analytics_module,
     model_EligibilityType_supports_expiration,
     mocked_funding_source,
-    mocked_group_funding_source_no_expiration,
+    mocked_group_funding_source_no_expiry,
     mocked_session_enrollment_expiry,
 ):
     mock_client_cls = mocker.patch("benefits.enrollment.views.Client")
     mock_client = mock_client_cls.return_value
     mock_client.get_funding_source_by_token.return_value = mocked_funding_source
 
-    mocker.patch("benefits.enrollment.views._get_group_funding_source", return_value=mocked_group_funding_source_no_expiration)
+    mocker.patch("benefits.enrollment.views._get_group_funding_source", return_value=mocked_group_funding_source_no_expiry)
 
     path = reverse(ROUTE_INDEX)
     response = client.post(path, card_tokenize_form_data)
@@ -389,7 +389,7 @@ def test_index_eligible_post_valid_form_success_supports_expiration_is_expired(
     mocked_analytics_module,
     model_EligibilityType_supports_expiration,
     mocked_funding_source,
-    mocked_group_funding_source_with_expiration,
+    mocked_group_funding_source_with_expiry,
     mocked_session_enrollment_expiry,
 ):
     mock_client_cls = mocker.patch("benefits.enrollment.views.Client")
@@ -397,9 +397,7 @@ def test_index_eligible_post_valid_form_success_supports_expiration_is_expired(
     mock_client.get_funding_source_by_token.return_value = mocked_funding_source
 
     # mock that a funding source already exists, doesn't matter what concession_expiry is
-    mocker.patch(
-        "benefits.enrollment.views._get_group_funding_source", return_value=mocked_group_funding_source_with_expiration
-    )
+    mocker.patch("benefits.enrollment.views._get_group_funding_source", return_value=mocked_group_funding_source_with_expiry)
 
     mocker.patch("benefits.enrollment.views._is_expired", return_value=True)
 
@@ -501,7 +499,7 @@ def test_index_eligible_post_valid_form_success_supports_expiration_is_within_re
     mocked_analytics_module,
     model_EligibilityType_supports_expiration,
     mocked_funding_source,
-    mocked_group_funding_source_with_expiration,
+    mocked_group_funding_source_with_expiry,
     mocked_session_enrollment_expiry,
 ):
     mock_client_cls = mocker.patch("benefits.enrollment.views.Client")
@@ -509,9 +507,7 @@ def test_index_eligible_post_valid_form_success_supports_expiration_is_within_re
     mock_client.get_funding_source_by_token.return_value = mocked_funding_source
 
     # mock that a funding source already exists, doesn't matter what concession_expiry is
-    mocker.patch(
-        "benefits.enrollment.views._get_group_funding_source", return_value=mocked_group_funding_source_with_expiration
-    )
+    mocker.patch("benefits.enrollment.views._get_group_funding_source", return_value=mocked_group_funding_source_with_expiry)
 
     mocker.patch("benefits.enrollment.views._is_within_reenrollment_window", return_value=True)
 
@@ -542,16 +538,14 @@ def test_index_eligible_post_valid_form_success_supports_expiration_is_not_expir
     card_tokenize_form_data,
     mocked_analytics_module,
     mocked_funding_source,
-    mocked_group_funding_source_with_expiration,
+    mocked_group_funding_source_with_expiry,
 ):
     mock_client_cls = mocker.patch("benefits.enrollment.views.Client")
     mock_client = mock_client_cls.return_value
     mock_client.get_funding_source_by_token.return_value = mocked_funding_source
 
     # mock that a funding source already exists, doesn't matter what concession_expiry is
-    mocker.patch(
-        "benefits.enrollment.views._get_group_funding_source", return_value=mocked_group_funding_source_with_expiration
-    )
+    mocker.patch("benefits.enrollment.views._get_group_funding_source", return_value=mocked_group_funding_source_with_expiry)
 
     mocker.patch("benefits.enrollment.views._is_expired", return_value=False)
     mocker.patch("benefits.enrollment.views._is_within_reenrollment_window", return_value=False)
@@ -573,16 +567,14 @@ def test_index_eligible_post_valid_form_success_does_not_support_expiration_has_
     mocked_analytics_module,
     model_EligibilityType,
     mocked_funding_source,
-    mocked_group_funding_source_with_expiration,
+    mocked_group_funding_source_with_expiry,
 ):
     mock_client_cls = mocker.patch("benefits.enrollment.views.Client")
     mock_client = mock_client_cls.return_value
     mock_client.get_funding_source_by_token.return_value = mocked_funding_source
 
     # mock that a funding source already exists, doesn't matter what concession_expiry is
-    mocker.patch(
-        "benefits.enrollment.views._get_group_funding_source", return_value=mocked_group_funding_source_with_expiration
-    )
+    mocker.patch("benefits.enrollment.views._get_group_funding_source", return_value=mocked_group_funding_source_with_expiry)
 
     path = reverse(ROUTE_INDEX)
     with pytest.raises(NotImplementedError):

--- a/tests/pytest/enrollment/test_views.py
+++ b/tests/pytest/enrollment/test_views.py
@@ -212,12 +212,12 @@ def test_get_group_funding_sources_funding_source_already_enrolled(
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_session_agency", "mocked_session_verifier", "mocked_session_eligibility")
-def test_index_eligible_post_valid_form_customer_already_enrolled_no_expiry(
+def test_index_eligible_post_valid_form_success_does_not_support_expiration_customer_already_enrolled_no_expiry(
     mocker,
     client,
     card_tokenize_form_data,
     mocked_analytics_module,
-    model_EligibilityType,
+    model_EligibilityType_does_not_support_expiration,
     mocked_funding_source,
     mocked_group_funding_source_no_expiry,
 ):
@@ -233,13 +233,20 @@ def test_index_eligible_post_valid_form_customer_already_enrolled_no_expiry(
     assert response.status_code == 200
     assert response.template_name == TEMPLATE_SUCCESS
     mocked_analytics_module.returned_success.assert_called_once()
-    assert model_EligibilityType.group_id in mocked_analytics_module.returned_success.call_args.args
+    assert (
+        model_EligibilityType_does_not_support_expiration.group_id in mocked_analytics_module.returned_success.call_args.args
+    )
 
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_session_agency", "mocked_session_verifier", "mocked_session_eligibility")
-def test_index_eligible_post_valid_form_success_no_expiry(
-    mocker, client, card_tokenize_form_data, mocked_analytics_module, model_EligibilityType, mocked_funding_source
+def test_index_eligible_post_valid_form_success_does_not_support_expiration_no_expiry(
+    mocker,
+    client,
+    card_tokenize_form_data,
+    mocked_analytics_module,
+    model_EligibilityType_does_not_support_expiration,
+    mocked_funding_source,
 ):
     mock_client_cls = mocker.patch("benefits.enrollment.views.Client")
     mock_client = mock_client_cls.return_value
@@ -249,12 +256,14 @@ def test_index_eligible_post_valid_form_success_no_expiry(
     response = client.post(path, card_tokenize_form_data)
 
     mock_client.link_concession_group_funding_source.assert_called_once_with(
-        funding_source_id=mocked_funding_source.id, group_id=model_EligibilityType.group_id
+        funding_source_id=mocked_funding_source.id, group_id=model_EligibilityType_does_not_support_expiration.group_id
     )
     assert response.status_code == 200
     assert response.template_name == TEMPLATE_SUCCESS
     mocked_analytics_module.returned_success.assert_called_once()
-    assert model_EligibilityType.group_id in mocked_analytics_module.returned_success.call_args.args
+    assert (
+        model_EligibilityType_does_not_support_expiration.group_id in mocked_analytics_module.returned_success.call_args.args
+    )
 
 
 def test_calculate_expiry():
@@ -565,7 +574,7 @@ def test_index_eligible_post_valid_form_success_does_not_support_expiration_has_
     client,
     card_tokenize_form_data,
     mocked_analytics_module,
-    model_EligibilityType,
+    model_EligibilityType_does_not_support_expiration,
     mocked_funding_source,
     mocked_group_funding_source_with_expiry,
 ):
@@ -584,13 +593,15 @@ def test_index_eligible_post_valid_form_success_does_not_support_expiration_has_
     #
     # mock_client.link_concession_group_funding_source.assert_called_once_with(
     #     funding_source_id=mocked_funding_source.id,
-    #     group_id=model_EligibilityType.group_id,
+    #     group_id=model_EligibilityType_does_not_support_expiration.group_id,
     #     expiry_date=None,
     # )
     # assert response.status_code == 200
     # assert response.template_name == TEMPLATE_SUCCESS
     # mocked_analytics_module.returned_success.assert_called_once()
-    # assert model_EligibilityType.group_id in mocked_analytics_module.returned_success.call_args.args
+    # assert (
+    #     model_EligibilityType_does_not_support_expiration.group_id in mocked_analytics_module.returned_success.call_args.args
+    # )
 
 
 @pytest.mark.django_db

--- a/tests/pytest/enrollment/test_views.py
+++ b/tests/pytest/enrollment/test_views.py
@@ -500,6 +500,43 @@ def test_index_eligible_post_valid_form_success_supports_expiration_is_within_re
 
 
 @pytest.mark.django_db
+@pytest.mark.usefixtures("mocked_session_agency", "mocked_session_verifier", "mocked_session_eligibility")
+def test_index_eligible_post_valid_form_success_does_not_support_expiration_has_expiration_date(
+    mocker,
+    client,
+    card_tokenize_form_data,
+    mocked_analytics_module,
+    model_EligibilityType,
+    mocked_funding_source,
+    mocked_group_funding_source_with_expiration,
+):
+    mock_client_cls = mocker.patch("benefits.enrollment.views.Client")
+    mock_client = mock_client_cls.return_value
+    mock_client.get_funding_source_by_token.return_value = mocked_funding_source
+
+    # mock that a funding source already exists, doesn't matter what concession_expiry is
+    mocker.patch(
+        "benefits.enrollment.views._get_group_funding_source", return_value=mocked_group_funding_source_with_expiration
+    )
+
+    path = reverse(ROUTE_INDEX)
+    with pytest.raises(NotImplementedError):
+        client.post(path, card_tokenize_form_data)
+
+    # this is what we would assert if removing expiration were supported
+    #
+    # mock_client.link_concession_group_funding_source.assert_called_once_with(
+    #     funding_source_id=mocked_funding_source.id,
+    #     group_id=model_EligibilityType.group_id,
+    #     expiry_date=None,
+    # )
+    # assert response.status_code == 200
+    # assert response.template_name == TEMPLATE_SUCCESS
+    # mocked_analytics_module.returned_success.assert_called_once()
+    # assert model_EligibilityType.group_id in mocked_analytics_module.returned_success.call_args.args
+
+
+@pytest.mark.django_db
 def test_index_ineligible(client):
     path = reverse(ROUTE_INDEX)
 


### PR DESCRIPTION
Closes #1877

This PR refactors the enrollment phase so that we no longer catch a 409 error to detect existing enrollments. Instead we see if the enrollment already exists for the group. This also allows us to inspect the expiration date of any existing enrollment.

So this PR also introduces support for enrollments that expire. See the table below for expected behavior.

# Combinations of states and their expected outcomes
_copied directly from [our dev meeting notes](https://docs.google.com/document/d/1vActZALSbRwO0HxDvm-YQK37p22SPbL4XuMdcRx-BI8/edit#heading=h.1qwtpkwx040s)_

<details><summary>Expand to view table</summary>

| Eligibility state           | Enrollment state | Expiration state                | Expected enrollment outcome              | Expected end page for user       |
| --------------------------- | ---------------- | ------------------------------- | ---------------------------------------- | -------------------------------- |
| Supports expiration         | Not enrolled     | No expiration                   | User can enroll, expiration date set     | Enrollment success               |
| Supports expiration         | Not enrolled     | Future expiration               | This state should not be possible        | N/A                              |
| Supports expiration         | Not enrolled     | Re-enrollment window expiration | This state should not be possible        | N/A                              |
| Supports expiration         | Not enrolled     | Past expiration                 | This state should not be possible        | N/A                              |
| Supports expiration         | Enrolled         | No expiration                   | Update expiration of existing enrollment | Enrollment success               |
| Supports expiration         | Enrolled         | Future expiration               | Re-enrollment error                      | Enrollment error with expiration |
| Supports expiration         | Enrolled         | Re-enrollment window expiration | Update expiration of existing enrollment | Enrollment success               |
| Supports expiration         | Enrolled         | Past expiration                 | Update expiration of existing enrollment | Enrollment success               |
| Does not support expiration | Not enrolled     | No expiration                   | User can enroll, no expiration date set  | Enrollment success               |
| Does not support expiration | Not enrolled     | Future expiration               | This state should not be possible        | N/A                              |
| Does not support expiration | Not enrolled     | Re-enrollment window expiration | This state should not be possible        | N/A                              |
| Does not support expiration | Not enrolled     | Past expiration                 | This state should not be possible        | N/A                              |
| Does not support expiration | Enrolled         | No expiration                   | No action                                | Enrollment success               |
| Does not support expiration | Enrolled         | Future expiration               | Remove expiration date                   | Enrollment success               |
| Does not support expiration | Enrolled         | Re-enrollment window expiration | Remove expiration date                   | Enrollment success               |
| Does not support expiration | Enrolled         | Past expiration                 | Remove expiration date                   | Enrollment success               |

</details>

# Some functions to be familiar with

In Python 3.9+, the standard library includes [`zoneinfo`](https://docs.python.org/3/library/zoneinfo.html) for working with time zones.

Django has a [`django.utils.timezone`](https://docs.djangoproject.com/en/5.0/ref/utils/#module-django.utils.timezone) module that exposes convenience methods for working with the built-in Python `datetime` module and incorporates its own [`USES_TZ`](https://docs.djangoproject.com/en/5.0/ref/settings/#std-setting-USE_TZ) and [`TIMEZONE`](https://docs.djangoproject.com/en/5.0/ref/settings/#std-setting-TIME_ZONE) settings. Because of that, I did not need to use `zoneinfo` (or `pytz` which was a popular option before `zoneinfo` was a thing).

I thought it might be helpful to write out brief summaries of how the functions below are useful in this PR.

## _Used in application code_

### [`django.utils.timezone.now()`](https://docs.djangoproject.com/en/5.0/ref/utils/#django.utils.timezone.now)
This function creates a standard Python `datetime.datetime` object representing the current point in time. 

More importantly, if `USE_TZ` is `True`, `timezone.now()` will return an aware `datetime` with UTC as its timezone. 

Benefits has `USE_TZ` set to `True`, so we can rely on this as an easy way to make an aware "now" `datetime` , for example in `_is_expired` and `_is_within_reenrollment_date`.

### [`django.utils.timezone.localtime(value=None, timezone=None)`](https://docs.djangoproject.com/en/5.0/ref/utils/#django.utils.timezone.localtime)
This function lets you give it an aware `datetime` and converts it to the `timezone` that you pass in.

If you don't give it a `value`, it will use `timezone.now()` for `value`.

This was useful for calculating the expiration date since we want to make sure the expiration time is midnight Pacific Time.

### [`django.utils.timezone.get_default_timezone()`](https://docs.djangoproject.com/en/5.0/ref/utils/#django.utils.timezone.get_default_timezone)
This function returns what you set the `TIME_ZONE` setting to, which Django refers to as the ["default time zone"](https://docs.djangoproject.com/en/5.0/topics/i18n/timezones/#default-time-zone-and-current-time-zone).

In this PR, we set Benefits's default timezone to `America/Los_Angeles`. This means we can call `timezone.get_default_timezone` and give it to `timezone.localtime` to create an aware `datetime` that is in Pacific Time.

_Aside_: "current time zone" is initially the same as the default time zone. If you call [`timezone.activate`](https://docs.djangoproject.com/en/5.0/ref/utils/#django.utils.timezone.activate) with some other time zone, that's when they'd be different. The way I think about this is that it's for cases like, for example, if we gave the user a drop-down of timezones and set their selection as the "current time zone" for their requests to the server. With that understanding, we can see that we don't want to use "current time zone" to calculate the expiration date.

## _Used only in test code_

### [`django.utils.timezone.make_aware(value, timezone=None)`](https://docs.djangoproject.com/en/5.0/ref/utils/#django.utils.timezone.make_aware)

This function lets you give it a naive `datetime` and a timezone to make an aware `datetime`. This is useful when you need a specific datetime, which I needed for testing.  If there is a more succinct way to do this, I'm open to it.