### PR TITLE
Enrollment Index: Remove space after Littlepay

### DIFF
--- a/benefits/enrollment/templates/enrollment/includes/media-item--bankcardcheck--index.html
+++ b/benefits/enrollment/templates/enrollment/includes/media-item--bankcardcheck--index.html
@@ -17,8 +17,7 @@
     <div class="media-body--details">
         <p>
             {% translate "You will be directed to our partner, " %}
-            {% include "core/includes/modal-trigger.html" with modal="modal--littlepay" text="Littlepay" period=False %}
-            {% translate ", to enter your contactless card details." %}
+            <!-- djlint:off --><a href="modal--littlepay" class="{{ classes }}" data-bs-toggle="modal" data-bs-target="#modal--littlepay">Littlepay</a>{% translate ", to enter your contactless card details." %}<!-- djlint:on -->
             {% translate "We don’t store your information, and you won’t be charged." %}
         </p>
         <p>{% translate "Please use a debit or credit card by Visa or Mastercard." %}</p>


### PR DESCRIPTION
closes #2428 

## What this PR does
- Make a fix to the Enrollment Index page that shows up on the Agency Card, Veterans, Senior, Medicare flows (all but CalFresh).
- Remove the space that appears after the Littlepay link by *not* using the includes and using the `a href` link code directly, allowing the link code to be right next to the copy, which allows the HTML to be rendered w/o any extra whitespaces.
- The only drawback to this is that if there is ever a style change to `modal-trigger`, we need to make sure the change is made here too. I found this drawback to be acceptable, b/c I think most changes if any that happen to the modal-trigger will be done with CSS classes, and it wouldn't be hard to add the CSS classes in both places. I'm open to the alternatives considered though.

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/34f2b7d8-213b-4c81-b71b-2f1debac4e61">

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/6054bf7b-d2c2-4d6d-86a9-38ec3651e7c3">

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/1854173e-211f-4300-9d65-0b2a79c5ad4b">

## Alternatives considered
- Tried removing line breaks from the `modal-trigger.html` template, from the `media-item` template, but didn't fix the bug.
- I considered trying to add conditional code to the `modal-trigger.html` includes, something like _If no_space=True, then render `{% translate ", to enter your contactless card details." %}`_ - but it felt a little over the top, doesn't scale if this ever happened on another page. Would this be preferred though? I can do that.  