### PR TITLE
Refactor: analytics for PaymentProcessor

### DIFF
--- a/benefits/enrollment/analytics.py
+++ b/benefits/enrollment/analytics.py
@@ -8,12 +8,12 @@ from benefits.core import analytics as core
 class ReturnedEnrollmentEvent(core.Event):
     """Analytics event representing the end of transit processor enrollment request."""
 
-    def __init__(self, request, status, error=None, payment_group=None):
+    def __init__(self, request, status, error=None, enrollment_group=None):
         super().__init__(request, "returned enrollment")
         if str(status).lower() in ("error", "retry", "success"):
             self.update_event_properties(status=status, error=error)
-        if payment_group is not None:
-            self.update_event_properties(payment_group=payment_group)
+        if enrollment_group is not None:
+            self.update_event_properties(enrollment_group=enrollment_group)
 
 
 class FailedAccessTokenRequestEvent(core.Event):
@@ -35,9 +35,9 @@ def returned_retry(request):
     core.send_event(ReturnedEnrollmentEvent(request, status="retry"))
 
 
-def returned_success(request, payment_group):
+def returned_success(request, enrollment_group):
     """Send the "returned enrollment" analytics event with a success status."""
-    core.send_event(ReturnedEnrollmentEvent(request, status="success", payment_group=payment_group))
+    core.send_event(ReturnedEnrollmentEvent(request, status="success", enrollment_group=enrollment_group))
 
 
 def failed_access_token_request(request, status_code=None):

--- a/benefits/enrollment/templates/enrollment/index.html
+++ b/benefits/enrollment/templates/enrollment/index.html
@@ -35,7 +35,7 @@
   {% endcomment %}
   {% translate "Please wait..." as loading_text %}
   <script nonce="{{ request.csp_nonce }}">
-      var startedEvent = "started payment connection", closedEvent = "closed payment connection";
+      var startedEvent = "started card tokenization", closedEvent = "ended card tokenization";
 
       $.ajax({ dataType: "script", attrs: { nonce: "{{ request.csp_nonce }}"}, url: "{{ card_tokenize_url }}" })
           .done(function() {

--- a/docs/development/application-logic.md
+++ b/docs/development/application-logic.md
@@ -271,10 +271,10 @@ benefits-->>user: access token
     activate user
 user->>user: click to initiate payment card collection
 user-->>user: display Littlepay overlay
-user-->>analytics: started payment connection
+user-->>analytics: started card tokenization
 user->>littlepay: provides debit or credit card details
 littlepay-->>user: card token
-user-->>analytics: closed payment connection
+user-->>analytics: ended card tokenization
 user->>benefits: POST back card token
     deactivate user
     activate benefits

--- a/docs/product-and-design/analytics.md
+++ b/docs/product-and-design/analytics.md
@@ -89,9 +89,9 @@ Read more on each of these events on the [Amplitude event documentation for Bene
 
 These events track the progress of a user who has successfully verified their eligibility and is enrolling their payment card with the system.
 
-- closed payment connection
+- ended card tokenization
 - returned enrollment
-- started payment connection
+- started card tokenization
 
 Read more on each of these events on the [Amplitude event documentation for Benefits, filtered by Enrollment](https://data.amplitude.com/public-doc/hdhfmlby2e?categories=id%3D1702329910563%26group%3Dcategories%26type%3DString%26operator%3Dis%26values%255B0%255D%3Denrollment%26dateValue%255Btype%255D%3DSINCE).
 
@@ -101,4 +101,4 @@ Various key metrics are collected and analyzed, including:
 
 - **Number of users who successfully completed authentication**: Users who `started sign in`, `finished sign in`
 - **Number of users who successfully verified eligibility**: Users who completed the above and `selected eligibility verifier`, `started eligibility`, `returned eligibility` with a status of `True`
-- **Numbers of users who successfully completed enrollment**: Users who completed all of the above and `started payment connection`, `closed payment connection` and `returned enrollment` with a status of `Success`
+- **Numbers of users who successfully completed enrollment**: Users who completed all of the above and `started card tokenization`, `ended card tokenization` and `returned enrollment` with a status of `Success`


### PR DESCRIPTION
Part of #2249

- Analytics event `started payment connection` renamed to `started card tokenization`
- Analytics event `closed payment connection` renamed to `ended card tokenization`
- Analytics event property `payment_group` renamed to `enrollment_group`
- Updated docs