### PR TITLE
fix(docker): remove platform attribute from server service

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -38,7 +38,6 @@ services:
   server:
     image: ghcr.io/cal-itp/eligibility-server:dev
     env_file: .devcontainer/server/.env.server
-    platform: linux/amd64
     ports:
       - "8000"
     volumes:


### PR DESCRIPTION
Since `ghcr.io/cal-itp/eligibility-server:dev` is now a multi-platform image (built off the multi-platform `ghcr.io/cal-itp/docker-python-web:main` image), the `platform` attribute is no longer needed.