### PR TITLE
CI: check for up-to-date migrations

### DIFF
--- a/.github/workflows/check-makemigrations.yml
+++ b/.github/workflows/check-makemigrations.yml
@@ -1,0 +1,8 @@
+name: Check for up-to-date Django migrations
+on:
+  pull_request:
+    paths:
+      - "benefits/**"
+  push:
+    paths:
+      - "benefits/**"

--- a/.github/workflows/check-makemigrations.yml
+++ b/.github/workflows/check-makemigrations.yml
@@ -27,3 +27,12 @@ jobs:
 
       - name: Install Python dependencies
         run: pip install -e .[dev,test]
+
+      - name: Run ./bin/makemigrations.sh
+        run: |
+          if ./bin/makemigrations.sh | grep -q 'No changes detected';
+          then
+             exit 0;
+          else
+             exit 1;
+          fi

--- a/.github/workflows/check-makemigrations.yml
+++ b/.github/workflows/check-makemigrations.yml
@@ -6,3 +6,24 @@ on:
   push:
     paths:
       - "benefits/**"
+
+jobs:
+  check-makemigrations:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Install system packages
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y gettext
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: .github/workflows/.python-version
+          cache: pip
+          cache-dependency-path: "**/pyproject.toml"
+
+      - name: Install Python dependencies
+        run: pip install -e .[dev,test]


### PR DESCRIPTION
Closes #2092 

I tested this locally with `act`:
![image](https://github.com/cal-itp/benefits/assets/25497886/6a7ec31f-080a-448b-ad5d-1c7d0e68b922)

I think this will need to be reviewed, approved, and merged into `dev` before we can see it in action on a PR.
