### PR TITLE
Feat: handle OAuth errors

### DIFF
--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2024-07-09 10:45-0700\n"
+"POT-Creation-Date: 2024-07-17 12:05-0700\n"
 "Language: English\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -779,6 +779,17 @@ msgstr ""
 msgid "Sign out of"
 msgstr ""
 
+msgid "Service is down"
+msgstr ""
+
+msgid "There was a problem with the service that checks your identity."
+msgstr ""
+
+msgid ""
+"We’re working to solve the problem. Please wait 24 hours and try to enroll "
+"again, or contact your transit agency for help."
+msgstr ""
+
 msgid "Start over"
 msgstr ""
 
@@ -791,9 +802,6 @@ msgid ""
 msgstr ""
 
 msgid "Start Here"
-msgstr ""
-
-msgid "Service is down"
 msgstr ""
 
 msgid "Sorry! Service for this site is down."

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2024-07-09 10:45-0700\n"
+"POT-Creation-Date: 2024-07-17 12:05-0700\n"
 "Language: Español\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -998,6 +998,20 @@ msgstr ""
 msgid "Sign out of"
 msgstr "Cierre sesión de"
 
+msgid "Service is down"
+msgstr "El servicio está inactivo"
+
+msgid "There was a problem with the service that checks your identity."
+msgstr "Hubo un problema con el servicio que verifica su identidad."
+
+msgid ""
+"We’re working to solve the problem. Please wait 24 hours and try to enroll "
+"again, or contact your transit agency for help."
+msgstr ""
+"Estamos trabajando para resolver el problema. Espere 24 horas e intente "
+"inscribirse nuevamente, o contacte a su agencia de tránsito para obtener "
+"ayuda."
+
 msgid "Start over"
 msgstr "Comenzar de nuevo"
 
@@ -1013,9 +1027,6 @@ msgstr ""
 
 msgid "Start Here"
 msgstr "Comenzar aquí"
-
-msgid "Service is down"
-msgstr "El servicio está inactivo"
 
 msgid "Sorry! Service for this site is down."
 msgstr "¡Lo sentimos! El servicio para este sitio está inactivo."

--- a/benefits/oauth/analytics.py
+++ b/benefits/oauth/analytics.py
@@ -15,6 +15,14 @@ class OAuthEvent(core.Event):
             self.update_event_properties(auth_provider=verifier.auth_provider.client_name)
 
 
+class OAuthErrorEvent(OAuthEvent):
+    """Analytics event representing an error using an OAuth client."""
+
+    def __init__(self, request, message, operation):
+        super().__init__(request, "oauth error")
+        self.update_event_properties(message=message, operation=operation)
+
+
 class StartedSignInEvent(OAuthEvent):
     """Analytics event representing the beginning of the OAuth sign in flow."""
 
@@ -51,6 +59,11 @@ class FinishedSignOutEvent(OAuthEvent):
     def __init__(self, request):
         super().__init__(request, "finished sign out")
         self.update_event_properties(origin=session.origin(request))
+
+
+def error(request, message, operation):
+    """Send the "oauth error" analytics event, specifying the message and operation"""
+    core.send_event(OAuthErrorEvent(request, message, operation))
 
 
 def started_sign_in(request):

--- a/benefits/oauth/middleware.py
+++ b/benefits/oauth/middleware.py
@@ -1,7 +1,13 @@
 import logging
 
+from django.shortcuts import redirect
+import sentry_sdk
+
 from benefits.core import session
 from benefits.core.middleware import VerifierSessionRequired, user_error
+
+from . import analytics
+from .redirects import ROUTE_SYSTEM_ERROR
 
 
 logger = logging.getLogger(__name__)
@@ -16,8 +22,19 @@ class VerifierUsesAuthVerificationSessionRequired(VerifierSessionRequired):
             # from the base middleware class, the session didn't have a verifier
             return result
 
