### PR TITLE
Docs: clean up / reorganize Infrastructure documentation

### DIFF
--- a/docs/deployment/infrastructure.md
+++ b/docs/deployment/infrastructure.md
@@ -52,11 +52,14 @@ flowchart LR
     frontdoor[Front Door]
     django[Django application]
     interconnections[Other system interconnections]
+
     internet --> Cloudflare
     Cloudflare --> frontdoor
     django <--> interconnections
+
     subgraph Azure
         frontdoor --> NGINX
+
         subgraph App Service
             subgraph Custom container
                 direction TB
@@ -134,7 +137,6 @@ Use the following shorthand for conveying the Resource Type as part of the Resou
 | Database         | `DB`       |
 | Subnet           | `SNET`     |
 | Front Door       | `FD`       |
-
 
 ## Making changes
 

--- a/docs/deployment/infrastructure.md
+++ b/docs/deployment/infrastructure.md
@@ -4,7 +4,9 @@ The infrastructure is configured as code via [Terraform](https://www.terraform.i
 
 ## Environments
 
-Within the `CDT Digital CA` directory ([how to switch](https://learn.microsoft.com/en-us/azure/devtest/offer/how-to-change-directory-tenants-visual-studio-azure)), there are two [Subscriptions](https://learn.microsoft.com/en-us/microsoft-365/enterprise/subscriptions-licenses-accounts-and-tenants-for-microsoft-cloud-offerings?view=o365-worldwide#subscriptions), with Resource Groups under each. Each environment corresponds to a single Resource Group, [Terraform Workspace](https://developer.hashicorp.com/terraform/language/state/workspaces), and branch.
+Within the `CDT Digital CA` directory, there are two [Subscriptions](https://learn.microsoft.com/en-us/microsoft-365/enterprise/subscriptions-licenses-accounts-and-tenants-for-microsoft-cloud-offerings?view=o365-worldwide#subscriptions), with Resource Groups under each. (Refer to Azure's documentation for [switching directories](https://learn.microsoft.com/en-us/azure/devtest/offer/how-to-change-directory-tenants-visual-studio-azure).)
+
+Each of our environments corresponds to a single Resource Group, [Terraform Workspace](https://developer.hashicorp.com/terraform/language/state/workspaces), and branch.
 
 | Environment | Subscription          | Resource Group                | Workspace | Branch |
 | ----------- | --------------------- | ----------------------------- | --------- | ------ |
@@ -16,10 +18,6 @@ All resources in these Resource Groups should be reflected in Terraform in this 
 
 - Secrets, such as values under [Key Vault](https://azure.microsoft.com/en-us/services/key-vault/). [`prevent_destroy`](https://developer.hashicorp.com/terraform/tutorials/state/resource-lifecycle#prevent-resource-deletion) is used on these Resources.
 - [Things managed by DevSecOps](#ownership)
-
-You'll see these referenced in Terraform as [data sources](https://developer.hashicorp.com/terraform/language/data-sources).
-
-For browsing the [Azure portal](https://portal.azure.com), you can [switch your `Default subscription filter`](https://docs.microsoft.com/en-us/azure/azure-portal/set-preferences).
 
 ### Ownership
 
@@ -34,7 +32,11 @@ The following things in Azure are managed by the California Department of Techno
 - IAM
 - Service connections
 
+You'll see these referenced in Terraform as [data sources](https://developer.hashicorp.com/terraform/language/data-sources), meaning they are managed outside of Terraform.
+
 ### Architecture
+
+These diagrams show a high-level view of the architecture per environment, including some external systems (e.g. analytics, error monitoring, eligibility servers).
 
 #### Benefits application
 
@@ -44,14 +46,11 @@ flowchart LR
     frontdoor[Front Door]
     django[Django application]
     interconnections[Other system interconnections]
-
     internet --> Cloudflare
     Cloudflare --> frontdoor
     django <--> interconnections
-
     subgraph Azure
         frontdoor --> NGINX
-
         subgraph App Service
             subgraph Custom container
                 direction TB

--- a/docs/deployment/infrastructure.md
+++ b/docs/deployment/infrastructure.md
@@ -40,11 +40,11 @@ The following things in Azure are managed by the California Department of Techno
 
 You'll see these referenced in Terraform as [data sources](https://developer.hashicorp.com/terraform/language/data-sources), meaning they are managed outside of Terraform.
 
-### Architecture
+## Architecture
 
 These diagrams show a high-level view of the architecture per environment, including some external systems (e.g. analytics, error monitoring, eligibility servers).
 
-#### Benefits application
+### Benefits application
 
 ```mermaid
 flowchart LR
@@ -71,7 +71,7 @@ flowchart LR
 
 [Front Door](https://docs.microsoft.com/en-us/azure/frontdoor/front-door-overview) also includes the [Web Application Firewall (WAF)](https://docs.microsoft.com/en-us/azure/web-application-firewall/afds/afds-overview) and handles TLS termination. Front Door is managed by the DevSecOps team.
 
-#### System interconnections
+### System interconnections
 
 ```mermaid
 flowchart LR
@@ -109,7 +109,7 @@ flowchart LR
     idg -->|User attributes| benefits
 ```
 
-### Naming conventions
+## Naming conventions
 
 The DevSecOps team sets the following naming convention for Resources:
 
@@ -117,13 +117,13 @@ The DevSecOps team sets the following naming convention for Resources:
 <<Resource Type>>-<<Department>>-<<Public/Private>>-<<Project Category>>-<<Project Name>>-<<Region>><<OS Type>>-<<Environment>>-<<Sequence Number>>
 ```
 
-#### Sample Names
+### Sample Names
 
 - `RG-CDT-PUB-VIP-BNSCN-E-D-001`
 - `ASP-CDT-PUB-VIP-BNSCN-EL-P-001`
 - `AS-CDT-PUB-VIP-BNSCN-EL-D-001`
 
-#### Resource Types
+### Resource Types
 
 Use the following shorthand for conveying the Resource Type as part of the Resource Name:
 

--- a/docs/deployment/infrastructure.md
+++ b/docs/deployment/infrastructure.md
@@ -138,16 +138,9 @@ Use the following shorthand for conveying the Resource Type as part of the Resou
 
 ## Making changes
 
-[![Build Status](https://calenterprise.visualstudio.com/CDT.OET.CAL-ITP/_apis/build/status/cal-itp.benefits%20Infra?branchName=dev)](https://calenterprise.visualstudio.com/CDT.OET.CAL-ITP/_build/latest?definitionId=828&branchName=dev)
+### Set up for local development
 
-Terraform is [`plan`](https://www.terraform.io/cli/commands/plan)'d when code is pushed to any branch on GitHub, then [`apply`](https://www.terraform.io/cli/commands/apply)'d when merged to `dev`. While other automation for this project is done through GitHub Actions, we use an Azure Pipeline (above) for a couple of reasons:
-
-- Easier authentication with the Azure API using a service connnection
-- Log output is hidden, avoiding accidentally leaking secrets
-
-### Local development
-
-1. Get access to the Azure account through the DevSecOps team.
+1. [Get access to the Azure account through the DevSecOps team.](#getting-started)
 1. Install dependencies:
 
    - [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
@@ -167,6 +160,11 @@ Terraform is [`plan`](https://www.terraform.io/cli/commands/plan)'d when code is
    ```
 
 1. Create a local `terraform.tfvars` file (ignored by git) from the sample; fill in the `*_OBJECT_ID` variables with values from the Azure Pipeline definition.
+
+### Development process
+
+When configuration changes to infrastructure resources are needed, they should be made to the resource definitions in Terraform and submitted via pull request.
+
 1. Make changes to Terraform files.
 1. Preview the changes, as necessary.
 
@@ -174,20 +172,33 @@ Terraform is [`plan`](https://www.terraform.io/cli/commands/plan)'d when code is
    terraform plan
    ```
 
-1. [Submit the changes via pull request.](../development/commits-branches-merging/)
+1. [Submit the changes via pull request.](../../development/commits-branches-merging)
 
-For Azure resources, you need to [ignore changes](https://www.terraform.io/language/meta-arguments/lifecycle#ignore_changes) to tags, since they are [automatically created by Azure Policy](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/tag-policies).
+!!! info "Azure tags"
+    For Azure resources, you need to [ignore changes](https://www.terraform.io/language/meta-arguments/lifecycle#ignore_changes) to tags, since they are [automatically created by an Azure Policy managed by CDT](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/tag-policies).
 
-```hcl
-lifecycle {
-  ignore_changes = [tags]
-}
-```
+    ```hcl
+    lifecycle {
+        ignore_changes = [tags]
+    }
+    ```
+
+### Infrastructure pipeline
+
+[![Build Status](https://calenterprise.visualstudio.com/CDT.OET.CAL-ITP/_apis/build/status/cal-itp.benefits%20Infra?branchName=dev)](https://calenterprise.visualstudio.com/CDT.OET.CAL-ITP/_build/latest?definitionId=828&branchName=dev)
+
+When code is pushed to any branch on GitHub, our infrastructure pipeline in Azure DevOps runs [`terraform plan`](https://www.terraform.io/cli/commands/plan). When the pull request is merged into `dev`, the pipeline runs [`terraform apply`](https://www.terraform.io/cli/commands/apply).
+
+While other automation for this project is done through GitHub Actions, we use an Azure Pipeline for a couple of reasons:
+
+- Easier authentication with the Azure API using a service connnection
+- Log output is hidden, avoiding accidentally leaking secrets
 
 ## Azure environment setup
 
-The following steps are required to set up the environment:
+These steps were followed when setting up our Azure deployment for the first time:
 
+- CDT team creates the [resources that they own](#ownership)
 - `terraform apply`
 - Set up Slack notifications by [creating a Slack email](https://slack.com/help/articles/206819278-Send-emails-to-Slack) for the [#notify-benefits](https://cal-itp.slack.com/archives/C022HHSEE3F) channel, then [setting it as a Secret in the Key Vault](https://learn.microsoft.com/en-us/azure/key-vault/secrets/quick-create-portal#add-a-secret-to-key-vault) named `slack-benefits-notify-email`
 - Set required [App Service configuration](../configuration/environment-variables.md) and [configuration](../configuration/data.md) by setting values in Key Vault (the mapping is defined in [app_service.tf](https://github.com/cal-itp/benefits/blob/dev/terraform/app_service.tf))

--- a/docs/deployment/infrastructure.md
+++ b/docs/deployment/infrastructure.md
@@ -2,6 +2,12 @@
 
 The infrastructure is configured as code via [Terraform](https://www.terraform.io/), for [various reasons](https://techcommunity.microsoft.com/t5/fasttrack-for-azure/the-benefits-of-infrastructure-as-code/ba-p/2069350).
 
+## Getting started
+
+Since the Benefits app is deployed into a Microsoft Azure account provided by the California Department of Technology (CDT)'s Office of Enterprise Technology (OET) team, you'll need to request access from them to the `CDT Digital CA` directory so you can get into the [Azure portal](https://portal.azure.com), and to the `California Department of Technology` directory so you can access [Azure DevOps](https://calenterprise.visualstudio.com/CDT.OET.CAL-ITP).
+
+The Azure portal is where you can view the infrastructure resources for Benefits. Azure DevOps is where our [infrastructure pipeline](https://github.com/cal-itp/benefits/blob/dev/terraform/azure-pipelines.yml) is run to build and deploy those infrastructure resources.
+
 ## Environments
 
 Within the `CDT Digital CA` directory, there are two [Subscriptions](https://learn.microsoft.com/en-us/microsoft-365/enterprise/subscriptions-licenses-accounts-and-tenants-for-microsoft-cloud-offerings?view=o365-worldwide#subscriptions), with Resource Groups under each. (Refer to Azure's documentation for [switching directories](https://learn.microsoft.com/en-us/azure/devtest/offer/how-to-change-directory-tenants-visual-studio-azure).)


### PR DESCRIPTION
This PR  reorganizes the infrastructure documentation to be friendlier to a new developer.

- Added an intro section with more context on how to get access
- Moved up sections that explain the environments and architecture
- Made some content edits to remove unnecessary detail  and use clearer wording