### PR TITLE
Chore: update Terraform version in pipeline

### DIFF
--- a/terraform/pipeline/deploy.yml
+++ b/terraform/pipeline/deploy.yml
@@ -9,7 +9,7 @@ steps:
   - task: TerraformInstaller@0
     displayName: Install Terraform
     inputs:
-      terraformVersion: 1.3.7
+      terraformVersion: 1.8.5
   # https://github.com/microsoft/azure-pipelines-terraform/tree/main/Tasks/TerraformTask/TerraformTaskV3#readme
   - task: TerraformTaskV3@3
     displayName: Terraform init


### PR DESCRIPTION
Resolves some issues with `Warning`s in the output.

For example:
```
 # azurerm_storage_account.main will be updated in-place
  ~ resource "azurerm_storage_account" "main" {
      - edge_zone                         = "" -> null
        ...
        name                              = "sacdtcalitpd001"
      # Warning: this attribute value will no longer be marked as sensitive
      # after applying this change. The value is unchanged.
      ~ primary_access_key                = (sensitive value)
      # Warning: this attribute value will no longer be marked as sensitive
      # after applying this change. The value is unchanged.
      ~ primary_blob_connection_string    = (sensitive value)
      # Warning: this attribute value will no longer be marked as sensitive
      # after applying this change. The value is unchanged.
      ~ primary_connection_string         = (sensitive value)
      # Warning: this attribute value will no longer be marked as sensitive
      # after applying this change. The value is unchanged.
      ~ secondary_access_key              = (sensitive value)
      # Warning: this attribute value will no longer be marked as sensitive
      # after applying this change. The value is unchanged.
      ~ secondary_blob_connection_string  = (sensitive value)
      # Warning: this attribute value will no longer be marked as sensitive
      # after applying this change. The value is unchanged.
      ~ secondary_connection_string       = (sensitive value)
      - secondary_file_endpoint           = "" -> null
      - secondary_file_host               = "" -> null
        tags           
```