### PR TITLE
Admin: Log in page

### DIFF
--- a/benefits/admin.py
+++ b/benefits/admin.py
@@ -46,7 +46,3 @@ class BenefitsAdminSite(admin.AdminSite):
                 )
 
             return TemplateResponse(request, "admin/agency-dashboard-index.html", context)
-
-
-BenefitsAdminSite.site_header = "Administrator"
-BenefitsAdminSite.site_title = "Cal-ITP Benefits - Administrator"

--- a/benefits/admin.py
+++ b/benefits/admin.py
@@ -46,3 +46,7 @@ class BenefitsAdminSite(admin.AdminSite):
                 )
 
             return TemplateResponse(request, "admin/agency-dashboard-index.html", context)
+
+
+BenefitsAdminSite.site_header = "Administrator"
+BenefitsAdminSite.site_title = "Cal-ITP Benefits - Administrator"

--- a/benefits/static/css/admin/styles.css
+++ b/benefits/static/css/admin/styles.css
@@ -1,5 +1,16 @@
 @import "../variables.css";
 
+/* CSS Variable overrides */
+
+html[data-theme="light"],
+:root {
+  --primary: #ffffff;
+  --secondary: var(--dark-color);
+  --link-fg: #ffffff;
+  --body-quiet-color: var(--dark-color);
+  --button-bg: #ffffff;
+}
+
 /* Buttons */
 /* Primary Button: Use all three classes: btn btn-lg btn-primary */
 /* Outline Primary Button: Use all three classes: btn btn-lg btn-outline-primary */
@@ -20,11 +31,13 @@
   color: var(--primary-color);
 }
 
+.login input[type="submit"],
 .btn.btn-lg.btn-primary {
   background-color: var(--primary-color);
 }
 
 .btn.btn-lg.btn-primary,
+.login input[type="submit"],
 .btn.btn-lg.btn-outline-primary {
   border-color: var(--primary-color);
   border-width: 2px;
@@ -36,6 +49,7 @@
 }
 
 .btn.btn-lg.btn-primary:hover,
+.login input[type="submit"]:hover,
 .btn.btn-lg.btn-outline-primary:hover {
   background-color: var(--hover-color);
   border-color: var(--hover-color);
@@ -48,7 +62,11 @@
 .btn-outline-dark:focus,
 .btn-outline-dark:focus-visible,
 .btn-outline-light:focus,
-.btn-ouline-dark:focus-visible {
+.btn-ouline-dark:focus-visible,
+input[type="text"]:focus,
+input[type="password"]:focus,
+.google-login-btn a:focus,
+.login input[type="submit"]:focus {
   outline: 3px solid var(--focus-color) !important;
   outline-offset: 2px !important;
   box-shadow: none !important; /* override CA State Web Template */
@@ -61,19 +79,13 @@
   letter-spacing: calc(var(--font-size-20px) * var(--letter-spacing-2));
 }
 
-html[data-theme="light"],
-:root {
-  --primary: #ffffff;
-  --secondary: var(--dark-color);
-  --link-fg: #ffffff;
-  --body-quiet-color: var(--dark-color);
-}
-
 #user-tools,
-#logout-form button {
+#logout-form button,
+.login .submit-row input[type="submit"] {
   text-transform: unset;
 }
 
+/* Eligibility Page */
 .checkbox-parent .form-group:last-of-type .col-12 {
   display: flex;
   flex-direction: row-reverse;
@@ -90,9 +102,94 @@ html[data-theme="light"],
   row-gap: 1rem;
 }
 
-/* Enrollment */
+/* Enrollment Page*/
 iframe.card-collection {
   border: 0px;
   width: 100%;
   height: 60vh;
+}
+
+/* Login Page */
+.login #header {
+  padding: 0 !important;
+}
+
+.login #branding {
+  flex-direction: column;
+  width: 100%;
+}
+
+.login #container {
+  background: var(--body-bg);
+  border: 1px solid var(--hairline-color);
+  overflow: hidden;
+  width: 28em;
+  min-width: 300px;
+  margin: 100px auto;
+  height: auto;
+}
+
+.login #login-form {
+  display: grid;
+  gap: 1em;
+}
+
+.login .form-row label {
+  display: block;
+  line-height: 2em;
+}
+
+.login .form-row #id_username,
+.login .form-row #id_password {
+  padding: 8px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.login .password-reset-link {
+  text-align: center;
+}
+
+.login .clear {
+  display: none;
+}
+
+/* Login Page: Google SSO Button */
+.login .login-btn-area {
+  width: 100%;
+}
+
+.login .google-login-btn {
+  border: 1px solid var(--bs-primary);
+  background-color: var(--white);
+  height: 100%;
+  border-radius: 4px;
+  padding: 0;
+}
+
+.login .google-login-btn .btn-content {
+  padding: 13.5px 0;
+  border-radius: 4px;
+}
+
+.login .google-btn-logo {
+  padding-right: 20px;
+  background-color: transparent;
+}
+
+.login .google-login-btn:hover {
+  color: var(--white);
+  background-color: var(--bs-primary);
+}
+
+.login .google-login-btn:hover .google-btn-label,
+.login .google-login-btn:hover a {
+  color: var(--bs-white);
+}
+
+.login .google-btn-label {
+  color: var(--bs-primary);
+  width: auto;
+  font-weight: var(--medium-font-weight);
+  font-size: var(--font-size-20px);
 }

