### PR TITLE
Feat: set up Playwright

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -41,3 +41,13 @@ services:
       - "8000"
     volumes:
       - ./.devcontainer:/.devcontainer
+
+  playwright:
+    build:
+      context: .
+      dockerfile: tests/playwright/Dockerfile
+    image: benefits_client:playwright
+    volumes:
+      - ./tests/playwright:/playwright
+    # https://code.visualstudio.com/docs/remote/create-dev-container#_use-docker-compose
+    entrypoint: sleep infinity

--- a/compose.yml
+++ b/compose.yml
@@ -49,5 +49,4 @@ services:
     image: benefits_client:playwright
     volumes:
       - ./tests/playwright:/playwright
-    # https://code.visualstudio.com/docs/remote/create-dev-container#_use-docker-compose
-    entrypoint: sleep infinity
+    command: ./run.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ test = [
     "pytest",
     "pytest-django",
     "pytest-mock",
+    "pytest-playwright", # only for writing tests. run tests using playwright Docker Compose service
     "pytest-socket",
 ]
 

--- a/tests/playwright/.gitignore
+++ b/tests/playwright/.gitignore
@@ -1,0 +1,3 @@
+__pycache__
+.pytest_cache
+test-results

--- a/tests/playwright/Dockerfile
+++ b/tests/playwright/Dockerfile
@@ -1,0 +1,11 @@
+# https://playwright.dev/docs/docker
+FROM mcr.microsoft.com/playwright/python:v1.48.0-jammy
+
+WORKDIR /playwright
+
+COPY tests/playwright/requirements.txt requirements.txt
+
+RUN python -m pip install --upgrade pip && \
+   pip install -r requirements.txt
+
+USER pwuser

--- a/tests/playwright/pytest.ini
+++ b/tests/playwright/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --tracing on -v --template=html1/index.html --report=test-results/report.html --video on

--- a/tests/playwright/requirements.txt
+++ b/tests/playwright/requirements.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-playwright
+pytest-reporter-html1

--- a/tests/playwright/run.sh
+++ b/tests/playwright/run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+pytest --tracing on -v --template=html1/index.html --report=test-results/report.html --video on

--- a/tests/playwright/run.sh
+++ b/tests/playwright/run.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-pytest --tracing on -v --template=html1/index.html --report=test-results/report.html --video on
+pytest

--- a/tests/playwright/test_healthcheck.py
+++ b/tests/playwright/test_healthcheck.py
@@ -1,0 +1,7 @@
+from playwright.sync_api import Page, expect
+
+
+def test_dev_healthcheck(page: Page):
+    page.goto("https://dev-benefits.calitp.org/healthcheck")
+
+    expect(page.get_by_text("Healthy")).to_be_visible()

--- a/tests/pytest/run.sh
+++ b/tests/pytest/run.sh
@@ -2,7 +2,7 @@
 set -eu
 
 # run normal pytests
-coverage run -m pytest
+coverage run -m pytest tests/pytest
 
 # clean out old coverage results
 rm -rf benefits/static/coverage


### PR DESCRIPTION
Closes #2533 

This PR sets us up to be able to run and write Playwright tests inside containers.
(_This is basically a re-do of #2500 with cleaner commits and smaller scope, i.e. this just focuses on getting the needed tooling in place._)

### Running
The `playwright` service added in this PR is to be used for running Playwright tests. 

The service uses an [image built by Microsoft](https://playwright.dev/python/docs/docker) that has Playwright + dependencies already installed as the base image.

<details><summary><b>Trying it out</b></summary>
<br/>
Outside of the devcontainer, run this in a terminal:

```bash
docker compose run --rm playwright
```

You can also start a terminal session in the `playwright` service by running:
```bash
docker compose run --rm playwright /bin/bash
```

and then you can run the tests and/or run other Playwright commands using that session.

The test will run as headless. A later PR will contain the setup for running in headed mode.

The console output will hopefully tell you the tests passed, and you can view more output under `tests/playwright/test-results`.

</details>

### Writing

We do install `pytest-playwright` into the devcontainer so that when viewing the test code in the devcontainer, we get syntax-highlighting, code completion, etc.

<details><summary><b>Docs on writing tests</b></summary>

- [Running tests using Pytest CLI](https://playwright.dev/python/docs/test-runners) 
   - this is what the helper script is doing
- The [Page](https://playwright.dev/python/docs/api/class-page) class
- Locator (element) [assertions](https://playwright.dev/python/docs/api/class-locatorassertion)
</details>

### Healthcheck test as a starting point

A test called `test_dev_healthcheck` is included here just so we have something to run. We can decide later if there's any value in keeping it once other tests are added.