### PR TITLE
Refactor: enrollment token logic

### DIFF
--- a/benefits/enrollment/enrollment.py
+++ b/benefits/enrollment/enrollment.py
@@ -33,7 +33,7 @@ class CardTokenizationAccessResponse:
     status_code: int = None
 
 
-def request_card_tokenization_access(request):
+def request_card_tokenization_access(request) -> CardTokenizationAccessResponse:
     """
     Requests an access token to be used for card tokenization.
     """
@@ -71,7 +71,7 @@ def request_card_tokenization_access(request):
     )
 
 
-def enroll(request, card_token):
+def enroll(request, card_token) -> tuple[Status, Exception]:
     """
     Attempts to enroll this card into the transit processor group for the flow in the request's session.
 

--- a/tests/pytest/enrollment/test_enrollment.py
+++ b/tests/pytest/enrollment/test_enrollment.py
@@ -531,6 +531,7 @@ def test_request_card_tokenization_access(mocker, app_request):
     assert response.expires_at == "2024-01-01T00:00:00"
     assert response.exception is None
     assert response.status_code is None
+    mock_client.oauth.ensure_active_token.assert_called_once()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Part of #2244 

Extracts logic from `benefits.enrollment.token` view into `benefits.enrollment.enrollment` module. This is needed for the in-person enrollment view.

Similar to #2338 

## Testing locally

There shouldn't be any regressions with enrollment in the Benefits app.