### PR TITLE
Feat: enable app service storage

### DIFF
--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -47,7 +47,7 @@ resource "azurerm_linux_web_app" "main" {
   app_settings = {
     "DOCKER_REGISTRY_SERVER_URL"          = "https://ghcr.io/"
     "WEBSITE_TIME_ZONE"                   = "America/Los_Angeles",
-    "WEBSITES_ENABLE_APP_SERVICE_STORAGE" = "false",
+    "WEBSITES_ENABLE_APP_SERVICE_STORAGE" = "true",
     "WEBSITES_PORT"                       = "8000",
 
     "ANALYTICS_KEY" = local.is_dev ? null : "${local.secret_prefix}analytics-key)",


### PR DESCRIPTION
Azure will manage the `/home` directory and restore it when the app restarts.

Closes #2153 