### PR TITLE
CI: remove path filters from migration check

### DIFF
--- a/.github/workflows/check-makemigrations.yml
+++ b/.github/workflows/check-makemigrations.yml
@@ -1,11 +1,5 @@
 name: Check for up-to-date Django migrations
-on:
-  pull_request:
-    paths:
-      - "benefits/**"
-  push:
-    paths:
-      - "benefits/**"
+on: [push, pull_request]
 
 jobs:
   check-makemigrations:


### PR DESCRIPTION
Closes #2092 

We want the migration check to be a required check but not for it to block PRs that don't match the path filter, so we have to remove the path filters