### PR TITLE
Fix: oauth client not registered exception in logout

### DIFF
--- a/benefits/oauth/views.py
+++ b/benefits/oauth/views.py
@@ -101,7 +101,7 @@ def cancel(request):
 def logout(request):
     """View implementing OIDC and application sign out."""
     verifier = session.verifier(request)
-    oauth_client = oauth.create_client(verifier.auth_provider.client_name)
+    oauth_client = create_client(oauth, verifier.auth_provider)
 
     if not oauth_client:
         raise Exception(f"oauth_client not registered: {verifier.auth_provider.client_name}")


### PR DESCRIPTION
Closes #2184

This PR changes the [`logout` view to call the helper function `create_client`](https://github.com/cal-itp/benefits/blob/dev/benefits/oauth/views.py#L104). Just a note that I couldn't recreate the exception described in #2184, but in any case, this PR makes creating an `oauth_client` consistent across the `login`, `authorize`, and `logout` views of [`oauth`](https://github.com/cal-itp/benefits/blob/dev/benefits/oauth/views.py).