### PR TITLE
Feat: Spanish translations for 500, user enrollment error

### DIFF
--- a/benefits/enrollment/templates/enrollment/retry.html
+++ b/benefits/enrollment/templates/enrollment/retry.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% block page-title %}
-  {% translate "Unable to register card" %}
+  {% translate "Unable to enroll card" %}
 {% endblock page-title %}
 
 {% block main-content %}

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -633,7 +633,7 @@ msgstr ""
 msgid "You are still enrolled in this benefit"
 msgstr ""
 
-msgid "Unable to register card"
+msgid "Unable to enroll card"
 msgstr ""
 
 msgid "The card information may not have been entered correctly."

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -875,9 +875,11 @@ msgstr ""
 "exista."
 
 msgid "We’re working on fixing a problem."
-msgstr ""
+msgstr "Estamos trabajando para solucionar un problema."
 
 msgid ""
 "There is a problem with the Benefits application, and we’re working to fix "
 "it. Please try again in a little while."
 msgstr ""
+"Hay un problema con la aplicación de Beneficios y estamos trabajando para "
+"solucionarlo. Inténtelo más tarde en un rato."

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -776,8 +776,8 @@ msgstr "Error de inscripción"
 msgid "You are still enrolled in this benefit"
 msgstr "Todavía está inscrito en este beneficio"
 
-msgid "Unable to register card"
-msgstr "No se pudo registrar la tarjeta"
+msgid "Unable to enroll card"
+msgstr "No se pudo inscribir la tarjeta"
 
 msgid "The card information may not have been entered correctly."
 msgstr ""

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -781,11 +781,15 @@ msgstr "No se pudo inscribir la tarjeta"
 
 msgid "The card information may not have been entered correctly."
 msgstr ""
+"Es posible que la información de la tarjeta no se haya ingresado "
+"correctamente."
 
 msgid ""
 "Please check the details on your card and try again, or contact your transit "
 "agency for help."
 msgstr ""
+"Verifique los datos de tu tarjeta e inténtelo de nuevo, o contacte a su "
+"agencia de tránsito para obtener ayuda."
 
 msgid ""
 "You were not charged anything today. When boarding an MST fixed route bus, "


### PR DESCRIPTION
Part of #2074 

Rows 21, 161, 205-207 of `forTranslation` tab.