### PR TITLE
Refactor: Multi-stage Docker build for app image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,9 +6,9 @@ USER root
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 USER $USER
 
+COPY . .
 # install devcontainer requirements
 RUN pip install -e .[dev,test]
 
 # docs requirements are in a separate file for the GitHub Action
-COPY docs/requirements.txt docs/requirements.txt
 RUN pip install -r docs/requirements.txt

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,10 @@
-.github/
-.vscode/
 **/__pycache__/
-.flake8
-.*ignore
+node_modules/
+static/
+.coverage
 *.db
 *.egg-info
+*.log
+*.mo
+.DS_Store
+.env

--- a/appcontainer/Dockerfile
+++ b/appcontainer/Dockerfile
@@ -36,8 +36,9 @@ COPY benefits benefits
 # install source as a package
 RUN pip install $(find /build/dist -name benefits*.whl)
 
-# ensure $USER can compile messages in the locale directories
 USER root
+COPY LICENSE LICENSE
+#ensure $USER can compile messages in the locale directories
 RUN chmod -R 777 benefits/locale
 USER $USER
 

--- a/appcontainer/Dockerfile
+++ b/appcontainer/Dockerfile
@@ -1,22 +1,40 @@
-FROM ghcr.io/cal-itp/docker-python-web:main
+# multi-stage build
+#
+# stage 1: builds the benefits package from source
+#          using the git metadata for version info
+FROM ghcr.io/cal-itp/docker-python-web:main AS build_wheel
+
+WORKDIR /build
 
 # upgrade pip
-RUN python -m pip install --upgrade pip
+RUN python -m pip install --upgrade pip && \
+    pip install build
+
+# copy source files
+COPY . .
+RUN git config --global --add safe.directory /build
+
+# build package
+RUN python -m build
+
+# multi-stage build
+#
+# stage 2: installs the benefits package in a fresh base container
+#          using the pre-built package, and copying only needed source
+FROM ghcr.io/cal-itp/docker-python-web:main AS appcontainer
 
 # overwrite default nginx.conf
 COPY appcontainer/nginx.conf /etc/nginx/nginx.conf
 COPY appcontainer/proxy.conf /calitp/run/proxy.conf
 
-# copy files needed for version metadata
-COPY .git .git
-
-# copy source files
+# copy runtime files
+COPY --from=build_wheel /build/dist /build/dist
 COPY manage.py manage.py
 COPY bin bin
 COPY benefits benefits
-COPY pyproject.toml pyproject.toml
 
-RUN pip install -e .
+# install source as a package
+RUN pip install $(find /build/dist -name benefits*.whl)
 
 # ensure $USER can compile messages in the locale directories
 USER root

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ Documentation = "https://docs.calitp.org/benefits"
 Issues = "https://github.com/cal-itp/benefits/issues"
 
 [build-system]
-requires = ["setuptools>=65", "wheel", "setuptools-scm>=8"]
+requires = ["setuptools>=65", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
@@ -79,8 +79,9 @@ markers = [
     "request_path: use with session_request to initialize with the given path",
 ]
 
-[tool.setuptools]
-packages = ["benefits"]
+[tool.setuptools.packages.find]
+include = ["benefits*"]
+namespaces = false
 
 [tool.setuptools_scm]
 # intentionally left blank, but we need the section header to activate the tool

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,9 @@ readme = "README.md"
 license = { file = "LICENSE" }
 classifiers = ["Programming Language :: Python :: 3 :: Only"]
 requires-python = ">=3.9"
+maintainers = [
+  { name = "Compiler LLC", email = "dev@compiler.la" }
+]
 dependencies = [
     "Authlib==1.3.2",
     "azure-keyvault-secrets==4.8.0",
@@ -39,8 +42,10 @@ test = [
 ]
 
 [project.urls]
+Changelog = "https://github.com/cal-itp/benefits/releases"
 Code = "https://github.com/cal-itp/benefits"
 Documentation = "https://docs.calitp.org/benefits"
+Homepage = "https://www.calitp.org/#initiatives-benefits"
 Issues = "https://github.com/cal-itp/benefits/issues"
 
 [build-system]


### PR DESCRIPTION
Closes #2389.

Fixes the issue with the dynamic version calculation being incorrect, because of a dirty git index during Docker build time / pip install time.

There's no reason to have the .git directory in the app image, same with all the extra files, tests, .devcontainer, etc.

Uses the approach from eligibility-server: https://github.com/cal-itp/eligibility-server/blob/main/Dockerfile

## How to test

1. Check out this branch locally, ensure you have no pending/unstaged changes (`git status`)
1. Apply an annotated tag e.g. `git tag -a 2024.10.999`
1. `docker compose build --no-cache client` to rebuild the app image
1. `docker compose up -d client` to start a new app container
1. `docker compose exec -ti client /bin/bash` to connect to running container
1. `python manage.py shell` to enter a Django shell with settings loaded
1. `import benefits; print(benefits.VERSION)` :white_check_mark: 
1. exit out of everything, back to your local terminal
1. `bin/build.sh` to rebuild the devcontainer
1. Confirm you can launch the devcontainer :white_check_mark: 
1. And the app :white_check_mark: 

![image](https://github.com/user-attachments/assets/da09f4b6-bee1-4f0c-a0c3-f15b705bd444)
