### PR TITLE
Feat: Cal-ITP staff can view configuration values

### DIFF
--- a/benefits/core/admin.py
+++ b/benefits/core/admin.py
@@ -24,7 +24,7 @@ admin.site.register(models.PemData)
 @admin.register(models.AuthProvider)
 class AuthProviderAdmin(admin.ModelAdmin):
     def get_exclude(self, request, obj=None):
-        if request.user.groups.contains(Group.objects.get(name=STAFF_GROUP_NAME)):
+        if not request.user.is_superuser:
             return ["client_id_secret_name"]
         else:
             return super().get_exclude(request, obj)
@@ -33,7 +33,7 @@ class AuthProviderAdmin(admin.ModelAdmin):
 @admin.register(models.EligibilityType)
 class EligibilityTypeAdmin(admin.ModelAdmin):
     def get_exclude(self, request, obj=None):
-        if request.user.groups.contains(Group.objects.get(name=STAFF_GROUP_NAME)):
+        if not request.user.is_superuser:
             return []
         else:
             return super().get_exclude(request, obj)
@@ -42,7 +42,7 @@ class EligibilityTypeAdmin(admin.ModelAdmin):
 @admin.register(models.EligibilityVerifier)
 class SortableEligibilityVerifierAdmin(SortableAdminMixin, admin.ModelAdmin):
     def get_exclude(self, request, obj=None):
