### PR TITLE
Fix: terraform plan and apply conditions

### DIFF
--- a/terraform/azure-pipelines.yml
+++ b/terraform/azure-pipelines.yml
@@ -29,11 +29,7 @@ stages:
           - name: IS_TAG
             value: $[startsWith(variables['Build.SourceBranch'], 'refs/tags/')]
         steps:
-          - bash: |
-              python terraform/pipeline/workspace.py
-
-              TAG_TYPE=$(python terraform/pipeline/tag.py)
-              echo "##vso[task.setvariable variable=tag_type;isOutput=true]$TAG_TYPE"
+          - bash: python terraform/pipeline/workspace.py
             displayName: Set environment-related variables
             # save the values
             # https://learn.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#use-outputs-in-a-different-job
@@ -45,22 +41,18 @@ stages:
         condition: eq(dependencies.environment.outputs['env_select.service_connection'], 'Development')
         variables:
           workspace: $[ dependencies.environment.outputs['env_select.workspace'] ]
-          tag_type: $[ dependencies.environment.outputs['env_select.tag_type'] ]
         steps:
           - template: pipeline/deploy.yml
             parameters:
               service_connection: Development
               workspace: $(workspace)
-              tag_type: $(tag_type)
       - job: prod
         dependsOn: environment
         condition: eq(dependencies.environment.outputs['env_select.service_connection'], 'Production')
         variables:
           workspace: $[ dependencies.environment.outputs['env_select.workspace'] ]
-          tag_type: $[ dependencies.environment.outputs['env_select.tag_type'] ]
         steps:
           - template: pipeline/deploy.yml
             parameters:
               service_connection: Production
               workspace: $(workspace)
-              tag_type: $(tag_type)

--- a/terraform/pipeline/deploy.yml
+++ b/terraform/pipeline/deploy.yml
@@ -3,8 +3,6 @@ parameters:
     type: string
   - name: workspace
     type: string
-  - name: tag_type
-    type: string
 
 steps:
   # https://github.com/microsoft/azure-pipelines-terraform/tree/main/Tasks/TerraformInstaller#readme
@@ -38,6 +36,18 @@ steps:
       workingDirectory: "$(System.DefaultWorkingDirectory)/terraform"
       # service connection
       environmentServiceNameAzureRM: "${{ parameters.service_connection }}"
+  - bash: |
+      echo "REASON is $REASON, INDIVIDUAL_SOURCE is $INDIVIDUAL_SOURCE, SOURCE_BRANCH is $SOURCE_BRANCH"
+      TAG_TYPE=$(python terraform/pipeline/tag.py)
+      echo "##vso[task.setvariable variable=tag_type]$TAG_TYPE"
+    displayName: Set tag-type variable
+    env:
+      REASON: $(Build.Reason)
+      INDIVIDUAL_SOURCE: $(Build.SourceBranchName)
+      SOURCE_BRANCH: $(Build.SourceBranch)
+  - bash: |
+      echo $(tag_type)
+    displayName: Display tag-type variable
   - task: TerraformTaskV3@3
     displayName: Terraform plan
     inputs:
@@ -51,12 +61,11 @@ steps:
       environmentServiceNameAzureRM: "${{ parameters.service_connection }}"
     # the plan is done as part of the apply (below), so don't bother doing it twice
     condition: |
-      ${{ and(
-            ne(variables['Build.SourceBranchName'], 'main'),
-            ne(parameters.tag_type, 'test'),
-            ne(parameters.tag_type, 'prod')
-          )
-      }}
+      and(
+        ne(variables['Build.SourceBranchName'], 'main'),
+        ne(variables['tag_type'], 'test'),
+        ne(variables['tag_type'], 'prod')
+      )
   - task: TerraformTaskV3@3
     displayName: Terraform apply
     inputs:
@@ -69,9 +78,8 @@ steps:
       environmentServiceNameAzureRM: "${{ parameters.service_connection }}"
     # only run on main branch OR if it's a tag for test or prod
     condition: |
-      ${{ or(
-            eq(variables['Build.SourceBranchName'], 'main'),
-            eq(parameters.tag_type, 'test'),
-            eq(parameters.tag_type, 'prod')
-          )
-      }}
+      or(
+        eq(variables['Build.SourceBranchName'], 'main'),
+        eq(variables['tag_type'], 'test'),
+        eq(variables['tag_type'], 'prod')
+      )

--- a/terraform/pipeline/tag.py
+++ b/terraform/pipeline/tag.py
@@ -4,7 +4,9 @@ import re
 REASON = os.environ["REASON"]
 # use variable corresponding to tag triggers
 SOURCE = os.environ["INDIVIDUAL_SOURCE"]
-IS_TAG = os.environ["IS_TAG"].lower() == "true"
+
+SOURCE_BRANCH = os.environ["SOURCE_BRANCH"]
+IS_TAG = SOURCE_BRANCH.startswith("refs/tags/") is True
 
 if REASON == "IndividualCI" and IS_TAG:
     if re.fullmatch(r"20\d\d.\d\d.\d+-rc\d+", SOURCE):


### PR DESCRIPTION
This PR is a follow-up to PR #2213. The terraform `plan` and `apply` steps were not running when expected because the conditions on the steps were not evaluating correctly. Contrary to the [documentation](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/conditions?view=azure-devops#parameters-in-conditions), we noticed that [`parameters` don't get evaluated in `conditions`](https://github.com/cal-itp/benefits/blob/2f628637fefe66fde24cebecdcd4cf3a7d6ddb1b/terraform/pipeline/deploy.yml#L74-L75). Because of this, even though `tag_type` was set in [`Terraform apply`](https://github.com/cal-itp/benefits/blob/main/terraform/pipeline/deploy.yml#L60), this step wouldn't run when a tag was pushed.

This PR fixes this behavior by changing `parameters.tag_type` to `variables['tag_type']` for [`Terraform plan`](https://github.com/cal-itp/benefits/blob/main/terraform/pipeline/deploy.yml#L41) and [`Terraform apply`](https://github.com/cal-itp/benefits/blob/main/terraform/pipeline/deploy.yml#L60) which requires:

- moving the step that generates the `tag_type` from `azure-pipelines.yml` into `deploy.yml` so that `tag_type` doesn't get passed as a parameter anymore
- using `tag.py` to determine the value of `IS_TAG` instead of an Azure pipeline expression since `env:` [does not support evaluating expressions](https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/steps-bash?view=azure-pipelines) and `variables:` is [out of scope](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#variable-scopes) in `deploy.yaml`.