### PR TITLE
Feat: system enrollment error - 500 error when linking

### DIFF
--- a/benefits/enrollment/templates/enrollment/system_error.html
+++ b/benefits/enrollment/templates/enrollment/system_error.html
@@ -6,7 +6,7 @@
 {% endblock classes %}
 
 {% block page-title %}
-  {% translate "System enrollment error" %}
+  {% translate "Enrollment system down" %}
 {% endblock page-title %}
 
 {% block main-content %}
@@ -18,12 +18,14 @@
 
     <div class="row justify-content-center">
       <div class="col-lg-8 pt-4">
-        <p>{% translate "We’re working to solve the problem. Please wait 48 hours and try to enroll again, or contact your transit agency for help." %}</p>
+        <p>
+          {% translate "We’re working to solve the problem. Please wait 48 hours and try to enroll again, or contact your transit agency for help." %}
+        </p>
       </div>
     </div>
 
     <div class="row justify-content-center">
-        <div class="col-lg-8">{% include "core/includes/agency-links.html" %}</div>
+      <div class="col-lg-8">{% include "core/includes/agency-links.html" %}</div>
     </div>
 
     <div class="row pt-8 justify-content-center">
@@ -32,7 +34,7 @@
           {% url "oauth:logout" as sign_out_url %}
           {% translate "Sign out of" as button_text %}
           <a href="{{ sign_out_url }}" class="btn btn-lg btn-primary login">
-          {{ button_text }} <span class="fallback-text white-logo">Login.gov</span>
+            {{ button_text }} <span class="fallback-text white-logo">Login.gov</span>
           </a>
         {% else %}
           {% include "core/includes/button--origin.html" %}

--- a/benefits/enrollment/templates/enrollment/system_error.html
+++ b/benefits/enrollment/templates/enrollment/system_error.html
@@ -1,0 +1,43 @@
+{% extends "core/base.html" %}
+{% load i18n %}
+
+{% block classes %}
+  {{ block.super | add:" system-enrollment-error" }}
+{% endblock classes %}
+
+{% block page-title %}
+  {% translate "System enrollment error" %}
+{% endblock page-title %}
+
+{% block main-content %}
+  <div class="container">
+    <h1 class="h2 text-center">
+      <span class="icon d-block pb-4">{% include "core/includes/icon.html" with name="bankcardquestion" %}</span>
+      {% translate "Our enrollment system is not working right now." %}
+    </h1>
+
+    <div class="row justify-content-center">
+      <div class="col-lg-8 pt-4">
+        <p>{% translate "We’re working to solve the problem. Please wait 48 hours and try to enroll again, or contact your transit agency for help." %}</p>
+      </div>
+    </div>
+
+    <div class="row justify-content-center">
+        <div class="col-lg-8">{% include "core/includes/agency-links.html" %}</div>
+    </div>
+
+    <div class="row pt-8 justify-content-center">
+      <div class="col-lg-3 col-8">
+        {% if authentication and authentication.sign_out_link_template %}
+          {% url "oauth:logout" as sign_out_url %}
+          {% translate "Sign out of" as button_text %}
+          <a href="{{ sign_out_url }}" class="btn btn-lg btn-primary login">
+          {{ button_text }} <span class="fallback-text white-logo">Login.gov</span>
+          </a>
+        {% else %}
+          {% include "core/includes/button--origin.html" %}
+        {% endif %}
+      </div>
+    </div>
+  </div>
+{% endblock main-content %}

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -10,6 +10,7 @@ from django.urls import reverse
 from django.utils.decorators import decorator_from_middleware
 from littlepay.api.client import Client
 from requests.exceptions import HTTPError
+import sentry_sdk
 
 from benefits.core import session
 from benefits.core.middleware import EligibleSessionRequired, VerifierSessionRequired, pageview_decorator
@@ -90,6 +91,7 @@ def index(request):
                 return success(request)
             elif e.response.status_code >= 500:
                 analytics.returned_error(request, str(e))
+                sentry_sdk.capture_exception(e)
 
                 # overwrite origin so that CTA takes user to agency index
                 session.update(request, origin=agency.index_url)

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -90,6 +90,9 @@ def index(request):
                 return success(request)
             elif e.response.status_code >= 500:
                 analytics.returned_error(request, str(e))
