### PR TITLE
Fix: show favicon on the Superuser's admin

### DIFF
--- a/benefits/templates/admin/base_site.html
+++ b/benefits/templates/admin/base_site.html
@@ -1,0 +1,5 @@
+{% extends "admin/base_site.html" %}
+
+{% block extrahead %}
+    {% include "admin/includes/favicon.html" %}
+{% endblock extrahead %}


### PR DESCRIPTION
Closes #2443

This PR overrides the `admin/base_site.html` template to show the favicon in the Superuser's admin page by [extending an overridden template](https://docs.djangoproject.com/en/5.1/howto/overriding-templates/#extending-an-overridden-template).

![image](https://github.com/user-attachments/assets/eb30e148-a2bb-4776-95f5-7cfbe19e4b25)

## Reviewing

Log in as a Superuser to the admin page, click around the different models and verify that the favicon appears on the pages.