### PR TITLE
Admin: Test that transit user does not get added to calitp group

### DIFF
--- a/tests/pytest/core/test_admin.py
+++ b/tests/pytest/core/test_admin.py
@@ -78,12 +78,12 @@ def test_pre_login_user_add_staff_to_group(mocker, model_AdminUser):
 
 
 @pytest.mark.django_db
-def test_pre_login_user_does_not_add_transit_staff_to_group(mocker, model_AdminUser):
+def test_pre_login_user_does_not_add_transit_staff_to_group(mocker, model_AdminUser, settings):
     mocked_request = mocker.Mock()
     mocked_request.session.get.return_value = None
 
-    mocker.patch.object(benefits.core.admin.settings, "GOOGLE_SSO_STAFF_LIST", [model_AdminUser.email])
-    mocker.patch.object(benefits.core.admin.settings, "GOOGLE_SSO_ALLOWABLE_DOMAINS", ["cst.org"])
+    settings.GOOGLE_SSO_STAFF_LIST = [model_AdminUser.email]
+    settings.GOOGLE_SSO_ALLOWABLE_DOMAINS = ["cst.org"]
     agency_user = User.objects.create_user(username="agency_user", email="manager@cst.org", is_staff=True)
 
     pre_login_user(agency_user, mocked_request)

--- a/tests/pytest/core/test_admin.py
+++ b/tests/pytest/core/test_admin.py
@@ -92,21 +92,3 @@ def test_pre_login_user_does_not_add_transit_staff_to_group(mocker, model_AdminU
     staff_group = Group.objects.get(name=STAFF_GROUP_NAME)
     assert staff_group.user_set.count() == 0
     assert agency_user.groups.count() == 0
-
-
-@pytest.mark.django_db
-def test_pre_login_user_adds_calitp_staff_to_group(mocker, model_AdminUser):
-    mocked_request = mocker.Mock()
-    mocked_request.session.get.return_value = None
-
-    mocker.patch.object(benefits.core.admin.settings, "GOOGLE_SSO_STAFF_LIST", [model_AdminUser.email])
-    mocker.patch.object(benefits.core.admin.settings, "GOOGLE_SSO_ALLOWABLE_DOMAINS", ["cst.org"])
-    calitp_user = User.objects.create_user(username="calitp_user", email=model_AdminUser.email, is_staff=True)
-
-    pre_login_user(calitp_user, mocked_request)
-
-    # assert that a user whos email is in the STAFF_LIST does get added to group
-    staff_group = Group.objects.get(name=STAFF_GROUP_NAME)
-    assert staff_group.user_set.count() == 1
-    assert calitp_user.groups.count() == 1
-    assert calitp_user.groups.first().name == staff_group.name

--- a/tests/pytest/core/test_admin.py
+++ b/tests/pytest/core/test_admin.py
@@ -92,3 +92,21 @@ def test_pre_login_user_does_not_add_transit_staff_to_group(mocker, model_AdminU
     staff_group = Group.objects.get(name=STAFF_GROUP_NAME)
     assert staff_group.user_set.count() == 0
     assert agency_user.groups.count() == 0
+
+
+@pytest.mark.django_db
+def test_pre_login_user_adds_calitp_staff_to_group(mocker, model_AdminUser):
+    mocked_request = mocker.Mock()
+    mocked_request.session.get.return_value = None
+
+    mocker.patch.object(benefits.core.admin.settings, "GOOGLE_SSO_STAFF_LIST", [model_AdminUser.email])
+    mocker.patch.object(benefits.core.admin.settings, "GOOGLE_SSO_ALLOWABLE_DOMAINS", ["cst.org"])
+    calitp_user = User.objects.create_user(username="calitp_user", email=model_AdminUser.email, is_staff=True)
+
+    pre_login_user(calitp_user, mocked_request)
+
+    # assert that a user whos email is in the STAFF_LIST does get added to group
+    staff_group = Group.objects.get(name=STAFF_GROUP_NAME)
+    assert staff_group.user_set.count() == 1
+    assert calitp_user.groups.count() == 1
+    assert calitp_user.groups.first().name == staff_group.name

--- a/tests/pytest/core/test_admin.py
+++ b/tests/pytest/core/test_admin.py
@@ -78,12 +78,13 @@ def test_pre_login_user_add_staff_to_group(mocker, model_AdminUser):
 
 
 @pytest.mark.django_db
-def test_pre_login_user_does_not_add_transit_staff_to_group(mocker, model_AdminUser, settings):
+def test_pre_login_user_does_not_add_transit_staff_to_group(mocker, settings):
     mocked_request = mocker.Mock()
     mocked_request.session.get.return_value = None
 
-    settings.GOOGLE_SSO_STAFF_LIST = [model_AdminUser.email]
+    settings.GOOGLE_SSO_STAFF_LIST = ["*"]
     settings.GOOGLE_SSO_ALLOWABLE_DOMAINS = ["cst.org"]
+    # simulate what `django_google_sso` does for us (sets is_staff to True)
     agency_user = User.objects.create_user(username="agency_user", email="manager@cst.org", is_staff=True)
 
     pre_login_user(agency_user, mocked_request)


### PR DESCRIPTION
closes #2242 

This PR does not add any code, but it adds 2 tests. 

This PR's tests test the `add_staff_user_to_group` method, which runs in the `pre_login_user` callback. In these tests, we are testing a new scenario that will come up when the Admin app starts allowing Transit Agency admin users:

- Engineers add a new transit agency's domain to the `GOOGLE_SSO_ALLOWABLE_DOMAINS` list, like `cst.org`
- Users with a `cst.org` email address can create Admin accounts via the site's OAuth button.
- But, these users should not be added to the Cal-ITP group, because their email addresses are not specifically in the `GOOGLE_SSO_STAFF_LIST` list.

These 2 specs test out both scenarios of ensuring a transit agency user does not get added to the Cal-ITP group, and to ensure that people with email addresses in the `GOOGLE_SSO_STAFF_LIST` _do_ get added to this group properly.