+
+                # overwrite origin so that CTA takes user to agency index
+                session.update(request, origin=agency.index_url)
                 return system_error(request)
             else:
                 analytics.returned_error(request, str(e))

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -24,6 +24,7 @@ ROUTE_SUCCESS = "enrollment:success"
 ROUTE_TOKEN = "enrollment:token"
 
 TEMPLATE_RETRY = "enrollment/retry.html"
+TEMPLATE_SYSTEM_ERROR = "enrollment/system_error.html"
 
 
 logger = logging.getLogger(__name__)
@@ -87,6 +88,9 @@ def index(request):
             if e.response.status_code == 409:
                 analytics.returned_success(request, eligibility.group_id)
                 return success(request)
+            elif e.response.status_code >= 500:
+                analytics.returned_error(request, str(e))
+                return system_error(request)
             else:
                 analytics.returned_error(request, str(e))
                 raise Exception(f"{e}: {e.response.json()}")
@@ -142,6 +146,12 @@ def retry(request):
     """View handler for a recoverable failure condition."""
     analytics.returned_retry(request)
     return TemplateResponse(request, TEMPLATE_RETRY)
+
+
+@decorator_from_middleware(EligibleSessionRequired)
+def system_error(request):
+    """View handler for an enrollment system error."""
+    return TemplateResponse(request, TEMPLATE_SYSTEM_ERROR)
 
 
 @pageview_decorator

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -93,8 +93,6 @@ def index(request):
                 analytics.returned_error(request, str(e))
                 sentry_sdk.capture_exception(e)
 
-                # overwrite origin so that CTA takes user to agency index
-                session.update(request, origin=agency.index_url)
                 return system_error(request)
             else:
                 analytics.returned_error(request, str(e))
@@ -156,6 +154,11 @@ def retry(request):
 @decorator_from_middleware(EligibleSessionRequired)
 def system_error(request):
     """View handler for an enrollment system error."""
+
+    # overwrite origin so that CTA takes user to agency index
+    agency = session.agency(request)
+    session.update(request, origin=agency.index_url)
+
     return TemplateResponse(request, TEMPLATE_SYSTEM_ERROR)
 
 

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2024-05-16 19:45+0000\n"
+"POT-Creation-Date: 2024-05-20 21:48+0000\n"
 "Language: English\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -706,7 +706,7 @@ msgstr ""
 msgid "If you are on a public or shared computer, don’t forget to sign out of "
 msgstr ""
 
-msgid "System enrollment error"
+msgid "Enrollment system down"
 msgstr ""
 
 msgid "Our enrollment system is not working right now."

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -706,6 +706,20 @@ msgstr ""
 msgid "If you are on a public or shared computer, don’t forget to sign out of "
 msgstr ""
 
+msgid "System enrollment error"
+msgstr ""
+
+msgid "Our enrollment system is not working right now."
+msgstr ""
+
+msgid ""
+"We’re working to solve the problem. Please wait 48 hours and try to enroll "
+"again, or contact your transit agency for help."
+msgstr ""
+
+msgid "Sign out of"
+msgstr ""
+
 msgid "Start over"
 msgstr ""
 

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2024-05-16 19:45+0000\n"
+"POT-Creation-Date: 2024-05-20 21:48+0000\n"
 "Language: Español\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -897,19 +897,22 @@ msgid "If you are on a public or shared computer, don’t forget to sign out of 
 msgstr ""
 "Si está en una computadora pública o compartida, no olvide cerrar sesión en "
 
-msgid "System enrollment error"
-msgstr ""
+msgid "Enrollment system down"
+msgstr "El sistema de inscripción no funciona"
 
 msgid "Our enrollment system is not working right now."
-msgstr ""
+msgstr "Nuestro sistema de inscripción no está funcionando en este momento."
 
 msgid ""
 "We’re working to solve the problem. Please wait 48 hours and try to enroll "
 "again, or contact your transit agency for help."
 msgstr ""
+"Estamos trabajando para resolver el problema. Espere 48 horas e intente "
+"inscribirse nuevamente, o contacte a su agencia de tránsito para obtener "
+"ayuda."
 
 msgid "Sign out of"
