### PR TITLE
Chore: Admin - Add jQuery to agency base template

### DIFF
--- a/benefits/templates/admin/agency-base.html
+++ b/benefits/templates/admin/agency-base.html
@@ -8,6 +8,10 @@
           rel="stylesheet"
           integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3"
           crossorigin="anonymous">
+    <script nonce="{{ request.csp_nonce }}"
+            src="https://cdn.jsdelivr.net/npm/jquery@3.6.1/dist/jquery.min.js"
+            integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ="
+            crossorigin="anonymous"></script>
 {% endblock extrastyle %}
 
 {% block title %}


### PR DESCRIPTION
closes #2328 

This PR adds jQuery to the `agency-base` template, so all Admin pages that use this template will have access to jQuery. jQuery is used in `form.html` - the main form base template that the app uses for all forms. 