### PR TITLE
Fix: Fix agency link regression

### DIFF
--- a/benefits/core/templates/core/includes/agency-links.html
+++ b/benefits/core/templates/core/includes/agency-links.html
@@ -1,3 +1,3 @@
-<label class="mt-4 d-block fs-base ls-base">{{ agency_name | default:agency.long_name }}</label>
-<a class="d-table fs-base ls-base" href="tel:{{ phone | default:agency.phone }}">{{ phone | default:agency.phone }}</a>
-<a class="d-table fs-base ls-base" href="{{ info_url | default:agency.info_url }}" target="_blank" rel="noopener noreferrer">{{ info_url | default:agency.info_url }}</a>
+<p class="h4 mt-4 d-block fs-base ls-base">{{ agency_name | default:agency.long_name }}</p>
+<a class="d-table mt-1 fs-base ls-base" href="tel:{{ phone | default:agency.phone }}">{{ phone | default:agency.phone }}</a>
+<a class="d-table mt-1 fs-base ls-base" href="{{ info_url | default:agency.info_url }}" target="_blank" rel="noopener noreferrer">{{ info_url | default:agency.info_url }}</a>

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -129,7 +129,8 @@ h2,
 .h2,
 h3,
 .h3,
-h4 {
+h4,
+.h4 {
   font-weight: var(--bold-font-weight);
   margin: 0;
 }
@@ -214,7 +215,8 @@ h3,
   }
 }
 
-h4 {
+h4,
+.h4 {
   font-size: var(--h4-font-size);
   letter-spacing: calc(var(--h4-font-size) * var(--h4-letter-spacing-percent));
   line-height: var(--h4-line-height);


### PR DESCRIPTION
closes #2590 

A regression was introduced in #2526. When I removed the CA State Web Template, it removed this piece of CSS:

<img width="542" alt="image" src="https://github.com/user-attachments/assets/46ca21af-7d6d-47a8-9159-f9d09118ecc0" />

Since the agency name area uses a `<label>` element, the element was getting `font-weight: 700` from there.

But I actually read that using [`<label>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label) for something that is not a form is not semantic!

So in this PR, I:

- Changed the `label` to a regular `p`
- Created a `.h4` CSS class, with the same exact attributes of the `h4` element. And used the `h4` class on this agency name, to get the h4 styles.
- Added `mt-1` to get the lines to be 4px away from each other.

