### PR TITLE
Feat: Medicare cardholder eligibility start template

### DIFF
--- a/benefits/eligibility/templates/eligibility/includes/media-item--idcardcheck--start--medicare.html
+++ b/benefits/eligibility/templates/eligibility/includes/media-item--idcardcheck--start--medicare.html
@@ -1,0 +1,15 @@
+{% extends "eligibility/includes/media-item--idcardcheck.html" %}
+
+{% load i18n %}
+
+{% block heading %}
+  {% translate "An online account with Medicare.gov" %}
+{% endblock heading %}
+
+{% block body %}
+  <div class="media-body--details">
+    <p>
+      {% translate "If you do not have an account you will be able to create one using your red, white, and blue Medicare card. We use your Medicare.gov account to verify you qualify." %}
+    </p>
+  </div>
+{% endblock body %}

--- a/benefits/eligibility/templates/eligibility/start--medicare.html
+++ b/benefits/eligibility/templates/eligibility/start--medicare.html
@@ -1,0 +1,24 @@
+{% extends "eligibility/start.html" %}
+{% load i18n %}
+
+{% block page-title %}
+    {% translate "Medicare benefit overview" %}
+{% endblock page-title %}
+
+{% block headline %}
+    <div class="col-lg-8">
+        <h1>{% translate "You selected a Medicare Cardholder transit benefit." %}</h1>
+    </div>
+{% endblock headline %}
+
+{% block media-item %}
+    {% include "eligibility/includes/media-item--idcardcheck--start--medicare.html" %}
+{% endblock media-item %}
+
+{% block call-to-action %}
+    <div class="row d-flex justify-content-lg-end">
+        <div class="col-lg-3 offset-2 offset-sm-2 offset-lg-0 col-sm-8 col-8">
+            <a href="{% url routes.OAUTH_LOGIN %}" class="btn btn-lg btn-primary" role="button">{% translate "Continue to Medicare.gov" %}</a>
+        </div>
+    </div>
+{% endblock call-to-action %}

--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2024-09-12 16:14-0700\n"
+"POT-Creation-Date: 2024-09-17 08:28-0700\n"
 "Language: English\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -420,6 +420,15 @@ msgstr ""
 msgid "A phone number with a phone plan associated with your name"
 msgstr ""
 
+msgid "An online account with Medicare.gov"
+msgstr ""
+
+msgid ""
+"If you do not have an account you will be able to create one using your red, "
+"white, and blue Medicare card. We use your Medicare.gov account to verify "
+"you qualify."
+msgstr ""
+
 msgid "Your current Courtesy Card number"
 msgstr ""
 
@@ -605,6 +614,15 @@ msgid "You selected an Agency Card transit benefit."
 msgstr ""
 
 msgid "Continue"
+msgstr ""
+
+msgid "Medicare benefit overview"
+msgstr ""
+
+msgid "You selected a Medicare Cardholder transit benefit."
+msgstr ""
+
+msgid "Continue to Medicare.gov"
 msgstr ""
 
 msgid "You selected a Courtesy Card transit benefit."

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2024-09-12 16:14-0700\n"
+"POT-Creation-Date: 2024-09-17 08:28-0700\n"
 "Language: Español\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -547,6 +547,18 @@ msgid "A phone number with a phone plan associated with your name"
 msgstr ""
 "Un número de teléfono en el cual pueda recibir llamadas o mensajes de texto"
 
+msgid "An online account with Medicare.gov"
+msgstr "TODO"
+
+msgid ""
+"If you do not have an account you will be able to create one using your red, "
+"white, and blue Medicare card. We use your Medicare.gov account to verify "
+"you qualify."
+msgstr ""
+"TODO If you do not have an account you will be able to create one using your "
+"red, white, and blue Medicare card. We use your Medicare.gov account to "
+"verify you qualify."
+
 msgid "Your current Courtesy Card number"
 msgstr "Su número actual de tarjeta de cortesía"
 
@@ -773,6 +785,15 @@ msgstr "Ha seleccionado un beneficio de tránsito de tarjeta de agencia."
 
 msgid "Continue"
 msgstr "Continuar"
+
+msgid "Medicare benefit overview"
+msgstr "TODO Medicare benefit overview"
+
+msgid "You selected a Medicare Cardholder transit benefit."
+msgstr "TODO You selected a Medicare Cardholder transit benefit."
+
+msgid "Continue to Medicare.gov"
+msgstr "TODO"
 
 msgid "You selected a Courtesy Card transit benefit."
 msgstr "Ha seleccionado un beneficio de tránsito de tarjeta de cortesía."


### PR DESCRIPTION
Closes #2352

This PR implements a new template for the start screen for the Medicare flow. The Spanish translation will be implemented as part of #2369.

![image](https://github.com/user-attachments/assets/2d188fa1-1f4f-43ac-8ad1-580ec76c3025)
