### PR TITLE
Eligibility: Filter enrollment flows by supported method

### DIFF
--- a/benefits/eligibility/forms.py
+++ b/benefits/eligibility/forms.py
@@ -26,7 +26,7 @@ class EnrollmentFlowSelectionForm(forms.Form):
 
     def __init__(self, agency: models.TransitAgency, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        flows = agency.enrollment_flows.all()
+        flows = agency.enrollment_flows.filter(supported_enrollment_methods__contains=models.EnrollmentMethods.DIGITAL)
 
         self.classes = "col-lg-8"
         # second element is not used since we render the whole label using selection_label_template,

--- a/benefits/in_person/forms.py
+++ b/benefits/in_person/forms.py
@@ -24,7 +24,7 @@ class InPersonEligibilityForm(forms.Form):
 
     def __init__(self, agency: models.TransitAgency, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        flows = agency.enrollment_flows.all()
+        flows = agency.enrollment_flows.filter(supported_enrollment_methods__contains=models.EnrollmentMethods.IN_PERSON)
 
         self.classes = "checkbox-parent"
         flow_field = self.fields["flow"]

--- a/tests/pytest/eligibility/test_views.py
+++ b/tests/pytest/eligibility/test_views.py
@@ -73,7 +73,7 @@ def model_EnrollmentFlow_with_form_class(mocker, model_EnrollmentFlow):
 
 
 @pytest.mark.django_db
-def test_index_filtering_fows(mocker, model_TransitAgency, client):
+def test_index_filtering_flows(mocker, model_TransitAgency, client):
     digital = models.EnrollmentFlow.objects.create(
         transit_agency=model_TransitAgency,
         supported_enrollment_methods=[models.EnrollmentMethods.DIGITAL],

--- a/tests/pytest/eligibility/test_views.py
+++ b/tests/pytest/eligibility/test_views.py
@@ -80,6 +80,7 @@ def test_index_get_agency_multiple_flows(mocker, model_TransitAgency, model_Enro
     mock_manager = mocker.Mock()
     mock_manager.all.return_value = [model_EnrollmentFlow, model_EnrollmentFlow]
     type(mock_agency).enrollment_flows = mocker.PropertyMock(return_value=mock_manager)
+    type(mock_agency).enrollment_flows.filter.return_value = [model_EnrollmentFlow, model_EnrollmentFlow]
 
     mock_agency.index_url = "/agency"
     mock_agency.eligibility_index_template = "eligibility/index.html"
@@ -103,6 +104,7 @@ def test_index_get_agency_single_flow(mocker, model_TransitAgency, model_Enrollm
     mock_manager = mocker.Mock()
     mock_manager.all.return_value = [model_EnrollmentFlow]
     type(mock_agency).enrollment_flows = mocker.PropertyMock(return_value=mock_manager)
+    type(mock_agency).enrollment_flows.filter.return_value = [model_EnrollmentFlow, model_EnrollmentFlow]
 
     mock_agency.index_url = "/agency"
     mock_agency.eligibility_index_template = "eligibility/index.html"

--- a/tests/pytest/eligibility/test_views.py
+++ b/tests/pytest/eligibility/test_views.py
@@ -2,6 +2,7 @@ from django.urls import reverse
 
 import pytest
 
+from benefits.core import models
 from benefits.routes import routes
 from benefits.core.middleware import TEMPLATE_USER_ERROR
 import benefits.core.session
@@ -69,6 +70,36 @@ def model_EnrollmentFlow_with_form_class(mocker, model_EnrollmentFlow):
     model_EnrollmentFlow.save()
     mocker.patch("benefits.eligibility.views.session.flow", return_value=model_EnrollmentFlow)
     return model_EnrollmentFlow
+
+
+@pytest.mark.django_db
+def test_index_filtering_fows(mocker, model_TransitAgency, client):
+    digital = models.EnrollmentFlow.objects.create(
+        transit_agency=model_TransitAgency,
+        supported_enrollment_methods=[models.EnrollmentMethods.DIGITAL],
+        label="Digital",
+        selection_label_template="eligibility/includes/selection-label.html",
+    )
+    in_person = models.EnrollmentFlow.objects.create(
+        transit_agency=model_TransitAgency,
+        supported_enrollment_methods=[models.EnrollmentMethods.IN_PERSON],
+        label="In-Person",
+        selection_label_template="eligibility/includes/selection-label.html",
+    )
+    both = models.EnrollmentFlow.objects.create(
+        transit_agency=model_TransitAgency,
+        supported_enrollment_methods=[models.EnrollmentMethods.DIGITAL, models.EnrollmentMethods.IN_PERSON],
+        label="Both",
+        selection_label_template="eligibility/includes/selection-label.html",
+    )
+    mocker.patch("benefits.core.session.agency", autospec=True, return_value=model_TransitAgency)
+
+    path = reverse(routes.ELIGIBILITY_INDEX)
+    response = client.get(path)
+    filtered_flow_ids = [choice[0] for choice in response.context_data["form"].fields["flow"].choices]
+
+    assert digital.id, both.id in filtered_flow_ids
+    assert in_person.id not in filtered_flow_ids
 
 
 @pytest.mark.django_db

--- a/tests/pytest/in_person/test_views.py
+++ b/tests/pytest/in_person/test_views.py
@@ -50,7 +50,7 @@ def test_eligibility_logged_in(admin_client):
 
 
 @pytest.mark.django_db
-def test_index_filtering_fows(mocker, model_TransitAgency, admin_client):
+def test_eligibility_logged_in_filtering_flows(mocker, model_TransitAgency, admin_client):
     digital = models.EnrollmentFlow.objects.create(
         transit_agency=model_TransitAgency, supported_enrollment_methods=[models.EnrollmentMethods.DIGITAL], label="Digital"
     )

--- a/tests/pytest/in_person/test_views.py
+++ b/tests/pytest/in_person/test_views.py
@@ -50,6 +50,31 @@ def test_eligibility_logged_in(admin_client):
 
 
 @pytest.mark.django_db
+def test_index_filtering_fows(mocker, model_TransitAgency, admin_client):
+    digital = models.EnrollmentFlow.objects.create(
+        transit_agency=model_TransitAgency, supported_enrollment_methods=[models.EnrollmentMethods.DIGITAL], label="Digital"
+    )
+    in_person = models.EnrollmentFlow.objects.create(
+        transit_agency=model_TransitAgency,
+        supported_enrollment_methods=[models.EnrollmentMethods.IN_PERSON],
+        label="In-Person",
+    )
+    both = models.EnrollmentFlow.objects.create(
+        transit_agency=model_TransitAgency,
+        supported_enrollment_methods=[models.EnrollmentMethods.DIGITAL, models.EnrollmentMethods.IN_PERSON],
+        label="Both",
+    )
+    mocker.patch("benefits.core.session.agency", autospec=True, return_value=model_TransitAgency)
+
+    path = reverse(routes.IN_PERSON_ELIGIBILITY)
+    response = admin_client.get(path)
+    filtered_flow_ids = [choice[0] for choice in response.context_data["form"].fields["flow"].choices]
+
+    assert in_person.id, both.id in filtered_flow_ids
+    assert digital.id not in filtered_flow_ids
+
+
+@pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_session_agency", "mocked_session_flow")
 def test_confirm_post_valid_form_eligibility_verified(admin_client):
 


### PR DESCRIPTION
closes #2396 

## What this PR does
- Only display supported enrollment flows (in-person, digital or both) on Eligibility forms for Digital flow and In-Person flow.
- Update tests: Adds a spec case to both in-person and digital specs, where a form must filter out the 2 supported flows out of 3 total flows.

## How to test
- Set some enrollment flows to be In-Person only or Digital only via the Admin tool
- Check the digital flow's eligibility page
- Log in as a CST staff user on Admin and check the in-person flow page