### PR TITLE
Refactor: use integer claims in OAuth

### DIFF
--- a/benefits/oauth/views.py
+++ b/benefits/oauth/views.py
@@ -69,11 +69,12 @@ def authorize(request):
 
         if userinfo:
             claim_value = userinfo.get(verifier_claim)
-            # the claim comes back in userinfo like { "claim": "True" | "False" }
+            # the claim comes back in userinfo like { "claim": "1" | "0" }
+            claim_value = int(claim_value) if claim_value else None
             if claim_value is None:
                 logger.warning(f"userinfo did not contain: {verifier_claim}")
-            elif claim_value.lower() == "true":
-                # if userinfo contains our claim and the flag is true, store the *claim*
+            elif claim_value == 1:
+                # if userinfo contains our claim and the flag is 1 (true), store the *claim*
                 stored_claim = verifier_claim
 
     session.update(request, oauth_token=id_token, oauth_claim=stored_claim)

--- a/tests/pytest/oauth/test_views.py
+++ b/tests/pytest/oauth/test_views.py
@@ -99,14 +99,11 @@ def test_authorize_success(mocked_oauth_create_client, mocked_analytics_module, 
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_analytics_module")
-@pytest.mark.parametrize("flag", ["true", "True", "tRuE"])
-def test_authorize_success_with_claim_true(
-    mocked_session_verifier_auth_required, mocked_oauth_create_client, app_request, flag
-):
+def test_authorize_success_with_claim_true(mocked_session_verifier_auth_required, mocked_oauth_create_client, app_request):
     verifier = mocked_session_verifier_auth_required.return_value
     verifier.auth_provider.claim = "claim"
     mocked_oauth_client = mocked_oauth_create_client.return_value
-    mocked_oauth_client.authorize_access_token.return_value = {"id_token": "token", "userinfo": {"claim": flag}}
+    mocked_oauth_client.authorize_access_token.return_value = {"id_token": "token", "userinfo": {"claim": "1"}}
 
     result = authorize(app_request)
 
@@ -118,14 +115,15 @@ def test_authorize_success_with_claim_true(
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_analytics_module")
-@pytest.mark.parametrize("flag", ["false", "False", "fAlSe"])
 def test_authorize_success_with_claim_false(
-    mocked_session_verifier_auth_required, mocked_oauth_create_client, app_request, flag
+    mocked_session_verifier_auth_required,
+    mocked_oauth_create_client,
+    app_request,
 ):
     verifier = mocked_session_verifier_auth_required.return_value
     verifier.auth_provider.claim = "claim"
     mocked_oauth_client = mocked_oauth_create_client.return_value
-    mocked_oauth_client.authorize_access_token.return_value = {"id_token": "token", "userinfo": {"claim": flag}}
+    mocked_oauth_client.authorize_access_token.return_value = {"id_token": "token", "userinfo": {"claim": "0"}}
 
     result = authorize(app_request)
 


### PR DESCRIPTION
Closes #2046 

## Steps for testing
Set Django's database `authprovider` fixtures to the new [scopes](https://cal-itp.slack.com/archives/C037Y3UE71P/p1715882088978089?thread_ts=1715881952.138259&cid=C037Y3UE71P)/[claims](https://cal-itp.slack.com/archives/C037Y3UE71P/p1715882216002199?thread_ts=1715881952.138259&cid=C037Y3UE71P). Run bin/reset_db.sh to reset database.

## Test results
  - [x] Successfully test older adult flow locally
  - [x] Successfully test veteran flow locally
