### PR TITLE
Fix: catch grep failure so reset script doesn't die

### DIFF
--- a/bin/reset_db.sh
+++ b/bin/reset_db.sh
@@ -23,7 +23,7 @@ else
     echo "DB_RESET is false, skipping"
 fi
 
-valid_fixtures=$(echo "$DJANGO_DB_FIXTURES" | grep -e fixtures\.json$)
+valid_fixtures=$(echo "$DJANGO_DB_FIXTURES" | grep -e fixtures\.json$ || test $? = 1)
 
 if [[ -n "$valid_fixtures" ]]; then
     # load data fixtures


### PR DESCRIPTION
With `-e`, the script returns an error code whenever any command does so, which can cause the rest of the Dev Container setup to fail.

`grep` returns an error code when no match is found, but we don't want that to end the script in error, so test the `grep` return code

See https://stackoverflow.com/a/49627999/453168