### PR TITLE
Admin: Eligibility View

### DIFF
--- a/benefits/in_person/forms.py
+++ b/benefits/in_person/forms.py
@@ -1,0 +1,32 @@
+"""
+The in-person eligibility application: Form definition for the
+in-person eligibility verification flow, in which a
+transit agency employee manually verifies a rider's eligibility.
+"""
+
+from django import forms
+from benefits.routes import routes
+from benefits.core import models
+
+
+class InPersonEligibilityForm(forms.Form):
+    """Form to capture eligibility for in-person verification flow selection."""
+
+    action_url = routes.IN_PERSON_ELIGIBILITY
+    id = "form-flow-selection"
+    method = "POST"
+
+    flow = forms.ChoiceField(label="Choose an eligibility type to qualify this rider.", widget=forms.widgets.RadioSelect)
+    verified = forms.BooleanField(label="I have verified this person’s eligibility for a transit benefit.", required=True)
+
+    cancel_url = routes.ADMIN_INDEX
+
+    def __init__(self, agency: models.TransitAgency, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        flows = agency.enrollment_flows.all()
+
+        self.classes = "checkbox-parent"
+        flow_field = self.fields["flow"]
+        flow_field.choices = [(f.id, f.label) for f in flows]
+        flow_field.widget.attrs.update({"data-custom-validity": "Please choose a transit benefit."})
+        self.use_custom_validity = True

--- a/benefits/in_person/templates/in_person/eligibility.html
+++ b/benefits/in_person/templates/in_person/eligibility.html
@@ -1,0 +1,30 @@
+{% extends "admin/agency-base.html" %}
+
+{% block title %}
+    Agency dashboard: In-person enrollment
+{% endblock title %}
+
+{% block content %}
+    <div class="row justify-content-center">
+        <div class="col-11 col-md-10 col-lg-6 border border-3 px-0">
+            <div class="border border-3 border-top-0 border-start-0 border-end-0">
+                <h2 class="p-3 m-0 text-left">In-person enrollment</h2>
+            </div>
+            <div class="p-3">{% include "core/includes/form.html" with form=form %}</div>
+            <div class="row d-flex justify-content-start p-3 pt-8">
+                <div class="col-6">
+                    {% url form.cancel_url as url_cancel %}
+                    <a href="{{ url_cancel }}" class="btn btn-lg btn-outline-primary d-block">Cancel</a>
+                </div>
+                <div class="col-6">
+                    <button class="btn btn-lg btn-primary d-flex justify-content-center align-items-center"
+                            data-action="submit"
+                            type="submit"
+                            form="{{ form.id }}">
+                        <span class="btn-text">Continue</span>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/benefits/in_person/views.py
+++ b/benefits/in_person/views.py
@@ -1,8 +1,39 @@
+from django.contrib.admin import site as admin_site
 from django.template.response import TemplateResponse
+from django.shortcuts import redirect
+from django.urls import reverse
+
+
+from benefits.routes import routes
+from benefits.core import session
+from benefits.core.models import EnrollmentFlow
+
+from benefits.in_person import forms
 
 
 def eligibility(request):
-    return TemplateResponse(request, "in_person/eligibility.html")
+    """View handler for the in-person eligibility flow selection form."""
+
+    agency = session.agency(request)
+    context = {**admin_site.each_context(request), "form": forms.InPersonEligibilityForm(agency=agency)}
+
+    if request.method == "POST":
+        form = forms.InPersonEligibilityForm(data=request.POST, agency=agency)
+
+        if form.is_valid():
+            flow_id = form.cleaned_data.get("flow")
+            flow = EnrollmentFlow.objects.get(id=flow_id)
+            session.update(request, flow=flow)
+
+            in_person_enrollment = reverse(routes.IN_PERSON_ENROLLMENT)
+            response = redirect(in_person_enrollment)
+        else:
+            context["form"] = form
+            response = TemplateResponse(request, "in_person/eligibility.html", context)
+    else:
+        response = TemplateResponse(request, "in_person/eligibility.html", context)
+
+    return response
 
 
 def enrollment(request):

--- a/benefits/routes.py
+++ b/benefits/routes.py
@@ -122,6 +122,11 @@ class Routes:
         return "enrollment:system_error"
 
     @property
+    def ADMIN_INDEX(self):
+        """Admin index page"""
+        return "admin:index"
+
+    @property
     def IN_PERSON_ELIGIBILITY(self):
         """In-person (e.g. agency assisted) eligibility"""
         return "in_person:eligibility"

--- a/benefits/static/css/admin/styles.css
+++ b/benefits/static/css/admin/styles.css
@@ -2,6 +2,7 @@
 
 /* Buttons */
 /* Primary Button: Use all three classes: btn btn-lg btn-primary */
+/* Outline Primary Button: Use all three classes: btn btn-lg btn-outline-primary */
 /* Set button width in parent with Bootstrap column */
 /* Height: 60px on Desktop; 72 on mobile*/
 
@@ -15,8 +16,16 @@
   }
 }
 
