### PR TITLE
Enrollment Success: Reduce h1 parent container width for readability

### DIFF
--- a/benefits/enrollment/templates/enrollment/success.html
+++ b/benefits/enrollment/templates/enrollment/success.html
@@ -12,7 +12,7 @@
 {% endblock page-title %}
 
 {% block headline %}
-  <div class="col-lg-8">
+  <div class="col-lg-7">
     <h1 class="pb-lg-4 mb-lg-3 pb-4">
       {% block headline-message %}
         {% blocktranslate trimmed %}


### PR DESCRIPTION
closes #2429 

## What this PR does
- Reduces the H1 parent container width from `col-8` to `col-7`, only on the Enrollment Success page, to get the headline to break into a second line at a semantic spot:

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/29a2f583-4d29-4c36-9d33-efa374a1b62f">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/70d2ed41-d25d-4ad5-8276-49c82bf8afb6">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/b67b38cd-a599-4aac-8555-971b0b4938fd">

- Alternatives considered: Use a manual `<br>` but that doesn't scale responsively well, and it's really hacky. 

## Note
A note to other developers - this is a bit of a heavy-handed custom override, and we (dev) don't want to be doing things like this too often. We want to be building an app that exists and works great in all browser-widths and all browser dimensions as possible. If the `col-7` trick didn't just happen to conveniently work, I wouldn't pursue this fix. This is truly a one-off case.