### PR TITLE
Error pages: Make text area narrower for better legibility

### DIFF
--- a/benefits/templates/error.html
+++ b/benefits/templates/error.html
@@ -15,7 +15,7 @@
     </h1>
 
     <div class="row justify-content-center">
-      <div class="col-lg-8 pt-4">
+      <div class="col-lg-6 pt-4">
         {% block paragraphs %}
         {% endblock paragraphs %}
       </div>


### PR DESCRIPTION
closes #2475 

This is a small design fix request from @srhhnry 

Makes the error page text easier to read, by making the text width narrower from 8 columns to 6 columns on desktop.

﻿
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/6e1e87a8-02a5-4487-86d7-82c849ec5ed5">


## How to test
- Run the app in `Debug=False` mode
- Go to a random fake URL, like `/asdfsdf`
<img width="431" alt="image" src="https://github.com/user-attachments/assets/ec884522-c4c8-462c-95db-b9ab134a1cb9">
