### PR TITLE
Chore: remove "Change password" link from admin interface for now

### DIFF
--- a/benefits/templates/admin/includes/usertools.html
+++ b/benefits/templates/admin/includes/usertools.html
@@ -13,9 +13,6 @@
                 {% url 'django-admindocs-docroot' as docsroot %}
                 {% if docsroot %}<a href="{{ docsroot }}">Documentation</a> /{% endif %}
             {% endif %}
-            {% if user.has_usable_password %}
-                <a href="{% url 'admin:password_change' %}">Change password</a> /
-            {% endif %}
             <img class="icon" width="15" height="15" src="{% static "img/icon/box-arrow-right.svg" %}" alt="" />
             <form id="logout-form" method="post" action="{% url 'admin:logout' %}">
                 {% csrf_token %}


### PR DESCRIPTION
Part of #2433 

@indexing mentioned we don't need the "Change password" feature for the in-person event on October 17th and that it would be better to not show it.