### PR TITLE
Refactor: test name clean-up and assertions for in-person analytics

### DIFF
--- a/tests/pytest/in_person/test_views.py
+++ b/tests/pytest/in_person/test_views.py
@@ -94,6 +94,7 @@ def test_eligibility_post_valid_form_eligibility_verified(
     assert mocked_session_update.call_args.kwargs["flow"] == model_EnrollmentFlow
     mocked_eligibility_analytics_module.selected_flow.assert_called_once()
     mocked_eligibility_analytics_module.started_eligibility.assert_called_once()
+    # mocked_eligibility_analytics_module.returned_success.assert_called_once()
 
 
 @pytest.mark.django_db

--- a/tests/pytest/in_person/test_views.py
+++ b/tests/pytest/in_person/test_views.py
@@ -392,13 +392,26 @@ def test_reenrollment_error(admin_client):
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_session_flow", "mocked_session_agency")
-def test_retry(admin_client):
+def test_retry(admin_client, mocked_enrollment_analytics_module):
     path = reverse(routes.IN_PERSON_ENROLLMENT_RETRY)
 
     response = admin_client.get(path)
 
     assert response.status_code == 200
     assert response.template_name == "in_person/enrollment/retry.html"
+    mocked_enrollment_analytics_module.returned_retry.assert_not_called()
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("mocked_session_flow", "mocked_session_agency")
+def test_retry_post(admin_client, mocked_enrollment_analytics_module):
+    path = reverse(routes.IN_PERSON_ENROLLMENT_RETRY)
+
+    response = admin_client.post(path)
+
+    assert response.status_code == 200
+    assert response.template_name == "in_person/enrollment/retry.html"
+    mocked_enrollment_analytics_module.returned_retry.assert_called_once()
 
 
 @pytest.mark.django_db

--- a/tests/pytest/in_person/test_views.py
+++ b/tests/pytest/in_person/test_views.py
@@ -76,7 +76,7 @@ def test_eligibility_logged_in_filtering_flows(mocker, model_TransitAgency, admi
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_session_agency", "mocked_session_flow")
-def test_confirm_post_valid_form_eligibility_verified(admin_client):
+def test_eligibility_post_valid_form_eligibility_verified(admin_client):
 
     path = reverse(routes.IN_PERSON_ELIGIBILITY)
     form_data = {"flow": 1, "verified": True}
@@ -88,7 +88,7 @@ def test_confirm_post_valid_form_eligibility_verified(admin_client):
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_session_agency")
-def test_confirm_post_valid_form_eligibility_unverified(admin_client):
+def test_eligibility_post_valid_form_eligibility_unverified(admin_client):
 
     path = reverse(routes.IN_PERSON_ELIGIBILITY)
     form_data = {"flow": 1, "verified": False}

--- a/tests/pytest/in_person/test_views.py
+++ b/tests/pytest/in_person/test_views.py
@@ -23,6 +23,11 @@ def invalid_form_data():
 
 
 @pytest.fixture
+def mocked_eligibility_analytics_module(mocker):
+    return mocker.patch.object(benefits.in_person.views, "eligibility_analytics")
+
+
+@pytest.fixture
 def mocked_sentry_sdk_module(mocker):
     return mocker.patch.object(benefits.in_person.views, "sentry_sdk")
 
@@ -76,7 +81,7 @@ def test_eligibility_logged_in_filtering_flows(mocker, model_TransitAgency, admi
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_session_agency", "mocked_session_flow")
-def test_eligibility_post_valid_form_eligibility_verified(admin_client):
+def test_eligibility_post_valid_form_eligibility_verified(admin_client, mocked_eligibility_analytics_module):
 
     path = reverse(routes.IN_PERSON_ELIGIBILITY)
     form_data = {"flow": 1, "verified": True}
@@ -84,6 +89,8 @@ def test_eligibility_post_valid_form_eligibility_verified(admin_client):
 
     assert response.status_code == 302
     assert response.url == reverse(routes.IN_PERSON_ENROLLMENT)
+    mocked_eligibility_analytics_module.selected_flow.assert_called_once()
+    mocked_eligibility_analytics_module.started_eligibility.assert_called_once()
 
 
 @pytest.mark.django_db

--- a/tests/pytest/in_person/test_views.py
+++ b/tests/pytest/in_person/test_views.py
@@ -81,7 +81,9 @@ def test_eligibility_logged_in_filtering_flows(mocker, model_TransitAgency, admi
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_session_agency", "mocked_session_flow")
-def test_eligibility_post_valid_form_eligibility_verified(admin_client, mocked_eligibility_analytics_module):
+def test_eligibility_post_valid_form_eligibility_verified(
+    admin_client, model_EnrollmentFlow, mocked_session_update, mocked_eligibility_analytics_module
+):
 
     path = reverse(routes.IN_PERSON_ELIGIBILITY)
     form_data = {"flow": 1, "verified": True}
@@ -89,6 +91,7 @@ def test_eligibility_post_valid_form_eligibility_verified(admin_client, mocked_e
 
     assert response.status_code == 302
     assert response.url == reverse(routes.IN_PERSON_ENROLLMENT)
+    assert mocked_session_update.call_args.kwargs["flow"] == model_EnrollmentFlow
     mocked_eligibility_analytics_module.selected_flow.assert_called_once()
     mocked_eligibility_analytics_module.started_eligibility.assert_called_once()
 

--- a/tests/pytest/in_person/test_views.py
+++ b/tests/pytest/in_person/test_views.py
@@ -99,7 +99,6 @@ def test_eligibility_post_valid_form_eligibility_verified(
     assert mocked_session_update.call_args.kwargs["flow"] == model_EnrollmentFlow
     mocked_eligibility_analytics_module.selected_flow.assert_called_once()
     mocked_eligibility_analytics_module.started_eligibility.assert_called_once()
-    # mocked_eligibility_analytics_module.returned_success.assert_called_once()
 
 
 @pytest.mark.django_db
@@ -304,6 +303,7 @@ def test_enrollment_post_valid_form_success(
     mocker,
     admin_client,
     card_tokenize_form_data,
+    mocked_eligibility_analytics_module,
     mocked_enrollment_analytics_module,
     model_TransitAgency,
     model_EnrollmentFlow,
@@ -329,6 +329,7 @@ def test_enrollment_post_valid_form_success(
 
     assert response.status_code == 302
     assert response.url == reverse(routes.IN_PERSON_ENROLLMENT_SUCCESS)
+    mocked_eligibility_analytics_module.returned_success.assert_called_once()
     mocked_enrollment_analytics_module.returned_success.assert_called_once()
 
 


### PR DESCRIPTION
Part of #2245 (and #2269, just by virtue of cleaning up the test names)

This PR adds assertions for the analytics calls that are expected to be made in in-person view functions.