-msgstr ""
+msgstr "Cierre sesión de"
 
 msgid "Start over"
 msgstr "Comenzar de nuevo"

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -897,6 +897,20 @@ msgid "If you are on a public or shared computer, don’t forget to sign out of 
 msgstr ""
 "Si está en una computadora pública o compartida, no olvide cerrar sesión en "
 
+msgid "System enrollment error"
+msgstr ""
+
+msgid "Our enrollment system is not working right now."
+msgstr ""
+
+msgid ""
+"We’re working to solve the problem. Please wait 48 hours and try to enroll "
+"again, or contact your transit agency for help."
+msgstr ""
+
+msgid "Sign out of"
+msgstr ""
+
 msgid "Start over"
 msgstr "Comenzar de nuevo"
 

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -470,9 +470,10 @@ footer .footer-links li a.footer-link:visited {
   }
 }
 
-/* Sign in with Login.gov (white logo) on Eligibility Start */
+/* Sign in with Login.gov (white logo) on Eligibility Start, System Enrollment Error */
 
-.eligibility-start .btn.btn-lg.btn-primary.login {
+.eligibility-start .btn.btn-lg.btn-primary.login,
+.system-enrollment-error .btn.btn-lg.btn-primary.login {
   padding: 10px 0;
 }
 

--- a/benefits/templates/error.html
+++ b/benefits/templates/error.html
@@ -8,7 +8,7 @@
 
 {% block main-content %}
   <div class="container">
-    <h1 class="icon-title h2 text-center">
+    <h1 class="h2 text-center">
       <span class="icon d-block pb-4">{% include "core/includes/icon.html" with name="sadbus" %}</span>
       {% block headline %}
       {% endblock headline %}

--- a/tests/pytest/enrollment/test_views.py
+++ b/tests/pytest/enrollment/test_views.py
@@ -14,6 +14,7 @@ from benefits.enrollment.views import (
     ROUTE_RETRY,
     ROUTE_SUCCESS,
     ROUTE_TOKEN,
+    TEMPLATE_SYSTEM_ERROR,
     TEMPLATE_RETRY,
 )
 
@@ -124,12 +125,36 @@ def test_index_eligible_post_invalid_form(client, invalid_form_data):
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize("status_code", [500, 501, 502, 503, 504])
 @pytest.mark.usefixtures("mocked_session_agency", "mocked_session_eligibility")
-def test_index_eligible_post_valid_form_http_error(mocker, client, card_tokenize_form_data):
+def test_index_eligible_post_valid_form_http_error_500(
+    mocker, client, mocked_analytics_module, card_tokenize_form_data, status_code
+):
     mock_client_cls = mocker.patch("benefits.enrollment.views.Client")
     mock_client = mock_client_cls.return_value
 
-    # any status_code that isn't 409 is considered an error
+    mock_error = {"message": "Mock error message"}
+    mock_error_response = mocker.Mock(status_code=status_code, **mock_error)
+    mock_error_response.json.return_value = mock_error
+    mock_client.link_concession_group_funding_source.side_effect = HTTPError(
+        response=mock_error_response,
+    )
+
+    path = reverse(ROUTE_INDEX)
+    response = client.post(path, card_tokenize_form_data)
+
+    assert response.status_code == 200
+    assert response.template_name == TEMPLATE_SYSTEM_ERROR
+    mocked_analytics_module.returned_error.assert_called_once()
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("mocked_session_agency", "mocked_session_eligibility")
+def test_index_eligible_post_valid_form_http_error_400(mocker, client, card_tokenize_form_data):
+    mock_client_cls = mocker.patch("benefits.enrollment.views.Client")
+    mock_client = mock_client_cls.return_value
+
+    # any 400 level status_code that isn't 409 is considered an error
     mock_error = {"message": "Mock error message"}
     mock_error_response = mocker.Mock(status_code=400, **mock_error)
     mock_error_response.json.return_value = mock_error

--- a/tests/pytest/enrollment/test_views.py
+++ b/tests/pytest/enrollment/test_views.py
@@ -35,6 +35,11 @@ def mocked_analytics_module(mocked_analytics_module):
 
 
 @pytest.fixture
+def mocked_sentry_sdk_module(mocker):
+    return mocker.patch.object(benefits.enrollment.views, "sentry_sdk")
+
+
+@pytest.fixture
 def mocked_funding_source():
     return FundingSourceResponse(
         id="0",
@@ -128,7 +133,7 @@ def test_index_eligible_post_invalid_form(client, invalid_form_data):
 @pytest.mark.parametrize("status_code", [500, 501, 502, 503, 504])
 @pytest.mark.usefixtures("mocked_session_agency", "mocked_session_eligibility")
 def test_index_eligible_post_valid_form_http_error_500(
-    mocker, client, mocked_analytics_module, card_tokenize_form_data, status_code
+    mocker, client, mocked_analytics_module, mocked_sentry_sdk_module, card_tokenize_form_data, status_code
 ):
     mock_client_cls = mocker.patch("benefits.enrollment.views.Client")
     mock_client = mock_client_cls.return_value
@@ -146,6 +151,7 @@ def test_index_eligible_post_valid_form_http_error_500(
     assert response.status_code == 200
     assert response.template_name == TEMPLATE_SYSTEM_ERROR
     mocked_analytics_module.returned_error.assert_called_once()
+    mocked_sentry_sdk_module.capture_exception.assert_called_once()
 
 
 @pytest.mark.django_db

--- a/tests/pytest/enrollment/test_views.py
+++ b/tests/pytest/enrollment/test_views.py
@@ -131,10 +131,19 @@ def test_index_eligible_post_invalid_form(client, invalid_form_data):
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("status_code", [500, 501, 502, 503, 504])
-@pytest.mark.usefixtures("mocked_session_agency", "mocked_session_eligibility")
+@pytest.mark.usefixtures("mocked_session_eligibility")
 def test_index_eligible_post_valid_form_http_error_500(
-    mocker, client, mocked_analytics_module, mocked_sentry_sdk_module, card_tokenize_form_data, status_code
+    mocker,
+    client,
+    mocked_session_agency,
+    mocked_analytics_module,
+    mocked_sentry_sdk_module,
+    card_tokenize_form_data,
+    status_code,
 ):
+    mock_session = mocker.patch("benefits.enrollment.views.session")
+    mock_session.agency.return_value = mocked_session_agency.return_value
+
     mock_client_cls = mocker.patch("benefits.enrollment.views.Client")
     mock_client = mock_client_cls.return_value
 
@@ -150,6 +159,7 @@ def test_index_eligible_post_valid_form_http_error_500(
 
     assert response.status_code == 200
     assert response.template_name == TEMPLATE_SYSTEM_ERROR
+    assert {"origin": mocked_session_agency.return_value.index_url} in mock_session.update.call_args
     mocked_analytics_module.returned_error.assert_called_once()
     mocked_sentry_sdk_module.capture_exception.assert_called_once()
 


### PR DESCRIPTION
Part of #2032 

This PR implements the system enrollment error page template and adds error-handling to the `benefits.enrollment.views.index` function so that if a 500-level HTTP error occurs when we try to link a funding source to a group, the system enrollment error page will be shown. The CTA takes the user back to the agency index.

A Sentry notification will be sent - see [an example from my testing](https://sentry.calitp.org/organizations/sentry/issues/75377/?project=3&referrer=slack). **Note:** since I don't know how to cause an actual 500 error with the linking endpoint, I had to add some code locally to fake it (more details in steps for reviewing / testing).

### Screenshots
<details><summary>Expand</summary>

| Desktop | Mobile |
| --- | --- |
| ![image](https://github.com/cal-itp/benefits/assets/25497886/44ef562f-6a66-4bd8-84ca-ee180c3c5e7d) | ![image](https://github.com/cal-itp/benefits/assets/25497886/932e0e10-bfdc-4e27-87c9-76b813f93b67) |
| ![image](https://github.com/cal-itp/benefits/assets/25497886/00a7734f-8720-497e-8ad5-f7214742c442) | ![image](https://github.com/cal-itp/benefits/assets/25497886/d51783ff-bb5d-4eb9-a8ea-eb4835f81538) |


</details>

### Steps for reviewing / testing

To simulate a 500-level HTTP error, I added this to my `index` function:
```diff
       try:
+           class response:
+               def __init__(self):
+                   self.status_code = 500
+           raise HTTPError(response=response())
            client.link_concession_group_funding_source(funding_source_id=funding_source.id, group_id=eligibility.group_id)
        except HTTPError as e:
```

Then run through a Login.gov flow and non-Login.gov flow all the way through enrollment as normal to see the system enrollment error page.