### PR TITLE
Chore: associate .pages files with yaml

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,9 @@
     "djlint.enableLinting": true,
     "djlint.profile": "django"
   },
+  "files.associations": {
+    ".pages": "yaml"
+  },
   "files.encoding": "utf8",
   "files.eol": "\n",
   "files.insertFinalNewline": true,


### PR DESCRIPTION
Closes #2281 

VS Code associates `.pages` files with `markdown`. Because of this, the indentation in the files is not preserved when saving them using VS Code. This PR [associates](https://code.visualstudio.com/docs/languages/overview#_add-a-file-extension-to-a-language) `.pages` files with `yaml` so that formatting is preserved when saving them using VS Code.