### PR TITLE
Feat: add webp CLI to devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,6 +4,11 @@ FROM benefits_client:latest
 # https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt
 USER root
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+
+# install webp CLI
+# https://developers.google.com/speed/webp/download
+RUN apt install webp -y
+
 USER $USER
 
 COPY . .


### PR DESCRIPTION
Part of #2490 

This is an optional PR. If we don't want this in the devcontainer, we can just close this.

This PR installs CLI tools from Google, including [`cwebp`](https://developers.google.com/speed/webp/docs/cwebp), to create and work with WebP images, giving us a consistent way to create WebP images rather than each of us doing it our own way, e.g. using online tools like https://squoosh.app/ (from https://github.com/GoogleChromeLabs/squoosh) or using [ImageMin](https://web.dev/articles/serve-images-webp#convert_images_to_webp), etc.

I couldn't find a way to just install `cwebp`, which is what I think we'd mainly use; the full `webp` package contains `cwebp`, so just install the whole thing.

### Trying it locally

Rebuild the devcontainer, and then in a terminal, run `cwebp` to see the help screen.

```
calitp@415aa65007bd:/calitp/app$ cwebp
Usage:

   cwebp [options] -q quality input.png -o output.webp

where quality is between 0 (poor) to 100 (very good).
Typical value is around 80.

Try -longhelp for an exhaustive list of advanced options.
```