### PR TITLE
Refactor: rename the finished card tokenization event

### DIFF
--- a/benefits/enrollment/templates/enrollment/index.html
+++ b/benefits/enrollment/templates/enrollment/index.html
@@ -35,7 +35,7 @@
   {% endcomment %}
   {% translate "Please wait..." as loading_text %}
   <script nonce="{{ request.csp_nonce }}">
-      var startedEvent = "started card tokenization", closedEvent = "ended card tokenization";
+      var startedEvent = "started card tokenization", closedEvent = "finished card tokenization";
 
       $.ajax({ dataType: "script", attrs: { nonce: "{{ request.csp_nonce }}"}, url: "{{ card_tokenize_url }}" })
           .done(function() {

--- a/benefits/in_person/templates/in_person/enrollment/index.html
+++ b/benefits/in_person/templates/in_person/enrollment/index.html
@@ -41,7 +41,7 @@
     </div>
 
     <script nonce="{{ request.csp_nonce }}">
-        var startedEvent = "started card tokenization", closedEvent = "ended card tokenization";
+        var startedEvent = "started card tokenization", closedEvent = "finished card tokenization";
 
         $.ajax({ dataType: "script", attrs: { nonce: "{{ request.csp_nonce }}"}, url: "{{ card_tokenize_url }}" })
             .done(function() {

--- a/docs/development/application-logic.md
+++ b/docs/development/application-logic.md
@@ -274,7 +274,7 @@ user-->>user: display Littlepay overlay
 user-->>analytics: started card tokenization
 user->>littlepay: provides debit or credit card details
 littlepay-->>user: card token
-user-->>analytics: ended card tokenization
+user-->>analytics: finished card tokenization
 user->>benefits: POST back card token
     deactivate user
     activate benefits

--- a/docs/product-and-design/analytics.md
+++ b/docs/product-and-design/analytics.md
@@ -89,7 +89,7 @@ Read more on each of these events on the [Amplitude event documentation for Bene
 
 These events track the progress of a user who has successfully verified their eligibility and is enrolling their payment card with the system.
 
-- ended card tokenization
+- finished card tokenization
 - returned enrollment
 - started card tokenization
 
@@ -101,4 +101,4 @@ Various key metrics are collected and analyzed, including:
 
 - **Number of users who successfully completed authentication**: Users who `started sign in`, `finished sign in`
 - **Number of users who successfully verified eligibility**: Users who completed the above and `selected enrollment flow`, `started eligibility`, `returned eligibility` with a status of `True`
-- **Numbers of users who successfully completed enrollment**: Users who completed all of the above and `started card tokenization`, `ended card tokenization` and `returned enrollment` with a status of `Success`
+- **Numbers of users who successfully completed enrollment**: Users who completed all of the above and `started card tokenization`, `finished card tokenization` and `returned enrollment` with a status of `success`


### PR DESCRIPTION
Looking through the analytics/warehouse as part of https://github.com/cal-itp/data-infra/pull/3468 and I noticed this slight inconsistency.

E.g. our OAuth events use

* `started sign in`
* `finished sign in`

So this small fix aligns the card tokenization event.

_this was my bad, I wrote the initial spec in #2249_