### PR TITLE
WIP

### DIFF
--- a/benefits/core/templates/core/includes/agency-links.html
+++ b/benefits/core/templates/core/includes/agency-links.html
@@ -1,3 +1,3 @@
-<p class="h4 mt-4 d-block">{{ agency_name | default:agency.long_name }}</p>
+<p class="h4 mt-4 d-block disable-rfs">{{ agency_name | default:agency.long_name }}</p>
 <a class="d-table mt-1 fs-base ls-base" href="tel:{{ phone | default:agency.phone }}">{{ phone | default:agency.phone }}</a>
 <a class="d-table mt-1 fs-base ls-base" href="{{ info_url | default:agency.info_url }}" target="_blank" rel="noopener noreferrer">{{ info_url | default:agency.info_url }}</a>


### PR DESCRIPTION
closes #2601 


- https://getbootstrap.com/docs/5.2/getting-started/rfs/
- https://github.com/twbs/rfs/tree/v9.0.

So far: Disabled it via class in that one spot. But is there a way to disable it ENTIRELY? Why is it triggered by this h4 class??!?!?!
<img width="921" alt="image" src="https://github.com/user-attachments/assets/2f3c811d-d0d0-4caa-89d6-af5777df8131" />
