### PR TITLE
Refactor: move the application directory up a level

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "dockerComposeFile": ["../compose.yml"],
   "service": "dev",
   "runServices": ["dev", "docs", "server"],
-  "workspaceFolder": "/home/calitp/app",
+  "workspaceFolder": "/calitp/app",
   "postStartCommand": ["/bin/bash", "bin/reset_db.sh"],
   "postAttachCommand": ["/bin/bash", ".devcontainer/postAttach.sh"],
   "customizations": {

--- a/.devcontainer/postAttach.sh
+++ b/.devcontainer/postAttach.sh
@@ -3,5 +3,5 @@ set -eu
 
 # initialize pre-commit
 
-git config --global --add safe.directory /home/calitp/app
+git config --global --add safe.directory /calitp/app
 pre-commit install --overwrite

--- a/appcontainer/Dockerfile
+++ b/appcontainer/Dockerfile
@@ -5,7 +5,7 @@ RUN python -m pip install --upgrade pip
 
 # overwrite default nginx.conf
 COPY appcontainer/nginx.conf /etc/nginx/nginx.conf
-COPY appcontainer/proxy.conf /home/calitp/run/proxy.conf
+COPY appcontainer/proxy.conf /calitp/run/proxy.conf
 
 # copy source files
 COPY manage.py manage.py

--- a/appcontainer/nginx.conf
+++ b/appcontainer/nginx.conf
@@ -22,7 +22,7 @@ http {
   upstream app_server {
     # fail_timeout=0 means we always retry an upstream even if it failed
     # to return a good HTTP response
-    server unix:/home/calitp/run/gunicorn.sock fail_timeout=0;
+    server unix:/calitp/run/gunicorn.sock fail_timeout=0;
   }
 
   # maps $binary_ip_address to $limit variable if request is of type POST
@@ -67,7 +67,7 @@ http {
 
     # path for static files
     location /static/ {
-      alias /home/calitp/app/static/;
+      alias /calitp/app/static/;
       expires 1y;
       add_header Cache-Control public;
     }
@@ -81,12 +81,12 @@ http {
     # case-insensitive regex matches path
     location ~* ^/(eligibility/confirm)$ {
         limit_req zone=rate_limit;
-        include /home/calitp/run/proxy.conf;
+        include /calitp/run/proxy.conf;
     }
 
     # app path
     location @proxy_to_app {
-      include /home/calitp/run/proxy.conf;
+      include /calitp/run/proxy.conf;
     }
   }
 }

--- a/compose.yml
+++ b/compose.yml
@@ -23,7 +23,7 @@ services:
     ports:
       - "${DJANGO_LOCAL_PORT:-8000}:8000"
     volumes:
-      - ./:/home/calitp/app
+      - ./:/calitp/app
 
   docs:
     image: benefits_client:dev
@@ -32,7 +32,7 @@ services:
     ports:
       - "8001"
     volumes:
-      - ./:/home/calitp/app
+      - ./:/calitp/app
 
   server:
     image: ghcr.io/cal-itp/eligibility-server:dev

--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -11,7 +11,7 @@ resource "azurerm_service_plan" "main" {
 }
 
 locals {
-  data_mount = "/home/calitp/app/data"
+  data_mount = "/calitp/app/data"
 }
 
 resource "azurerm_linux_web_app" "main" {


### PR DESCRIPTION
Part of #2153 

Related to:

* https://github.com/cal-itp/docker-python-web/pull/42
* https://github.com/cal-itp/eligibility-server/pull/463

This PR should be merged after the one in `docker-python-web`.

From that PR's description:

> There are two directories with application code:
>
> * `run/` is created by this image and contains the default `nginx` and `gunicorn` configuration
> * `app/` is created by the consuming image (`benefits` or `eligibility-server`) and contains the application code
> 
> This image defines these two directories under `/home/calitp/` (the Docker `$USER`s home).
> 
> This PR moves them to the top-level `/calitp/` (again, from the Docker `$USER`).
> 
> This change is part of addressing #2153. When we enable the setting `WEBSITES_ENABLE_APP_SERVICE_STORAGE=true`, `/home` will be a directory managed by the Azure App Service, so we need the application code out of that directory.

## Testing locally

Build the `benefits_client`, ensuring the `docker-python-web` digest SHA matches the [expected digest SHA](https://github.com/cal-itp/docker-python-web/pkgs/container/docker-python-web/228737997?tag=main): `sha256:c937ae01afebab96473045c3a0f3aa9c3a28609d1ff33d756740d2eea254c61f`

```console
$ bin/build.sh
=> [client internal] load build definition from Dockerfile                                                                                                              0.0s
 => => transferring dockerfile: xxxB
=> [client internal] load metadata for ghcr.io/cal-itp/docker-python-web:main
...
=> [client  1/10] FROM ghcr.io/cal-itp/docker-python-web:main@sha256:c937ae01afebab96473045c3a0f3aa9c3a28609d1ff33d756740d2eea254c61f
...
=> [client] exporting to image
 => => exporting layers
 => => writing image sha256:xxx
 => => naming to docker.io/library/benefits_client:latest
```

And restart the devcontainer in VS Code. Then run the app as normal with F5.
