### PR TITLE
Updated initial agency launch date for MST

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ The following California transit agencies have launched Cal-ITP Benefits for the
 
 | Transit agency                                  | Older adults | Agency card | Veterans | Initial agency launch |
 | ----------------------------------------------- | ------------ | ----------- | -------- | --------------------- |
-| **Monterey-Salinas Transit**                    | Live         | Live        | Live     | 05/2021               |
+| **Monterey-Salinas Transit**                    | Live         | Live        | Live     | 12/2021               |
 | **Santa Barbara Metropolitan Transit District** | Live         | Live        |          | 10/2023               |
 | **Sacramento Regional Transit District**        | In test      |             |          |                       |
 


### PR DESCRIPTION
As part of the effort to backfill enrollment data from the early days of Benefits when we used the DMV for eligibility verification, @thekaveman did some research to determine the date of our official deployment of Benefits for MST. We're using [this release](https://github.com/cal-itp/benefits/tree/2021.12.0) to denote launch. I updated the documentation accordingly.