### PR TITLE
Fix: getting a group's transit agency

### DIFF
--- a/benefits/core/models.py
+++ b/benefits/core/models.py
@@ -403,7 +403,7 @@ class TransitAgency(models.Model):
     def for_user(user: User):
         group = user.groups.first()
 
-        if group is not None:
+        if group is not None and hasattr(group, "transitagency"):
             return group.transitagency
         else:
             return None

--- a/tests/pytest/core/test_models.py
+++ b/tests/pytest/core/test_models.py
@@ -360,3 +360,13 @@ def test_TransitAgency_for_user_not_in_group(model_TransitAgency):
     user = User.objects.create_user(username="test_user", email="test_user@example.com", password="test", is_staff=True)
 
     assert TransitAgency.for_user(user) is None
+
+
+@pytest.mark.django_db
+def test_TransitAgency_for_user_in_group_not_linked_to_any_agency():
+    group = Group.objects.create(name="another test group")
+
+    user = User.objects.create_user(username="test_user", email="test_user@example.com", password="test", is_staff=True)
+    user.groups.add(group)
+
+    assert TransitAgency.for_user(user) is None


### PR DESCRIPTION
Follow-up to #2307 

If we use `group.transitagency` to get a `Group`'s `TransitAgency`, Django will raise a `RelatedObjectDoesNotExist` error if the group does not have a `TransitAgency`.

The Django docs recommend either catching the exception or checking for the attribute. This PR checks if the group has the attribute before trying to get the object.

https://docs.djangoproject.com/en/5.1/topics/db/examples/one_to_one/

![image](https://github.com/user-attachments/assets/5b268d46-6228-43d5-bb91-1aa23d98dcd1)
