### PR TITLE
CI: update littlepay switch syntax

### DIFF
--- a/.github/workflows/check-api.yml
+++ b/.github/workflows/check-api.yml
@@ -32,8 +32,7 @@ jobs:
 
       - name: Run littlepay to get access token
         run: |
-          littlepay switch env ${{ matrix.env }}
-          littlepay switch participant ${{ matrix.participant }}
+          littlepay switch -e ${{ matrix.env }} -p ${{ matrix.participant }}
 
       - name: Report failure to Slack
         if: always()


### PR DESCRIPTION
Should not be merged until after https://github.com/cal-itp/littlepay/pull/72

But _needs_ to be merged after that PR for this check to continue to work.