### PR TITLE
Feat: implement the top-right usertools block

### DIFF
--- a/benefits/static/css/admin/styles.css
+++ b/benefits/static/css/admin/styles.css
@@ -58,3 +58,8 @@ html[data-theme="light"],
   --link-fg: #ffffff;
   --body-quiet-color: var(--dark-color);
 }
+
+#user-tools,
+#logout-form button {
+  text-transform: unset;
+}

--- a/benefits/static/img/icon/box-arrow-right.svg
+++ b/benefits/static/img/icon/box-arrow-right.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="white" class="bi bi-box-arrow-right" viewBox="0 0 16 16">
+  <path fill-rule="evenodd" d="M10 12.5a.5.5 0 0 1-.5.5h-8a.5.5 0 0 1-.5-.5v-9a.5.5 0 0 1 .5-.5h8a.5.5 0 0 1 .5.5v2a.5.5 0 0 0 1 0v-2A1.5 1.5 0 0 0 9.5 2h-8A1.5 1.5 0 0 0 0 3.5v9A1.5 1.5 0 0 0 1.5 14h8a1.5 1.5 0 0 0 1.5-1.5v-2a.5.5 0 0 0-1 0z"/>
+  <path fill-rule="evenodd" d="M15.854 8.354a.5.5 0 0 0 0-.708l-3-3a.5.5 0 0 0-.708.708L14.293 7.5H5.5a.5.5 0 0 0 0 1h8.793l-2.147 2.146a.5.5 0 0 0 .708.708z"/>
+</svg>

--- a/benefits/templates/admin/agency-base.html
+++ b/benefits/templates/admin/agency-base.html
@@ -17,8 +17,8 @@
     <div id="header-container" class="navbar navbar-expand-sm navbar-dark justify-content-between">
         <div class="container">
             <span class="navbar-brand p-0">
-                <img class="sm d-lg-none" src="{% static "img/logo-sm.svg" %}" width="90" height="51.3" alt="{% translate "California Integrated Travel Project: Benefits logo (small)" context "image alt text" %}" />
-                <img class="lg d-none d-lg-block" src="{% static "img/logo-lg.svg" %}" width="220" height="50" alt="{% translate "California Integrated Travel Project: Benefits logo (large)" context "image alt text" %}" />
+                <img class="sm d-lg-none" src="{% static "img/logo-sm.svg" %}" width="90" height="51.3" alt="California Integrated Travel Project: Benefits logo (small)" />
+                <img class="lg d-none d-lg-block" src="{% static "img/logo-lg.svg" %}" width="220" height="50" alt="California Integrated Travel Project: Benefits logo (large)" />
             </span>
         </div>
         <h1 class="p-0 m-0 text-white">Administrator</h1>
@@ -26,27 +26,50 @@
 {% endblock branding %}
 
 {% block usertools %}
-{% endblock usertools %}
+    {% if has_permission %}
+        <div id="user-tools">
+            {% block welcome-msg %}
+                <span class="text-uppercase text-white">
+                    Welcome,
+                    <span class="fw-bold">{% firstof user.get_short_name user.get_username %}</span>. </span>
+                {% endblock welcome-msg %}
+                {% block userlinks %}
+                    {% if user.is_active and user.is_staff %}
+                        {% url 'django-admindocs-docroot' as docsroot %}
+                        {% if docsroot %}<a href="{{ docsroot }}">Documentation</a> /{% endif %}
+                    {% endif %}
+                    {% if user.has_usable_password %}
+                        <a href="{% url 'admin:password_change' %}">Change password</a> /
+                    {% endif %}
+                    <img class="icon" width="15" height="15" src="{% static "img/icon/box-arrow-right.svg" %}" alt="" />
+                    <form id="logout-form" method="post" action="{% url 'admin:logout' %}">
+                        {% csrf_token %}
+                        <button type="submit" class="border-0">Sign out</button>
+                    </form>
+                {% endblock userlinks %}
+            </div>
+        {% endif %}
+    {% endblock usertools %}
 
-{% block coltype %}
-    w-100
-{% endblock coltype %}
+    {% block coltype %}
+        w-100
+    {% endblock coltype %}
 
-{% block bodyclass %}
-    {{ block.super }} dashboard
-{% endblock bodyclass %}
+    {% block bodyclass %}
+        {{ block.super }} dashboard
+    {% endblock bodyclass %}
 
-{% block nav-breadcrumbs %}
-{% endblock nav-breadcrumbs %}
+    {% block nav-breadcrumbs %}
+    {% endblock nav-breadcrumbs %}
 
-{% block nav-sidebar %}
-{% endblock nav-sidebar %}
+    {% block nav-sidebar %}
+    {% endblock nav-sidebar %}
 
-{% block content_title %}
-{% endblock content_title %}
+    {% block content_title %}
+    {% endblock content_title %}
 
-{% block content %}
-{% endblock content %}
+    {% block content %}
+    {% endblock content %}
 
-{% block sidebar %}
-{% endblock sidebar %}
+    {% block sidebar %}
+    {% endblock sidebar %}


### PR DESCRIPTION
Closes #2246

This PR is the last part of #2246 and it implements the top right usertools block for in-person eligibility/enrollment pages. It overrides the `text-transform` property it inherits from Django's base admin site so that the welcome message is capitalized (WELCOME, USER) but the sign out message isn't (Sign out). ~It uses the same idea to remove the underline from `Sign out`.~ In addition, it adds a [Bootstrap icon](https://icons.getbootstrap.com/icons/box-arrow-right/) and uses it as the `Sign out` icon.
