### PR TITLE
Chore: extract common Admin overrides

### DIFF
--- a/benefits/templates/admin/agency-base.html
+++ b/benefits/templates/admin/agency-base.html
@@ -28,30 +28,7 @@
 {% endblock branding %}
 
 {% block usertools %}
-    {% if has_permission %}
-        <div id="user-tools">
-            {% block welcome-msg %}
-                <span class="text-uppercase text-white">
-                    Welcome,
-                    <span class="fw-bold">{% firstof user.get_short_name user.get_username %}</span>.
-                </span>
-            {% endblock welcome-msg %}
-            {% block userlinks %}
-                {% if user.is_active and user.is_staff %}
-                    {% url 'django-admindocs-docroot' as docsroot %}
-                    {% if docsroot %}<a href="{{ docsroot }}">Documentation</a> /{% endif %}
-                {% endif %}
-                {% if user.has_usable_password %}
-                    <a href="{% url 'admin:password_change' %}">Change password</a> /
-                {% endif %}
-                <img class="icon" width="15" height="15" src="{% static "img/icon/box-arrow-right.svg" %}" alt="" />
-                <form id="logout-form" method="post" action="{% url 'admin:logout' %}">
-                    {% csrf_token %}
-                    <button type="submit" class="border-0">Log out</button>
-                </form>
-            {% endblock userlinks %}
-        </div>
-    {% endif %}
+    {% include "admin/includes/usertools.html" %}
 {% endblock usertools %}
 
 {% block coltype %}

--- a/benefits/templates/admin/agency-base.html
+++ b/benefits/templates/admin/agency-base.html
@@ -36,45 +36,46 @@
             {% block welcome-msg %}
                 <span class="text-uppercase text-white">
                     Welcome,
-                    <span class="fw-bold">{% firstof user.get_short_name user.get_username %}</span>. </span>
-                {% endblock welcome-msg %}
-                {% block userlinks %}
-                    {% if user.is_active and user.is_staff %}
-                        {% url 'django-admindocs-docroot' as docsroot %}
-                        {% if docsroot %}<a href="{{ docsroot }}">Documentation</a> /{% endif %}
-                    {% endif %}
-                    {% if user.has_usable_password %}
-                        <a href="{% url 'admin:password_change' %}">Change password</a> /
-                    {% endif %}
-                    <img class="icon" width="15" height="15" src="{% static "img/icon/box-arrow-right.svg" %}" alt="" />
-                    <form id="logout-form" method="post" action="{% url 'admin:logout' %}">
-                        {% csrf_token %}
-                        <button type="submit" class="border-0">Log out</button>
-                    </form>
-                {% endblock userlinks %}
-            </div>
-        {% endif %}
-    {% endblock usertools %}
+                    <span class="fw-bold">{% firstof user.get_short_name user.get_username %}</span>.
+                </span>
+            {% endblock welcome-msg %}
+            {% block userlinks %}
+                {% if user.is_active and user.is_staff %}
+                    {% url 'django-admindocs-docroot' as docsroot %}
+                    {% if docsroot %}<a href="{{ docsroot }}">Documentation</a> /{% endif %}
+                {% endif %}
+                {% if user.has_usable_password %}
+                    <a href="{% url 'admin:password_change' %}">Change password</a> /
+                {% endif %}
+                <img class="icon" width="15" height="15" src="{% static "img/icon/box-arrow-right.svg" %}" alt="" />
+                <form id="logout-form" method="post" action="{% url 'admin:logout' %}">
+                    {% csrf_token %}
+                    <button type="submit" class="border-0">Log out</button>
+                </form>
+            {% endblock userlinks %}
+        </div>
+    {% endif %}
+{% endblock usertools %}
 
-    {% block coltype %}
-        w-100
-    {% endblock coltype %}
+{% block coltype %}
+    w-100
+{% endblock coltype %}
 
-    {% block bodyclass %}
-        {{ block.super }} dashboard
-    {% endblock bodyclass %}
+{% block bodyclass %}
+    {{ block.super }} dashboard
+{% endblock bodyclass %}
 
-    {% block nav-breadcrumbs %}
-    {% endblock nav-breadcrumbs %}
+{% block nav-breadcrumbs %}
+{% endblock nav-breadcrumbs %}
 
-    {% block nav-sidebar %}
-    {% endblock nav-sidebar %}
+{% block nav-sidebar %}
+{% endblock nav-sidebar %}
 
-    {% block content_title %}
-    {% endblock content_title %}
+{% block content_title %}
+{% endblock content_title %}
 
-    {% block content %}
-    {% endblock content %}
+{% block content %}
+{% endblock content %}
 
-    {% block sidebar %}
-    {% endblock sidebar %}
+{% block sidebar %}
+{% endblock sidebar %}

--- a/benefits/templates/admin/agency-base.html
+++ b/benefits/templates/admin/agency-base.html
@@ -5,16 +5,13 @@
 {% endblock dark-mode-vars %}
 
 {% block extrastyle %}
-    <link href="{% static "img/favicon.ico" %}" rel="icon" type="image/x-icon" />
+    {% include "admin/includes/favicon.html" %}
     <script nonce="{{ request.csp_nonce }}"
             src="https://cdn.jsdelivr.net/npm/jquery@3.6.1/dist/jquery.min.js"
             integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ="
             crossorigin="anonymous"></script>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
