### PR TITLE
Fix: unnecessary space on required form field label

### DIFF
--- a/benefits/core/templates/core/includes/form.html
+++ b/benefits/core/templates/core/includes/form.html
@@ -11,12 +11,12 @@
         {% for field in form %}
           <div class="row form-group mb-0">
             <div class="col-12">
+              {# djlint:off #}
               {% if field.label %}
-                <label for="{{ field.id_for_label }}" class="form-control-label">
-                  {{ field.label }}
-                  {% if field.field.required %}<span class="required-label text-body">*</span>{% endif %}
-                </label>
+              <label for="{{ field.id_for_label }}" class="form-control-label">{{ field.label }}{% if field.field.required %}<span class="required-label text-body">*</span>{% endif %}
+              </label>
               {% endif %}
+              {# djlint:on #}
 
               {{ field }}
 


### PR DESCRIPTION
Fixes #2033 

djlint was re-formatting the HTML to put the `label` element on separate lines. However, this caused there to be whitespace surrounding the text for the field label.

This PR disables djlint for the form's `label` elements and removes the whitespace. See [djlint docs](https://djlint.com/docs/ignoring-code/) on ignoring code.

The built-in [`spaceless` tag](https://docs.djangoproject.com/en/5.0/ref/templates/builtins/#spaceless) from Django was close to what we needed except that it doesn't remove whitespace between tags and text.