### PR TITLE
Feat: analytics for auth claims flow

### DIFF
--- a/benefits/oauth/analytics.py
+++ b/benefits/oauth/analytics.py
@@ -32,8 +32,10 @@ class CanceledSignInEvent(OAuthEvent):
 class FinishedSignInEvent(OAuthEvent):
     """Analytics event representing the end of the OAuth sign in flow."""
 
-    def __init__(self, request):
+    def __init__(self, request, error=None):
         super().__init__(request, "finished sign in")
+        if error is not None:
+            self.update_event_properties(error_code=error)
 
 
 class StartedSignOutEvent(OAuthEvent):
@@ -61,9 +63,9 @@ def canceled_sign_in(request):
     core.send_event(CanceledSignInEvent(request))
 
 
-def finished_sign_in(request):
+def finished_sign_in(request, error=None):
     """Send the "finished sign in" analytics event."""
-    core.send_event(FinishedSignInEvent(request))
+    core.send_event(FinishedSignInEvent(request, error))
 
 
 def started_sign_out(request):

--- a/benefits/oauth/views.py
+++ b/benefits/oauth/views.py
@@ -64,6 +64,8 @@ def authorize(request):
     verifier_claim = verifier.auth_provider.claim
     stored_claim = None
 
+    error_claim = None
+
     if verifier_claim:
         userinfo = token.get("userinfo")
 
@@ -76,10 +78,11 @@ def authorize(request):
             elif claim_value == 1:
                 # if userinfo contains our claim and the flag is 1 (true), store the *claim*
                 stored_claim = verifier_claim
+            elif claim_value >= 10:
+                error_claim = claim_value
 
     session.update(request, oauth_token=id_token, oauth_claim=stored_claim)
-
-    analytics.finished_sign_in(request)
+    analytics.finished_sign_in(request, error=error_claim)
 
     return redirect(ROUTE_CONFIRM)
 

--- a/tests/pytest/oauth/test_analytics.py
+++ b/tests/pytest/oauth/test_analytics.py
@@ -1,6 +1,6 @@
 import pytest
 
-from benefits.oauth.analytics import OAuthEvent
+from benefits.oauth.analytics import OAuthEvent, FinishedSignInEvent
 
 
 @pytest.mark.django_db
@@ -22,3 +22,15 @@ def test_OAuthEvent_verifier_no_client_name_when_does_not_use_auth_verification(
     event = OAuthEvent(app_request, "event type")
 
     assert "auth_provider" not in event.event_properties
+
+
+@pytest.mark.django_db
+def test_FinishedSignInEvent_with_error(app_request):
+    event = FinishedSignInEvent(app_request, error=10)
+    assert event.event_properties["error_code"] == 10
+
+
+@pytest.mark.django_db
+def test_FinishedSignInEvent_without_error(app_request):
+    event = FinishedSignInEvent(app_request)
+    assert "error_code" not in event.event_properties


### PR DESCRIPTION
Closes #2049 

## How to test
To test the error condition, insert something like `claim_value = "20"` after line 73 in `benefits.oauth.views.authorize`. Then check that `"error_code": 20` appears as a property of `"event_properties"` in the log.

## Notes
The behavior originally described in these notes was fixed by #2127.

~~When running the test `test_authorize_success_without_verifier_claim`, the oauth middleware `VerifierUsesAuthVerificationSessionRequired` that decorates the `authorize` view seems to behave differently compared to debugging the application.~~

~~Specifically, [line 19](https://github.com/cal-itp/benefits/blob/dev/benefits/oauth/middleware.py#L19C12-L19C59) in `benefits/oauth/middleware.py` evaluates to a `<Mock>` object if running the test, but it evaluates to a boolean if debugging the application.~~

~~To see this behavior, debug the test and notice that [line 19](https://github.com/cal-itp/benefits/blob/dev/benefits/oauth/middleware.py#L19C12-L19C59) evaluates to a`<Mock>` object, so the `if` condition evaluates to `True` and returns `None` instead of returning the user error page.
However, when debugging the application and setting `claim` in `AuthProvider` to blank (to simulate a missing verifier claim in the database), [line 19](https://github.com/cal-itp/benefits/blob/dev/benefits/oauth/middleware.py#L19C12-L19C59) will evaluate to `False` and the conditional will return the user error page.~~

~~Also, seems like `verifier.auth_provider.claim = ""` in the test only sets `verifier_claim = verifier.auth_provider.claim` (line 64 in the view). For a test closer to the behavior being tested, we may need to set the `claim` to blank in a fixture similar to `model_AuthProvider_with_verification`.~~