-          rel="stylesheet"
-          integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3"
-          crossorigin="anonymous">
-    <link href="{% static "css/admin/styles.css" %}" rel="stylesheet">
+    {% include "admin/includes/bootstrap.html" %}
+    {% include "admin/includes/style-admin.html" %}
     {% include "core/includes/analytics.html" with api_key=analytics.api_key uid=analytics.uid did=analytics.did %}
 {% endblock extrastyle %}
 

--- a/benefits/templates/admin/includes/bootstrap.html
+++ b/benefits/templates/admin/includes/bootstrap.html
@@ -1,0 +1,4 @@
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3"
+      crossorigin="anonymous">

--- a/benefits/templates/admin/includes/branding-login.html
+++ b/benefits/templates/admin/includes/branding-login.html
@@ -1,0 +1,9 @@
+{% load i18n static %}
+
+<div class="d-flex justify-content-center w-100 bg-primary">
+    <img class="my-3" src="{% static "img/logo-lg.svg" %}" width="220" height="50" alt="California Integrated Travel Project: Benefits logo (large)" />
+</div>
+
+<div id="site-name">
+    <h1 class="text-center text-white fs-3 py-3 m-0">{{ site_header }}</h1>
+</div>

--- a/benefits/templates/admin/includes/favicon.html
+++ b/benefits/templates/admin/includes/favicon.html
@@ -1,0 +1,3 @@
+{% load i18n static %}
+
+<link href="{% static "img/favicon.ico" %}" rel="icon" type="image/x-icon" />

--- a/benefits/templates/admin/includes/style-admin.html
+++ b/benefits/templates/admin/includes/style-admin.html
@@ -1,0 +1,3 @@
+{% load i18n static %}
+
+<link href="{% static "css/admin/styles.css" %}" rel="stylesheet">

--- a/benefits/templates/admin/includes/usertools.html
+++ b/benefits/templates/admin/includes/usertools.html
@@ -1,0 +1,26 @@
+{% load i18n static %}
+
+{% if has_permission %}
+    <div id="user-tools">
+        {% block welcome-msg %}
+            <span class="text-uppercase text-white">
+                Welcome,
+                <span class="fw-bold">{% firstof user.get_short_name user.get_username %}</span>.
+            </span>
+        {% endblock welcome-msg %}
+        {% block userlinks %}
+            {% if user.is_active and user.is_staff %}
+                {% url 'django-admindocs-docroot' as docsroot %}
+                {% if docsroot %}<a href="{{ docsroot }}">Documentation</a> /{% endif %}
+            {% endif %}
+            {% if user.has_usable_password %}
+                <a href="{% url 'admin:password_change' %}">Change password</a> /
+            {% endif %}
+            <img class="icon" width="15" height="15" src="{% static "img/icon/box-arrow-right.svg" %}" alt="" />
+            <form id="logout-form" method="post" action="{% url 'admin:logout' %}">
+                {% csrf_token %}
+                <button type="submit" class="border-0">Log out</button>
+            </form>
+        {% endblock userlinks %}
+    </div>
+{% endif %}

--- a/benefits/templates/admin/login.html
+++ b/benefits/templates/admin/login.html
@@ -12,11 +12,5 @@
 {% endblock extrastyle %}
 
 {% block branding %}
-    <div class="d-flex justify-content-center w-100 bg-primary">
-        <img class="my-3" src="{% static "img/logo-lg.svg" %}" width="220" height="50" alt="California Integrated Travel Project: Benefits logo (large)" />
-    </div>
-
-    <div id="site-name">
-        <h1 class="text-center text-white fs-3 py-3 m-0">{{ site_header }}</h1>
-    </div>
+    {% include "admin/includes/branding-login.html" %}
 {% endblock branding %}

--- a/benefits/templates/admin/login.html
+++ b/benefits/templates/admin/login.html
@@ -6,12 +6,9 @@
 
 {% block extrastyle %}
     {% comment %} Overriding instead of extending agency-base here to remove jQuery declaration, which admin/login.html includes on its own {% endcomment %}
-    <link href="{% static "img/favicon.ico" %}" rel="icon" type="image/x-icon" />
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
-          rel="stylesheet"
-          integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3"
-          crossorigin="anonymous">
-    <link href="{% static "css/admin/styles.css" %}" rel="stylesheet">
+    {% include "admin/includes/favicon.html" %}
+    {% include "admin/includes/bootstrap.html" %}
+    {% include "admin/includes/style-admin.html" %}
 {% endblock extrastyle %}
 
 {% block branding %}

--- a/benefits/templates/registration/logged_out.html
+++ b/benefits/templates/registration/logged_out.html
@@ -15,13 +15,7 @@
 {% endblock bodyclass %}
 
 {% block branding %}
-    <div class="d-flex justify-content-center w-100 bg-primary">
-        <img class="my-3" src="{% static "img/logo-lg.svg" %}" width="220" height="50" alt="California Integrated Travel Project: Benefits logo (large)" />
-    </div>
-
-    <div id="site-name">
-        <h1 class="text-center text-white fs-3 py-3 m-0">{{ site_header }}</h1>
-    </div>
+    {% include "admin/includes/branding-login.html" %}
 {% endblock branding %}
 
 {% block content %}


### PR DESCRIPTION
Closes #2425

This PR has a few cleanups. It fixes the indentation of the `usertools` block in `agency-base`; extracts `favicon`, `Bootstrap`, and `styles.css` for the admin app; and extracts  the `login` and `logged_out` branding.
