### PR TITLE
Research: run Playwright tests based on marker and base-url

### DIFF
--- a/tests/playwright/pytest.ini
+++ b/tests/playwright/pytest.ini
@@ -1,2 +1,6 @@
 [pytest]
 addopts = --tracing on -v --template=html1/index.html --report=test-results/report.html --video on
+markers =
+    dev
+    test
+    prod

--- a/tests/playwright/run.sh
+++ b/tests/playwright/run.sh
@@ -1,5 +1,24 @@
 #!/bin/bash
 
-set -e
+set -eux
 
-pytest
+ENV=$1
+
+if [ $# -ne 1 ]; then
+  echo "No environment given... running against local environment"
+else
+  MARK="-m ${ENV}"
+fi
+
+if [ "$ENV" = "dev" ]; then
+  BASE_URL="https://dev-benefits.calitp.org"
+elif [ "$ENV" = "test" ]; then
+  BASE_URL="https://test-benefits.calitp.org"
+elif [ "$ENV" = "prod" ]; then
+  BASE_URL="https://benefits.calitp.org"
+else
+  BASE_URL="http://localhost:11369"
+  MARK=""
+fi
+
+pytest --base-url "$BASE_URL" "$MARK"

--- a/tests/playwright/test_healthcheck.py
+++ b/tests/playwright/test_healthcheck.py
@@ -1,7 +1,11 @@
 from playwright.sync_api import Page, expect
+import pytest
 
 
-def test_dev_healthcheck(page: Page):
-    page.goto("https://dev-benefits.calitp.org/healthcheck")
+@pytest.mark.dev
+@pytest.mark.test
+@pytest.mark.prod
+def test_healthcheck(page: Page):
+    page.goto("/healthcheck")
 
     expect(page.get_by_text("Healthy")).to_be_visible()


### PR DESCRIPTION
Part of #2504

This is an approach for running tests for specific environments. 

It requires that you pass the marker and base URL that you want the tests to use. Only one environment can be run at a time.

Example:
```
pytest -m dev --base-url https://dev-benefits.calitp.org
```

The helper script provides some convenience.