### PR TITLE
Fix: terraform source control block

### DIFF
--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -106,6 +106,14 @@ resource "azurerm_app_service_source_control" "main" {
   repo_url               = "https://github.com/cal-itp/benefits"
   branch                 = local.env_name
   use_manual_integration = true
+
+  github_action_configuration {
+    generate_workflow_file = false
+    container_configuration {
+      registry_url = "https://ghcr.io/"
+      image_name   = "cal-itp/benefits"
+    }
+  }
 }
 
 resource "azurerm_app_service_custom_hostname_binding" "main" {

--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -102,9 +102,10 @@ resource "azurerm_linux_web_app" "main" {
 }
 
 resource "azurerm_app_service_source_control" "main" {
-  app_id   = azurerm_linux_web_app.main.id
-  repo_url = "https://github.com/cal-itp/benefits"
-  branch   = local.env_name
+  app_id                 = azurerm_linux_web_app.main.id
+  repo_url               = "https://github.com/cal-itp/benefits"
+  branch                 = local.env_name
+  use_manual_integration = true
 }
 
 resource "azurerm_app_service_custom_hostname_binding" "main" {


### PR DESCRIPTION
After deleting all of the Azure Webhooks in this git repo, we saw one show up for the `dev` app:

![image](https://github.com/cal-itp/benefits/assets/1783439/003537eb-1a96-40d1-aff7-12b64f3eca0d)

_(I disabled this webhook for working on this PR, we should delete it before merging to ensure Azure doesn't re-create)_.

It seems like this was created because the Azure Deployment Center settings didn't take for **GitHub Actions** with the old **Container Registry** still being selected with unsaved _pending_ state.

![image](https://github.com/cal-itp/benefits/assets/1783439/f8f997de-f150-477b-b271-6e6ed5bf08ee)

Now that we know the Terraform state is aligned, this PR introduces some changes to hopefully get the UI where we want.

* Turn [`use_manual_integration = true`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service_source_control#use_manual_integration), from the default of `false`. The docs say: _Set to `false` to enable continuous integration, such as webhooks into online repos such as GitHub. Defaults to `false`. Changing this forces a new resource to be created._
* Add a [`github_action_configuration`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service_source_control#github_action_configuration) block with a [`container_configuration`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service_source_control#container_configuration) block.