### PR TITLE
Fix: changing languages on the enrollment success page

### DIFF
--- a/benefits/core/templates/core/includes/lang-selector.html
+++ b/benefits/core/templates/core/includes/lang-selector.html
@@ -14,6 +14,7 @@ If more language support is added, the hidden input can be replaced by a select
     <form method="post" action="{% url "set_language" %}">
       {% csrf_token %}
       {% get_language_info for code as langinfo %}
+      <input name="next" type="hidden" value="{{ redirect_to }}" />
       <input name="language" type="hidden" value="{{ code }}" />
       <button class="btn btn-lg btn-outline-light" type="submit">{{ langinfo.name_local | capfirst }}</button>
     </form>

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -289,4 +289,5 @@ def success(request):
         session.update(request, origin=reverse(ROUTE_LOGGED_OUT))
 
     analytics.returned_success(request, eligibility.group_id)
-    return TemplateResponse(request, eligibility.enrollment_success_template)
+    context = {"redirect_to": request.path}
+    return TemplateResponse(request, eligibility.enrollment_success_template, context)


### PR DESCRIPTION
Closes #2058 

On the enrollment success page, the Django [`set_language`](https://github.com/django/django/blob/main/django/views/i18n.py#L30) redirect view was redirecting the user to the enrollment index page when the language was changed. Looking at the [Django documentation](https://docs.djangoproject.com/en/5.0/topics/i18n/translation/#the-set-language-redirect-view), adding a `next` parameter in the `POST` data and explicitly including the enrollment success page url in the context seems to be what was missing.

For all other views, when changing languages, I think we don't see this behavior because the `Referer` request header contains the address of the same view, but for the enrollment success view, `Referer` is `/enrollment/` (I think because it is called from `/enrollment/` initially), so using the `next` parameter is required.