### PR TITLE
Fix: Use same Bootstrap version for both Admin and Benefits

### DIFF
--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -20,10 +20,7 @@
     {% endblock preload %}
 
     <link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet" type="text/css">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
-          rel="stylesheet"
-          integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
-          crossorigin="anonymous">
+    {% include "core/includes/bootstrap-css.html" %}
     <link href="{% static "css/styles.css" %}" rel="stylesheet">
     <link href="{% static "img/favicon.ico" %}" rel="icon" type="image/x-icon" />
 

--- a/benefits/core/templates/core/includes/bootstrap-css.html
+++ b/benefits/core/templates/core/includes/bootstrap-css.html
@@ -1,0 +1,4 @@
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+      crossorigin="anonymous">

--- a/benefits/templates/admin/agency-base.html
+++ b/benefits/templates/admin/agency-base.html
@@ -10,7 +10,7 @@
             src="https://cdn.jsdelivr.net/npm/jquery@3.6.1/dist/jquery.min.js"
             integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ="
             crossorigin="anonymous"></script>
-    {% include "admin/includes/bootstrap.html" %}
+    {% include "core/includes/bootstrap-css.html" %}
     {% include "admin/includes/style-admin.html" %}
     {% include "core/includes/analytics.html" with api_key=analytics.api_key uid=analytics.uid did=analytics.did %}
 {% endblock extrastyle %}

--- a/benefits/templates/admin/includes/bootstrap.html
+++ b/benefits/templates/admin/includes/bootstrap.html
@@ -1,4 +1,0 @@
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
-      rel="stylesheet"
-      integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3"
-      crossorigin="anonymous">

--- a/benefits/templates/admin/login.html
+++ b/benefits/templates/admin/login.html
@@ -7,7 +7,7 @@
 {% block extrastyle %}
     {% comment %} Overriding instead of extending agency-base here to remove jQuery declaration, which admin/login.html includes on its own {% endcomment %}
     {% include "admin/includes/favicon.html" %}
-    {% include "admin/includes/bootstrap.html" %}
+    {% include "core/includes/bootstrap-css.html" %}
     {% include "admin/includes/style-admin.html" %}
 {% endblock extrastyle %}
 


### PR DESCRIPTION
closes #2551

The #2491 PR made a regression on Admin, by changing this line in the settings CSP: https://github.com/cal-itp/benefits/pull/2526/files#diff-d71405aa44f1e899a9cd920e5187aa1d02affdbd0da472eca95f814b0a8c1210R357, which then made the Bootstrap CSS version used on Admin inaccessible.

This PR:
- Moves the Bootstrap includes from Admin into Core
- Upgrades the Bootstrap includes version to 5.3.3
- Uses that includes in both Admin and Benefits apps

QA:
- QA the app flow on Benefits
- QA a in-person verification flow on Admin
- QA logging in and out of Admin

---

I've now realized that #2491 introduced a few small changes (mostly deleting style declarations no longer necessary, that were overriding CA State Web Template) to the Button CSS in the Benefits app stylesheet, but not Admin's Button CSS - which had copied Benefits' CSS. This PR is not attempting to bring in those changes from Benefits CSS to Admin CSS. It's still a little weird that the two files' Button CSS are now diverging, and I think that can be done in a future clean up ticket.