### PR TITLE
Feat: fallback background color

### DIFF
--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -843,6 +843,7 @@ a.card:focus-visible {
   --landing-main-height: calc(100vh - 80px); /* Header Height (80px) */
   --landing-background: url("/static/img/benefits-bg-mobile.webp") no-repeat
     var(--primary-color);
+  --landing-background-fallback-color: #1a1b16; /* same color the left side of the background image */
   --landing-box-background: var(--bs-white);
   --landing-box-border: 12px solid var(--primary-color);
   --landing-text-color: var(--text-primary-color);
@@ -865,6 +866,7 @@ a.card:focus-visible {
 .landing main#main-content {
   background: var(--landing-background);
   background-size: cover;
+  background-color: var(--landing-background-fallback-color);
 }
 
 .landing main#main-content .container .row:first-child {


### PR DESCRIPTION
Part of #2490 

This PR will be merged in to #2523.

I think it makes sense for the changes from both PRs to be merged into `main` together, but I also wanted to have separate code reviews.

### Fallback background color

I took the color from the left side of the background image and used that as the `background-color` for the main section of the landing page.

<img src="https://github.com/user-attachments/assets/df459195-9636-4be0-8ba6-7854e4b16670" width="450">

The WebAIM contrast checker shows this contrast ratio [passes WCAG AAA requirements](https://webaim.org/resources/contrastchecker/?fcolor=FFFFFF&bcolor=1A1B16).

### Screenshots of background-color in use (background image does not load)

| Desktop | Mobile |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/c1652518-c17e-485d-beba-90d91e851ac2) | ![localhost_11369_(Moto G Power)](https://github.com/user-attachments/assets/8eecbf4c-403f-45f2-8866-60df576eb496) | 

