### PR TITLE
Feat: default dependabot PR status to In review

### DIFF
--- a/.github/workflows/add-to-project-dependabot.yml
+++ b/.github/workflows/add-to-project-dependabot.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: EndBug/project-fields@v2
         with:
           operation: set
-          fields: Effort
-          values: 1
+          fields: Effort,Status
+          values: 1,In review
           project_url: https://github.com/orgs/cal-itp/projects/${{ secrets.GH_PROJECT }}
           github_token: ${{ secrets.GH_PROJECTS_TOKEN }}


### PR DESCRIPTION
New practice established in the June 2024 Backlog Review session. This is part of focusing the Sprint time on Sprint items and saving dependencies for Slush time.