### PR TITLE
CI: initialize Dependabot PR effort to 1

### DIFF
--- a/.github/workflows/add-to-project-dependabot.yml
+++ b/.github/workflows/add-to-project-dependabot.yml
@@ -14,3 +14,11 @@ jobs:
         with:
           project-url: https://github.com/orgs/cal-itp/projects/${{ secrets.GH_PROJECT }}
           github-token: ${{ secrets.GH_PROJECTS_TOKEN }}
+
+      - uses: EndBug/project-fields@v2
+        with:
+          operation: set
+          fields: Effort
+          values: 1
+          project-url: https://github.com/orgs/cal-itp/projects/${{ secrets.GH_PROJECT }}
+          github-token: ${{ secrets.GH_PROJECTS_TOKEN }}


### PR DESCRIPTION
This is a good default and can always be adjusted. I usually set this manually on just about every Dependabot PR :upside_down_face: 