### PR TITLE
Feat: set language code on Littlepay overlay

### DIFF
--- a/benefits/enrollment/templates/enrollment/index.html
+++ b/benefits/enrollment/templates/enrollment/index.html
@@ -67,7 +67,8 @@
                   element: '#{{ cta_button }}',
                   envUrl: '{{ card_tokenize_env }}',
                   options: {
-                      color: '#046b99'
+                      color: '#046b99',
+                      language: '{{ overlay_language }}'
                   },
                   onTokenize: function (response) {
                       /* This function executes when the

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -186,6 +186,9 @@ def index(request):
         tokenize_system_error_form = forms.CardTokenizeFailForm(ROUTE_SYSTEM_ERROR, "form-card-tokenize-fail-system-error")
         tokenize_success_form = forms.CardTokenizeSuccessForm(auto_id=True, label_suffix="")
 
+        # mapping from Django's I18N LANGUAGE_CODE to Littlepay's overlay language code
+        overlay_language = {"en": "en", "es": "es-419"}.get(request.LANGUAGE_CODE, "en")
+
         context = {
             "forms": [tokenize_retry_form, tokenize_server_error_form, tokenize_system_error_form, tokenize_success_form],
             "cta_button": "tokenize_card",
@@ -197,6 +200,7 @@ def index(request):
             "form_server_error": tokenize_server_error_form.id,
             "form_success": tokenize_success_form.id,
             "form_system_error": tokenize_system_error_form.id,
+            "overlay_language": overlay_language,
         }
 
         logger.debug(f'card_tokenize_url: {context["card_tokenize_url"]}')

--- a/tests/pytest/enrollment/test_views.py
+++ b/tests/pytest/enrollment/test_views.py
@@ -249,6 +249,18 @@ def test_index_eligible_get(client, model_EligibilityType):
     assert "token_field" in response.context_data
     assert "form_retry" in response.context_data
     assert "form_success" in response.context_data
+    assert "overlay_language" in response.context_data
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("mocked_session_agency", "mocked_session_verifier", "mocked_session_eligibility")
+@pytest.mark.parametrize("LANGUAGE_CODE, overlay_language", [("en", "en"), ("es", "es-419"), ("unsupported", "en")])
+def test_index_eligible_get_changed_language(client, LANGUAGE_CODE, overlay_language):
+    path = reverse(ROUTE_INDEX)
+    client.post(reverse("set_language"), data={"language": LANGUAGE_CODE})
+    response = client.get(path)
+
+    assert response.context_data["overlay_language"] == overlay_language
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Closes #2195 

Given that the Littlepay Hosted Card Tokenization overlay supports multiple languages, this PR uses this feature to set the overlay's language to the user's language in Benefits.

Note that the Littlepay docs list `es_419` as the code for `Spanish (Latin America)`, but this seems to be a typo since the overlay did not work with this code, instead it does work with `es-419`.

## Steps for testing

Run through a complete flow until you get to the enrollment index page. Then, change languages in Benefits and close/open the overlay to see the overlay in the language that was selected in Benefits.