### PR TITLE
Feat: create base template for in-person eligibility

### DIFF
--- a/benefits/templates/admin/agency-base.html
+++ b/benefits/templates/admin/agency-base.html
@@ -1,0 +1,52 @@
+{% extends "admin/base.html" %}
+{% load i18n static %}
+
+{% block extrastyle %}
+    <link href="{% static "css/admin/styles.css" %}" rel="stylesheet">
+    <link href="{% static "img/favicon.ico" %}" rel="icon" type="image/x-icon" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
+          rel="stylesheet"
+          integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3"
+          crossorigin="anonymous">
+{% endblock extrastyle %}
+
+{% block title %}
+{% endblock title %}
+
+{% block branding %}
+    <div id="header-container" class="navbar navbar-expand-sm navbar-dark justify-content-between">
+        <div class="container">
+            <span class="navbar-brand p-0">
+                <img class="sm d-lg-none" src="{% static "img/logo-sm.svg" %}" width="90" height="51.3" alt="{% translate "California Integrated Travel Project: Benefits logo (small)" context "image alt text" %}" />
+                <img class="lg d-none d-lg-block" src="{% static "img/logo-lg.svg" %}" width="220" height="50" alt="{% translate "California Integrated Travel Project: Benefits logo (large)" context "image alt text" %}" />
+            </span>
+        </div>
+        <h1 class="p-0 m-0 text-white">Administrator</h1>
+    </div>
+{% endblock branding %}
+
+{% block usertools %}
+{% endblock usertools %}
+
+{% block coltype %}
+    w-100
+{% endblock coltype %}
+
+{% block bodyclass %}
+    {{ block.super }} dashboard
+{% endblock bodyclass %}
+
+{% block nav-breadcrumbs %}
+{% endblock nav-breadcrumbs %}
+
+{% block nav-sidebar %}
+{% endblock nav-sidebar %}
+
+{% block content_title %}
+{% endblock content_title %}
+
+{% block content %}
+{% endblock content %}
+
+{% block sidebar %}
+{% endblock sidebar %}

--- a/benefits/templates/admin/agency-dashboard-index.html
+++ b/benefits/templates/admin/agency-dashboard-index.html
@@ -1,50 +1,9 @@
-{% extends "admin/base.html" %}
+{% extends "admin/agency-base.html" %}
 {% load i18n static %}
-
-{% block extrastyle %}
-    <link href="{% static "css/admin/styles.css" %}" rel="stylesheet">
-    <link href="{% static "img/favicon.ico" %}" rel="icon" type="image/x-icon" />
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
-          rel="stylesheet"
-          integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3"
-          crossorigin="anonymous">
-{% endblock extrastyle %}
 
 {% block title %}
     Agency dashboard
 {% endblock title %}
-
-{% block branding %}
-    <div id="header-container" class="navbar navbar-expand-sm navbar-dark justify-content-between">
-        <div class="container">
-            <span class="navbar-brand p-0">
-                <img class="sm d-lg-none" src="{% static "img/logo-sm.svg" %}" width="90" height="51.3" alt="{% translate "California Integrated Travel Project: Benefits logo (small)" context "image alt text" %}" />
-                <img class="lg d-none d-lg-block" src="{% static "img/logo-lg.svg" %}" width="220" height="50" alt="{% translate "California Integrated Travel Project: Benefits logo (large)" context "image alt text" %}" />
-            </span>
-        </div>
-        <h1 class="p-0 m-0 text-white">Administrator</h1>
-    </div>
-{% endblock branding %}
-
-{% block usertools %}
-{% endblock usertools %}
-
-{% block coltype %}
-    w-100
-{% endblock coltype %}
-
-{% block bodyclass %}
-    {{ block.super }} dashboard
-{% endblock bodyclass %}
-
-{% block nav-breadcrumbs %}
-{% endblock nav-breadcrumbs %}
-
-{% block nav-sidebar %}
-{% endblock nav-sidebar %}
-
-{% block content_title %}
-{% endblock content_title %}
 
 {% block content %}
     <div class="row">
@@ -64,6 +23,3 @@
     </div>
 
 {% endblock content %}
-
-{% block sidebar %}
-{% endblock sidebar %}


### PR DESCRIPTION
Part of #2246

This PR creates a base template which defines the header navbar and includes the styles that every in-person eligibility/enrollment page will need at a minimum. It extends Django's [admin base template](https://github.com/django/django/blob/main/django/contrib/admin/templates/admin/base.html). 

The `agency-dashboard-index.html` template is also refactored to use this new base template.