-        if session.verifier(request).uses_auth_verification:
+        verifier = session.verifier(request)
+
+        if verifier.uses_auth_verification:
+            # all good, the chosen verifier is configured correctly
             return None
+        elif not (verifier.api_url or verifier.form_class):
+            # the chosen verifier doesn't have Eligibility API config OR auth provider config
+            # this is likely a misconfiguration on the backend, not a user error
+            message = f"Verifier with no API or IDP config: {verifier.name} (id={verifier.id})"
+            analytics.error(request, message=message, operation=request.path)
+            sentry_sdk.capture_exception(Exception(message))
+            return redirect(ROUTE_SYSTEM_ERROR)
         else:
+            # the chosen verifier was for Eligibility API
             logger.debug("Session not configured with eligibility verifier that uses auth verification")
             return user_error(request)

--- a/benefits/oauth/redirects.py
+++ b/benefits/oauth/redirects.py
@@ -3,10 +3,12 @@ from django.utils.http import urlencode
 
 import sentry_sdk
 
+from . import analytics
+
 ROUTE_SYSTEM_ERROR = "oauth:system-error"
 
 
-def deauthorize_redirect(oauth_client, token, redirect_uri):
+def deauthorize_redirect(request, oauth_client, token, redirect_uri):
     """Helper implements OIDC signout via the `end_session_endpoint`."""
 
     # Authlib has not yet implemented `end_session_endpoint` as the OIDC Session Management 1.0 spec is still in draft
@@ -16,6 +18,7 @@ def deauthorize_redirect(oauth_client, token, redirect_uri):
     try:
         metadata = oauth_client.load_server_metadata()
     except Exception as ex:
+        analytics.error(request, message=str(ex), operation="load_server_metadata")
         sentry_sdk.capture_exception(ex)
         return redirect(ROUTE_SYSTEM_ERROR)
 

--- a/benefits/oauth/templates/oauth/system_error.html
+++ b/benefits/oauth/templates/oauth/system_error.html
@@ -1,0 +1,31 @@
+{% extends "core/base.html" %}
+{% load i18n %}
+
+{% block page-title %}
+  {% translate "Service is down" %}
+{% endblock page-title %}
+
+{% block main-content %}
+  <div class="container">
+    <h1 class="h2 text-center">
+      <span class="icon d-block pb-4">{% include "core/includes/icon.html" with name="sadbus" %}</span>
+      {% translate "There was a problem with the service that checks your identity." %}
+    </h1>
+
+    <div class="row justify-content-center">
+      <div class="col-lg-8 pt-4">
+        <p>
+          {% translate "We’re working to solve the problem. Please wait 24 hours and try to enroll again, or contact your transit agency for help." %}
+        </p>
+      </div>
+    </div>
+
+    <div class="row justify-content-center">
+      <div class="col-lg-8">{% include "core/includes/agency-links.html" %}</div>
+    </div>
+
+    <div class="row pt-8 justify-content-center">
+      <div class="col-lg-3 col-8">{% include "core/includes/button--origin.html" %}</div>
+    </div>
+  </div>
+{% endblock main-content %}

--- a/benefits/oauth/urls.py
+++ b/benefits/oauth/urls.py
@@ -11,4 +11,5 @@ urlpatterns = [
     path("cancel", views.cancel, name="cancel"),
     path("logout", views.logout, name="logout"),
     path("post_logout", views.post_logout, name="post_logout"),
+    path("error", views.system_error, name="system-error"),
 ]

--- a/benefits/oauth/views.py
+++ b/benefits/oauth/views.py
@@ -73,10 +73,12 @@ def login(request):
     try:
         result = oauth_client.authorize_redirect(request, redirect_uri)
     except Exception as ex:
+        analytics.error(request, message=str(ex), operation="authorize_redirect")
         sentry_sdk.capture_exception(ex)
         result = redirect(redirects.ROUTE_SYSTEM_ERROR)
 
     if result.status_code >= 400:
