### PR TITLE
Fix: verifier help templates

### DIFF
--- a/benefits/core/context_processors.py
+++ b/benefits/core/context_processors.py
@@ -15,7 +15,7 @@ def unique_values(original_list):
 def _agency_context(agency):
     return {
         "eligibility_index_url": agency.eligibility_index_url,
-        "help_templates": unique_values([v.help_template for v in agency.active_verifiers if v.help_template is not None]),
+        "help_templates": unique_values([v.help_template for v in agency.active_verifiers if v.help_template]),
         "info_url": agency.info_url,
         "long_name": agency.long_name,
         "phone": agency.phone,


### PR DESCRIPTION
This PR fixes #2168  by making sure the context variable `agency.help_templates` doesn't include empty strings.

The logic previously did not consider the case where the admin interface populates the `help_template` as an empty string rather than `None`. If you load an `EligibilityVerifier` fixture that doesn't specify `help_template`, the field gets set as `None`.