### PR TITLE
Fix: Elig Index - Wrap explanatory text in centered row

### DIFF
--- a/benefits/eligibility/templates/eligibility/index.html
+++ b/benefits/eligibility/templates/eligibility/index.html
@@ -20,8 +20,14 @@
   </div>
 {% endblock headline %}
 
-{% block explanatory-text %}
-{% endblock explanatory-text %}
+{% block explanatory-text-wrapper %}
+  <div class="row justify-content-center">
+    <div class="col-lg-8">
+      {% block explanatory-text %}
+      {% endblock explanatory-text %}
+    </div>
+  </div>
+{% endblock explanatory-text-wrapper %}
 
 {% block inner-content %}
   {% include "core/includes/form.html" with form=form %}


### PR DESCRIPTION
closes #2288 

<img width="1510" alt="image" src="https://github.com/user-attachments/assets/26fd22f8-f00a-4490-ac1a-f640a58972cc">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/e6fc9397-9665-4d17-a9f1-18bb5f02bec1">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/e8e9a7b3-5dfc-4495-bdbf-053e5321ea79">


## How to test
- Go through full flow in desktop and mobile to ensure no visual regressions