### PR TITLE
Research: run Playwright tests based on marker

### DIFF
--- a/tests/playwright/pytest.ini
+++ b/tests/playwright/pytest.ini
@@ -1,2 +1,6 @@
 [pytest]
 addopts = --tracing on -v --template=html1/index.html --report=test-results/report.html --video on
+markers =
+    dev
+    test
+    prod

--- a/tests/playwright/test_healthcheck.py
+++ b/tests/playwright/test_healthcheck.py
@@ -26,12 +26,63 @@ def env_base_url(request):
         return "http://localhost:11369"  # use port that will work with IdG
 
 
+# region --- Test that needs to run for multiple environments
+
+
+# region helper function
 def env(*marks):
     return pytest.mark.parametrize("env_name", [pytest.param(mark.name, marks=mark) for mark in marks])
 
 
+# endregion
+
+
+# this is what the helper function evaluates to
+# @pytest.mark.parametrize(
+#     "env_name",
+#     [
+#         pytest.param("dev", marks=[pytest.mark.dev]),
+#         pytest.param("test", marks=[pytest.mark.test]),
+#         pytest.param("prod", marks=[pytest.mark.prod]),
+#     ],
+# )
 @env(pytest.mark.dev, pytest.mark.test, pytest.mark.prod)
 def test_healthcheck(page: Page, env_base_url, env_name):
     page.goto(env_base_url + "/healthcheck")
 
     expect(page.get_by_text("Healthy")).to_be_visible()
+
+
+# endregion
+
+
+# region--- Test that needs to run for multiple environments with parametrized values
+
+
+@pytest.mark.parametrize(
+    "sub,name",
+    [
+        pytest.param("12345", "Example", marks=[pytest.mark.dev]),
+        pytest.param("1234", "Le", marks=[pytest.mark.dev]),
+        pytest.param("4321", "Garcia", marks=[pytest.mark.test]),
+        pytest.param("54321", "Sample", marks=[pytest.mark.prod]),
+    ],
+)
+def test_agency_card_flow(page, env_base_url, sub, name):
+    print(env_base_url)
+    print(sub)
+    print(name)
+
+
+# endregion
+
+
+# region --- Test specific to only one environment that does not need parameterization, can use mark more simply
+
+
+@pytest.mark.dev
+def test_only_for_dev(env_base_url):
+    print(env_base_url)
+
+
+# endregion

--- a/tests/playwright/test_healthcheck.py
+++ b/tests/playwright/test_healthcheck.py
@@ -1,7 +1,37 @@
 from playwright.sync_api import Page, expect
+import pytest
 
 
-def test_dev_healthcheck(page: Page):
-    page.goto("https://dev-benefits.calitp.org/healthcheck")
+@pytest.fixture
+def env_base_url(request):
+    marker = (
+        request.node.get_closest_marker("dev")
+        or request.node.get_closest_marker("test")
+        or request.node.get_closest_marker("prod")
+    )
+    print(marker)
+
+    if marker:
+        env = marker.name
+    else:
+        env = None
+
+    if env == "dev":
+        return "https://dev-benefits.calitp.org"
+    elif env == "test":
+        return "https://test-benefits.calitp.org"
+    elif env == "prod":
+        return "http://dev-benefits.calitp.org"  # use dev for now, don't want to spam prod
+    else:
+        return "http://localhost:11369"  # use port that will work with IdG
+
+
+def env(*marks):
+    return pytest.mark.parametrize("env_name", [pytest.param(mark.name, marks=mark) for mark in marks])
+
+
+@env(pytest.mark.dev, pytest.mark.test, pytest.mark.prod)
+def test_healthcheck(page: Page, env_base_url, env_name):
+    page.goto(env_base_url + "/healthcheck")
 
     expect(page.get_by_text("Healthy")).to_be_visible()


### PR DESCRIPTION
Part of #2504 

This is an approach for running tests for specific environments.

It requires that you pass the marker that you want the tests to use. A fixture called `env_base_url` calculates the value for the base URL. Tests must request this fixture.

One or more environments can be run at a time because this approach utilizes parametrization (`@pytest.mark.parametrize`).

Examples:
```
pytest -m dev
```
runs tests marked with `@pytest.mark.dev` against dev-benefits.

```
pytest -m "dev or test"
```
runs tests marked with `@pytest.mark.dev` and/or `@pytest.mark.test` against their respective environments.

```
pytest
```
runs all tests against their respective environments.