--- a/benefits/templates/admin/agency-base.html
+++ b/benefits/templates/admin/agency-base.html
@@ -1,17 +1,20 @@
 {% extends "admin/base.html" %}
 {% load i18n static %}
 
+{% block dark-mode-vars %}
+{% endblock dark-mode-vars %}
+
 {% block extrastyle %}
-    <link href="{% static "css/admin/styles.css" %}" rel="stylesheet">
     <link href="{% static "img/favicon.ico" %}" rel="icon" type="image/x-icon" />
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
-          rel="stylesheet"
-          integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3"
-          crossorigin="anonymous">
     <script nonce="{{ request.csp_nonce }}"
             src="https://cdn.jsdelivr.net/npm/jquery@3.6.1/dist/jquery.min.js"
             integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ="
             crossorigin="anonymous"></script>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
+          rel="stylesheet"
+          integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3"
+          crossorigin="anonymous">
+    <link href="{% static "css/admin/styles.css" %}" rel="stylesheet">
 {% endblock extrastyle %}
 
 {% block title %}

--- a/benefits/templates/admin/login.html
+++ b/benefits/templates/admin/login.html
@@ -1,0 +1,28 @@
+{% extends "admin/login.html" %}
+{% load i18n static %}
+
+{% block dark-mode-vars %}
+{% endblock dark-mode-vars %}
+
+{% block extrastyle %}
+    <link href="{% static "img/favicon.ico" %}" rel="icon" type="image/x-icon" />
+    <script nonce="{{ request.csp_nonce }}"
+            src="https://cdn.jsdelivr.net/npm/jquery@3.6.1/dist/jquery.min.js"
+            integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ="
+            crossorigin="anonymous"></script>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
+          rel="stylesheet"
+          integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3"
+          crossorigin="anonymous">
+    <link href="{% static "css/admin/styles.css" %}" rel="stylesheet">
+{% endblock extrastyle %}
+
+{% block branding %}
+    <div class="d-flex justify-content-center w-100 bg-primary">
+        <img class="my-3" src="{% static "img/logo-lg.svg" %}" width="220" height="50" alt="California Integrated Travel Project: Benefits logo (large)" />
+    </div>
+
+    <div id="site-name">
+        <h1 class="text-center text-white fs-3 py-3 m-0">{{ site_header }}</h1>
+    </div>
+{% endblock branding %}

--- a/benefits/templates/admin/login.html
+++ b/benefits/templates/admin/login.html
@@ -6,10 +6,6 @@
 
 {% block extrastyle %}
     <link href="{% static "img/favicon.ico" %}" rel="icon" type="image/x-icon" />
-    <script nonce="{{ request.csp_nonce }}"
-            src="https://cdn.jsdelivr.net/npm/jquery@3.6.1/dist/jquery.min.js"
-            integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ="
-            crossorigin="anonymous"></script>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
           rel="stylesheet"
           integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3"

--- a/benefits/templates/admin/login.html
+++ b/benefits/templates/admin/login.html
@@ -4,6 +4,10 @@
 {% block dark-mode-vars %}
 {% endblock dark-mode-vars %}
 
+{% block title %}
+    Log in | Cal-ITP Benefits Administrator
+{% endblock title %}
+
 {% block extrastyle %}
     <link href="{% static "img/favicon.ico" %}" rel="icon" type="image/x-icon" />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
@@ -19,6 +23,6 @@
     </div>
 
     <div id="site-name">
-        <h1 class="text-center text-white fs-3 py-3 m-0">{{ site_header }}</h1>
+        <h1 class="text-center text-white fs-3 py-3 m-0">Administrator</h1>
     </div>
 {% endblock branding %}

--- a/benefits/templates/admin/login.html
+++ b/benefits/templates/admin/login.html
@@ -9,6 +9,7 @@
 {% endblock title %}
 
 {% block extrastyle %}
+    {% comment %} Overriding instead of extending agency-base here to remove jQuery declaration, which admin/login.html includes on its own {% endcomment %}
     <link href="{% static "img/favicon.ico" %}" rel="icon" type="image/x-icon" />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
           rel="stylesheet"


### PR DESCRIPTION
closes #2265 

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/9b2ac265-49c7-4b54-b090-06f08bc89cd4">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/90bdb384-2fa9-4928-8ddd-c1cbbc115c53">
<img width="1505" alt="image" src="https://github.com/user-attachments/assets/5ed1d3de-1cdd-4713-ae66-df8ffe892bdd">

## What this PR does
- Sets `site_header`, `site_title` for BenefitsAdminSite
- CSS: Add default Benefit focus states to login inputs, buttons
- CSS: Removes darkmode from Agency Base and Login
- Templates: Login and Agency Base - Moves Django's Login.css code to Styles.css and changes some of the style declarations
- Login template: Creates login.html to override parts of Django's login.html's branding section to add the Cal-ITP image.

## How to test
- Test with `SSO_SHOW_FORM_ON_ADMIN_PAGE` set to False 
- Test with `SSO_SHOW_FORM_ON_ADMIN_PAGE` set to True
- Test with an error/info/warning message
- Test on dark (browser set to dark mode) and light mode - Should only show light mode
- Test focus states
- Test with a wrong password, error message should show up

This PR also resolves all outstanding WCAG 2.0 issues: 
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/930c7306-d02d-449b-8876-3ccc83be9c8d">
