### PR TITLE
CI: guard against empty language array for CodeQL runs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,6 +37,7 @@ jobs:
     name: CodeQL Analyze
     runs-on: ubuntu-latest
     needs: setup
+    if: ${{ fromJSON(needs.setup.outputs.languages) != [] }}
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
Only run the CodeQL Analyze job if there are languages to analyze.

I'm not 100% this is the right syntax :crossed_fingers: 