### PR TITLE
Agency link focus rings are now rounded

### DIFF
--- a/benefits/core/templates/core/includes/agency-links.html
+++ b/benefits/core/templates/core/includes/agency-links.html
@@ -1,3 +1,9 @@
 <p class="h4 mt-4 d-block">{{ agency_name | default:agency.long_name }}</p>
-<a class="d-table mt-1 fs-base ls-base" href="tel:{{ phone | default:agency.phone }}">{{ phone | default:agency.phone }}</a>
-<a class="d-table mt-1 fs-base ls-base" href="{{ info_url | default:agency.info_url }}" target="_blank" rel="noopener noreferrer">{{ info_url | default:agency.info_url }}</a>
+<ul class="ps-0 d-flex flex-column gap-1 mt-1">
+    <li class="list-unstyled">
+        <a href="tel:{{ phone | default:agency.phone }}">{{ phone | default:agency.phone }}</a>
+    </li>
+    <li class="list-unstyled">
+        <a href="{{ info_url | default:agency.info_url }}" target="_blank" rel="noopener noreferrer">{{ info_url | default:agency.info_url }}</a>
+    </li>
+</ul>


### PR DESCRIPTION
fixes #2547 

## A series of Whys??
- Why did this focus ring have square corners, rather than rounded corners - even though this <a> tag has the exact same CSS styles were applied as the rest of the links on the site and page?

Because of the `d-table`, display: table on these links. Turning that class off makes the corners round again. (I guess a table can't have rounded corners).

- But why was the `d-table` applied? (What even is `display: table` anyway. This is not a table or tabular data.)

Because without `d-table`, the links would appear in one row one after each other, like a `display: inline` text. 

- Why not use `d-block`?

That would make the links go on each line, but then the focus ring would be the whole width of the container.

- So maybe having two `<a>` links here is not right somehow. Why not use `<ul>` with `<li>` with `<a>` in them, and apply `list-unstyled` to the links? I then used some flexbox and gap to give the links the spacing they need.

_That works_

<img width="447" alt="image" src="https://github.com/user-attachments/assets/d1cf6067-0238-43a3-83f5-935d6bbdb72b" />


## Test
- Test on Help page
- Test on agency-specific error pages, like `eligibility/unverified`
- Test on Firefox, Chrome
- Tested on Safari