### PR TITLE
Fix: allow mkdocs preview job to write comments on PRs

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -29,6 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     # only pull requests should generate a preview
     if: github.event.pull_request
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This permission is needed to allow the step that adds a comment with the preview URL