### PR TITLE
Medicare: Eligibility Index - Modal and Radio Button Label

### DIFF
--- a/benefits/core/migrations/local_fixtures.json
+++ b/benefits/core/migrations/local_fixtures.json
@@ -46,7 +46,7 @@
       "label": "(CST) Senior Discount",
       "group_id": "group123",
       "enrollment_success_template": "enrollment/success--cst.html",
-      "display_order": 1,
+      "display_order": 2,
       "claims_provider": 1,
       "selection_label_template": "eligibility/includes/selection-label--senior.html",
       "eligibility_start_template": "eligibility/start--senior.html",
@@ -62,7 +62,7 @@
       "label": "(CST) Veteran Discount",
       "group_id": "group123",
       "enrollment_success_template": "enrollment/success--cst.html",
-      "display_order": 3,
+      "display_order": 4,
       "claims_provider": 1,
       "selection_label_template": "eligibility/includes/selection-label--veteran.html",
       "eligibility_start_template": "eligibility/start--veteran.html",
@@ -99,7 +99,7 @@
     "pk": 4,
     "fields": {
       "system_name": "calfresh",
-      "label": "CalFresh",
+      "label": "(CST) CalFresh",
       "group_id": "group123",
       "supports_expiration": "True",
       "expiration_days": 5,
@@ -113,6 +113,22 @@
       "help_template": "core/includes/help--calfresh.html",
       "claims_scope": "verify:calfresh",
       "claims_claim": "calfresh"
+    }
+  },
+  {
+    "model": "core.enrollmentflow",
+    "pk": 5,
+    "fields": {
+      "system_name": "medicare",
+      "label": "(CST) Medicare Discount",
+      "group_id": "group123",
+      "enrollment_success_template": "enrollment/success--cst.html",
+      "display_order": 1,
+      "claims_provider": 1,
+      "selection_label_template": "eligibility/includes/selection-label--medicare.html",
+      "eligibility_start_template": "eligibility/start--medicare.html",
+      "claims_scope": "verify:medicare",
+      "claims_claim": "medicare"
     }
   },
   {
@@ -131,7 +147,7 @@
     "pk": 1,
     "fields": {
       "active": true,
-      "enrollment_flows": [1, 2, 3, 4],
+      "enrollment_flows": [1, 2, 3, 4, 5],
       "slug": "cst",
       "short_name": "CST (local)",
       "long_name": "California State Transit (local)",

--- a/benefits/core/migrations/local_fixtures.json
+++ b/benefits/core/migrations/local_fixtures.json
@@ -32,7 +32,17 @@
     "fields": {
       "sign_out_button_template": "core/includes/button--sign-out--login-gov.html",
       "sign_out_link_template": "core/includes/link--sign-out--login-gov.html",
-      "client_name": "benefits-oauth-client-name",
+      "client_name": "benefits-logingov",
+      "client_id_secret_name": "claims-provider-client-id",
+      "authority": "https://example.com",
+      "scheme": "dev-cal-itp_benefits"
+    }
+  },
+  {
+    "model": "core.claimsprovider",
+    "pk": 2,
+    "fields": {
+      "client_name": "benefits-medicaregov",
       "client_id_secret_name": "claims-provider-client-id",
       "authority": "https://example.com",
       "scheme": "dev-cal-itp_benefits"
@@ -124,7 +134,7 @@
       "group_id": "group123",
       "enrollment_success_template": "enrollment/success--cst.html",
       "display_order": 1,
-      "claims_provider": 1,
+      "claims_provider": 2,
       "selection_label_template": "eligibility/includes/selection-label--medicare.html",
       "eligibility_start_template": "eligibility/start--medicare.html",
       "claims_scope": "verify:medicare",

--- a/benefits/eligibility/templates/eligibility/includes/modal--medicare.html
+++ b/benefits/eligibility/templates/eligibility/includes/modal--medicare.html
@@ -1,0 +1,38 @@
+{% extends "core/includes/modal.html" %}
+{% load i18n %}
+{% load static %}
+
+{% block modal-content %}
+    <h2 class="me-4 me-md-0">{% translate "Learn more about the option for Medicare Cardholders" %}</h2>
+    <div class="row">
+        <h3 class="pt-4">{% translate "How do I know if I qualify for the Medicare Cardholder option?" %}</h3>
+        <p class="pt-1">
+            {% blocktranslate trimmed %}
+                You qualify for this option if you have a Medicare card. To enroll you will need an account with Medicare.gov. You will need to sign up for a Medicare.gov account if you do not currently have one. Deceased Medicare cardholders do not qualify.
+            {% endblocktranslate %}
+        </p>
+
+        <h3 class="pt-4">{% translate "Do I need my Medicare card to enroll?" %}</h3>
+        <p class="pt-1">
+            {% blocktranslate trimmed %}
+                No, you do not need your physical Medicare card to enroll in a transit benefit. You will need the information on your card to create an account at Medicare.gov if you have do not currently have an online account.
+            {% endblocktranslate %}
+        </p>
+        <h3 class="pt-4">{% translate "Do I need to bring my Medicare card when I ride public transportation?" %}</h3>
+        <p class="pt-1">
+            {% blocktranslate trimmed %}
+                No, you do not need your physical Medicare card to use your transit benefit on public transportation. Once you have enrolled you can use your contactless debit or credit card to tap to ride with a reduced fare.
+            {% endblocktranslate %}
+        </p>
+        <h3 class="pt-4">{% translate "What if I qualify for more than one option?" %}</h3>
+        <p class="pt-1">
+            {% blocktranslate trimmed %}
+                You can enroll in any option you qualify for. We recommend enrolling in the Medicare Cardholder option if you qualify for it.
+            {% endblocktranslate %}
+        </p>
+
+        <p class="pt-4 d-block d-sm-none">
+            <a href="#" data-bs-dismiss="modal" aria-label="Close">{% translate "Go back" %}</a>
+        </p>
+    </div>
+{% endblock modal-content %}

--- a/benefits/eligibility/templates/eligibility/includes/selection-label--medicare.html
+++ b/benefits/eligibility/templates/eligibility/includes/selection-label--medicare.html
@@ -1,0 +1,13 @@
+{% extends "eligibility/includes/selection-label.html" %}
+{% load i18n %}
+
+{% block label %}
+    {% translate "Medicare Cardholder" %}
+{% endblock label %}
+
+{% block description %}
+    {% translate "You must be" %}
+    {% translate "currently enrolled in Medicare" as medicare_modal_link %}
+    {% include "core/includes/modal-trigger.html" with modal="modal--medicare" text=medicare_modal_link period=True %}
+    {% include "eligibility/includes/modal--medicare.html" with id="modal--medicare" size="modal-lg" header="p-md-2 p-3" body="pb-md-3 mb-md-3 mx-md-3 py-0 pt-0 absolute-top" %}
+{% endblock description %}

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2024-09-11 12:40-0700\n"
+"POT-Creation-Date: 2024-09-12 16:14-0700\n"
 "Language: English\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -457,6 +457,45 @@ msgid ""
 "the transit benefit you selected."
 msgstr ""
 
+msgid "Learn more about the option for Medicare Cardholders"
+msgstr ""
+
+msgid "How do I know if I qualify for the Medicare Cardholder option?"
+msgstr ""
+
+msgid ""
+"You qualify for this option if you have a Medicare card. To enroll you will "
+"need an account with Medicare.gov. You will need to sign up for a Medicare."
+"gov account if you do not currently have one. Deceased Medicare cardholders "
+"do not qualify."
+msgstr ""
+
+msgid "Do I need my Medicare card to enroll?"
+msgstr ""
+
+msgid ""
+"No, you do not need your physical Medicare card to enroll in a transit "
+"benefit. You will need the information on your card to create an account at "
+"Medicare.gov if you have do not currently have an online account."
+msgstr ""
+
+msgid "Do I need to bring my Medicare card when I ride public transportation?"
+msgstr ""
+
+msgid ""
+"No, you do not need your physical Medicare card to use your transit benefit "
+"on public transportation. Once you have enrolled you can use your "
+"contactless debit or credit card to tap to ride with a reduced fare."
+msgstr ""
+
+msgid "What if I qualify for more than one option?"
+msgstr ""
+
+msgid ""
+"You can enroll in any option you qualify for. We recommend enrolling in the "
+"Medicare Cardholder option if you qualify for it."
+msgstr ""
+
 msgid "CalFresh Cardholder"
 msgstr ""
 
@@ -477,6 +516,15 @@ msgstr ""
 msgid ""
 "This option is for people who have a current CST Agency Card or a CST "
 "Paratransit Eligibility Card."
+msgstr ""
+
+msgid "Medicare Cardholder"
+msgstr ""
+
+msgid "You must be"
+msgstr ""
+
+msgid "currently enrolled in Medicare"
 msgstr ""
 
 msgid "Courtesy Card"

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2024-09-11 12:40-0700\n"
+"POT-Creation-Date: 2024-09-12 16:14-0700\n"
 "Language: Español\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -590,6 +590,58 @@ msgstr ""
 "Utilizamos Login.gov para verificar su identidad para asegurarnos de que "
 "seas elegible para el beneficio de tránsito que seleccionaste."
 
+msgid "Learn more about the option for Medicare Cardholders"
+msgstr "TODO Learn more about the option for Medicare Cardholders"
+
+msgid "How do I know if I qualify for the Medicare Cardholder option?"
+msgstr "TODO How do I know if I qualify for the Medicare Cardholder option?"
+
+msgid ""
+"You qualify for this option if you have a Medicare card. To enroll you will "
+"need an account with Medicare.gov. You will need to sign up for a Medicare."
+"gov account if you do not currently have one. Deceased Medicare cardholders "
+"do not qualify."
+msgstr ""
+"TODO You qualify for this option if you have a Medicare card. To enroll you "
+"will need an account with Medicare.gov. You will need to sign up for a "
+"Medicare.gov account if you do not currently have one. Deceased Medicare "
+"cardholders do not qualify."
+
+msgid "Do I need my Medicare card to enroll?"
+msgstr "TODO Do I need my Medicare card to enroll?"
+
+msgid ""
+"No, you do not need your physical Medicare card to enroll in a transit "
+"benefit. You will need the information on your card to create an account at "
+"Medicare.gov if you have do not currently have an online account."
+msgstr ""
+"TODO No, you do not need your physical Medicare card to enroll in a transit "
+"benefit. You will need the information on your card to create an account at "
+"Medicare.gov if you have do not currently have an online account."
+
+msgid "Do I need to bring my Medicare card when I ride public transportation?"
+msgstr ""
+"TODO Do I need to bring my Medicare card when I ride public transportation?"
+
+msgid ""
+"No, you do not need your physical Medicare card to use your transit benefit "
+"on public transportation. Once you have enrolled you can use your "
+"contactless debit or credit card to tap to ride with a reduced fare."
+msgstr ""
+"TODO No, you do not need your physical Medicare card to use your transit "
+"benefit on public transportation. Once you have enrolled you can use your "
+"contactless debit or credit card to tap to ride with a reduced fare."
+
+msgid "What if I qualify for more than one option?"
+msgstr "TODO What if I qualify for more than one option?"
+
+msgid ""
+"You can enroll in any option you qualify for. We recommend enrolling in the "
+"Medicare Cardholder option if you qualify for it."
+msgstr ""
+"TODO You can enroll in any option you qualify for. We recommend enrolling in "
+"the Medicare Cardholder option if you qualify for it."
+
 msgid "CalFresh Cardholder"
 msgstr "Titular de la tarjeta CalFresh"
 
@@ -615,6 +667,15 @@ msgid ""
 msgstr ""
 "Esta opción es para personas que cuentan actualmente con una tarjeta de la "
 "CST o una tarjeta de elegibilidad CST Paratransit."
+
+msgid "Medicare Cardholder"
+msgstr "TODO Medicare Cardholder"
+
+msgid "You must be"
+msgstr "TODO Debe haber"
+
+msgid "currently enrolled in Medicare"
+msgstr "TODO currently enrolled in Medicare"
 
 msgid "Courtesy Card"
 msgstr "Tarjeta de cortesía de MST"

--- a/tests/cypress/specs/benefit-select.cy.js
+++ b/tests/cypress/specs/benefit-select.cy.js
@@ -8,20 +8,20 @@ describe("Benefit selection", () => {
     helpers.selectAgency();
   });
 
-  it("User sees 4 radio buttons", () => {
-    cy.get("input:radio").should("have.length", 4);
+  it("User sees 5 radio buttons", () => {
+    cy.get("input:radio").should("have.length", 5);
     cy.contains("Agency Card");
     cy.contains("65 years");
   });
 
   it("User must select a radio button, or else see a validation message", () => {
-    cy.get("input:radio").should("have.length", 4);
+    cy.get("input:radio").should("have.length", 5);
     cy.get("input:radio:checked").should("have.length", 0);
     cy.get("#form-flow-selection").submit();
 
     cy.url().should("include", flow_selection_url);
     cy.get("input:radio:checked").should("have.length", 0);
-    cy.get("input:invalid").should("have.length", 4);
+    cy.get("input:invalid").should("have.length", 5);
     cy.get("input:radio")
       .first()
       .invoke("prop", "validationMessage")


### PR DESCRIPTION
closes #2351 
closes #2350 
closes #2358 

## What this PR does
- [x] Add Medicare as the first enrollment flow for CST
- [x] Add Medicare modal
- [x] Add Medicare label
- [x] Set Enrollment Success template to be the default CST one.
- [x] Add English copy; the Spanish translation are still filled with TODOs.
- [x] Update specs

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/51d70783-73ab-4aa3-a8dc-e88a5718fd06">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/55ad21ce-c015-40aa-85df-62e9dbd55c0d">

## How to test

To get the new fixture and copy:
```
./bin/reset_db.sh
./bin/init.sh
```
