### PR TITLE
Fix: Eligibility Confirm - Unnest explanatory-text-wrapper div

### DIFF
--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -79,13 +79,13 @@
           <div class="row justify-content-center">
             {% block headline %}
             {% endblock headline %}
-            {% block explanatory-text-wrapper %}
+          </div>
+          {% block explanatory-text-wrapper %}
             <div class="col-lg-8">
               {% block explanatory-text %}
               {% endblock explanatory-text %}
             </div>
-            {% endblock explanatory-text-wrapper %}
-          </div>
+          {% endblock explanatory-text-wrapper %}
           <div class="row justify-content-center">
             {% block inner-content %}
             {% endblock inner-content %}


### PR DESCRIPTION
closes #2271 


The problem: Vertical alignment of the `We use the ...` paragraph is off for both Desktop and Tablet.
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/b2fb9959-38b1-4878-b1d7-ae523a999f7c">

The issue:
<img width="552" alt="image" src="https://github.com/user-attachments/assets/dce97a2b-abdc-47a9-b127-257ab64c7c5a">

These two divs need to be siblings, not a parent/child relationship. Having a `row justify-content-center` _inside_ another `row justify-content-center` is giving the paragraph in the child div a more padding left and right. The heading text and the paragraph text need to be siblings, not a parent/child.

This parent/child relationship was created in the `base.html` file that the `confirm.html` is based off of.

Since `explanatory-text-wrapper` is _only_ used on this `confirm.html` page, I was able to safely change the `base.html` to fix the issue, and know that this is will only change the confirm page and not any other pages.

Test is by looking at all pages for other regressions, and testing the Confirm page in desktop and mobile