### PR TITLE
Fix: model cleanups for the Admin

### DIFF
--- a/benefits/core/models.py
+++ b/benefits/core/models.py
@@ -100,6 +100,9 @@ class AuthProvider(models.Model):
     def client_id(self):
         return get_secret_by_name(self.client_id_secret_name)
 
+    def __str__(self) -> str:
+        return self.client_name
+
 
 class EligibilityType(models.Model):
     """A single conditional eligibility type."""

--- a/benefits/core/models.py
+++ b/benefits/core/models.py
@@ -37,8 +37,6 @@ class SecretNameField(models.SlugField):
         # although the validator also checks for a max length of 127
         # this setting enforces the length at the database column level as well
         kwargs["max_length"] = 127
-        # similar to max_length, enforce at the field (form) validation level to not allow blanks
-        kwargs["blank"] = False
         # the default is False, but this is more explicit
         kwargs["allow_unicode"] = False
         super().__init__(*args, **kwargs)

--- a/tests/pytest/core/test_models.py
+++ b/tests/pytest/core/test_models.py
@@ -96,6 +96,7 @@ def test_PemData_data_text_secret_name_and_remote__uses_remote(
 def test_model_AuthProvider(model_AuthProvider):
     assert not model_AuthProvider.supports_claims_verification
     assert model_AuthProvider.supports_sign_out
+    assert str(model_AuthProvider) == model_AuthProvider.client_name
 
 
 @pytest.mark.django_db

--- a/tests/pytest/core/test_models.py
+++ b/tests/pytest/core/test_models.py
@@ -25,6 +25,13 @@ def test_SecretNameField_init():
     assert field.description != ""
 
 
+def test_SecretNameField_init_null_blank():
+    field = SecretNameField(blank=True, null=True)
+
+    assert field.blank is True
+    assert field.null is True
+
+
 @pytest.mark.django_db
 def test_PemData_str(model_PemData):
     assert str(model_PemData) == model_PemData.label


### PR DESCRIPTION
Closes #2065
* implements the `__str__` method on `AuthProvider` so it gets a human-readable label in the Admin

Closes #2072 
* removes the override of `blank = False` from `SecretNameField` to prevent validation errors in the Admin