### PR TITLE
Feat: error templates for in-person enrollment

### DIFF
--- a/benefits/in_person/templates/error-base.html
+++ b/benefits/in_person/templates/error-base.html
@@ -1,0 +1,25 @@
+{% extends "admin/agency-base.html" %}
+{% load static %}
+
+{% block content %}
+    <div class="row justify-content-center">
+        <div class="col-lg-6">
+            <div class="border border-3 p-3">
+                <h2 class="p-0 m-0 text-left">In-person enrollment</h2>
+            </div>
+            <div class="border border-3 border-top-0 p-3 min-vh-60 d-flex flex-column justify-content-between">
+                <div class="d-flex">
+                    <i class="error-icon"></i>
+                    <div class="mt-lg-3">
+                        {% block error-message %}
+                        {% endblock error-message %}
+                    </div>
+                </div>
+                <div class="row">
+                    {% block cta-buttons %}
+                    {% endblock cta-buttons %}
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/benefits/in_person/templates/in_person/enrollment/reenrollment_error.html
+++ b/benefits/in_person/templates/in_person/enrollment/reenrollment_error.html
@@ -1,0 +1,16 @@
+{% extends "error-base.html" %}
+
+{% block error-message %}
+    <h3 class="fw-bold h4">This person is still enrolled in the {{ flow_label }} benefit.</h3>
+
+    <p class="my-4">
+        <span class="fw-bold">This rider will enjoy a transit benefit until {{ enrollment.expires|date }}.</span> They can re-enroll for this benefit beginning on {{ enrollment.reenrollment|date }}. Please try again then.
+    </p>
+{% endblock error-message %}
+
+{% block cta-buttons %}
+    <div class="col-12">
+        {% url routes.ADMIN_INDEX as url_return_to_dashboard %}
+        <a href="{{ url_return_to_dashboard }}" class="btn btn-lg btn-primary d-block">Return to dashboard</a>
+    </div>
+{% endblock cta-buttons %}

--- a/benefits/in_person/templates/in_person/enrollment/retry.html
+++ b/benefits/in_person/templates/in_person/enrollment/retry.html
@@ -1,0 +1,20 @@
+{% extends "error-base.html" %}
+
+{% block error-message %}
+    <h3 class="fw-bold h4">Card not found.</h3>
+
+    <p class="my-4">
+        The card information may not have been entered correctly. Please check the details on your card and try again.
+    </p>
+{% endblock error-message %}
+
+{% block cta-buttons %}
+    <div class="col-6">
+        {% url routes.ADMIN_INDEX as url_cancel %}
+        <a href="{{ url_cancel }}" class="btn btn-lg btn-outline-primary d-block">Cancel</a>
+    </div>
+    <div class="col-6">
+        {% url routes.IN_PERSON_ENROLLMENT as url_try_again %}
+        <a href="{{ url_try_again }}" class="btn btn-lg btn-primary d-block">Try again</a>
+    </div>
+{% endblock cta-buttons %}

--- a/benefits/in_person/templates/in_person/enrollment/server_error.html
+++ b/benefits/in_person/templates/in_person/enrollment/server_error.html
@@ -1,0 +1,16 @@
+{% extends "error-base.html" %}
+
+{% block error-message %}
+    <h3 class="fw-bold h4">We're working to fix a problem.</h3>
+
+    <p class="my-4">
+        There is a problem with the application configuration, but we're working to fix it. Please try again in a little while.
+    </p>
+{% endblock error-message %}
+
+{% block cta-buttons %}
+    <div class="col-12">
+        {% url routes.ADMIN_INDEX as url_return_to_dashboard %}
+        <a href="{{ url_return_to_dashboard }}" class="btn btn-lg btn-primary d-block">Return to dashboard</a>
+    </div>
+{% endblock cta-buttons %}

--- a/benefits/in_person/templates/in_person/enrollment/system_error.html
+++ b/benefits/in_person/templates/in_person/enrollment/system_error.html
@@ -1,0 +1,14 @@
+{% extends "error-base.html" %}
+
+{% block error-message %}
+    <h3 class="fw-bold h4">The enrollment system isn't working right now.</h3>
+
+    <p class="my-4">Please wait 24 hours and try to enroll again.</p>
+{% endblock error-message %}
+
+{% block cta-buttons %}
+    <div class="col-12">
+        {% url routes.ADMIN_INDEX as url_return_to_dashboard %}
+        <a href="{{ url_return_to_dashboard }}" class="btn btn-lg btn-primary d-block">Return to dashboard</a>
+    </div>
+{% endblock cta-buttons %}