+        analytics.error(request, message=result.status_code, operation="authorize_redirect")
         sentry_sdk.capture_exception(
             Exception(f"authorize_redirect error response [{result.status_code}]: {result.content.decode()}")
         )

--- a/benefits/oauth/views.py
+++ b/benefits/oauth/views.py
@@ -71,7 +71,19 @@ def login(request):
 
     analytics.started_sign_in(request)
 
-    return oauth_client.authorize_redirect(request, redirect_uri)
+    try:
+        result = oauth_client.authorize_redirect(request, redirect_uri)
+    except Exception as ex:
+        sentry_sdk.capture_exception(ex)
+        result = redirect(ROUTE_SYSTEM_ERROR)
+
+    if result.status_code >= 400:
+        sentry_sdk.capture_exception(
+            Exception(f"authorize_redirect error response [{result.status_code}]: {result.content.decode()}")
+        )
+        result = redirect(ROUTE_SYSTEM_ERROR)
+
+    return result
 
 
 @decorator_from_middleware(VerifierUsesAuthVerificationSessionRequired)

--- a/benefits/oauth/views.py
+++ b/benefits/oauth/views.py
@@ -20,7 +20,6 @@ ROUTE_AUTH = "oauth:authorize"
 ROUTE_CONFIRM = "eligibility:confirm"
 ROUTE_UNVERIFIED = "eligibility:unverified"
 ROUTE_POST_LOGOUT = "oauth:post_logout"
-ROUTE_SYSTEM_ERROR = "oauth:system-error"
 
 TEMPLATE_SYSTEM_ERROR = "oauth/system_error.html"
 
@@ -44,7 +43,7 @@ def _oauth_client_or_error_redirect(auth_provider):
 
     if exception:
         sentry_sdk.capture_exception(exception)
-        return redirect(ROUTE_SYSTEM_ERROR)
+        return redirect(redirects.ROUTE_SYSTEM_ERROR)
 
     return oauth_client
 
@@ -74,13 +73,13 @@ def login(request):
         result = oauth_client.authorize_redirect(request, redirect_uri)
     except Exception as ex:
         sentry_sdk.capture_exception(ex)
-        result = redirect(ROUTE_SYSTEM_ERROR)
+        result = redirect(redirects.ROUTE_SYSTEM_ERROR)
 
     if result.status_code >= 400:
         sentry_sdk.capture_exception(
             Exception(f"authorize_redirect error response [{result.status_code}]: {result.content.decode()}")
         )
-        result = redirect(ROUTE_SYSTEM_ERROR)
+        result = redirect(redirects.ROUTE_SYSTEM_ERROR)
 
     return result
 
@@ -106,12 +105,12 @@ def authorize(request):
         token = oauth_client.authorize_access_token(request)
     except Exception as ex:
         sentry_sdk.capture_exception(ex)
-        return redirect(ROUTE_SYSTEM_ERROR)
+        return redirect(redirects.ROUTE_SYSTEM_ERROR)
 
     if token is None:
         logger.warning("Could not authorize OAuth access token")
         sentry_sdk.capture_exception(Exception("oauth_client.authorize_access_token returned None"))
-        return redirect(ROUTE_SYSTEM_ERROR)
+        return redirect(redirects.ROUTE_SYSTEM_ERROR)
 
     logger.debug("OAuth access token authorized")
 

--- a/benefits/oauth/views.py
+++ b/benefits/oauth/views.py
@@ -107,11 +107,13 @@ def authorize(request):
     try:
         token = oauth_client.authorize_access_token(request)
     except Exception as ex:
+        analytics.error(request, message=str(ex), operation="authorize_access_token")
         sentry_sdk.capture_exception(ex)
         return redirect(redirects.ROUTE_SYSTEM_ERROR)
 
     if token is None:
         logger.warning("Could not authorize OAuth access token")
