### PR TITLE
Docs: add note about Compiler to both READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # Benefits
+
 ![Cal-ITP Benefits - Landing - Laptop+Mobile](https://github.com/cal-itp/benefits/assets/6279581/3f5c558b-ad45-49cd-bb51-b230c625837b)
 
 <a href="https://benefits.calitp.org" target="_blank">Cal-ITP Benefits</a> is a web application that enables digital eligibility verification and enrollment for transit benefits onto transit riders’ existing contactless debit and credit cards.
+
+Benefits is open-source software that is designed, developed, and maintained by <a href="https://compiler.la/" target="_blank">Compiler LLC</a> on behalf of Caltrans, Cal-ITP, and our agency partners.
 
 View the technical documentation online: <https://docs.calitp.org/benefits>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,27 +13,29 @@ The development of this publicly-accessible client is being managed by Caltrans'
 >
 > We worked with state partners on this product launch, and next we're working to bring youth, lower-income riders, veterans, people with disabilities, and others the same instant access to free or reduced fares across all California transit providers, without having to prove eligibility to each agency.
 
+Benefits is open-source software that is designed, developed, and maintained by <a href="https://compiler.la/" target="_blank">Compiler LLC</a> on behalf of Caltrans, Cal-ITP, and our agency partners.
+
 ## Adoption by transit agencies
 
 The following California transit agencies have launched Cal-ITP Benefits for their riders, with the following enrollment pathway options:
 
 | Transit agency                                  | Older adults | Agency card | Veterans | Low-income | Initial agency launch |
-| ----------------------------------------------- | ------------ | ----------- | -------- | -- |--------------------- |
-| **Monterey-Salinas Transit**                    | Live         | Live        | Live     | |12/2021               |
-| **Santa Barbara Metropolitan Transit District** | Live         | Live        |          | |10/2023               |
-| **Sacramento Regional Transit District**        | In test      |             |          | |                      |
+| ----------------------------------------------- | ------------ | ----------- | -------- | ---------- | --------------------- |
+| **Monterey-Salinas Transit**                    | Live         | Live        | Live     |            | 12/2021               |
+| **Santa Barbara Metropolitan Transit District** | Live         | Live        |          |            | 10/2023               |
+| **Sacramento Regional Transit District**        | In test      |             |          |            |                       |
 
 ## Supported enrollment pathways
 
 The Cal-ITP Benefits app supports the following enrollment pathways that use the corresponding eligibility verification methods:
 
-| Enrollment pathway                                                               | Eligibility verification                                                              | Status | Launch                                                                |
-| ---------------------------------------------------------------------------------| ------------------------------------------------------------------------------------- | ------ | --------------------------------------------------------------------- |
-| [**Older adults**](/benefits/enrollment-pathways/older-adults)                   | [Login.gov ID Proofed](https://developers.login.gov/attributes/)                      | Live   | [08/2022](https://github.com/cal-itp/benefits/releases/tag/2022.08.1) |
-| [**Agency cards**](/benefits/enrollment-pathways/agency-cards)                   | [Eligibility API](https://docs.calitp.org/eligibility-api/specification/)             | Live   | [11/2022](https://github.com/cal-itp/benefits/releases/tag/2022.11.1) |
-| [**Veterans**](/benefits/enrollment-pathways/veterans)                           | [Veteran Confirmation API](https://developer.va.gov/explore/api/veteran-confirmation) | Live   | [09/2023](https://github.com/cal-itp/benefits/releases/tag/2023.09.1) |
-| [**Low-income**](/benefits/enrollment-pathways/low-income)                       | CalFresh Confirm API                                                                  | Code complete | [07/2024](https://github.com/cal-itp/benefits/releases/tag/2024.07.1) |
-| [**Medicare cardholders**](/benefits/enrollment-pathways/medicare-cardholders)   | [Blue Button API](https://bluebutton.cms.gov/developers/#overview)                    | Code complete | [09/2024](https://github.com/cal-itp/benefits/releases/tag/2024.09.3) |
+| Enrollment pathway                                                             | Eligibility verification                                                              | Status        | Launch                                                                |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- | ------------- | --------------------------------------------------------------------- |
+| [**Older adults**](/benefits/enrollment-pathways/older-adults)                 | [Login.gov ID Proofed](https://developers.login.gov/attributes/)                      | Live          | [08/2022](https://github.com/cal-itp/benefits/releases/tag/2022.08.1) |
+| [**Agency cards**](/benefits/enrollment-pathways/agency-cards)                 | [Eligibility API](https://docs.calitp.org/eligibility-api/specification/)             | Live          | [11/2022](https://github.com/cal-itp/benefits/releases/tag/2022.11.1) |
+| [**Veterans**](/benefits/enrollment-pathways/veterans)                         | [Veteran Confirmation API](https://developer.va.gov/explore/api/veteran-confirmation) | Live          | [09/2023](https://github.com/cal-itp/benefits/releases/tag/2023.09.1) |
+| [**Low-income**](/benefits/enrollment-pathways/low-income)                     | CalFresh Confirm API                                                                  | Code complete | [07/2024](https://github.com/cal-itp/benefits/releases/tag/2024.07.1) |
+| [**Medicare cardholders**](/benefits/enrollment-pathways/medicare-cardholders) | [Blue Button API](https://bluebutton.cms.gov/developers/#overview)                    | Code complete | [09/2024](https://github.com/cal-itp/benefits/releases/tag/2024.09.3) |
 
 Read more about each [enrollment pathway](/benefits/enrollment-pathways/).
 


### PR DESCRIPTION
closes #2448 

- Updates README that appears https://github.com/cal-itp/benefits/
- Update README that appears https://docs.calitp.org/benefits/, preview link here https://benefits-2457--cal-itp-previews.netlify.app/

I don't know why all the other tables on the docs/README.md file got formatted, but seems to read better.