### PR TITLE
Feat: server error - 400 errors / other exceptions during /token

### DIFF
--- a/benefits/core/urls.py
+++ b/benefits/core/urls.py
@@ -50,4 +50,5 @@ urlpatterns = [
     path("<agency:agency>", views.agency_index, name="agency_index"),
     path("<agency:agency>/publickey", views.agency_public_key, name="agency_public_key"),
     path("logged_out", views.logged_out, name="logged_out"),
+    path("error", views.server_error, name="server-error"),
 ]

--- a/benefits/core/views.py
+++ b/benefits/core/views.py
@@ -12,6 +12,7 @@ from .middleware import pageview_decorator, index_or_agencyindex_origin_decorato
 ROUTE_ELIGIBILITY = "eligibility:index"
 ROUTE_HELP = "core:help"
 ROUTE_LOGGED_OUT = "core:logged_out"
+ROUTE_SERVER_ERROR = "core:server-error"
 
 TEMPLATE_INDEX = "core/index.html"
 TEMPLATE_AGENCY = "core/agency-index.html"

--- a/benefits/enrollment/templates/enrollment/index.html
+++ b/benefits/enrollment/templates/enrollment/index.html
@@ -45,6 +45,7 @@
                 // https://stackoverflow.com/a/42469170
                 // use 'assign' because 'replace' was giving strange Back button behavior
                 window.location.assign(data.redirect);
+                return;
               }
 
               $(".loading").remove();

--- a/benefits/enrollment/templates/enrollment/index.html
+++ b/benefits/enrollment/templates/enrollment/index.html
@@ -45,7 +45,7 @@
                 // https://stackoverflow.com/a/42469170
                 // use 'assign' because 'replace' was giving strange Back button behavior
                 window.location.assign(data.redirect);
-                return;
+                return; // exit early so the rest of this function doesn't execute
               }
 
               $(".loading").remove();

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -50,6 +50,7 @@ def token(request):
         try:
             response = client.request_card_tokenization_access()
         except Exception as e:
+            logger.debug("Error occurred while requesting access token", exc_info=e)
             sentry_sdk.capture_exception(e)
 
             if isinstance(e, HTTPError):

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -45,9 +45,9 @@ def token(request):
             client_secret=payment_processor.client_secret,
             audience=payment_processor.audience,
         )
-        client.oauth.ensure_active_token(client.token)
 
         try:
+            client.oauth.ensure_active_token(client.token)
             response = client.request_card_tokenization_access()
         except Exception as e:
             logger.debug("Error occurred while requesting access token", exc_info=e)

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -55,7 +55,7 @@ def token(request):
             if isinstance(e, HTTPError):
                 status_code = e.response.status_code
 
-                if e.response.status_code >= 500:
+                if status_code >= 500:
                     redirect = reverse(ROUTE_SYSTEM_ERROR)
                 else:
                     redirect = reverse(ROUTE_SERVER_ERROR)

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -39,14 +39,14 @@ def token(request):
     if not session.enrollment_token_valid(request):
         agency = session.agency(request)
         payment_processor = agency.payment_processor
-        client = Client(
-            base_url=payment_processor.api_base_url,
-            client_id=payment_processor.client_id,
-            client_secret=payment_processor.client_secret,
-            audience=payment_processor.audience,
-        )
 
         try:
+            client = Client(
+                base_url=payment_processor.api_base_url,
+                client_id=payment_processor.client_id,
+                client_secret=payment_processor.client_secret,
+                audience=payment_processor.audience,
+            )
             client.oauth.ensure_active_token(client.token)
             response = client.request_card_tokenization_access()
         except Exception as e:

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -14,14 +14,13 @@ import sentry_sdk
 
 from benefits.core import session
 from benefits.core.middleware import EligibleSessionRequired, VerifierSessionRequired, pageview_decorator
-from benefits.core.views import ROUTE_LOGGED_OUT
+from benefits.core.views import ROUTE_LOGGED_OUT, ROUTE_SERVER_ERROR
 
 from . import analytics, forms
 
 ROUTE_INDEX = "enrollment:index"
 ROUTE_REENROLLMENT_ERROR = "enrollment:reenrollment-error"
 ROUTE_RETRY = "enrollment:retry"
-ROUTE_SERVER_ERROR = "core:server-error"
 ROUTE_SUCCESS = "enrollment:success"
 ROUTE_SYSTEM_ERROR = "enrollment:system-error"
 ROUTE_TOKEN = "enrollment:token"


### PR DESCRIPTION
Part of #2032 

 - [x] 400-level error or a non-`HTTPError` exception during `/token` returns a JSON response that is used to send user to `/error`
 - [x] `/error` shows server error template
 - [x] Sentry notification is sent
 - [x] Analytic event is sent (`failed access token request`)

### Reviewing / testing

**To test handling of 400-level HTTP errors**, you'll have to force it like in other PRs such as #2089.
To `/token`, add:
```diff
        try:
+          class response:
+             def __init__(self):
+                self.status_code = 400
+
+          raise HTTPError(response=response())
           response = client.request_card_tokenization_access()
        except Exception as e:
```

**To test other exceptions**:
- setting an incorrect `client_id` on `PaymentProcessor` causes `UnsupportedTokenTypeError` on `client.request_card_tokenization_access`
- setting an incorrect `api_base_url` on `PaymentProcessor` causes a `ConnectionError` on `client.ensure_active_token`
- setting an incorrect `client_secret_name` on `PaymentProcessor` could cause an error when creating `Client` (we read from `payment_processor.client_secret_name`)