### PR TITLE
Admin: Log out page styled

### DIFF
--- a/benefits/templates/registration/logged_out.html
+++ b/benefits/templates/registration/logged_out.html
@@ -1,0 +1,35 @@
+{% extends "admin/agency-base.html" %}
+{% load static %}
+
+{% block title %}
+    Logged out | Cal-ITP Benefits Administrator
+{% endblock title %}
+
+{% block extrastyle %}
+    {{ block.super }}
+    <link rel="stylesheet" href="{% static "admin/css/login.css" %}">
+{% endblock extrastyle %}
+
+{% block bodyclass %}
+    {{ block.super }} login
+{% endblock bodyclass %}
+
+{% block branding %}
+    <div class="d-flex justify-content-center w-100 bg-primary">
+        <img class="my-3" src="{% static "img/logo-lg.svg" %}" width="220" height="50" alt="California Integrated Travel Project: Benefits logo (large)" />
+    </div>
+
+    <div id="site-name">
+        <h1 class="text-center text-white fs-3 py-3 m-0">Administrator</h1>
+    </div>
+{% endblock branding %}
+
+{% block content %}
+
+    <div id="content-main">
+        <p class="text-center mt-4">You have logged out successfully.</p>
+
+        <a class="btn btn-lg btn-outline-primary d-block my-5" href="{% url 'admin:index' %}">Log in again</a>
+    </div>
+
+{% endblock content %}


### PR DESCRIPTION
closes #2359 

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/43db1f31-cb40-4d94-b2eb-3d89c271af08">

This PR creates a template, `logged_out.html`, which extends `agency-base` to get Bootstrap and Button styles, and combines code from:

- the default Django log out page for the HTML https://github.com/django/django/blob/39de2e97a06d0317973b280bc159ca6f89fc64e3/django/contrib/admin/templates/registration/logged_out.html
- the default Django log in page css style (adding the `login`class to the body element) brings in default Django login page styles
- the customizations created in app's Log in page https://github.com/cal-itp/benefits/blob/main/benefits/templates/admin/login.html for the repeated styles of the branding header and the main div.

0 WCAG AA issues.