-        if request.user.groups.contains(Group.objects.get(name=STAFF_GROUP_NAME)):
+        if not request.user.is_superuser:
             return [
                 "api_auth_header",
                 "api_auth_key_secret_name",
@@ -59,7 +59,7 @@ class SortableEligibilityVerifierAdmin(SortableAdminMixin, admin.ModelAdmin):
 @admin.register(models.PaymentProcessor)
 class PaymentProcessorAdmin(admin.ModelAdmin):
     def get_exclude(self, request, obj=None):
-        if request.user.groups.contains(Group.objects.get(name=STAFF_GROUP_NAME)):
+        if not request.user.is_superuser:
             return [
                 "client_id",
                 "client_secret_name",
@@ -72,7 +72,7 @@ class PaymentProcessorAdmin(admin.ModelAdmin):
 @admin.register(models.TransitAgency)
 class TransitAgencyAdmin(admin.ModelAdmin):
     def get_exclude(self, request, obj=None):
-        if request.user.groups.contains(Group.objects.get(name=STAFF_GROUP_NAME)):
+        if not request.user.is_superuser:
             return [
                 "private_key",
                 "public_key",

--- a/benefits/core/admin.py
+++ b/benefits/core/admin.py
@@ -41,7 +41,19 @@ class EligibilityTypeAdmin(admin.ModelAdmin):
 
 @admin.register(models.EligibilityVerifier)
 class SortableEligibilityVerifierAdmin(SortableAdminMixin, admin.ModelAdmin):
-    pass
+    def get_exclude(self, request, obj=None):
+        if request.user.groups.contains(Group.objects.get(name=STAFF_GROUP_NAME)):
+            return [
+                "api_auth_header",
+                "api_auth_key_secret_name",
+                "public_key",
+                "jwe_cek_enc",
+                "jwe_encryption_alg",
+                "jws_signing_alg",
+                "form_class",
+            ]
+        else:
+            return super().get_exclude(request, obj)
 
 
 @admin.register(models.PaymentProcessor)

--- a/benefits/core/admin.py
+++ b/benefits/core/admin.py
@@ -32,7 +32,11 @@ class AuthProviderAdmin(admin.ModelAdmin):
 
 @admin.register(models.EligibilityType)
 class EligibilityTypeAdmin(admin.ModelAdmin):
-    pass
+    def get_exclude(self, request, obj=None):
+        if request.user.groups.contains(Group.objects.get(name=STAFF_GROUP_NAME)):
+            return []
+        else:
+            return super().get_exclude(request, obj)
 
 
 @admin.register(models.EligibilityVerifier)

--- a/benefits/core/admin.py
+++ b/benefits/core/admin.py
@@ -71,7 +71,15 @@ class PaymentProcessorAdmin(admin.ModelAdmin):
 
 @admin.register(models.TransitAgency)
 class TransitAgencyAdmin(admin.ModelAdmin):
-    pass
+    def get_exclude(self, request, obj=None):
+        if request.user.groups.contains(Group.objects.get(name=STAFF_GROUP_NAME)):
+            return [
+                "private_key",
+                "public_key",
+                "jws_signing_alg",
+            ]
+        else:
+            return super().get_exclude(request, obj)
 
 
 def pre_login_user(user, request):

--- a/benefits/core/admin.py
+++ b/benefits/core/admin.py
@@ -22,7 +22,7 @@ admin.site.register(models.PemData)
 
 
 @admin.register(models.AuthProvider)
-class AuthProviderAdmin(admin.ModelAdmin):
+class AuthProviderAdmin(admin.ModelAdmin):  # pragma: no cover
     def get_exclude(self, request, obj=None):
         if not request.user.is_superuser:
             return ["client_id_secret_name"]
@@ -31,7 +31,7 @@ class AuthProviderAdmin(admin.ModelAdmin):
 
 
 @admin.register(models.EligibilityType)
-class EligibilityTypeAdmin(admin.ModelAdmin):
+class EligibilityTypeAdmin(admin.ModelAdmin):  # pragma: no cover
     def get_exclude(self, request, obj=None):
         if not request.user.is_superuser:
             return []
@@ -40,7 +40,7 @@ class EligibilityTypeAdmin(admin.ModelAdmin):
 
 
 @admin.register(models.EligibilityVerifier)
-class SortableEligibilityVerifierAdmin(SortableAdminMixin, admin.ModelAdmin):
+class SortableEligibilityVerifierAdmin(SortableAdminMixin, admin.ModelAdmin):  # pragma: no cover
     def get_exclude(self, request, obj=None):
         if not request.user.is_superuser:
             return [
@@ -57,7 +57,7 @@ class SortableEligibilityVerifierAdmin(SortableAdminMixin, admin.ModelAdmin):
 
 
 @admin.register(models.PaymentProcessor)
-class PaymentProcessorAdmin(admin.ModelAdmin):
+class PaymentProcessorAdmin(admin.ModelAdmin):  # pragma: no cover
     def get_exclude(self, request, obj=None):
         if not request.user.is_superuser:
             return [
@@ -70,7 +70,7 @@ class PaymentProcessorAdmin(admin.ModelAdmin):
 
 
 @admin.register(models.TransitAgency)
-class TransitAgencyAdmin(admin.ModelAdmin):
+class TransitAgencyAdmin(admin.ModelAdmin):  # pragma: no cover
     def get_exclude(self, request, obj=None):
         if not request.user.is_superuser:
             return [

--- a/benefits/core/admin.py
+++ b/benefits/core/admin.py
@@ -58,7 +58,15 @@ class SortableEligibilityVerifierAdmin(SortableAdminMixin, admin.ModelAdmin):
 
 @admin.register(models.PaymentProcessor)
 class PaymentProcessorAdmin(admin.ModelAdmin):
-    pass
+    def get_exclude(self, request, obj=None):
+        if request.user.groups.contains(Group.objects.get(name=STAFF_GROUP_NAME)):
+            return [
+                "client_id",
+                "client_secret_name",
+                "audience",
+            ]
+        else:
+            return super().get_exclude(request, obj)
 
 
 @admin.register(models.TransitAgency)

--- a/benefits/core/admin.py
+++ b/benefits/core/admin.py
@@ -17,20 +17,32 @@ logger = logging.getLogger(__name__)
 GOOGLE_USER_INFO_URL = "https://www.googleapis.com/oauth2/v3/userinfo"
 STAFF_GROUP_NAME = "Cal-ITP"
 
+logger.debug("Register models with admin site")
+admin.site.register(models.PemData)
 
-for model in [
-    models.AuthProvider,
-    models.EligibilityType,
-    models.PaymentProcessor,
-    models.PemData,
-    models.TransitAgency,
-]:
-    logger.debug(f"Register {model.__name__}")
-    admin.site.register(model)
+
+@admin.register(models.AuthProvider)
+class AuthProviderAdmin(admin.ModelAdmin):
+    pass
+
+
+@admin.register(models.EligibilityType)
+class EligibilityTypeAdmin(admin.ModelAdmin):
+    pass
 
 
 @admin.register(models.EligibilityVerifier)
 class SortableEligibilityVerifierAdmin(SortableAdminMixin, admin.ModelAdmin):
+    pass
+
+
+@admin.register(models.PaymentProcessor)
+class PaymentProcessorAdmin(admin.ModelAdmin):
+    pass
+
+
+@admin.register(models.TransitAgency)
+class TransitAgencyAdmin(admin.ModelAdmin):
     pass
 
 

--- a/benefits/core/admin.py
+++ b/benefits/core/admin.py
@@ -23,7 +23,11 @@ admin.site.register(models.PemData)
 
 @admin.register(models.AuthProvider)
 class AuthProviderAdmin(admin.ModelAdmin):
-    pass
+    def get_exclude(self, request, obj=None):
+        if request.user.groups.contains(Group.objects.get(name=STAFF_GROUP_NAME)):
+            return ["client_id_secret_name"]
+        else:
+            return super().get_exclude(request, obj)
 
 
 @admin.register(models.EligibilityType)

--- a/benefits/core/migrations/0014_staff_group_view_permissions.py
+++ b/benefits/core/migrations/0014_staff_group_view_permissions.py
@@ -1,0 +1,40 @@
+from django.contrib.auth.management import create_permissions
+from django.db import migrations
+
+
+def create_all_permissions(apps, schema_editor):
+    for app_config in apps.get_app_configs():
+        app_config.models_module = True
+        create_permissions(app_config, apps=apps, verbosity=0)
+        app_config.models_module = None
+
+
+def add_view_permissions(apps, schema_editor):
+    Group = apps.get_model("auth", "Group")
+    staff_group = Group.objects.get(name="Cal-ITP")
+
+    Permission = apps.get_model("auth", "Permission")
+    permission_names = [
+        "Can view auth provider",
+        "Can view eligibility type",
+        "Can view eligibility verifier",
+        "Can view payment processor",
+        "Can view transit agency",
+    ]
+
+    for name in permission_names:
+        view_permission = Permission.objects.get(name=name)
+        staff_group.permissions.add(view_permission)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0013_create_staff_group"),
+    ]
+
+    operations = [
+        # create permissions at this point instead of waiting for the `auth` app's post-migrate signal
+        # https://github.com/django/django/blob/082fe2b5a83571dec4aa97580af0fe8cf2a5214e/django/contrib/auth/apps.py#L19-L20
+        migrations.RunPython(create_all_permissions),
+        migrations.RunPython(add_view_permissions),
+    ]


### PR DESCRIPTION
Closes #2199 

### Screenshots

This is what the user sees upon logging in:

![image](https://github.com/user-attachments/assets/aae9d070-7fb2-47ed-bf6f-5c11ecb42724)

When viewing model objects, the user sees a read-only view of fields that are not in the `exclude` list for each model.

Here is an example using the `TransitAgency` model:


![image](https://github.com/user-attachments/assets/a678e5df-591d-48a9-af63-bb824ebbaae6)
