### PR TITLE
Chore: update enrollment retry page

### DIFF
--- a/benefits/enrollment/templates/enrollment/retry.html
+++ b/benefits/enrollment/templates/enrollment/retry.html
@@ -12,7 +12,7 @@
 
   <div class="container">
     <h1 class="h2 text-center">
-      <span class="icon d-block pb-5">{% include "core/includes/icon.html" with name="bankcardquestion" %}</span>
+      <span class="icon d-block pb-4">{% include "core/includes/icon.html" with name="bankcardquestion" %}</span>
       {% translate "The card information may not have been entered correctly." %}
     </h1>
 

--- a/benefits/enrollment/templates/enrollment/retry.html
+++ b/benefits/enrollment/templates/enrollment/retry.html
@@ -13,12 +13,12 @@
   <div class="container">
     <h1 class="h2 text-center">
       <span class="icon d-block pb-5">{% include "core/includes/icon.html" with name="bankcardquestion" %}</span>
-      {% translate "We couldn’t connect your card" %}
+      {% translate "The card information may not have been entered correctly." %}
     </h1>
 
     <div class="row justify-content-center">
       <div class="col-lg-8 pt-4">
-        <p>{% translate "You can try again or reach out to your transit provider for assistance." %}</p>
+        <p>{% translate "Please check the details on your card and try again, or contact your transit agency for help." %}</p>
       </div>
     </div>
 

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -212,17 +212,8 @@ def reenrollment_error(request):
 @decorator_from_middleware(EligibleSessionRequired)
 def retry(request):
     """View handler for a recoverable failure condition."""
-    if request.method == "POST":
-        analytics.returned_retry(request)
-        form = forms.CardTokenizeFailForm(request.POST)
-        if form.is_valid():
-            return TemplateResponse(request, TEMPLATE_RETRY)
-        else:
-            analytics.returned_error(request, "Invalid retry submission.")
-            raise Exception("Invalid retry submission.")
-    else:
-        analytics.returned_error(request, "This view method only supports POST.")
-        raise Exception("This view method only supports POST.")
+    analytics.returned_retry(request)
+    return TemplateResponse(request, TEMPLATE_RETRY)
 
 
 @pageview_decorator

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2024-04-18 14:01-0700\n"
+"POT-Creation-Date: 2024-04-18 14:27-0700\n"
 "Language: English\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -587,10 +587,12 @@ msgstr ""
 msgid "Unable to register card"
 msgstr ""
 
-msgid "We couldn’t connect your card"
+msgid "The card information may not have been entered correctly."
 msgstr ""
 
-msgid "You can try again or reach out to your transit provider for assistance."
+msgid ""
+"Please check the details on your card and try again, or contact your transit "
+"agency for help."
 msgstr ""
 
 msgid "Try again"

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2024-04-18 14:01-0700\n"
+"POT-Creation-Date: 2024-04-18 14:27-0700\n"
 "Language: Español\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -705,13 +705,13 @@ msgstr "Conecta su tarjeta"
 msgid "Unable to register card"
 msgstr "No se pudo registrar la tarjeta"
 
-msgid "We couldn’t connect your card"
-msgstr "No pudimos conectar su tarjeta"
-
-msgid "You can try again or reach out to your transit provider for assistance."
+msgid "The card information may not have been entered correctly."
 msgstr ""
-"Puede intentarlo de nuevo o comunicarse con su proveedor de transporte local "
-"para obtener ayuda."
+
+msgid ""
+"Please check the details on your card and try again, or contact your transit "
+"agency for help."
+msgstr ""
 
 msgid "Try again"
 msgstr "Intentar otra vez"

--- a/tests/pytest/enrollment/test_views.py
+++ b/tests/pytest/enrollment/test_views.py
@@ -623,28 +623,19 @@ def test_retry_ineligible(client):
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("mocked_session_eligibility")
-def test_retry_get(client):
+@pytest.mark.usefixtures("mocked_session_agency", "mocked_session_eligibility")
+def test_retry_get(client, mocked_analytics_module):
     path = reverse(ROUTE_RETRY)
-    with pytest.raises(Exception, match=r"POST"):
-        client.get(path)
+    response = client.get(path)
 
-
-@pytest.mark.django_db
-@pytest.mark.usefixtures("mocked_session_eligibility")
-def test_retry_invalid_form(mocker, client):
-    mocker.patch("benefits.enrollment.views.forms.CardTokenizeFailForm.is_valid", return_value=False)
-
-    path = reverse(ROUTE_RETRY)
-    with pytest.raises(Exception, match=r"Invalid"):
-        client.post(path)
+    assert response.status_code == 200
+    assert response.template_name == TEMPLATE_RETRY
+    mocked_analytics_module.returned_retry.assert_called_once()
 
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_session_agency", "mocked_session_eligibility")
-def test_retry_valid_form(mocker, client, mocked_analytics_module):
-    mocker.patch("benefits.enrollment.views.forms.CardTokenizeFailForm.is_valid", return_value=True)
-
+def test_retry_valid_form(client, mocked_analytics_module):
     path = reverse(ROUTE_RETRY)
     response = client.post(path)
 


### PR DESCRIPTION
Closes #2031 

The `/retry` page was functioning as both our "user" enrollment error page (i.e. #2031) and our "system" enrollment error page (i.e. #2032).

This PR updates the language so the page is more explicitly for "user" enrollment errors.

#2032 will have to make additional changes e.g. by creating a new route/template.

This PR also simplifies the view logic of `/retry`, to remove the unnecessary blocking of `GET` requests to that endpoint (which makes testing easier).

_Current on top of #2039_

## Reviewing

1. Launch the app locally
2. Verify eligibility for any flow
3. One verified, visit `/enrollment/retry`
4. See the updated copy and design