### PR TITLE
Chore: normalize lines for tag_type

### DIFF
--- a/terraform/pipeline/deploy.yml
+++ b/terraform/pipeline/deploy.yml
@@ -36,18 +36,12 @@ steps:
       workingDirectory: "$(System.DefaultWorkingDirectory)/terraform"
       # service connection
       environmentServiceNameAzureRM: "${{ parameters.service_connection }}"
-  - bash: |
-      echo "REASON is $REASON, INDIVIDUAL_SOURCE is $INDIVIDUAL_SOURCE, SOURCE_BRANCH is $SOURCE_BRANCH"
-      TAG_TYPE=$(python terraform/pipeline/tag.py)
-      echo "##vso[task.setvariable variable=tag_type]$TAG_TYPE"
+  - bash: python terraform/pipeline/tag.py
     displayName: Set tag-type variable
     env:
       REASON: $(Build.Reason)
       INDIVIDUAL_SOURCE: $(Build.SourceBranchName)
       SOURCE_BRANCH: $(Build.SourceBranch)
-  - bash: |
-      echo $(tag_type)
-    displayName: Display tag-type variable
   - task: TerraformTaskV3@3
     displayName: Terraform plan
     inputs:

--- a/terraform/pipeline/tag.py
+++ b/terraform/pipeline/tag.py
@@ -18,4 +18,10 @@ if REASON == "IndividualCI" and IS_TAG:
 else:
     tag_type = None
 
-print(tag_type)
+print(f"REASON: {REASON}")
+print(f"INDIVIDUAL_SOURCE: {SOURCE}")
+print(f"SOURCE_BRANCH: {SOURCE_BRANCH}")
+print(f"Tag type: {tag_type}")
+
+# https://learn.microsoft.com/en-us/azure/devops/pipelines/process/set-variables-scripts?view=azure-devops&tabs=bash#about-tasksetvariable
+print(f"##vso[task.setvariable variable=tag_type]{tag_type}")


### PR DESCRIPTION
Closes #2240 

This PR normalizes setting `tag_type`. It moves the setting of `tag_type` from the shell into `tag.py`, consistent with how setting the environment-related variables is done in [`workspace.py`](https://github.com/cal-itp/benefits/blob/main/terraform/pipeline/workspace.py#L52-L53).