### PR TITLE
Chore: add back values for CST local fixture

### DIFF
--- a/benefits/core/migrations/local_fixtures.json
+++ b/benefits/core/migrations/local_fixtures.json
@@ -53,6 +53,8 @@
       "slug": "cst",
       "short_name": "CST (local)",
       "long_name": "California State Transit (local)",
+      "info_url": "https://www.agency-website.com",
+      "phone": "1-800-555-5555",
       "eligibility_api_id": "cst",
       "eligibility_api_private_key": 2,
       "eligibility_api_public_key": 3,
@@ -61,7 +63,9 @@
       "transit_processor_client_id": "",
       "transit_processor_client_secret_name": "cst-transit-processor-client-secret",
       "staff_group": 2,
-      "customer_service_group": 2
+      "customer_service_group": 2,
+      "logo_large": "agencies/cst-lg.png",
+      "logo_small": "agencies/cst-sm.png"
     }
   },
   {


### PR DESCRIPTION
This is a follow-up to #2471 to add back values for the local CST TransitAgency fixture's `info_url`, `phone`, `logo_large`, and `logo_small` fields.

In that PR, those values were removed from the local fixtures because the idea at one point was to use them as defaults for those fields. 

We decided to default to the empty string instead after discussion in https://github.com/cal-itp/benefits/pull/2471#discussion_r1858988519 and https://github.com/cal-itp/benefits/pull/2471#discussion_r1859137740.

Currently in `main`, if you run `./bin/reset_db.sh` and run the app, you will see missing values:

**Missing logo**
![Screenshot from 2024-12-04 15-32-55](https://github.com/user-attachments/assets/3fddc208-a538-41cc-9952-389992087ef6)

**Missing `info_url` and `phone`**
![Screenshot from 2024-12-04 15-33-13](https://github.com/user-attachments/assets/9c7bdc22-5d96-4d06-b2cf-ca4856b74520)

