### PR TITLE
Refactor: delete app setting meant for refreshing secrets

### DIFF
--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -45,9 +45,6 @@ resource "azurerm_linux_web_app" "main" {
   }
 
   app_settings = {
-    # app setting used solely for refreshing secrets - see https://github.com/MicrosoftDocs/azure-docs/issues/79855#issuecomment-1265664801
-    "change_me_to_refresh_secrets" = "change me in the portal to refresh all secrets",
-
     "DOCKER_ENABLE_CI"                    = "false",
     "WEBSITE_HTTPLOGGING_RETENTION_DAYS"  = "99999",
     "WEBSITE_TIME_ZONE"                   = "America/Los_Angeles",


### PR DESCRIPTION
Closes #1948 

This is what I see in the Azure portal. Looks like they might've renamed the button

<img width="641" alt="Screenshot 2024-06-05 113516" src="https://github.com/cal-itp/benefits/assets/25497886/405caeba-d515-4d22-b9bd-351f38b846e7">   


<br>
<br>
Message when you click the button:
<br><br>
<img width="815" alt="Screenshot 2024-06-05 113526" src="https://github.com/cal-itp/benefits/assets/25497886/2bf74e8e-fe6d-4b6c-a4cf-d34cd3498e7a">