--- a/benefits/in_person/views.py
+++ b/benefits/in_person/views.py
@@ -133,19 +133,27 @@ def enrollment(request):
 
 
 def reenrollment_error(request):
-    return TemplateResponse(request, "in_person/enrollment/reenrollment_error.html")
+    context = {**admin_site.each_context(request)}
+
+    return TemplateResponse(request, "in_person/enrollment/reenrollment_error.html", context)
 
 
 def retry(request):
-    return TemplateResponse(request, "in_person/enrollment/retry.html")
+    context = {**admin_site.each_context(request)}
+
+    return TemplateResponse(request, "in_person/enrollment/retry.html", context)
 
 
 def system_error(request):
-    return TemplateResponse(request, "in_person/enrollment/system_error.html")
+    context = {**admin_site.each_context(request)}
+
+    return TemplateResponse(request, "in_person/enrollment/system_error.html", context)
 
 
 def server_error(request):
-    return TemplateResponse(request, "in_person/enrollment/server_error.html")
+    context = {**admin_site.each_context(request)}
+
+    return TemplateResponse(request, "in_person/enrollment/server_error.html", context)
 
 
 def success(request):

--- a/benefits/in_person/views.py
+++ b/benefits/in_person/views.py
@@ -133,7 +133,11 @@ def enrollment(request):
 
 
 def reenrollment_error(request):
+    """View handler for a re-enrollment attempt that is not yet within the re-enrollment window."""
     context = {**admin_site.each_context(request)}
+
+    flow = session.flow(request)
+    context["flow_label"] = flow.label
 
     return TemplateResponse(request, "in_person/enrollment/reenrollment_error.html", context)
 

--- a/benefits/in_person/views.py
+++ b/benefits/in_person/views.py
@@ -67,6 +67,7 @@ def token(request):
 
 
 def enrollment(request):
+    """View handler for the in-person enrollment page."""
     # POST back after transit processor form, process card token
     if request.method == "POST":
         form = forms.CardTokenizeSuccessForm(request.POST)
@@ -159,12 +160,14 @@ def system_error(request):
 
 
 def server_error(request):
+    """View handler for errors caused by a misconfiguration or bad request."""
     context = {**admin_site.each_context(request)}
 
     return TemplateResponse(request, "in_person/enrollment/server_error.html", context)
 
 
 def success(request):
+    """View handler for the final success page."""
     context = {**admin_site.each_context(request)}
 
     return TemplateResponse(request, "in_person/enrollment/success.html", context)

--- a/benefits/in_person/views.py
+++ b/benefits/in_person/views.py
@@ -93,6 +93,7 @@ def enrollment(request):
                 return redirect(routes.IN_PERSON_ENROLLMENT_SUCCESS)
 
             case Status.SYSTEM_ERROR:
+                sentry_sdk.capture_exception(exception)
                 return redirect(routes.IN_PERSON_ENROLLMENT_SYSTEM_ERROR)
 
             case Status.EXCEPTION:
@@ -150,6 +151,7 @@ def retry(request):
 
 
 def system_error(request):
+    """View handler for an enrollment system error."""
     context = {**admin_site.each_context(request)}
 
     return TemplateResponse(request, "in_person/enrollment/system_error.html", context)

--- a/benefits/in_person/views.py
+++ b/benefits/in_person/views.py
@@ -143,6 +143,7 @@ def reenrollment_error(request):
 
 
 def retry(request):
+    """View handler for card verification failure."""
     context = {**admin_site.each_context(request)}
 
     return TemplateResponse(request, "in_person/enrollment/retry.html", context)

--- a/benefits/in_person/views.py
+++ b/benefits/in_person/views.py
@@ -97,6 +97,7 @@ def enrollment(request):
                 return redirect(routes.IN_PERSON_ENROLLMENT_SYSTEM_ERROR)
 
             case Status.EXCEPTION:
+                sentry_sdk.capture_exception(exception)
                 return redirect(routes.IN_PERSON_SERVER_ERROR)
 
             case Status.REENROLLMENT_ERROR:

--- a/benefits/static/css/admin/styles.css
+++ b/benefits/static/css/admin/styles.css
@@ -125,6 +125,19 @@ iframe.card-collection {
   min-height: 60vh;
 }
 
