### PR TITLE
Feat: add Slack thread to Release issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.yml
+++ b/.github/ISSUE_TEMPLATE/release.yml
@@ -39,7 +39,7 @@ body:
       description: GitHub handle of who is responsible for smoke testing this release
       placeholder: "@cal-itp-bot"
     validations:
-      required: true
+      required: false
   - type: input
     id: version
     attributes:
@@ -48,6 +48,14 @@ body:
       placeholder: YYYY.0M.R
     validations:
       required: true
+  - type: input
+    id: slack
+    attributes:
+      label: Slack thread
+      description: Link to the Slack thread for this release
+      placeholder: "https://slack.com/archives/ABC/XZY"
+    validations:
+      required: false
   - type: markdown
     attributes:
       value: |


### PR DESCRIPTION
Adds a new question / section for the the Release process issue template to make it easier to paste in the Slack thread in a standard location.

This is not required to create a Release issue. Also removed the requirement for smoke tester, as that is not always known when the Release issue is created.