### PR TITLE
Chore: update docs on tagging a release

### DIFF
--- a/docs/deployment/release.md
+++ b/docs/deployment/release.md
@@ -88,7 +88,11 @@ git checkout prod
 git reset --hard origin/prod
 
 git tag -a YYYY.0M.R
+```
 
+Git will open your default text editor and prompt you for the tag annotation. For the tag annotation, use the title of the `release`-tagged Issue that kicked off the release. Finally, after closing the text editor:
+
+```bash
 git push origin YYYY.0M.R
 ```
 

--- a/docs/deployment/release.md
+++ b/docs/deployment/release.md
@@ -87,7 +87,7 @@ git checkout prod
 
 git reset --hard origin/prod
 
-git tag YYYY.0M.R
+git tag -a YYYY.0M.R
 
 git push origin YYYY.0M.R
 ```


### PR DESCRIPTION
We have been using annotated tags, so this updates our docs to reflect that.