### PR TITLE
Feat: system enrollment error - 500 error during /token

### DIFF
--- a/benefits/enrollment/analytics.py
+++ b/benefits/enrollment/analytics.py
@@ -16,6 +16,15 @@ class ReturnedEnrollmentEvent(core.Event):
             self.update_event_properties(payment_group=payment_group)
 
 
+class FailedAccessTokenRequestEvent(core.Event):
+    """Analytics event representing a failure to acquire an access token for card tokenization."""
+
+    def __init__(self, request, status_code=None):
+        super().__init__(request, "failed access token request")
+        if status_code is not None:
+            self.update_event_properties(status_code=status_code)
+
+
 def returned_error(request, error):
     """Send the "returned enrollment" analytics event with an error status and message."""
     core.send_event(ReturnedEnrollmentEvent(request, status="error", error=error))
@@ -29,3 +38,8 @@ def returned_retry(request):
 def returned_success(request, payment_group):
     """Send the "returned enrollment" analytics event with a success status."""
     core.send_event(ReturnedEnrollmentEvent(request, status="success", payment_group=payment_group))
+
+
+def failed_access_token_request(request, status_code=None):
+    """Send the "failed access token request" analytics event with the response status code."""
+    core.send_event(FailedAccessTokenRequestEvent(request, status_code=status_code))

