### PR TITLE
CI: deploy Azure Web App with GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,3 +62,10 @@ jobs:
           file: appcontainer/Dockerfile
           push: true
           tags: ghcr.io/${{ github.repository }}:${{ github.sha }}
+
+      - name: Deploy to Azure Web App
+        uses: azure/webapps-deploy@v2
+        with:
+          app-name: ${{ vars.AZURE_WEBAPP_NAME }}
+          images: ghcr.io/${{ github.repository }}:${{ github.sha }}
+          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,6 +61,4 @@ jobs:
           context: .
           file: appcontainer/Dockerfile
           push: true
-          tags: |
-            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
-            ghcr.io/${{ github.repository }}:${{ github.sha }}
+          tags: ghcr.io/${{ github.repository }}:${{ github.sha }}


### PR DESCRIPTION
Closes #1880 

This PR replaces usage of GitHub webhooks for the `package.publish` event that trigger the Azure Web App image pull + restart, with the [`azure/webapps-deploy`](https://github.com/Azure/webapps-deploy/) action step. Using this actions step, we can target the specific Web App (e.g. `dev`, `test`, or `prod`) that needs to be deployed/restarted, and avoid the current situation where the `package.publish` event triggers a restart in all 3 environments, regardless of which branch/environment was deployed.

Use of a Publish Profile avoids needing a Microsoft Entra ID generated Service Principle.

Following the outline on [Deploy a custom container to App Service using GitHub Actions](https://learn.microsoft.com/en-us/azure/app-service/deploy-container-github-action?tabs=publish-profile).

## Post-merge follow-up

### `dev`

- [ ] Delete the webhook

### `test`

- [ ] Turn off webhook deploys (e.g. the `Container Registry` option) in the [Azure App Service "Deployment Center"](https://portal.azure.com/#@digitalca.onmicrosoft.com/resource/subscriptions/9bdb8e29-156f-4fc9-a1fe-1bb6a915a4f0/resourceGroups/RG-CDT-PUB-VIP-CALITP-T-001/providers/Microsoft.Web/sites/AS-CDT-PUB-VIP-CALITP-T-001/vstscd); instead choose the `GitHub Actions` option
- [ ] Fill in details for `GitHub Actions` deploy; don't generate a workflow file, we'll use the existing one
- [x] Create an environment variable `AZURE_WEBAPP_NAME` to hold the name of the Azure App Service, `AS-CDT-PUB-VIP-CALITP-T-001`
- [x] Create an environment secret `AZURE_WEBAPP_PUBLISH_PROFILE` to hold the contents of the Publish Profile for this App Service
- [ ] Delete the webhook

### `prod`

- [ ] Turn off webhook deploys (e.g. the `Container Registry` option) in the [Azure App Service "Deployment Center"](https://portal.azure.com/#@digitalca.onmicrosoft.com/resource/subscriptions/005fa005-b981-47d8-8b39-5b82adf6569c/resourceGroups/RG-CDT-PUB-VIP-CALITP-P-001/providers/Microsoft.Web/sites/AS-CDT-PUB-VIP-CALITP-P-001/vstscd); instead choose the `GitHub Actions` option
- [ ] Fill in details for `GitHub Actions` deploy; don't generate a workflow file, we'll use the existing one
- [x] Create an environment variable `AZURE_WEBAPP_NAME` to hold the name of the Azure App Service, `AS-CDT-PUB-VIP-CALITP-P-001`
- [x] Create an environment secret `AZURE_WEBAPP_PUBLISH_PROFILE` to hold the contents of the Publish Profile for this App Service
- [ ] Delete the webhook