+        analytics.error(request, message="token was None", operation="authorize_access_token")
         sentry_sdk.capture_exception(Exception("oauth_client.authorize_access_token returned None"))
         return redirect(redirects.ROUTE_SYSTEM_ERROR)
 

--- a/benefits/oauth/views.py
+++ b/benefits/oauth/views.py
@@ -186,7 +186,7 @@ def logout(request):
 
     # send the user through the end_session_endpoint, redirecting back to
     # the post_logout route
-    return redirects.deauthorize_redirect(oauth_client, token, redirect_uri)
+    return redirects.deauthorize_redirect(request, oauth_client, token, redirect_uri)
 
 
 @decorator_from_middleware(VerifierUsesAuthVerificationSessionRequired)

--- a/tests/pytest/oauth/test_analytics.py
+++ b/tests/pytest/oauth/test_analytics.py
@@ -1,6 +1,6 @@
 import pytest
 
-from benefits.oauth.analytics import OAuthEvent, FinishedSignInEvent
+from benefits.oauth.analytics import OAuthErrorEvent, OAuthEvent, FinishedSignInEvent
 
 
 @pytest.mark.django_db
@@ -22,6 +22,16 @@ def test_OAuthEvent_verifier_no_client_name_when_does_not_use_auth_verification(
     event = OAuthEvent(app_request, "event type")
 
     assert "auth_provider" not in event.event_properties
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("mocked_session_verifier_uses_auth_verification")
+def test_OAuthErrorEvent(app_request):
+    event_default = OAuthErrorEvent(app_request, "the message", "the operation")
+
+    assert event_default.event_type == "oauth error"
+    assert event_default.event_properties["message"] == "the message"
+    assert event_default.event_properties["operation"] == "the operation"
 
 
 @pytest.mark.django_db

--- a/tests/pytest/oauth/test_middleware_authverifier_required.py
+++ b/tests/pytest/oauth/test_middleware_authverifier_required.py
@@ -1,14 +1,27 @@
+from django.urls import reverse
 from django.utils.decorators import decorator_from_middleware
 
 import pytest
 
 from benefits.core.middleware import TEMPLATE_USER_ERROR
 from benefits.oauth.middleware import VerifierUsesAuthVerificationSessionRequired
+import benefits.oauth.middleware
+from benefits.oauth.redirects import ROUTE_SYSTEM_ERROR
 
 
 @pytest.fixture
 def decorated_view(mocked_view):
     return decorator_from_middleware(VerifierUsesAuthVerificationSessionRequired)(mocked_view)
+
+
+@pytest.fixture
+def mocked_analytics_module(mocked_analytics_module):
+    return mocked_analytics_module(benefits.oauth.middleware)
+
+
+@pytest.fixture
+def mocked_sentry_sdk_module(mocker):
+    return mocker.patch.object(benefits.oauth.middleware, "sentry_sdk")
 
 
 @pytest.mark.django_db
@@ -28,6 +41,31 @@ def test_authverifier_required_no_authverifier(app_request, mocked_view, decorat
     mocked_view.assert_not_called()
     assert response.status_code == 200
     assert response.template_name == TEMPLATE_USER_ERROR
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(("api_url", "form_class"), [(None, None), (None, ""), ("", None), ("", "")])
+def test_authverifier_required_misconfigured_verifier(
+    app_request,
+    mocked_view,
+    decorated_view,
+    mocked_session_verifier_does_not_use_auth_verification,
+    mocked_analytics_module,
+    mocked_sentry_sdk_module,
+    api_url,
+    form_class,
+):
+    # fake a misconfigured verifier
+    mocked_session_verifier_does_not_use_auth_verification.return_value.api_url = api_url
+    mocked_session_verifier_does_not_use_auth_verification.return_value.form_class = form_class
+
+    response = decorated_view(app_request)
+
+    mocked_view.assert_not_called()
+    mocked_analytics_module.error.assert_called_once()
+    mocked_sentry_sdk_module.capture_exception.assert_called_once()
+    assert response.status_code == 302
+    assert response.url == reverse(ROUTE_SYSTEM_ERROR)
 
 
 @pytest.mark.django_db

--- a/tests/pytest/oauth/test_redirects.py
+++ b/tests/pytest/oauth/test_redirects.py
@@ -1,4 +1,15 @@
-from benefits.oauth.redirects import deauthorize_redirect, generate_redirect_uri
+from django.urls import reverse
+
+
+from benefits.oauth.redirects import ROUTE_SYSTEM_ERROR, deauthorize_redirect, generate_redirect_uri
+import benefits.oauth.redirects
+
+import pytest
+
+
+@pytest.fixture
+def mocked_sentry_sdk_module(mocker):
+    return mocker.patch.object(benefits.oauth.redirects, "sentry_sdk")
 
 
 def test_deauthorize_redirect(mocked_oauth_client):
@@ -12,6 +23,16 @@ def test_deauthorize_redirect(mocked_oauth_client):
         result.url
         == "https://server/endsession?id_token_hint=token&post_logout_redirect_uri=https%3A%2F%2Flocalhost%2Fredirect_uri"
     )
+
+
+def test_deauthorize_redirect_load_server_metadata_error(mocked_oauth_client, mocked_sentry_sdk_module):
+    mocked_oauth_client.load_server_metadata.side_effect = Exception("Side effect")
+
+    result = deauthorize_redirect(mocked_oauth_client, "token", "https://localhost/redirect_uri")
+
+    assert result.status_code == 302
+    assert result.url == reverse(ROUTE_SYSTEM_ERROR)
+    mocked_sentry_sdk_module.capture_exception.assert_called_once()
 
 
 def test_generate_redirect_uri_default(rf):

--- a/tests/pytest/oauth/test_views.py
+++ b/tests/pytest/oauth/test_views.py
@@ -112,7 +112,7 @@ def test_login_no_session_verifier(app_request):
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_session_verifier_uses_auth_verification")
-def test_login(mocked_oauth_client_or_error_redirect__client, mocked_analytics_module, app_request):
+def test_login(app_request, mocked_oauth_client_or_error_redirect__client, mocked_analytics_module):
     assert not session.logged_in(app_request)
     mocked_oauth_client = mocked_oauth_client_or_error_redirect__client.return_value
     # fake a permanent redirect response from the client
@@ -236,7 +236,7 @@ def test_authorize_success(mocked_oauth_client_or_error_redirect__client, mocked
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_analytics_module")
 def test_authorize_success_with_claim_true(
-    mocked_session_verifier_uses_auth_verification, mocked_oauth_client_or_error_redirect__client, app_request
+    app_request, mocked_session_verifier_uses_auth_verification, mocked_oauth_client_or_error_redirect__client
 ):
     verifier = mocked_session_verifier_uses_auth_verification.return_value
     verifier.auth_provider.claim = "claim"
@@ -254,9 +254,7 @@ def test_authorize_success_with_claim_true(
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_analytics_module")
 def test_authorize_success_with_claim_false(
-    mocked_session_verifier_uses_auth_verification,
-    mocked_oauth_client_or_error_redirect__client,
-    app_request,
+    app_request, mocked_session_verifier_uses_auth_verification, mocked_oauth_client_or_error_redirect__client
 ):
     verifier = mocked_session_verifier_uses_auth_verification.return_value
     verifier.auth_provider.claim = "claim"
@@ -273,10 +271,10 @@ def test_authorize_success_with_claim_false(
 
 @pytest.mark.django_db
 def test_authorize_success_with_claim_error(
+    app_request,
     mocked_session_verifier_uses_auth_verification,
     mocked_oauth_client_or_error_redirect__client,
     mocked_analytics_module,
-    app_request,
 ):
     verifier = mocked_session_verifier_uses_auth_verification.return_value
     verifier.auth_provider.claim = "claim"
@@ -295,7 +293,7 @@ def test_authorize_success_with_claim_error(
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_analytics_module")
 def test_authorize_success_without_verifier_claim(
-    mocked_session_verifier_uses_auth_verification, mocked_oauth_client_or_error_redirect__client, app_request
+    app_request, mocked_session_verifier_uses_auth_verification, mocked_oauth_client_or_error_redirect__client
 ):
     verifier = mocked_session_verifier_uses_auth_verification.return_value
     verifier.auth_provider.claim = ""
@@ -319,9 +317,9 @@ def test_authorize_success_without_verifier_claim(
     ],
 )
 def test_authorize_success_without_claim_in_response(
+    app_request,
     mocked_session_verifier_uses_auth_verification,
     mocked_oauth_client_or_error_redirect__client,
-    app_request,
     access_token_response,
 ):
     verifier = mocked_session_verifier_uses_auth_verification.return_value
@@ -339,7 +337,7 @@ def test_authorize_success_without_claim_in_response(
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_session_verifier_uses_auth_verification")
-def test_cancel(mocked_analytics_module, app_request):
+def test_cancel(app_request, mocked_analytics_module):
     unverified_route = reverse(ROUTE_UNVERIFIED)
 
     result = cancel(app_request)
@@ -376,7 +374,7 @@ def test_logout_no_session_verifier(app_request):
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_session_verifier_uses_auth_verification")
-def test_logout(mocker, mocked_oauth_client_or_error_redirect__client, mocked_analytics_module, app_request):
+def test_logout(app_request, mocker, mocked_oauth_client_or_error_redirect__client, mocked_analytics_module):
     # logout internally calls deauthorize_redirect
     # this mocks that function and a success response
     # and returns a spy object we can use to validate calls
@@ -390,7 +388,7 @@ def test_logout(mocker, mocked_oauth_client_or_error_redirect__client, mocked_an
 
     result = logout(app_request)
 
-    mocked_redirect.assert_called_with(mocked_oauth_client, token, "https://testserver/oauth/post_logout")
+    mocked_redirect.assert_called_with(app_request, mocked_oauth_client, token, "https://testserver/oauth/post_logout")
     mocked_analytics_module.started_sign_out.assert_called_once()
     assert result.status_code == 200
     assert message in str(result.content)

--- a/tests/pytest/oauth/test_views.py
+++ b/tests/pytest/oauth/test_views.py
@@ -8,9 +8,9 @@ from benefits.core.middleware import ROUTE_INDEX, TEMPLATE_USER_ERROR
 
 from benefits.eligibility.views import ROUTE_START
 
+from benefits.oauth.redirects import ROUTE_SYSTEM_ERROR
 from benefits.oauth.views import (
     ROUTE_CONFIRM,
-    ROUTE_SYSTEM_ERROR,
     ROUTE_UNVERIFIED,
     TEMPLATE_SYSTEM_ERROR,
     _oauth_client_or_error_redirect,


### PR DESCRIPTION
Closes #2019 

* Implements a new error screen in the `oauth` app
* Handles errors on creation/registration of the OAuth client
* Handles errors for all OAuth client method calls
* Sends a new analytics event `oauth error` in all cases
  * `operation` property indicates the specific client call: `init`, `authorize_redirect`, `authorize_access_token`, and `load_server_metadata`
  * `message` property describes the exception
* Captures an exception in Sentry in all cases

## How to test

1. Checkout the branch locally
2. Run `bin/init.sh` to get the PO file updates
3. Launch the app with `F5`
4. Select an agency or enter via their slug URL
5. Manually enter the URL in the browser: `/oauth/error`: see the error page
6. Attempt a Login.gov flow for the agency (without configuring the `AuthProvider`): see the error page
7. Misconfigure an `EligibilityVerifier` to not specify an `AuthProvider` _and_ without an Eligibility API base URL or form class and attempt to sign in with this verifier selected: see the error page