### PR TITLE
Refactor: allow different action URLs on card-tokenize success form

### DIFF
--- a/benefits/enrollment/forms.py
+++ b/benefits/enrollment/forms.py
@@ -4,15 +4,16 @@ The enrollment application: Form definitions for results from Hosted Card Verifi
 
 from django import forms
 
-from benefits.routes import routes
-
 
 class CardTokenizeSuccessForm(forms.Form):
     """Form to bring client card token back to server."""
 
-    action_url = routes.ENROLLMENT_INDEX
     id = "form-card-tokenize-success"
     method = "POST"
+
+    def __init__(self, data=None, action_url=None, *args, **kwargs):
+        super().__init__(data, *args, **kwargs)
+        self.action_url = action_url
 
     # hidden input with no label
     card_token = forms.CharField(widget=forms.HiddenInput(), label="")

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -177,7 +177,9 @@ def index(request):
         tokenize_system_error_form = forms.CardTokenizeFailForm(
             routes.ENROLLMENT_SYSTEM_ERROR, "form-card-tokenize-fail-system-error"
         )
-        tokenize_success_form = forms.CardTokenizeSuccessForm(auto_id=True, label_suffix="")
+        tokenize_success_form = forms.CardTokenizeSuccessForm(
+            action_url=routes.ENROLLMENT_INDEX, auto_id=True, label_suffix=""
+        )
 
         # mapping from Django's I18N LANGUAGE_CODE to Littlepay's overlay language code
         overlay_language = {"en": "en", "es": "es-419"}.get(request.LANGUAGE_CODE, "en")


### PR DESCRIPTION
Part of #2327 

This PR makes a small refactor so that `CardTokenizeSuccessForm` allows for different `action_url`s. This is needed for the in-person enrollment view.