### PR TITLE
Fix: test assertions for missing claim on AuthProvider

### DIFF
--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -274,7 +274,7 @@ def mocked_session_verifier_oauth(mocker, model_EligibilityVerifier_AuthProvider
 
 
 @pytest.fixture
-def mocked_session_verifier_auth_required(
+def mocked_session_verifier_uses_auth_verification(
     mocker, model_EligibilityVerifier_AuthProvider_with_verification, mocked_session_verifier_oauth
 ):
     mock_verifier = mocker.Mock(spec=model_EligibilityVerifier_AuthProvider_with_verification)
@@ -291,11 +291,11 @@ def mocked_session_verifier_auth_required(
 
 
 @pytest.fixture
-def mocked_session_verifier_auth_not_required(mocked_session_verifier_auth_required):
-    # mocked_session_verifier_auth_required.return_value is the Mock(spec=model_EligibilityVerifier) from that fixture
-    mocked_session_verifier_auth_required.return_value.is_auth_required = False
-    mocked_session_verifier_auth_required.return_value.uses_auth_verification = False
-    return mocked_session_verifier_auth_required
+def mocked_session_verifier_does_not_use_auth_verification(mocked_session_verifier_uses_auth_verification):
+    # mocked_session_verifier_uses_auth_verification.return_value is the Mock(spec=model_EligibilityVerifier) from that fixture
+    mocked_session_verifier_uses_auth_verification.return_value.is_auth_required = False
+    mocked_session_verifier_uses_auth_verification.return_value.uses_auth_verification = False
+    return mocked_session_verifier_uses_auth_verification
 
 
 @pytest.fixture

--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -275,11 +275,10 @@ def mocked_session_verifier_oauth(mocker, model_EligibilityVerifier_AuthProvider
 
 @pytest.fixture
 def mocked_session_verifier_uses_auth_verification(
-    mocker, model_EligibilityVerifier_AuthProvider_with_verification, mocked_session_verifier_oauth
+    model_EligibilityVerifier_AuthProvider_with_verification, mocked_session_verifier_oauth
 ):
-    mock_verifier = mocker.Mock(spec=model_EligibilityVerifier_AuthProvider_with_verification)
+    mock_verifier = model_EligibilityVerifier_AuthProvider_with_verification
     mock_verifier.name = model_EligibilityVerifier_AuthProvider_with_verification.name
-    mock_verifier.is_auth_required = True
     mock_verifier.auth_provider.sign_out_button_template = (
         model_EligibilityVerifier_AuthProvider_with_verification.auth_provider.sign_out_button_template
     )
@@ -291,11 +290,12 @@ def mocked_session_verifier_uses_auth_verification(
 
 
 @pytest.fixture
-def mocked_session_verifier_does_not_use_auth_verification(mocked_session_verifier_uses_auth_verification):
-    # mocked_session_verifier_uses_auth_verification.return_value is the Mock(spec=model_EligibilityVerifier) from that fixture
-    mocked_session_verifier_uses_auth_verification.return_value.is_auth_required = False
-    mocked_session_verifier_uses_auth_verification.return_value.uses_auth_verification = False
-    return mocked_session_verifier_uses_auth_verification
+def mocked_session_verifier_does_not_use_auth_verification(
+    mocked_session_verifier_uses_auth_verification, model_AuthProvider_without_verification
+):
+    mocked_verifier = mocked_session_verifier_uses_auth_verification
+    mocked_verifier.auth_provider = model_AuthProvider_without_verification
+    return mocked_verifier
 
 
 @pytest.fixture

--- a/tests/pytest/eligibility/test_verify.py
+++ b/tests/pytest/eligibility/test_verify.py
@@ -52,10 +52,12 @@ def test_eligibility_from_api_no_verified_types(
 
 
 @pytest.mark.django_db
-def test_eligibility_from_oauth_auth_not_required(mocked_session_verifier_auth_not_required, model_TransitAgency):
-    # mocked_session_verifier_auth_not_required is Mocked version of the session.verifier() function
+def test_eligibility_from_oauth_does_not_use_auth_verification(
+    mocked_session_verifier_does_not_use_auth_verification, model_TransitAgency
+):
+    # mocked_session_verifier_does_not_use_auth_verification is Mocked version of the session.verifier() function
     # call it (with a None request) to return a verifier object
-    verifier = mocked_session_verifier_auth_not_required(None)
+    verifier = mocked_session_verifier_does_not_use_auth_verification(None)
 
     types = eligibility_from_oauth(verifier, "claim", model_TransitAgency)
 
@@ -63,10 +65,10 @@ def test_eligibility_from_oauth_auth_not_required(mocked_session_verifier_auth_n
 
 
 @pytest.mark.django_db
-def test_eligibility_from_oauth_auth_claim_mismatch(mocked_session_verifier_auth_required, model_TransitAgency):
-    # mocked_session_verifier_auth_required is Mocked version of the session.verifier() function
+def test_eligibility_from_oauth_auth_claim_mismatch(mocked_session_verifier_uses_auth_verification, model_TransitAgency):
+    # mocked_session_verifier_uses_auth_verification is Mocked version of the session.verifier() function
     # call it (with a None request) to return a verifier object
-    verifier = mocked_session_verifier_auth_required(None)
+    verifier = mocked_session_verifier_uses_auth_verification(None)
     verifier.auth_claim = "claim"
 
     types = eligibility_from_oauth(verifier, "some_other_claim", model_TransitAgency)
@@ -76,11 +78,11 @@ def test_eligibility_from_oauth_auth_claim_mismatch(mocked_session_verifier_auth
 
 @pytest.mark.django_db
 def test_eligibility_from_oauth_auth_claim_match(
-    mocked_session_verifier_auth_required, model_EligibilityType, model_TransitAgency
+    mocked_session_verifier_uses_auth_verification, model_EligibilityType, model_TransitAgency
 ):
-    # mocked_session_verifier_auth_required is Mocked version of the session.verifier() function
+    # mocked_session_verifier_uses_auth_verification is Mocked version of the session.verifier() function
     # call it (with a None request) to return a verifier object
-    verifier = mocked_session_verifier_auth_required.return_value
+    verifier = mocked_session_verifier_uses_auth_verification.return_value
     verifier.auth_provider.claim = "claim"
     verifier.eligibility_type = model_EligibilityType
 

--- a/tests/pytest/eligibility/test_views.py
+++ b/tests/pytest/eligibility/test_views.py
@@ -230,9 +230,7 @@ def test_confirm_get_unverified(mocker, client):
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures(
-    "mocked_session_agency", "mocked_session_eligibility", "mocked_session_verifier_does_not_use_auth_verification"
-)
+@pytest.mark.usefixtures("mocked_session_agency", "mocked_session_eligibility", "mocked_session_verifier")
 def test_confirm_get_verified(client, mocked_session_update):
     path = reverse(ROUTE_CONFIRM)
     response = client.get(path)

--- a/tests/pytest/eligibility/test_views.py
+++ b/tests/pytest/eligibility/test_views.py
@@ -171,7 +171,9 @@ def test_index_calls_session_logout(client, session_logout_spy):
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("mocked_session_agency", "mocked_verifier_selection_form", "mocked_session_verifier_auth_required")
+@pytest.mark.usefixtures(
+    "mocked_session_agency", "mocked_verifier_selection_form", "mocked_session_verifier_uses_auth_verification"
+)
 def test_start_verifier_auth_required_logged_in(mocker, client):
     mock_session = mocker.patch("benefits.eligibility.views.session")
     mock_session.logged_in.return_value = True
@@ -183,7 +185,9 @@ def test_start_verifier_auth_required_logged_in(mocker, client):
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("mocked_session_agency", "mocked_verifier_selection_form", "mocked_session_verifier_auth_required")
+@pytest.mark.usefixtures(
+    "mocked_session_agency", "mocked_verifier_selection_form", "mocked_session_verifier_uses_auth_verification"
+)
 def test_start_verifier_auth_required_not_logged_in(mocker, client):
     mock_session = mocker.patch("benefits.eligibility.views.session")
     mock_session.logged_in.return_value = False
@@ -196,7 +200,7 @@ def test_start_verifier_auth_required_not_logged_in(mocker, client):
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures(
-    "mocked_session_agency", "mocked_verifier_selection_form", "mocked_session_verifier_auth_not_required"
+    "mocked_session_agency", "mocked_verifier_selection_form", "mocked_session_verifier_does_not_use_auth_verification"
 )
 def test_start_verifier_auth_not_required(client):
     path = reverse(ROUTE_START)
@@ -226,7 +230,9 @@ def test_confirm_get_unverified(mocker, client):
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("mocked_session_agency", "mocked_session_eligibility", "mocked_session_verifier_auth_not_required")
+@pytest.mark.usefixtures(
+    "mocked_session_agency", "mocked_session_eligibility", "mocked_session_verifier_does_not_use_auth_verification"
+)
 def test_confirm_get_verified(client, mocked_session_update):
     path = reverse(ROUTE_CONFIRM)
     response = client.get(path)

--- a/tests/pytest/enrollment/test_views.py
+++ b/tests/pytest/enrollment/test_views.py
@@ -354,7 +354,7 @@ def test_success_no_verifier(client):
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("mocked_session_verifier_auth_required")
+@pytest.mark.usefixtures("mocked_session_verifier_uses_auth_verification")
 def test_success_authentication_logged_in(mocker, client, model_TransitAgency, model_EligibilityType):
     mock_session = mocker.patch("benefits.enrollment.views.session")
     mock_session.logged_in.return_value = True
@@ -370,7 +370,7 @@ def test_success_authentication_logged_in(mocker, client, model_TransitAgency, m
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("mocked_session_verifier_auth_required")
+@pytest.mark.usefixtures("mocked_session_verifier_uses_auth_verification")
 def test_success_authentication_not_logged_in(mocker, client, model_TransitAgency, model_EligibilityType):
     mock_session = mocker.patch("benefits.enrollment.views.session")
     mock_session.logged_in.return_value = False
@@ -385,7 +385,7 @@ def test_success_authentication_not_logged_in(mocker, client, model_TransitAgenc
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("mocked_session_agency", "mocked_session_verifier_auth_not_required")
+@pytest.mark.usefixtures("mocked_session_agency", "mocked_session_verifier_does_not_use_auth_verification")
 def test_success_no_authentication(mocker, client, model_EligibilityType):
     mock_session = mocker.patch("benefits.enrollment.views.session")
     mock_session.eligibility.return_value = model_EligibilityType

--- a/tests/pytest/oauth/test_analytics.py
+++ b/tests/pytest/oauth/test_analytics.py
@@ -4,8 +4,8 @@ from benefits.oauth.analytics import OAuthEvent
 
 
 @pytest.mark.django_db
-def test_OAuthEvent_checks_verifier_uses_auth_verification(app_request, mocked_session_verifier_auth_required):
-    mocked_verifier = mocked_session_verifier_auth_required(app_request)
+def test_OAuthEvent_checks_verifier_uses_auth_verification(app_request, mocked_session_verifier_uses_auth_verification):
+    mocked_verifier = mocked_session_verifier_uses_auth_verification(app_request)
 
     OAuthEvent(app_request, "event type")
 
@@ -13,8 +13,10 @@ def test_OAuthEvent_checks_verifier_uses_auth_verification(app_request, mocked_s
 
 
 @pytest.mark.django_db
-def test_OAuthEvent_verifier_client_name_when_uses_auth_verification(app_request, mocked_session_verifier_auth_required):
-    mocked_verifier = mocked_session_verifier_auth_required(app_request)
+def test_OAuthEvent_verifier_client_name_when_uses_auth_verification(
+    app_request, mocked_session_verifier_uses_auth_verification
+):
+    mocked_verifier = mocked_session_verifier_uses_auth_verification(app_request)
     mocked_verifier.auth_provider.client_name = "ClientName"
 
     event = OAuthEvent(app_request, "event type")
@@ -24,7 +26,7 @@ def test_OAuthEvent_verifier_client_name_when_uses_auth_verification(app_request
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("mocked_session_verifier_auth_not_required")
+@pytest.mark.usefixtures("mocked_session_verifier_does_not_use_auth_verification")
 def test_OAuthEvent_verifier_no_client_name_when_does_not_use_auth_verification(app_request):
     event = OAuthEvent(app_request, "event type")
 

--- a/tests/pytest/oauth/test_analytics.py
+++ b/tests/pytest/oauth/test_analytics.py
@@ -4,15 +4,6 @@ from benefits.oauth.analytics import OAuthEvent
 
 
 @pytest.mark.django_db
-def test_OAuthEvent_checks_verifier_uses_auth_verification(app_request, mocked_session_verifier_uses_auth_verification):
-    mocked_verifier = mocked_session_verifier_uses_auth_verification(app_request)
-
-    OAuthEvent(app_request, "event type")
-
-    mocked_verifier.uses_auth_verification.assert_called_once
-
-
-@pytest.mark.django_db
 def test_OAuthEvent_verifier_client_name_when_uses_auth_verification(
     app_request, mocked_session_verifier_uses_auth_verification
 ):

--- a/tests/pytest/oauth/test_middleware_authverifier_required.py
+++ b/tests/pytest/oauth/test_middleware_authverifier_required.py
@@ -21,7 +21,7 @@ def test_authverifier_required_no_verifier(app_request, mocked_view, decorated_v
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("mocked_session_verifier_auth_not_required")
+@pytest.mark.usefixtures("mocked_session_verifier_does_not_use_auth_verification")
 def test_authverifier_required_no_authverifier(app_request, mocked_view, decorated_view):
     response = decorated_view(app_request)
 

--- a/tests/pytest/oauth/test_views.py
+++ b/tests/pytest/oauth/test_views.py
@@ -16,7 +16,7 @@ def mocked_analytics_module(mocked_analytics_module):
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("mocked_session_verifier_auth_required")
+@pytest.mark.usefixtures("mocked_session_verifier_uses_auth_verification")
 def test_login_no_oauth_client(mocked_oauth_create_client, app_request):
     mocked_oauth_create_client.return_value = None
 
@@ -33,7 +33,9 @@ def test_login_no_session_verifier(app_request):
 
 
 @pytest.mark.django_db
-def test_login(mocked_oauth_create_client, mocked_session_verifier_auth_required, mocked_analytics_module, app_request):
+def test_login(
+    mocked_oauth_create_client, mocked_session_verifier_uses_auth_verification, mocked_analytics_module, app_request
+):
     assert not session.logged_in(app_request)
 
     mocked_oauth_client = mocked_oauth_create_client.return_value
@@ -41,7 +43,7 @@ def test_login(mocked_oauth_create_client, mocked_session_verifier_auth_required
 
     login(app_request)
 
-    mocked_verifier = mocked_session_verifier_auth_required.return_value
+    mocked_verifier = mocked_session_verifier_uses_auth_verification.return_value
     mocked_oauth_create_client.assert_called_once_with(mocked_verifier.auth_provider.client_name)
     mocked_oauth_client.authorize_redirect.assert_called_with(app_request, "https://testserver/oauth/authorize")
     mocked_analytics_module.started_sign_in.assert_called_once()
@@ -49,7 +51,7 @@ def test_login(mocked_oauth_create_client, mocked_session_verifier_auth_required
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("mocked_session_verifier_auth_required")
+@pytest.mark.usefixtures("mocked_session_verifier_uses_auth_verification")
 def test_authorize_no_oauth_client(mocked_oauth_create_client, app_request):
     mocked_oauth_create_client.return_value = None
 
@@ -66,7 +68,7 @@ def test_authorize_no_session_verifier(app_request):
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("mocked_session_verifier_auth_required")
+@pytest.mark.usefixtures("mocked_session_verifier_uses_auth_verification")
 def test_authorize_fail(mocked_oauth_create_client, app_request):
     mocked_oauth_client = mocked_oauth_create_client.return_value
     mocked_oauth_client.authorize_access_token.return_value = None
@@ -82,7 +84,7 @@ def test_authorize_fail(mocked_oauth_create_client, app_request):
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("mocked_session_verifier_auth_required")
+@pytest.mark.usefixtures("mocked_session_verifier_uses_auth_verification")
 def test_authorize_success(mocked_oauth_create_client, mocked_analytics_module, app_request):
     mocked_oauth_client = mocked_oauth_create_client.return_value
     mocked_oauth_client.authorize_access_token.return_value = {"id_token": "token"}
@@ -99,8 +101,10 @@ def test_authorize_success(mocked_oauth_create_client, mocked_analytics_module, 
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_analytics_module")
-def test_authorize_success_with_claim_true(mocked_session_verifier_auth_required, mocked_oauth_create_client, app_request):
-    verifier = mocked_session_verifier_auth_required.return_value
+def test_authorize_success_with_claim_true(
+    mocked_session_verifier_uses_auth_verification, mocked_oauth_create_client, app_request
+):
+    verifier = mocked_session_verifier_uses_auth_verification.return_value
     verifier.auth_provider.claim = "claim"
     mocked_oauth_client = mocked_oauth_create_client.return_value
     mocked_oauth_client.authorize_access_token.return_value = {"id_token": "token", "userinfo": {"claim": "1"}}
@@ -116,11 +120,11 @@ def test_authorize_success_with_claim_true(mocked_session_verifier_auth_required
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_analytics_module")
 def test_authorize_success_with_claim_false(
-    mocked_session_verifier_auth_required,
+    mocked_session_verifier_uses_auth_verification,
     mocked_oauth_create_client,
     app_request,
 ):
-    verifier = mocked_session_verifier_auth_required.return_value
+    verifier = mocked_session_verifier_uses_auth_verification.return_value
     verifier.auth_provider.claim = "claim"
     mocked_oauth_client = mocked_oauth_create_client.return_value
     mocked_oauth_client.authorize_access_token.return_value = {"id_token": "token", "userinfo": {"claim": "0"}}
@@ -136,9 +140,9 @@ def test_authorize_success_with_claim_false(
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_analytics_module")
 def test_authorize_success_without_verifier_claim(
-    mocked_session_verifier_auth_required, mocked_oauth_create_client, app_request
+    mocked_session_verifier_uses_auth_verification, mocked_oauth_create_client, app_request
 ):
-    verifier = mocked_session_verifier_auth_required.return_value
+    verifier = mocked_session_verifier_uses_auth_verification.return_value
     verifier.auth_provider.claim = ""
     mocked_oauth_client = mocked_oauth_create_client.return_value
     mocked_oauth_client.authorize_access_token.return_value = {"id_token": "token", "userinfo": {"claim": "True"}}
@@ -160,9 +164,9 @@ def test_authorize_success_without_verifier_claim(
     ],
 )
 def test_authorize_success_without_claim_in_response(
-    mocked_session_verifier_auth_required, mocked_oauth_create_client, app_request, access_token_response
+    mocked_session_verifier_uses_auth_verification, mocked_oauth_create_client, app_request, access_token_response
 ):
-    verifier = mocked_session_verifier_auth_required.return_value
+    verifier = mocked_session_verifier_uses_auth_verification.return_value
     verifier.auth_provider.claim = "claim"
     mocked_oauth_client = mocked_oauth_create_client.return_value
     mocked_oauth_client.authorize_access_token.return_value = access_token_response
@@ -176,7 +180,7 @@ def test_authorize_success_without_claim_in_response(
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("mocked_session_verifier_auth_required")
+@pytest.mark.usefixtures("mocked_session_verifier_uses_auth_verification")
 def test_cancel(mocked_analytics_module, app_request):
     unverified_route = reverse(ROUTE_UNVERIFIED)
 
@@ -196,7 +200,7 @@ def test_cancel_no_session_verifier(app_request):
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("mocked_session_verifier_auth_required")
+@pytest.mark.usefixtures("mocked_session_verifier_uses_auth_verification")
 def test_logout_no_oauth_client(mocked_oauth_create_client, app_request):
     mocked_oauth_create_client.return_value = None
 
@@ -213,7 +217,7 @@ def test_logout_no_session_verifier(app_request):
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("mocked_session_verifier_auth_required")
+@pytest.mark.usefixtures("mocked_session_verifier_uses_auth_verification")
 def test_logout(mocker, mocked_oauth_create_client, mocked_analytics_module, app_request):
     # logout internally calls deauthorize_redirect
     # this mocks that function and a success response
@@ -240,7 +244,7 @@ def test_logout(mocker, mocked_oauth_create_client, mocked_analytics_module, app
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("mocked_session_verifier_auth_required")
+@pytest.mark.usefixtures("mocked_session_verifier_uses_auth_verification")
 def test_post_logout(app_request, mocked_analytics_module):
     origin = reverse(ROUTE_INDEX)
     session.update(app_request, origin=origin)

--- a/tests/pytest/oauth/test_views.py
+++ b/tests/pytest/oauth/test_views.py
@@ -145,10 +145,9 @@ def test_authorize_success_without_verifier_claim(
 
     result = authorize(app_request)
 
-    mocked_oauth_client.authorize_access_token.assert_called_with(app_request)
     assert session.oauth_claim(app_request) is None
-    assert result.status_code == 302
-    assert result.url == reverse(ROUTE_CONFIRM)
+    assert result.status_code == 200
+    assert result.template_name == TEMPLATE_USER_ERROR
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Prompted by @lalver1 's questions / notes for #2125

`test_authorize_success_without_verifier_claim` was giving us a false positive because the verifier fixture is also not behaving correctly when returning `uses_auth_verification`. Also see our [Slack thread](https://cal-itp.slack.com/archives/C037Y3UE71P/p1717085288461349).

I'm not sure at what point this test became incorrect. It could be that when the test was written, we were using `VerifierSessionRequired` rather than `VerifierUsesAuthVerificationSessionRequired`, and so we expected to be able to reach `ROUTE_CONFIRM` which would then handle the fact that no claim was stored. See https://github.com/cal-itp/benefits/issues/1535 for why we changed the middleware behavior.

We can revisit if showing `user_error` is the correct UX here, but for now, the test should at least reflect the application behavior rather than giving us a false positive and blocking #2125.