+/* Error Pages */
+.error-icon {
+  background-color: var(--bs-danger);
+  mask: url("../../../static/img/icon/exclamation-circle-fill.svg") no-repeat;
+  -webkit-mask: url("../../../static/img/icon/exclamation-circle-fill.svg")
+    no-repeat;
+
+  display: inline-block;
+  width: 64px;
+  height: 64px;
+  margin-right: calc(12rem / 16);
+}
+
 /* Login Page */
 .login #header {
   padding: 0 !important;

--- a/benefits/static/img/icon/exclamation-circle-fill.svg
+++ b/benefits/static/img/icon/exclamation-circle-fill.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="bi bi-exclamation-circle-fill" viewBox="0 0 16 16">
+  <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0M8 4a.905.905 0 0 0-.9.995l.35 3.507a.552.552 0 0 0 1.1 0l.35-3.507A.905.905 0 0 0 8 4m.002 6a1 1 0 1 0 0 2 1 1 0 0 0 0-2"/>
+</svg>

--- a/tests/pytest/in_person/test_views.py
+++ b/tests/pytest/in_person/test_views.py
@@ -321,6 +321,7 @@ def test_retry(admin_client):
 
     response = admin_client.get(path)
 
+    assert response.status_code == 200
     assert response.template_name == "in_person/enrollment/retry.html"
 
 

--- a/tests/pytest/in_person/test_views.py
+++ b/tests/pytest/in_person/test_views.py
@@ -305,11 +305,14 @@ def test_enrollment_post_valid_form_reenrollment_error(mocker, admin_client, car
     assert response.url == reverse(routes.IN_PERSON_ENROLLMENT_REENROLLMENT_ERROR)
 
 
+@pytest.mark.django_db
+@pytest.mark.usefixtures("mocked_session_flow")
 def test_reenrollment_error(admin_client):
     path = reverse(routes.IN_PERSON_ENROLLMENT_REENROLLMENT_ERROR)
 
     response = admin_client.get(path)
 
+    assert response.status_code == 200
     assert response.template_name == "in_person/enrollment/reenrollment_error.html"
 
 


### PR DESCRIPTION
Closes #2345 

This PR implements the templates for in-person error pages and also adds the call to send a Sentry notification for those errors.

## Testing locally

You can view the pages by going directly to the URLs:
- system error: `in_person/enrollment/error`
- server error: `in_person/error`
- re-enrollment error: `in_person/enrollment/error/reenrollment`
- user enrollment error: `in_person/enrollment/retry`

If you want to test the actual view redirecting logic, you'll need to simulate the errors.

You can simulate errors by changing the returned `Status` and exception on this line: https://github.com/cal-itp/benefits/blob/e6af3db073e1c816b1b2e61a8e97bb6989d46e42/benefits/in_person/views.py#L78

For re-enrollment errors, you also need the dates to be populated, so:
- (Temporarily) override the value returned by `session.enrollment_expiry()` e.g.
```python
expiry = datetime(2025, 9, 20, tzinfo=timezone.utc).timestamp()
if expiry:
    return datetime.fromtimestamp(expiry, tz=timezone.utc)
else:
    return None
```
- In the Admin, update the flow that you plan to test with: 
   - check supports expiration
   - add a value for the expiration days and re-enrollment days

Don't forget that there are also the [`onVerificationFailure`](https://github.com/cal-itp/benefits/blob/e6af3db073e1c816b1b2e61a8e97bb6989d46e42/benefits/in_person/templates/in_person/enrollment.html#L83-L90) and [`onError`](https://github.com/cal-itp/benefits/blob/e6af3db073e1c816b1b2e61a8e97bb6989d46e42/benefits/in_person/templates/in_person/enrollment.html#L91-L102) callback functions in the front-end that will redirect to error pages as well.

## Screenshots
<details><summary>Expand</summary>

### System error
![image](https://github.com/user-attachments/assets/4437d747-0826-488c-b3f1-eb29aac16877)

### Server error
![image](https://github.com/user-attachments/assets/ce042b16-63dd-47f3-a572-4e2322340e7b)

### Re-enrollment error
![image](https://github.com/user-attachments/assets/adc2b86c-f5be-427e-a954-dc134e0fd5bf)

### User enrollment error
![image](https://github.com/user-attachments/assets/ae510797-dac8-4d7c-a4f3-9f4d35f32bcd)

</details>
