### PR TITLE
reCAPTCHA: Enrollment Success, Logged Out

### DIFF
--- a/benefits/core/templates/core/logged-out.html
+++ b/benefits/core/templates/core/logged-out.html
@@ -7,12 +7,10 @@
 
 {% block main-content %}
   <div class="container">
-    <div class="row justify-content-lg-center">
+    <div class="row justify-content-center">
       <div class="col-md-6">
-        <h1 class="h2 text-center">
-          <span class="d-block pb-lg-8 pb-5">{% include "core/includes/icon.html" with name="happybus" %}</span>
-          {% translate "You have successfully logged out. Thank you for using Cal-ITP Benefits!" %}
-        </h1>
+        <div class="py-4 mt-4 text-center">{% include "core/includes/icon.html" with name="happybus" %}</div>
+        <h1 class="h2 pt-0">{% translate "You have successfully logged out. Thank you for using Cal-ITP Benefits!" %}</h1>
       </div>
     </div>
   </div>

--- a/benefits/core/templates/core/logged-out.html
+++ b/benefits/core/templates/core/logged-out.html
@@ -9,7 +9,7 @@
   <div class="container">
     <div class="row justify-content-center">
       <div class="col-md-6">
-        <div class="py-4 mt-4 text-center">{% include "core/includes/icon.html" with name="happybus" %}</div>
+        <div class="py-4 mt-5 text-center">{% include "core/includes/icon.html" with name="happybus" %}</div>
         <h1 class="h2 pt-0">{% translate "You have successfully logged out. Thank you for using Cal-ITP Benefits!" %}</h1>
       </div>
     </div>

--- a/benefits/enrollment/templates/enrollment/success.html
+++ b/benefits/enrollment/templates/enrollment/success.html
@@ -24,7 +24,7 @@
 {% endblock headline %}
 
 {% block inner-content %}
-  <div class="col-12 col-sm-12 col-lg-9">
+  <div class="col-12 col-lg-9">
     <div class="row flex-column-reverse flex-lg-row">
       <div class="col-12 col-lg-7 pe-1">
         {# djlint:off #}
@@ -58,7 +58,7 @@
 {% block call-to-action %}
   {% if authentication and authentication.logged_in and authentication.sign_out_button_template %}
     <div class="row d-flex justify-content-start justify-content-lg-center">
-      <div class="col-12 col-lg-8 pt-lg-5 mt-lg-0 pt-4 mt-2">
+      <div class="col-12 col-lg-9 pt-lg-5 mt-lg-0 pt-4 mt-2">
         <p>
           {% translate "If you are on a public or shared computer, don’t forget to sign out of " %}
           {% include authentication.sign_out_button_template %}

--- a/benefits/enrollment/templates/enrollment/success.html
+++ b/benefits/enrollment/templates/enrollment/success.html
@@ -12,7 +12,7 @@
 {% endblock page-title %}
 
 {% block headline %}
-  <div class="col-lg-7">
+  <div class="col-lg-9">
     <h1 class="pb-lg-4 mb-lg-3 pb-4">
       {% block headline-message %}
         {% blocktranslate trimmed %}

--- a/benefits/enrollment/templates/enrollment/success.html
+++ b/benefits/enrollment/templates/enrollment/success.html
@@ -52,18 +52,13 @@
              alt="" />
       </div>
     </div>
-  </div>
-{% endblock inner-content %}
-
-{% block call-to-action %}
-  {% if authentication and authentication.logged_in and authentication.sign_out_button_template %}
-    <div class="row d-flex justify-content-start justify-content-lg-center">
-      <div class="col-12 col-lg-9 pt-lg-5 mt-lg-0 pt-4 mt-2">
-        <p>
+    {% if authentication and authentication.logged_in and authentication.sign_out_button_template %}
+      <div class="row justify-content-start justify-content-lg-center">
+        <p class="pt-lg-5 mt-lg-0 pt-4 mt-2">
           {% translate "If you are on a public or shared computer, don’t forget to sign out of " %}
           {% include authentication.sign_out_button_template %}
         </p>
       </div>
-    </div>
-  {% endif %}
-{% endblock call-to-action %}
+    {% endif %}
+  </div>
+{% endblock inner-content %}


### PR DESCRIPTION
closes #2544 

## What this PR does

### Enrollment Success
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/f693ca98-ad58-4e75-8acd-5920be22ad5e">

This is now the only page in the flow that _isn't_ `col-lg-6`. Though, as a reminder, the home page and the Help page aren't either. The Help page will remain `col-lg-8`. This page doesn't by any columns on Figma, both the headline text and the image/text combo. On the app, we are using a `col-lg-9` as our closest approximate.

### Logged out
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/3a56faa7-0efd-47a3-bd29-8ee2bc7d7836">

A `col-lg-6` page with the now standard, 72px between header and headline, and 24px between icon and graf.
