### PR TITLE
Chore: Rename `dev` branch to `main`

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.yml
+++ b/.github/ISSUE_TEMPLATE/release.yml
@@ -55,8 +55,8 @@ body:
 
         Reference the diagram and discussion on [the release process docs](https://docs.calitp.org/benefits/deployment/release/).
 
-        * `Regular` release: propagates from `dev` to `test`, and then `test` to `prod`. Only possible if `dev` is ready to deploy.
-        * `Hotfix` release: fix is merged into `prod`. After release, fix is propagated to `dev` and `test`.
+        * `Regular` release: propagates from `main` to `test`, and then `test` to `prod`. Only possible if `main` is ready to deploy.
+        * `Hotfix` release: fix is merged into `prod`. After release, fix is propagated to `main` and `test`.
   - type: dropdown
     id: type
     attributes:
@@ -78,12 +78,12 @@ body:
       label: Regular release checklist
       description: Complete these items in sequence as the `Regular` release progresses
       options:
-        - label: Ensure the `dev` branch and secrets are up to date
+        - label: Ensure the `main` branch and secrets are up to date
         - label: Create a branch called release/version from the source branch
         - label: Bump the application version
-        - label: Open a PR for the release branch into `dev`, merge
+        - label: Open a PR for the release branch into `main`, merge
         - label: Ensure `test` secrets are up to date
-        - label: Open another PR from `dev` to `test`, merge
+        - label: Open another PR from `main` to `test`, merge
         - label: QA the app in test
         - label: Ensure `prod` secrets are up to date
         - label: Open a PR for the `test` branch into `prod`, merge
@@ -109,7 +109,7 @@ body:
         - label: Create a release in GitHub for the tag, generating release notes
         - label: Edit release notes to link back to this Release process issue
         - label: Edit release notes with additional context, images, animations, etc. as-needed
-        - label: Create a branch off `dev`
+        - label: Create a branch off `main`
         - label: Open a PR from `prod` into that branch, merge
-        - label: (optional) Adapt hotfix to current state of `dev` in that same branch
-        - label: Merge the PR into `dev`
+        - label: (optional) Adapt hotfix to current state of `main` in that same branch
+        - label: Merge the PR into `main`

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,7 +7,7 @@ on:
       - "**.js"
       - "**.py"
   pull_request:
-    branches: [dev, test, prod]
+    branches: [main, test, prod]
     paths:
       - "**.js"
       - "**.py"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - dev
+      - main
       - test
       - prod
 

--- a/.github/workflows/labeler-deploy-dev.yml
+++ b/.github/workflows/labeler-deploy-dev.yml
@@ -2,7 +2,7 @@ name: Label dev deploys
 
 on:
   pull_request:
-    branches: [dev]
+    branches: [main]
     types: [opened]
     paths:
       - ".github/workflows/deploy-*.yml"

--- a/.github/workflows/labeler-docs.yml
+++ b/.github/workflows/labeler-docs.yml
@@ -2,7 +2,7 @@ name: Label docs
 
 on:
   pull_request:
-    branches: [dev]
+    branches: [main]
     types: [opened]
     paths:
       - 'docs/**'

--- a/.github/workflows/labeler-infrastructure.yml
+++ b/.github/workflows/labeler-infrastructure.yml
@@ -2,7 +2,7 @@ name: Label infrastructure
 
 on:
   pull_request:
-    branches: [dev]
+    branches: [main]
     types: [opened]
     paths:
       - 'docs/deployment/**'

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -7,17 +7,17 @@ on:
     types:
       - completed
     branches:
-      - dev
+      - main
   pull_request:
     branches:
-      - dev
+      - main
     paths:
       - "docs/**"
       - "mkdocs.yml"
       - ".github/workflows/mkdocs.yml"
   push:
     branches:
-      - dev
+      - main
     paths:
       - "docs/**"
       - "mkdocs.yml"
@@ -95,7 +95,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v6
         with:
           workflow: tests-pytest.yml
-          branch: dev
+          branch: main
           event: push
           name: coverage-report
           path: docs/tests/coverage

--- a/.github/workflows/tests-ui.yml
+++ b/.github/workflows/tests-ui.yml
@@ -3,7 +3,7 @@ name: UI & a11y tests
 on:
   workflow_dispatch:
   pull_request:
-    branches: [dev, test, prod]
+    branches: [main, test, prod]
 
 defaults:
   run:

--- a/benefits/secrets.py
+++ b/benefits/secrets.py
@@ -65,7 +65,7 @@ def get_secret_by_name(secret_name, client=None):
     elif client is None:
         # construct the KeyVault URL from the runtime environment
         # see https://docs.calitp.org/benefits/deployment/infrastructure/#environments
-        # and https://github.com/cal-itp/benefits/blob/dev/terraform/key_vault.tf
+        # and https://github.com/cal-itp/benefits/blob/main/terraform/key_vault.tf
         vault_url = KEY_VAULT_URL.format(env=runtime_env[0])
         logger.debug(f"Configuring Azure KeyVault secrets client for: {vault_url}")
 

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -74,9 +74,9 @@ else:
     # do something when this agency is inactive
 ```
 
-[benefits-manage]: https://github.com/cal-itp/benefits/blob/dev/manage.py
-[benefits-settings]: https://github.com/cal-itp/benefits/blob/dev/benefits/settings.py
-[benefits-wsgi]: https://github.com/cal-itp/benefits/blob/dev/benefits/wsgi.py
+[benefits-manage]: https://github.com/cal-itp/benefits/blob/main/manage.py
+[benefits-settings]: https://github.com/cal-itp/benefits/blob/main/benefits/settings.py
+[benefits-wsgi]: https://github.com/cal-itp/benefits/blob/main/benefits/wsgi.py
 [django-model]: https://docs.djangoproject.com/en/5.0/topics/db/models/
 [django-settings]: https://docs.djangoproject.com/en/5.0/topics/settings/
 [django-using-settings]: https://docs.djangoproject.com/en/5.0/topics/settings/#using-settings-in-python-code

--- a/docs/configuration/data.md
+++ b/docs/configuration/data.md
@@ -52,10 +52,10 @@ bin/reset_db.sh
 See the [Django Environment Variables](environment-variables.md#django) section for details about how to configure the local
 database rebuild.
 
-[core-models]: https://github.com/cal-itp/benefits/blob/dev/benefits/core/models.py
+[core-models]: https://github.com/cal-itp/benefits/blob/main/benefits/core/models.py
 [django-fixtures]: https://docs.djangoproject.com/en/5.0/topics/db/fixtures/
 [django-load-initial-data]: https://docs.djangoproject.com/en/5.0/howto/initial-data/
 [eligibility-server]: https://docs.calitp.org/eligibility-server
-[init]: https://github.com/cal-itp/benefits/blob/dev/bin/init.sh
-[reset-db]: https://github.com/cal-itp/benefits/blob/dev/bin/reset_db.sh
-[sample-fixtures]: https://github.com/cal-itp/benefits/tree/dev/benefits/core/migrations/local_fixtures.json
+[init]: https://github.com/cal-itp/benefits/blob/main/bin/init.sh
+[reset-db]: https://github.com/cal-itp/benefits/blob/main/bin/reset_db.sh
+[sample-fixtures]: https://github.com/cal-itp/benefits/tree/main/benefits/core/migrations/local_fixtures.json

--- a/docs/configuration/oauth.md
+++ b/docs/configuration/oauth.md
@@ -36,4 +36,4 @@ use in e.g. views.
 Consumers call `benefits.oauth.client.create_client(oauth, provider)` with the name of a client to obtain an Authlib client
 instance. If that client name has not been registered yet, `_register_provider(oauth_registry, provider)` uses data from the given `AuthProvider` instance to register the client into this instance and returns the client object.
 
-[oauth-client]: https://github.com/cal-itp/benefits/blob/dev/benefits/oauth/client.py
+[oauth-client]: https://github.com/cal-itp/benefits/blob/main/benefits/oauth/client.py

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -31,7 +31,7 @@ Docker images for each of the deploy branches are available from GitHub Containe
 [oet]: https://techblog.cdt.ca.gov/2020/06/cdt-taking-the-lead-in-digital-transformation/
 [app-service-containers]: https://docs.microsoft.com/en-us/azure/app-service/configure-custom-container
 [app-service]: https://docs.microsoft.com/en-us/azure/app-service/overview
-[deploy-workflow]: https://github.com/cal-itp/benefits/blob/dev/.github/workflows/deploy.yml
-[dockerfile]: https://github.com/cal-itp/benefits/blob/dev/Dockerfile
+[deploy-workflow]: https://github.com/cal-itp/benefits/blob/main/.github/workflows/deploy.yml
+[dockerfile]: https://github.com/cal-itp/benefits/blob/main/Dockerfile
 [az-webapp]: https://azure.microsoft.com/en-us/services/app-service/containers/
 [ghcr]: https://github.com/features/packages

--- a/docs/deployment/infrastructure.md
+++ b/docs/deployment/infrastructure.md
@@ -6,7 +6,7 @@ The infrastructure is configured as code via [Terraform](https://www.terraform.i
 
 Since the Benefits app is deployed into a Microsoft Azure account provided by the California Department of Technology (CDT)'s Office of Enterprise Technology (OET) team, you'll need to request access from them to the `CDT Digital CA` directory so you can get into the [Azure portal](https://portal.azure.com), and to the `California Department of Technology` directory so you can access [Azure DevOps](https://calenterprise.visualstudio.com/CDT.OET.CAL-ITP).
 
-The Azure portal is where you can view the infrastructure resources for Benefits. Azure DevOps is where our [infrastructure pipeline](https://github.com/cal-itp/benefits/blob/dev/terraform/azure-pipelines.yml) is run to build and deploy those infrastructure resources.
+The Azure portal is where you can view the infrastructure resources for Benefits. Azure DevOps is where our [infrastructure pipeline](https://github.com/cal-itp/benefits/blob/main/terraform/azure-pipelines.yml) is run to build and deploy those infrastructure resources.
 
 ## Environments
 
@@ -16,7 +16,7 @@ Each of our environments corresponds to a single Resource Group, [Terraform Work
 
 | Environment | Subscription          | Resource Group                | Workspace | Branch |
 | ----------- | --------------------- | ----------------------------- | --------- | ------ |
-| Dev         | `CDT/ODI Development` | `RG-CDT-PUB-VIP-CALITP-D-001` | `dev`     | `dev`  |
+| Dev         | `CDT/ODI Development` | `RG-CDT-PUB-VIP-CALITP-D-001` | `dev`     | `main`  |
 | Test        | `CDT/ODI Development` | `RG-CDT-PUB-VIP-CALITP-T-001` | `test`    | `test` |
 | Prod        | `CDT/ODI Production`  | `RG-CDT-PUB-VIP-CALITP-P-001` | `default` | `prod` |
 
@@ -146,7 +146,7 @@ Use the following shorthand for conveying the Resource Type as part of the Resou
 1. Install dependencies:
 
    - [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
-   - [Terraform](https://www.terraform.io/downloads) - see exact version in [`deploy.yml`](https://github.com/cal-itp/benefits/blob/dev/terraform/pipeline/deploy.yml)
+   - [Terraform](https://www.terraform.io/downloads) - see exact version in [`deploy.yml`](https://github.com/cal-itp/benefits/blob/main/terraform/pipeline/deploy.yml)
 
 1. [Authenticate using the Azure CLI](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli).
 
@@ -154,7 +154,7 @@ Use the following shorthand for conveying the Resource Type as part of the Resou
    az login
    ```
 
-1. Outside the [dev container](../../getting-started/), navigate to the [`terraform/`](https://github.com/cal-itp/benefits/tree/dev/terraform) directory.
+1. Outside the [dev container](../../getting-started/), navigate to the [`terraform/`](https://github.com/cal-itp/benefits/tree/main/terraform) directory.
 1. [Initialize Terraform.](https://www.terraform.io/cli/commands/init) You can also use this script later to switch between [environments](#environments).
 
    ```sh
@@ -189,7 +189,7 @@ When configuration changes to infrastructure resources are needed, they should b
 
 [![Build Status](https://calenterprise.visualstudio.com/CDT.OET.CAL-ITP/_apis/build/status/cal-itp.benefits%20Infra?branchName=dev)](https://calenterprise.visualstudio.com/CDT.OET.CAL-ITP/_build/latest?definitionId=828&branchName=dev)
 
-When code is pushed to any branch on GitHub, our infrastructure pipeline in Azure DevOps runs [`terraform plan`](https://www.terraform.io/cli/commands/plan). When the pull request is merged into `dev`, the pipeline runs [`terraform apply`](https://www.terraform.io/cli/commands/apply).
+When code is pushed to any branch on GitHub, our infrastructure pipeline in Azure DevOps runs [`terraform plan`](https://www.terraform.io/cli/commands/plan). When the pull request is merged into `main`, the pipeline runs [`terraform apply`](https://www.terraform.io/cli/commands/apply).
 
 While other automation for this project is done through GitHub Actions, we use an Azure Pipeline for a couple of reasons:
 
@@ -203,6 +203,6 @@ These steps were followed when setting up our Azure deployment for the first tim
 - CDT team creates the [resources that they own](#ownership)
 - `terraform apply`
 - Set up Slack notifications by [creating a Slack email](https://slack.com/help/articles/206819278-Send-emails-to-Slack) for the [#notify-benefits](https://cal-itp.slack.com/archives/C022HHSEE3F) channel, then [setting it as a Secret in the Key Vault](https://learn.microsoft.com/en-us/azure/key-vault/secrets/quick-create-portal#add-a-secret-to-key-vault) named `slack-benefits-notify-email`
-- Set required [App Service configuration](../configuration/environment-variables.md) and [configuration](../configuration/data.md) by setting values in Key Vault (the mapping is defined in [app_service.tf](https://github.com/cal-itp/benefits/blob/dev/terraform/app_service.tf))
+- Set required [App Service configuration](../configuration/environment-variables.md) and [configuration](../configuration/data.md) by setting values in Key Vault (the mapping is defined in [app_service.tf](https://github.com/cal-itp/benefits/blob/main/terraform/app_service.tf))
 
 This is not a complete step-by-step guide; more a list of things to remember. This may be useful as part of [incident response](https://docs.google.com/document/d/1qtev8qItPiTB4Tp9FQ87XsLtWZ4HlNXqoe9vF2VuGcY/edit#).

--- a/docs/deployment/release.md
+++ b/docs/deployment/release.md
@@ -27,10 +27,10 @@ version numbers look like: `YYYY.0M.R`
 
 ## 1. Prepare release in a branch
 
-Typically changes for a release will move from `dev`, to `test`, to `prod`. This
-assumes `dev` is in a state that it can be deployed without disruption. (This is called a `Regular` release.)
+Typically changes for a release will move from `main`, to `test`, to `prod`. This
+assumes `main` is in a state that it can be deployed without disruption. (This is called a `Regular` release.)
 
-If `dev` or `test` contain in-progress work that is not ready for production,
+If `main` or `test` contain in-progress work that is not ready for production,
 and a hotfix is needed in production, a separate process to test the changes
 before deploying to `prod` must be undertaken. (This is called a `Hotfix` release.)
 
@@ -41,8 +41,8 @@ different circumstances:
 
 ```mermaid
 graph LR
-    A(Release branch) --> B{Are dev and test ready to deploy?};
-    B -->|Yes| C(dev);
+    A(Release branch) --> B{Are main and test ready to deploy?};
+    B -->|Yes| C(main);
     C --> D(test);
     D --> E(prod);
     B -->|No| E;
@@ -54,7 +54,7 @@ upcoming version number.
 ## 2. Bump the application version number
 
 The app code maintains a version number in
-[`benefits/__init__.py`](https://github.com/cal-itp/benefits/blob/dev/benefits/__init__.py),
+[`benefits/__init__.py`](https://github.com/cal-itp/benefits/blob/main/benefits/__init__.py),
 used by the instrumentation and logging systems.
 
 This version number must be updated to match the new version in the same format:

--- a/docs/deployment/workflows.md
+++ b/docs/deployment/workflows.md
@@ -15,7 +15,7 @@ When a deployment workflow runs, the following steps are taken:
 
 ### 1. Checkout code
 
-From the tip of the corresponding branch (e.g. `dev`)
+From the tip of the corresponding branch (e.g. `main`)
 
 ### 2. Authenticate to GHCR
 
@@ -31,7 +31,7 @@ Push this image:tag into [GHCR][ghcr].
 
 Push the new image:tag to the Azure App Service instance.
 
-[deploy]: https://github.com/cal-itp/benefits/blob/dev/.github/workflows/deploy.yml
-[dockerfile]: https://github.com/cal-itp/benefits/blob/dev/Dockerfile
+[deploy]: https://github.com/cal-itp/benefits/blob/main/.github/workflows/deploy.yml
+[dockerfile]: https://github.com/cal-itp/benefits/blob/main/Dockerfile
 [ghcr]: https://github.com/features/packages
 [gh-actions-trigger]: https://docs.github.com/en/actions/reference/events-that-trigger-workflows

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -77,6 +77,6 @@ To close out of the container and re-open the directory locally in Visual Studio
 1. Type `Remote-Containers` to filter the commands
 1. Select `Reopen Locally`
 
-[config-file]: https://github.com/cal-itp/benefits/blob/dev/.devcontainer/devcontainer.json
+[config-file]: https://github.com/cal-itp/benefits/blob/main/.devcontainer/devcontainer.json
 [vscode]: https://code.visualstudio.com/
 [vscode-containers]: https://code.visualstudio.com/docs/remote/containers

--- a/docs/development/application-logic.md
+++ b/docs/development/application-logic.md
@@ -28,15 +28,15 @@ flowchart LR
     enrollment --> complete
 ```
 
-The structure of the source code in [`benefits/`](https://github.com/cal-itp/benefits/tree/dev/benefits)
+The structure of the source code in [`benefits/`](https://github.com/cal-itp/benefits/tree/main/benefits)
 generally follows from these phases:
 
-- [`benefits/core/`](https://github.com/cal-itp/benefits/tree/dev/benefits/core) implements shared logic and models, and
+- [`benefits/core/`](https://github.com/cal-itp/benefits/tree/main/benefits/core) implements shared logic and models, and
   defines the user's entrypoint into the app
-- [`benefits/oauth/`](https://github.com/cal-itp/benefits/tree/dev/benefits/oauth) implements identity proofing
-- [`benefits/eligibility/`](https://github.com/cal-itp/benefits/tree/dev/benefits/eligibility) implements eligibility
+- [`benefits/oauth/`](https://github.com/cal-itp/benefits/tree/main/benefits/oauth) implements identity proofing
+- [`benefits/eligibility/`](https://github.com/cal-itp/benefits/tree/main/benefits/eligibility) implements eligibility
   verification
-- [`benefits/enrollment/`](https://github.com/cal-itp/benefits/tree/dev/benefits/enrollment) implements enrollment
+- [`benefits/enrollment/`](https://github.com/cal-itp/benefits/tree/main/benefits/enrollment) implements enrollment
 
 Each of these directories contains a standalone Django app registered in the [settings](../configuration/README.md#django-settings).
 
@@ -287,15 +287,15 @@ benefits-->>analytics: returned enrollment
     deactivate benefits
 ```
 
-[core-context-processors]: https://github.com/cal-itp/benefits/blob/dev/benefits/core/context_processors.py
-[core-middleware]: https://github.com/cal-itp/benefits/blob/dev/benefits/core/middleware.py
-[core-models]: https://github.com/cal-itp/benefits/blob/dev/benefits/core/models.py
-[core-session]: https://github.com/cal-itp/benefits/blob/dev/benefits/core/session.py
-[core-views]: https://github.com/cal-itp/benefits/blob/dev/benefits/core/views.py
-[eligibility-verify]: https://github.com/cal-itp/benefits/blob/dev/benefits/eligibility/verify.py
-[eligibility-views]: https://github.com/cal-itp/benefits/blob/dev/benefits/eligibility/views.py
-[enrollment-views]: https://github.com/cal-itp/benefits/blob/dev/benefits/enrollment/views.py
+[core-context-processors]: https://github.com/cal-itp/benefits/blob/main/benefits/core/context_processors.py
+[core-middleware]: https://github.com/cal-itp/benefits/blob/main/benefits/core/middleware.py
+[core-models]: https://github.com/cal-itp/benefits/blob/main/benefits/core/models.py
+[core-session]: https://github.com/cal-itp/benefits/blob/main/benefits/core/session.py
+[core-views]: https://github.com/cal-itp/benefits/blob/main/benefits/core/views.py
+[eligibility-verify]: https://github.com/cal-itp/benefits/blob/main/benefits/eligibility/verify.py
+[eligibility-views]: https://github.com/cal-itp/benefits/blob/main/benefits/eligibility/views.py
+[enrollment-views]: https://github.com/cal-itp/benefits/blob/main/benefits/enrollment/views.py
 [littlepay]: https://github.com/cal-itp/littlepay
-[oauth-client]: https://github.com/cal-itp/benefits/blob/dev/benefits/oauth/client.py
-[oauth-redirects]: https://github.com/cal-itp/benefits/blob/dev/benefits/oauth/redirects.py
-[oauth-views]: https://github.com/cal-itp/benefits/blob/dev/benefits/oauth/views.py
+[oauth-client]: https://github.com/cal-itp/benefits/blob/main/benefits/oauth/client.py
+[oauth-redirects]: https://github.com/cal-itp/benefits/blob/main/benefits/oauth/redirects.py
+[oauth-views]: https://github.com/cal-itp/benefits/blob/main/benefits/oauth/views.py

--- a/docs/development/commits-branches-merging.md
+++ b/docs/development/commits-branches-merging.md
@@ -32,10 +32,10 @@ git commit -m "feat(eligibility/urls): add path for start"
 
 ## Branches
 
-The default GitHub branch is `dev`. All new feature work should be in the form of Pull Requests (PR) that target `dev` as their
+The default GitHub branch is `main`. All new feature work should be in the form of Pull Requests (PR) that target `main` as their
 base.
 
-In addition to `dev`, the repository has three other long-lived branches:
+In addition to `main`, the repository has three other long-lived branches:
 
 - `test` and `prod` correspond to the Test and Production [deploy environments](../deployment/README.md), respectively.
 - `gh-pages` hosts the compiled documentation, and is always forced-pushed by the
@@ -43,7 +43,7 @@ In addition to `dev`, the repository has three other long-lived branches:
 
 ### Protection rules
 
-[Branch protection rules][gh-branch-protection] are in place on three environment branches (`dev`, `test`, `prod`) to:
+[Branch protection rules][gh-branch-protection] are in place on three environment branches (`main`, `test`, `prod`) to:
 
 - Prevent branch deletion
 - Restrict force-pushing, where appropriate
@@ -76,7 +76,7 @@ PR branches are deleted once their PR is merged.
 Merging of PRs should be done using the _merge commit_ strategy. The PR author should utilize `git rebase -i` to ensure
 their PR commit history is clean, logical, and free of typos.
 
-When merging a PR into `dev`, it is customary to format the merge commit message like:
+When merging a PR into `main`, it is customary to format the merge commit message like:
 
 ```console
 Title of PR (#number)

--- a/docs/development/i18n.md
+++ b/docs/development/i18n.md
@@ -8,7 +8,7 @@
 
 !!! example "Message files"
 
-    English messages: [benefits/locale/en/LC_MESSAGES/django.po](https://github.com/cal-itp/benefits/blob/dev/benefits/locale/en/LC_MESSAGES/django.po)
+    English messages: [benefits/locale/en/LC_MESSAGES/django.po](https://github.com/cal-itp/benefits/blob/main/benefits/locale/en/LC_MESSAGES/django.po)
 
 The Cal-ITP Benefits application is fully internationalized and available in both English and Spanish.
 
@@ -18,7 +18,7 @@ It uses Django's built-in support for translation using [message files](https://
 
 Django has a utility command called `makemessages` to help maintain message files. It ensures that `msgid`s in the message files are actually used somewhere in source code and also detects new `msgid`s.
 
-There is a helper script that runs this command with some arguments: [`bin/makemessages.sh`](https://github.com/cal-itp/benefits/blob/dev/bin/makemessages.sh)
+There is a helper script that runs this command with some arguments: [`bin/makemessages.sh`](https://github.com/cal-itp/benefits/blob/main/bin/makemessages.sh)
 
 ```bash
 bin/makemessages.sh
@@ -38,7 +38,7 @@ Find the English copy in the Spanish `django.po` file as a `msgid`, and add the 
 
 ### Adding agency-specific copy
 
-When templates have different copy per agency, create a new template for that agency-specific copy to live in. See the example of the MST-specific agency index page file, named [`index--mst.html`](https://github.com/cal-itp/benefits/blob/dev/benefits/core/templates/core/index--mst.html). Include the agency-specific template file name in the migration object, as done here for [MST](https://github.com/cal-itp/benefits/blob/dev/benefits/core/migrations/0002_data.py#L260), with `eligibility_index_template="eligibility/index--mst.html"`.
+When templates have different copy per agency, create a new template for that agency-specific copy to live in. See the example of the MST-specific agency index page file, named [`index--mst.html`](https://github.com/cal-itp/benefits/blob/main/benefits/core/templates/core/index--mst.html). Include the agency-specific template file name in the migration object, as done here for [MST](https://github.com/cal-itp/benefits/blob/main/benefits/core/migrations/0002_data.py#L260), with `eligibility_index_template="eligibility/index--mst.html"`.
 
 ### Fuzzy strings
 

--- a/docs/development/models-migrations.md
+++ b/docs/development/models-migrations.md
@@ -31,6 +31,6 @@ This script:
 
 Commit the new migration file along with the model changes.
 
-[core-models]: https://github.com/cal-itp/benefits/blob/dev/benefits/core/models.py
-[core-migrations]: https://github.com/cal-itp/benefits/blob/dev/benefits/core/migrations/0001_initial.py
-[makemigrations]: https://github.com/cal-itp/benefits/blob/dev/bin/makemigrations.sh
+[core-models]: https://github.com/cal-itp/benefits/blob/main/benefits/core/models.py
+[core-migrations]: https://github.com/cal-itp/benefits/blob/main/benefits/core/migrations/0001_initial.py
+[makemigrations]: https://github.com/cal-itp/benefits/blob/main/bin/makemigrations.sh

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -69,4 +69,4 @@ docker compose down
 ```
 
 [docker]: https://www.docker.com/products/docker-desktop
-[data-migration]: (https://github.com/cal-itp/benefits/tree/dev/benefits/core/migrations)
+[data-migration]: (https://github.com/cal-itp/benefits/tree/main/benefits/core/migrations)

--- a/docs/getting-started/documentation.md
+++ b/docs/getting-started/documentation.md
@@ -1,6 +1,6 @@
 # Documentation
 
-This website is built using [`mkdocs`](https://www.mkdocs.org/) from the contents of the `dev` (default) branch.
+This website is built using [`mkdocs`](https://www.mkdocs.org/) from the contents of the `main` (default) branch.
 
 The [`mkdocs.yml`][mkdocs.yml] file in the repository root configures the build process, including the available plugins.
 
@@ -62,11 +62,11 @@ See [Docker dynamic ports](../development/docker-dynamic-ports.md) for more info
 
 ## Deploying
 
-A [GitHub Action][mkdocs-action] watches for pushes to `dev`, and uses
+A [GitHub Action][mkdocs-action] watches for pushes to `main`, and uses
 [`mhausenblas/mkdocs-deploy-gh-pages`][mkdocs-deploy-gh-pages] to build the `mkdocs` content, force-pushing to the `gh-pages`
 branch. At that point, GitHub Pages redeploys the docs site.
 
-[docs]: https://github.com/cal-itp/benefits/tree/dev/docs
-[mkdocs.yml]: https://github.com/cal-itp/benefits/blob/dev/mkdocs.yml
-[mkdocs-action]: https://github.com/cal-itp/benefits/blob/dev/.github/workflows/mkdocs.yml
+[docs]: https://github.com/cal-itp/benefits/tree/main/docs
+[mkdocs.yml]: https://github.com/cal-itp/benefits/blob/main/mkdocs.yml
+[mkdocs-action]: https://github.com/cal-itp/benefits/blob/main/.github/workflows/mkdocs.yml
 [mkdocs-deploy-gh-pages]: https://github.com/mhausenblas/mkdocs-deploy-gh-pages

--- a/docs/product-and-design/analytics.md
+++ b/docs/product-and-design/analytics.md
@@ -9,7 +9,7 @@ The following user attributes are *not* collected:
 - IP address
 - Designated Market Area (DMA)
 
-See the [Amplitude analytics code on GitHub](https://github.com/cal-itp/benefits/blob/dev/benefits/core/templates/core/includes/analytics.html#L30).
+See the [Amplitude analytics code on GitHub](https://github.com/cal-itp/benefits/blob/main/benefits/core/templates/core/includes/analytics.html#L30).
 
 ## User information collected
 

--- a/docs/product-and-design/copy-delivery.md
+++ b/docs/product-and-design/copy-delivery.md
@@ -1,6 +1,6 @@
 # Copy delivery process
 
-The [`locale`](https://github.com/cal-itp/benefits/tree/dev/benefits/locale) folder in this repository contain the `django.po` message files for English and Spanish translation strings for the Benefits application.
+The [`locale`](https://github.com/cal-itp/benefits/tree/main/benefits/locale) folder in this repository contain the `django.po` message files for English and Spanish translation strings for the Benefits application.
 
 Translation strings include all application copy, including:
 
@@ -8,7 +8,7 @@ Translation strings include all application copy, including:
 - Image and illustration alt tags
 - Page titles used in the browser tab
 - In-line link URLs
-- Error messages (like [no script](https://github.com/cal-itp/benefits/blob/dev/benefits/core/templates/core/includes/noscript.html), [no cookies](https://github.com/cal-itp/benefits/blob/dev/benefits/core/templates/core/includes/nocookies.html) warnings)
+- Error messages (like [no script](https://github.com/cal-itp/benefits/blob/main/benefits/core/templates/core/includes/noscript.html), [no cookies](https://github.com/cal-itp/benefits/blob/main/benefits/core/templates/core/includes/nocookies.html) warnings)
 
 ## Cal-ITP Benefits Application Copy
 

--- a/docs/tests/automated-tests.md
+++ b/docs/tests/automated-tests.md
@@ -3,7 +3,7 @@
 ## Cypress
 
 Feature and user interface tests are implemented with [`cypress`](https://www.cypress.io/) and can be found in the
-[`tests/cypress`](https://github.com/cal-itp/benefits/tree/dev/tests/cypress) directory in the repository.
+[`tests/cypress`](https://github.com/cal-itp/benefits/tree/main/tests/cypress) directory in the repository.
 
 See the [`cypress` Command Line](https://docs.cypress.io/guides/guides/command-line) guide for more information.
 
@@ -77,4 +77,4 @@ The report files include a local `.gitignore` file, so the entire directory is h
 
 ### Latest coverage report
 
-We also make the latest (from `dev`) coverage report available online here: [Coverage report](../coverage)
+We also make the latest (from `main`) coverage report available online here: [Coverage report](../coverage)

--- a/terraform/azure-pipelines.yml
+++ b/terraform/azure-pipelines.yml
@@ -3,7 +3,7 @@ trigger:
   # https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#pr-triggers
   branches:
     include:
-      - dev
+      - main
       - test
       - prod
   # only run for changes to Terraform files

--- a/terraform/pipeline/deploy.yml
+++ b/terraform/pipeline/deploy.yml
@@ -48,7 +48,7 @@ steps:
       # service connection
       environmentServiceNameAzureRM: "${{ parameters.service_connection }}"
     # the plan is done as part of the apply (below), so don't bother doing it twice
-    condition: notIn(variables['Build.SourceBranchName'], 'dev', 'test', 'prod')
+    condition: notIn(variables['Build.SourceBranchName'], 'main', 'test', 'prod')
   - task: TerraformTaskV3@3
     displayName: Terraform apply
     inputs:
@@ -60,4 +60,4 @@ steps:
       # service connection
       environmentServiceNameAzureRM: "${{ parameters.service_connection }}"
     # only run on certain branches
-    condition: in(variables['Build.SourceBranchName'], 'dev', 'test', 'prod')
+    condition: in(variables['Build.SourceBranchName'], 'main', 'test', 'prod')

--- a/terraform/pipeline/workspace.py
+++ b/terraform/pipeline/workspace.py
@@ -5,29 +5,30 @@ import os
 import sys
 
 REASON = os.environ["REASON"]
+
 # the name of the variable that Azure Pipelines uses for the source branch
 # depends on the type of run, so need to check both
 SOURCE = os.environ.get("OTHER_SOURCE") or os.environ["INDIVIDUAL_SOURCE"]
+
 TARGET = os.environ["TARGET"]
 
-# the branches that correspond to environments
-ENV_BRANCHES = ["dev", "test", "prod"]
+# branch to workspace mapping
+WORKSPACES = {"main": "dev", "test": "test", "prod": "default"}
+# workspace to service connection mapping
+SERVICE_CONNECTIONS = {"dev": "Development", "test": "Development", "default": "Production"}
 
-if REASON == "PullRequest" and TARGET in ENV_BRANCHES:
+if REASON == "PullRequest" and TARGET in WORKSPACES:
     # it's a pull request against one of the environment branches, so use the
     # target branch
-    environment = TARGET
-elif REASON in ["IndividualCI", "Manual"] and SOURCE in ENV_BRANCHES:
+    workspace = WORKSPACES[TARGET]
+elif REASON in ["IndividualCI", "Manual"] and SOURCE in WORKSPACES:
     # it's being run on one of the environment branches, so use that
-    environment = SOURCE
+    workspace = WORKSPACES[SOURCE]
 else:
     # default to running against dev
-    environment = "dev"
+    workspace = "dev"
 
-# matching logic in ../init.sh
-workspace = "default" if environment == "prod" else environment
-
-service_connection = "Production" if environment == "prod" else "Development"
+service_connection = SERVICE_CONNECTIONS[workspace]
 
 # just for troubleshooting
 if TARGET is not None:


### PR DESCRIPTION
This PR implements the first step of code changes needed to transition the `benefits` repository to tag-based deployments as described in #1527. The code changes are associated with:

- GitHub workflows
- GitHub Issues template
- Terraform
- References to `dev` in the documentation or code comments

To merge these code changes:

- [x] [Rename](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch#renaming-a-branch) the `dev` branch to `main` in the repository's settings. Renaming instead of creating a new branch avoids having to set up branch protection rules again for `main`.
- [x] Create the `main` environment in GitHub’s Environments settings page following the same configuration as the `dev` environment
  - [ ] Set `AZURE_WEBAPP_PUBLISH_PROFILE`
  - [ ] Set `AZURE_WEBAPP_NAME`
- [ ] Merge this PR since GitHub will automatically [update the base branch of this PR to `main`](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch#about-renaming-branches).

## Notes

These may be helpful when reviewing [workspace.py](https://github.com/cal-itp/benefits/pull/2202/files#diff-33a8fda4d235c86352a2629618f4d0829b626df6084edef709ad22d97e8f80fc):

- `REASON` = `Build.Reason`: The event that caused the build to run.
- `OTHER_SOURCE` = `System.PullRequest.SourceBranch`: The branch that is being reviewed in a pull request.
- `INDIVIDUAL_SOURCE` = `Build.SourceBranchName`: The name of the branch in the triggering repo the build was queued for.
- `TARGET` = `System.PullRequest.TargetBranch`: The branch that is the target of a pull request.
