### PR TITLE
Admin: Update admin page titles

### DIFF
--- a/benefits/admin.py
+++ b/benefits/admin.py
@@ -8,6 +8,10 @@ from benefits.core import session
 
 class BenefitsAdminSite(admin.AdminSite):
 
+    site_title = "Cal-ITP Benefits Administrator"
+    site_header = "Administrator"
+    index_title = "Dashboard"
+
     def index(self, request, extra_context=None):
         """
         Display the main admin index page if the user is a superuser or a "staff_group" user.
@@ -42,6 +46,7 @@ class BenefitsAdminSite(admin.AdminSite):
                     {
                         "has_permission_for_in_person": has_permission_for_in_person,
                         "transit_processor_portal_url": transit_processor_portal_url,
+                        "title": f"{agency.long_name} | {self.index_title} | {self.site_title}",
                     }
                 )
 

--- a/benefits/in_person/templates/error-base.html
+++ b/benefits/in_person/templates/error-base.html
@@ -1,6 +1,10 @@
 {% extends "admin/agency-base.html" %}
 {% load static %}
 
+{% block title %}
+    {{ title }}
+{% endblock title %}
+
 {% block content %}
     <div class="row justify-content-center">
         <div class="col-lg-6">

--- a/benefits/in_person/templates/in_person/eligibility.html
+++ b/benefits/in_person/templates/in_person/eligibility.html
@@ -1,7 +1,7 @@
 {% extends "admin/agency-base.html" %}
 
 {% block title %}
-    Agency dashboard: In-person enrollment
+    {{ title }}
 {% endblock title %}
 
 {% block content %}

--- a/benefits/in_person/templates/in_person/enrollment.html
+++ b/benefits/in_person/templates/in_person/enrollment.html
@@ -1,5 +1,9 @@
 {% extends "admin/agency-base.html" %}
 
+{% block title %}
+    {{ title }}
+{% endblock title %}
+
 {% block content %}
 
     <div class="row justify-content-center">

--- a/benefits/in_person/templates/in_person/enrollment/success.html
+++ b/benefits/in_person/templates/in_person/enrollment/success.html
@@ -1,6 +1,10 @@
 {% extends "admin/agency-base.html" %}
 {% load static %}
 
+{% block title %}
+    {{ title }}
+{% endblock title %}
+
 {% block content %}
     <div class="row justify-content-center">
         <div class="col-lg-6">

--- a/benefits/in_person/views.py
+++ b/benefits/in_person/views.py
@@ -142,7 +142,12 @@ def enrollment(request):
 
 def reenrollment_error(request):
     """View handler for a re-enrollment attempt that is not yet within the re-enrollment window."""
-    context = {**admin_site.each_context(request)}
+
+    agency = session.agency(request)
+    context = {
+        **admin_site.each_context(request),
+        "title": f"{agency.long_name} | In-person enrollment | {admin_site.site_title}",
+    }
 
     flow = session.flow(request)
     context["flow_label"] = flow.label
@@ -152,27 +157,43 @@ def reenrollment_error(request):
 
 def retry(request):
     """View handler for card verification failure."""
-    context = {**admin_site.each_context(request)}
+    agency = session.agency(request)
+    context = {
+        **admin_site.each_context(request),
+        "title": f"{agency.long_name} | In-person enrollment | {admin_site.site_title}",
+    }
 
     return TemplateResponse(request, "in_person/enrollment/retry.html", context)
 
 
 def system_error(request):
     """View handler for an enrollment system error."""
-    context = {**admin_site.each_context(request)}
+    agency = session.agency(request)
+    context = {
+        **admin_site.each_context(request),
+        "title": f"{agency.long_name} | In-person enrollment | {admin_site.site_title}",
+    }
 
     return TemplateResponse(request, "in_person/enrollment/system_error.html", context)
 
 
 def server_error(request):
     """View handler for errors caused by a misconfiguration or bad request."""
-    context = {**admin_site.each_context(request)}
+    agency = session.agency(request)
+    context = {
+        **admin_site.each_context(request),
+        "title": f"{agency.long_name} | In-person enrollment | {admin_site.site_title}",
+    }
 
     return TemplateResponse(request, "in_person/enrollment/server_error.html", context)
 
 
 def success(request):
     """View handler for the final success page."""
-    context = {**admin_site.each_context(request)}
+    agency = session.agency(request)
+    context = {
+        **admin_site.each_context(request),
+        "title": f"{agency.long_name} | In-person enrollment | {admin_site.site_title}",
+    }
 
     return TemplateResponse(request, "in_person/enrollment/success.html", context)

--- a/benefits/in_person/views.py
+++ b/benefits/in_person/views.py
@@ -21,7 +21,11 @@ def eligibility(request):
     """View handler for the in-person eligibility flow selection form."""
 
     agency = session.agency(request)
-    context = {**admin_site.each_context(request), "form": forms.InPersonEligibilityForm(agency=agency)}
+    context = {
+        **admin_site.each_context(request),
+        "form": forms.InPersonEligibilityForm(agency=agency),
+        "title": f"{agency.long_name} | In-person enrollment | {admin_site.site_title}",
+    }
 
     if request.method == "POST":
         form = forms.InPersonEligibilityForm(data=request.POST, agency=agency)
@@ -130,6 +134,7 @@ def enrollment(request):
             "form_server_error": tokenize_server_error_form.id,
             "form_success": tokenize_success_form.id,
             "form_system_error": tokenize_system_error_form.id,
+            "title": f"{agency.long_name} | In-person enrollment | {admin_site.site_title}",
         }
 
         return TemplateResponse(request, "in_person/enrollment.html", context)

--- a/benefits/templates/admin/agency-base.html
+++ b/benefits/templates/admin/agency-base.html
@@ -17,9 +17,6 @@
     <link href="{% static "css/admin/styles.css" %}" rel="stylesheet">
 {% endblock extrastyle %}
 
-{% block title %}
-{% endblock title %}
-
 {% block branding %}
     <div id="header-container" class="navbar navbar-expand-sm navbar-dark justify-content-between">
         <div class="container">
@@ -28,7 +25,7 @@
                 <img class="lg d-none d-lg-block" src="{% static "img/logo-lg.svg" %}" width="220" height="50" alt="California Integrated Travel Project: Benefits logo (large)" />
             </span>
         </div>
-        <h1 class="p-0 m-0 text-white">Administrator</h1>
+        <h1 class="p-0 m-0 text-white">{{ site_header }}</h1>
     </div>
 {% endblock branding %}
 

--- a/benefits/templates/admin/agency-dashboard-index.html
+++ b/benefits/templates/admin/agency-dashboard-index.html
@@ -2,7 +2,7 @@
 {% load i18n static %}
 
 {% block title %}
-    Agency dashboard
+    {{ title }}
 {% endblock title %}
 
 {% block content %}

--- a/benefits/templates/admin/login.html
+++ b/benefits/templates/admin/login.html
@@ -4,10 +4,6 @@
 {% block dark-mode-vars %}
 {% endblock dark-mode-vars %}
 
-{% block title %}
-    Log in | Cal-ITP Benefits Administrator
-{% endblock title %}
-
 {% block extrastyle %}
     {% comment %} Overriding instead of extending agency-base here to remove jQuery declaration, which admin/login.html includes on its own {% endcomment %}
     <link href="{% static "img/favicon.ico" %}" rel="icon" type="image/x-icon" />
@@ -24,6 +20,6 @@
     </div>
 
     <div id="site-name">
-        <h1 class="text-center text-white fs-3 py-3 m-0">Administrator</h1>
+        <h1 class="text-center text-white fs-3 py-3 m-0">{{ site_header }}</h1>
     </div>
 {% endblock branding %}

--- a/benefits/templates/registration/logged_out.html
+++ b/benefits/templates/registration/logged_out.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block title %}
-    Logged out | Cal-ITP Benefits Administrator
+    Logged out | {{ site_title }}
 {% endblock title %}
 
 {% block extrastyle %}
@@ -20,7 +20,7 @@
     </div>
 
     <div id="site-name">
-        <h1 class="text-center text-white fs-3 py-3 m-0">Administrator</h1>
+        <h1 class="text-center text-white fs-3 py-3 m-0">{{ site_header }}</h1>
     </div>
 {% endblock branding %}
 

--- a/tests/pytest/in_person/test_views.py
+++ b/tests/pytest/in_person/test_views.py
@@ -317,7 +317,7 @@ def test_enrollment_post_valid_form_reenrollment_error(mocker, admin_client, car
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("mocked_session_flow")
+@pytest.mark.usefixtures("mocked_session_flow", "mocked_session_agency")
 def test_reenrollment_error(admin_client):
     path = reverse(routes.IN_PERSON_ENROLLMENT_REENROLLMENT_ERROR)
 
@@ -327,6 +327,8 @@ def test_reenrollment_error(admin_client):
     assert response.template_name == "in_person/enrollment/reenrollment_error.html"
 
 
+@pytest.mark.django_db
+@pytest.mark.usefixtures("mocked_session_flow", "mocked_session_agency")
 def test_retry(admin_client):
     path = reverse(routes.IN_PERSON_ENROLLMENT_RETRY)
 
@@ -336,6 +338,8 @@ def test_retry(admin_client):
     assert response.template_name == "in_person/enrollment/retry.html"
 
 
+@pytest.mark.django_db
+@pytest.mark.usefixtures("mocked_session_flow", "mocked_session_agency")
 def test_system_error(admin_client):
     path = reverse(routes.IN_PERSON_ENROLLMENT_SYSTEM_ERROR)
 
@@ -345,6 +349,8 @@ def test_system_error(admin_client):
     assert response.template_name == "in_person/enrollment/system_error.html"
 
 
+@pytest.mark.django_db
+@pytest.mark.usefixtures("mocked_session_flow", "mocked_session_agency")
 def test_server_error(admin_client):
     path = reverse(routes.IN_PERSON_SERVER_ERROR)
 
@@ -354,6 +360,8 @@ def test_server_error(admin_client):
     assert response.template_name == "in_person/enrollment/server_error.html"
 
 
+@pytest.mark.django_db
+@pytest.mark.usefixtures("mocked_session_flow", "mocked_session_agency")
 def test_success(admin_client):
     path = reverse(routes.IN_PERSON_ENROLLMENT_SUCCESS)
 


### PR DESCRIPTION
closes #2381 

## What this PR does
- Updates all Administrator app page titles according to what's on https://miro.com/app/board/uXjVKwXyUy0=/ - check the text above the bordered page sections
- Uses Django admin variables or Django template default titles for as much as possible: https://docs.djangoproject.com/en/5.1/ref/contrib/admin/#adminsite-attributes
- Updated anywhere we could use above variables