--- a/benefits/enrollment/templates/enrollment/index.html
+++ b/benefits/enrollment/templates/enrollment/index.html
@@ -41,6 +41,12 @@
       $.ajax({ dataType: "script", attrs: { nonce: "{{ request.csp_nonce }}"}, url: "{{ card_tokenize_url }}" })
           .done(function() {
           $.get("{{ access_token_url }}", function(data) {
+              if (data.redirect) {
+                // https://stackoverflow.com/a/42469170
+                // use 'assign' because 'replace' was giving strange Back button behavior
+                window.location.assign(data.redirect);
+              }
+
               $(".loading").remove();
               // remove invisible and add back visible, so we aren't left with
               // a div with an empty class attribute

--- a/benefits/enrollment/urls.py
+++ b/benefits/enrollment/urls.py
@@ -15,4 +15,5 @@ urlpatterns = [
     path("reenrollment-error", views.reenrollment_error, name="reenrollment-error"),
     path("retry", views.retry, name="retry"),
     path("success", views.success, name="success"),
+    path("error", views.system_error, name="system-error"),
 ]

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -50,6 +50,7 @@ def token(request):
             response = client.request_card_tokenization_access()
         except Exception as e:
             if isinstance(e, HTTPError) and e.response.status_code >= 500:
+                analytics.failed_access_token_request(request, e.response.status_code)
                 sentry_sdk.capture_exception(e)
                 data = {"redirect": reverse(ROUTE_SYSTEM_ERROR)}
                 return JsonResponse(data)

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -49,9 +49,10 @@ def token(request):
         try:
             response = client.request_card_tokenization_access()
         except Exception as e:
+            sentry_sdk.capture_exception(e)
+
             if isinstance(e, HTTPError) and e.response.status_code >= 500:
                 analytics.failed_access_token_request(request, e.response.status_code)
-                sentry_sdk.capture_exception(e)
                 data = {"redirect": reverse(ROUTE_SYSTEM_ERROR)}
                 return JsonResponse(data)
             else:

--- a/tests/pytest/enrollment/test_analytics.py
+++ b/tests/pytest/enrollment/test_analytics.py
@@ -1,0 +1,10 @@
+import pytest
+
+from benefits.enrollment.analytics import FailedAccessTokenRequestEvent
+
+
+@pytest.mark.django_db
+def test_FailedAccessTokenRequestEvent_sets_status_code(app_request):
+    event = FailedAccessTokenRequestEvent(app_request, 500)
+
+    assert event.event_properties["status_code"] == 500

--- a/tests/pytest/enrollment/test_views.py
+++ b/tests/pytest/enrollment/test_views.py
@@ -13,6 +13,7 @@ from benefits.enrollment.views import (
     ROUTE_REENROLLMENT_ERROR,
     ROUTE_RETRY,
     ROUTE_SUCCESS,
+    ROUTE_SYSTEM_ERROR,
     ROUTE_TOKEN,
     TEMPLATE_SYSTEM_ERROR,
     TEMPLATE_RETRY,
@@ -100,6 +101,31 @@ def test_token_valid(mocker, client):
     data = response.json()
     assert "token" in data
     assert data["token"] == "enrollment_token"
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("mocked_session_agency", "mocked_session_eligibility")
+def test_token_http_error_500(mocker, client):
+    mocker.patch("benefits.core.session.enrollment_token_valid", return_value=False)
+
+    mock_client_cls = mocker.patch("benefits.enrollment.views.Client")
+    mock_client = mock_client_cls.return_value
+
+    mock_error = {"message": "Mock error message"}
+    mock_error_response = mocker.Mock(status_code=500, **mock_error)
+    mock_error_response.json.return_value = mock_error
+    mock_client.request_card_tokenization_access.side_effect = HTTPError(
+        response=mock_error_response,
+    )
+
+    path = reverse(ROUTE_TOKEN)
+    response = client.get(path)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "token" not in data
+    assert "redirect" in data
+    assert data["redirect"] == reverse(ROUTE_SYSTEM_ERROR)
 
 
 @pytest.mark.django_db

--- a/tests/pytest/enrollment/test_views.py
+++ b/tests/pytest/enrollment/test_views.py
@@ -105,7 +105,7 @@ def test_token_valid(mocker, client):
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_session_agency", "mocked_session_eligibility")
-def test_token_http_error_500(mocker, client):
+def test_token_http_error_500(mocker, client, mocked_analytics_module):
     mocker.patch("benefits.core.session.enrollment_token_valid", return_value=False)
 
     mock_client_cls = mocker.patch("benefits.enrollment.views.Client")
@@ -126,6 +126,8 @@ def test_token_http_error_500(mocker, client):
     assert "token" not in data
     assert "redirect" in data
     assert data["redirect"] == reverse(ROUTE_SYSTEM_ERROR)
+    mocked_analytics_module.failed_access_token_request.assert_called_once()
+    assert 500 in mocked_analytics_module.failed_access_token_request.call_args.args
 
 
 @pytest.mark.django_db

--- a/tests/pytest/enrollment/test_views.py
+++ b/tests/pytest/enrollment/test_views.py
@@ -105,7 +105,7 @@ def test_token_valid(mocker, client):
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_session_agency", "mocked_session_eligibility")
-def test_token_http_error_500(mocker, client, mocked_analytics_module):
+def test_token_http_error_500(mocker, client, mocked_analytics_module, mocked_sentry_sdk_module):
     mocker.patch("benefits.core.session.enrollment_token_valid", return_value=False)
 
     mock_client_cls = mocker.patch("benefits.enrollment.views.Client")
@@ -128,6 +128,7 @@ def test_token_http_error_500(mocker, client, mocked_analytics_module):
     assert data["redirect"] == reverse(ROUTE_SYSTEM_ERROR)
     mocked_analytics_module.failed_access_token_request.assert_called_once()
     assert 500 in mocked_analytics_module.failed_access_token_request.call_args.args
+    mocked_sentry_sdk_module.capture_exception.assert_called_once()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Part of #2032 

 - [x] 500-level error that occurs during `/token` returns a JSON response that is used to send user to `/enrollment/error`
 - [x] `/enrollment/error` shows system enrollment error template
 - [x] Sentry notification is sent
 - [x] Analytic event is sent (`failed access token request` with `status_code` in `event_properties`)

### Reviewing / testing
Similar to review steps for #2088, you can add some code locally to simulate a 500 error.
To `/token`, add:
```diff
        try:
+          class response:
+             def __init__(self):
+                self.status_code = 500
+
+          raise HTTPError(response=response())
           response = client.request_card_tokenization_access()
        except Exception as e:
```
