### PR TITLE
Admin: Use "log" not "sign"

### DIFF
--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -72,6 +72,7 @@ GOOGLE_SSO_ALLOWABLE_DOMAINS = _filter_empty(os.environ.get("GOOGLE_SSO_ALLOWABL
 GOOGLE_SSO_STAFF_LIST = _filter_empty(os.environ.get("GOOGLE_SSO_STAFF_LIST", "").split(","))
 GOOGLE_SSO_SUPERUSER_LIST = _filter_empty(os.environ.get("GOOGLE_SSO_SUPERUSER_LIST", "").split(","))
 GOOGLE_SSO_LOGO_URL = "/static/img/icon/google_sso_logo.svg"
+GOOGLE_SSO_TEXT = "Log in with Google"
 GOOGLE_SSO_SAVE_ACCESS_TOKEN = True
 GOOGLE_SSO_PRE_LOGIN_CALLBACK = "benefits.core.admin.pre_login_user"
 GOOGLE_SSO_SCOPES = [

--- a/benefits/templates/admin/agency-base.html
+++ b/benefits/templates/admin/agency-base.html
@@ -51,7 +51,7 @@
                     <img class="icon" width="15" height="15" src="{% static "img/icon/box-arrow-right.svg" %}" alt="" />
                     <form id="logout-form" method="post" action="{% url 'admin:logout' %}">
                         {% csrf_token %}
-                        <button type="submit" class="border-0">Sign out</button>
+                        <button type="submit" class="border-0">Log out</button>
                     </form>
                 {% endblock userlinks %}
             </div>


### PR DESCRIPTION
closes #2380 

The Administrator app should use "Log in" and "Log out" in app copy. This PR changes this in:

- Google SSO button copy
- Admin header

Test this by logging in and out as a super user and a transit agency user.