+.btn.btn-lg.btn-outline-primary:not(:hover) {
+  color: var(--primary-color);
+}
+
 .btn.btn-lg.btn-primary {
   background-color: var(--primary-color);
+}
+
+.btn.btn-lg.btn-primary,
+.btn.btn-lg.btn-outline-primary {
   border-color: var(--primary-color);
   border-width: 2px;
   font-weight: var(--medium-font-weight);
@@ -26,7 +35,8 @@
   padding: var(--primary-button-padding);
 }
 
-.btn.btn-lg.btn-primary:hover {
+.btn.btn-lg.btn-primary:hover,
+.btn.btn-lg.btn-outline-primary:hover {
   background-color: var(--hover-color);
   border-color: var(--hover-color);
 }
@@ -62,4 +72,20 @@ html[data-theme="light"],
 #user-tools,
 #logout-form button {
   text-transform: unset;
+}
+
+.checkbox-parent .form-group:last-of-type .col-12 {
+  display: flex;
+  flex-direction: row-reverse;
+  justify-content: start;
+  column-gap: 0.5rem;
+  margin-top: 2rem;
+}
+
+.checkbox-parent,
+.checkbox-parent .form-group .col-12,
+.checkbox-parent .form-group .col-12 #id_flow {
+  display: flex;
+  flex-direction: column;
+  row-gap: 1rem;
 }

--- a/tests/pytest/in_person/test_views.py
+++ b/tests/pytest/in_person/test_views.py
@@ -5,15 +5,6 @@ import pytest
 from benefits.routes import routes
 
 
-@pytest.fixture
-def mocked_eligibility_auth_request(mocked_eligibility_request_session, mocked_session_agency):
-    """
-    Stub fixture combines mocked_eligibility_request_session and mocked_session_oauth_token
-    so that session behaves like in an authenticated request to the eligibility app
-    """
-    pass
-
-
 @pytest.mark.django_db
 @pytest.mark.parametrize("viewname", [routes.IN_PERSON_ELIGIBILITY, routes.IN_PERSON_ENROLLMENT])
 def test_view_not_logged_in(client, viewname):


### PR DESCRIPTION
closes #2269 

http://localhost:11369/in_person/eligibility/

Light mode
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/c59f6dfd-3746-4ca6-8992-1462351fbac5">

Dark mode
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/81900012-4312-4a16-8297-9e3df2829160">


## How to test
- Follow https://github.com/cal-itp/benefits/pull/2325#issue-2489892807 to get into the dashboard
- Click New Enrollment button
- Test clicking submit without choosing anything
- Test clicking submit with only checkbox
- Test clicking submit with only radio button
- Use <kbd>enter</kbd> or <kbd>spacebar</kbd> and <kbd>tab</kbd> for form completion and submission
- Use <kbd>tab</kbd> to skip to main content correctly
- Accessibility: Passes WCAG AA (except for 1 known ARIA form issue coming from `form.html` - which isn't going to be changed in this PR)
- Check that the Console warning area is empty

## What this PR does

### Known issues/questions
- The log out user tools area does not get rendered.

### Form
- Has jQuery library loaded
- Does not have recaptcha
- Uses Django base form inputs (`RadioSelect` and `BooleanField`) on top of `form.html` from `core`
- Uses HTML5 validation and Django default back-end validation
- Has some hacky CSS written for styles, instead of adding utility classes through Django or adding logic to the Django template. 
- This PR aims to not make any changes to `forms.html` and just go with defaults. The required `*` is black because the `forms.html` utility classes make it so, and overriding a style that already has an `!important` style declaration is kinda messy. So we're keeping it black for now.

### Copy
- Is not internationalized.

### Tests
- [x] Write tests for form submission

### CSS
- Adds an Outline Button style, use with `"btn btn-lg btn-outline-primary"` (On view and hover)
<img width="360" alt="image" src="https://github.com/user-attachments/assets/895ccd94-1072-42cb-a916-f1b08d8dfe85">
<img width="345" alt="image" src="https://github.com/user-attachments/assets/edd2c13f-f78b-464b-bee2-0f6c7329a56b">

