### PR TITLE
Hide native Django login fields

### DIFF
--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -72,6 +72,7 @@ GOOGLE_SSO_SCOPES = [
     "https://www.googleapis.com/auth/userinfo.email",
     "https://www.googleapis.com/auth/userinfo.profile",
 ]
+SSO_SHOW_FORM_ON_ADMIN_PAGE = False
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",


### PR DESCRIPTION
closes #2264 

<img width="1507" alt="image" src="https://github.com/user-attachments/assets/334ee5e7-a758-4a49-8497-d73f865a57ac">
