### PR TITLE
Feat: add properties for UTM codes

### DIFF
--- a/benefits/core/analytics.py
+++ b/benefits/core/analytics.py
@@ -92,6 +92,18 @@ class ViewedPageEvent(Event):
 
     def __init__(self, request):
         super().__init__(request, "viewed page")
+        # Add UTM codes
+        utm_campaign = request.GET.get("utm_campaign")
+        utm_source = request.GET.get("utm_source")
+        utm_medium = request.GET.get("utm_medium")
+        utm_content = request.GET.get("utm_content")
+        utm_id = request.GET.get("utm_id")
+        self.update_event_properties(
+            utm_campaign=utm_campaign, utm_source=utm_source, utm_medium=utm_medium, utm_content=utm_content, utm_id=utm_id
+        )
+        self.update_user_properties(
+            utm_campaign=utm_campaign, utm_source=utm_source, utm_medium=utm_medium, utm_content=utm_content, utm_id=utm_id
+        )
 
 
 class ChangedLanguageEvent(Event):

--- a/tests/pytest/core/test_analytics.py
+++ b/tests/pytest/core/test_analytics.py
@@ -1,7 +1,41 @@
 import pytest
 
 import benefits.core.analytics
-from benefits.core.analytics import Event
+from benefits.core.analytics import Event, ViewedPageEvent
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.middleware.locale import LocaleMiddleware
+
+
+@pytest.fixture
+def app_request_utm(rf):
+    """
+    Fixture creates and initializes a new Django request object similar to a real application request with UTM codes.
+    """
+    # create a request for the path with UTM codes, initialize
+    app_request = rf.get(
+        "/some/arbitrary/path?utm_campaign=campaign&utm_source=source&utm_medium=medium&utm_content=content&utm_id=id"
+    )
+
+    # https://stackoverflow.com/a/55530933/358804
+    middleware = [SessionMiddleware(lambda x: x), LocaleMiddleware(lambda x: x)]
+    for m in middleware:
+        m.process_request(app_request)
+
+    app_request.session.save()
+    benefits.core.analytics.session.reset(app_request)
+
+    return app_request
+
+
+@pytest.fixture
+def utm_code_data():
+    return {
+        "utm_campaign": "campaign",
+        "utm_source": "source",
+        "utm_medium": "medium",
+        "utm_content": "content",
+        "utm_id": "id",
+    }
 
 
 @pytest.mark.django_db
@@ -80,3 +114,21 @@ def test_Event_update_user_properties(app_request):
 
     assert key in event.user_properties
     assert event.user_properties[key] == value
+
+
+@pytest.mark.django_db
+def test_ViewedPageEvent_with_UTM(app_request_utm, utm_code_data):
+    event = ViewedPageEvent(app_request_utm)
+
+    for key, value in utm_code_data.items():
+        assert event.event_properties[key] == value
+        assert event.user_properties[key] == value
+
+
+@pytest.mark.django_db
+def test_ViewedPageEvent_without_UTM(app_request, utm_code_data):
+    event = ViewedPageEvent(app_request)
+
+    for key in utm_code_data:
+        assert event.event_properties[key] is None
+        assert event.user_properties[key] is None


### PR DESCRIPTION
Closes #2034.

Uses [request.GET.get()](https://docs.djangoproject.com/en/5.0/ref/request-response/#django.http.QueryDict.get) to get the UTM code. If a UTM code is not present in the query string, returns `null` for that UTM code.
## How to test

Using a local instance of `benefits`, send a request that looks something like `http://localhost:port/?utm_campaign=transit`. Verify that the property `utm_campaign` has been added to `event_properties` and `user_properties`.

| Browser | Debug Message |
|---|---|
| ![image](https://github.com/cal-itp/benefits/assets/20033812/25b599f0-1a71-4aef-87dd-a2d9632c60cd) | ![image](https://github.com/cal-itp/benefits/assets/20033812/fc1d8dfe-3811-40e4-9d13-64aefcad2b42) |