### PR TITLE
Fix: correct invalid syntax in CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,7 @@ jobs:
     name: CodeQL Analyze
     runs-on: ubuntu-latest
     needs: setup
-    if: ${{ fromJSON(needs.setup.outputs.languages) != [] }}
+    if: ${{ needs.setup.outputs.languages != "[]" }}
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
Follow-up to #2137, the syntax was in fact wrong :roll_eyes: 

Failed workflow run: https://github.com/cal-itp/benefits/actions/runs/9391520844