### PR TITLE
Fix: correct syntax in field update step

### DIFF
--- a/.github/workflows/add-to-project-dependabot.yml
+++ b/.github/workflows/add-to-project-dependabot.yml
@@ -20,5 +20,5 @@ jobs:
           operation: set
           fields: Effort
           values: 1
-          project-url: https://github.com/orgs/cal-itp/projects/${{ secrets.GH_PROJECT }}
-          github-token: ${{ secrets.GH_PROJECTS_TOKEN }}
+          project_url: https://github.com/orgs/cal-itp/projects/${{ secrets.GH_PROJECT }}
+          github_token: ${{ secrets.GH_PROJECTS_TOKEN }}


### PR DESCRIPTION
Quick follow-up to #2083 -- the step inputs use underscores, not dashes: https://github.com/EndBug/project-fields?tab=readme-ov-file#inputs