### PR TITLE
Fix: reCAPTCHA-related - Fix Admin form style regression

### DIFF
--- a/benefits/core/templates/core/includes/form.html
+++ b/benefits/core/templates/core/includes/form.html
@@ -3,7 +3,7 @@
 
   {% url form.action_url as form_action %}
 
-  <form id="{{ form.id }}" action="{{ form_action }}" method="{{ form.method | default:"post" | upper }}" role="form">
+  <form id="{{ form.id }}" action="{{ form_action }}" method="{{ form.method | default:"post" | upper }}">
     {% csrf_token %}
 
     <div class="form-field-container d-flex flex-column {{ form.classes }}">

--- a/benefits/core/templates/core/includes/form.html
+++ b/benefits/core/templates/core/includes/form.html
@@ -6,7 +6,7 @@
   <form id="{{ form.id }}" action="{{ form_action }}" method="{{ form.method | default:"post" | upper }}">
     {% csrf_token %}
 
-    <div class="form-field-container d-flex flex-column {{ form.classes }}">
+    <div class="form-field-container {{ form.classes }}">
       {% for field in form %}
         <div class="form-group mb-0">
           {# djlint:off #}

--- a/benefits/core/templates/core/includes/form.html
+++ b/benefits/core/templates/core/includes/form.html
@@ -3,14 +3,10 @@
 
   {% url form.action_url as form_action %}
 
-  <form id="{{ form.id }}"
-        class="{{ form.classes }}"
-        action="{{ form_action }}"
-        method="{{ form.method | default:"post" | upper }}"
-        role="form">
+  <form id="{{ form.id }}" action="{{ form_action }}" method="{{ form.method | default:"post" | upper }}" role="form">
     {% csrf_token %}
 
-    <div class="form-field-container d-flex flex-column gap-4">
+    <div class="form-field-container d-flex flex-column {{ form.classes }}">
       {% for field in form %}
         <div class="form-group mb-0">
           {# djlint:off #}

--- a/benefits/eligibility/forms.py
+++ b/benefits/eligibility/forms.py
@@ -28,6 +28,7 @@ class EnrollmentFlowSelectionForm(forms.Form):
         super().__init__(*args, **kwargs)
         flows = agency.enrollment_flows.filter(supported_enrollment_methods__contains=models.EnrollmentMethods.DIGITAL)
 
+        self.classes = "gap-4"
         # second element is not used since we render the whole label using selection_label_template,
         # therefore set to None
         flow_field = self.fields["flow"]
@@ -108,6 +109,7 @@ class EligibilityVerificationForm(forms.Form):
         self.title = title
         self.headline = headline
         self.blurb = blurb
+        self.classes = "gap-4"
 
         sub_widget = widgets.FormControlTextInput(placeholder=sub_placeholder)
         if sub_pattern:

--- a/benefits/eligibility/forms.py
+++ b/benefits/eligibility/forms.py
@@ -28,7 +28,6 @@ class EnrollmentFlowSelectionForm(forms.Form):
         super().__init__(*args, **kwargs)
         flows = agency.enrollment_flows.filter(supported_enrollment_methods__contains=models.EnrollmentMethods.DIGITAL)
 
-        self.classes = "gap-4"
         # second element is not used since we render the whole label using selection_label_template,
         # therefore set to None
         flow_field = self.fields["flow"]
@@ -109,7 +108,7 @@ class EligibilityVerificationForm(forms.Form):
         self.title = title
         self.headline = headline
         self.blurb = blurb
-        self.classes = "gap-4"
+        self.classes = "eligibility-verification-form"
 
         sub_widget = widgets.FormControlTextInput(placeholder=sub_placeholder)
         if sub_pattern:

--- a/benefits/in_person/forms.py
+++ b/benefits/in_person/forms.py
@@ -26,7 +26,7 @@ class InPersonEligibilityForm(forms.Form):
         super().__init__(*args, **kwargs)
         flows = agency.enrollment_flows.filter(supported_enrollment_methods__contains=models.EnrollmentMethods.IN_PERSON)
 
-        self.classes = "checkbox-parent"
+        self.classes = "flex-reverse gap-2"
         flow_field = self.fields["flow"]
         verified_field = self.fields["verified"]
 

--- a/benefits/in_person/forms.py
+++ b/benefits/in_person/forms.py
@@ -26,7 +26,7 @@ class InPersonEligibilityForm(forms.Form):
         super().__init__(*args, **kwargs)
         flows = agency.enrollment_flows.filter(supported_enrollment_methods__contains=models.EnrollmentMethods.IN_PERSON)
 
-        self.classes = "flex-reverse gap-4"
+        self.classes = "in-person-eligibility-form"
         flow_field = self.fields["flow"]
         verified_field = self.fields["verified"]
 

--- a/benefits/in_person/forms.py
+++ b/benefits/in_person/forms.py
@@ -26,7 +26,7 @@ class InPersonEligibilityForm(forms.Form):
         super().__init__(*args, **kwargs)
         flows = agency.enrollment_flows.filter(supported_enrollment_methods__contains=models.EnrollmentMethods.IN_PERSON)
 
-        self.classes = "flex-reverse gap-2"
+        self.classes = "flex-reverse gap-4"
         flow_field = self.fields["flow"]
         verified_field = self.fields["verified"]
 

--- a/benefits/static/css/admin/styles.css
+++ b/benefits/static/css/admin/styles.css
@@ -91,7 +91,12 @@ input[type="password"]:focus,
   display: flex;
   flex-direction: row-reverse;
   justify-content: start;
-  column-gap: 0.5rem;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.form-field-container .form-group:has(div):has(label) div {
+  margin-top: 1rem;
 }
 
 /* Enrollment Page*/

--- a/benefits/static/css/admin/styles.css
+++ b/benefits/static/css/admin/styles.css
@@ -85,17 +85,23 @@ input[type="password"]:focus,
   text-transform: unset;
 }
 
-/* Eligibility Page */
+/* Eligibility Page:  In-person Enrollment */
 /* Checkbox form fields should show the checkbox first, then label */
 .form-field-container .form-group:has(input[type="checkbox"]) {
   display: flex;
   flex-direction: row-reverse;
   justify-content: start;
   gap: 0.5rem;
-  margin-top: 1rem;
+  margin-top: 2rem;
 }
 
-.form-field-container .form-group:has(div):has(label) div {
+.form-field-container.in-person-eligibility-form {
+  gap: 1rem;
+}
+
+.form-field-container.in-person-eligibility-form
+  .form-group:has(div):has(label)
+  div {
   margin-top: 1rem;
 }
 

--- a/benefits/static/css/admin/styles.css
+++ b/benefits/static/css/admin/styles.css
@@ -86,20 +86,12 @@ input[type="password"]:focus,
 }
 
 /* Eligibility Page */
-.checkbox-parent .form-group:last-of-type .col-12 {
+/* Checkbox form fields should show the checkbox first, then label */
+.form-field-container .form-group:has(input[type="checkbox"]) {
   display: flex;
   flex-direction: row-reverse;
   justify-content: start;
   column-gap: 0.5rem;
-  margin-top: 2rem;
-}
-
-.checkbox-parent,
-.checkbox-parent .form-group .col-12,
-.checkbox-parent .form-group .col-12 #id_flow {
-  display: flex;
-  flex-direction: column;
-  row-gap: 1rem;
 }
 
 /* Enrollment Page*/

--- a/benefits/static/css/admin/styles.css
+++ b/benefits/static/css/admin/styles.css
@@ -87,7 +87,8 @@ input[type="password"]:focus,
 
 /* Eligibility Page:  In-person Enrollment */
 /* Checkbox form fields should show the checkbox first, then label */
-.form-field-container .form-group:has(input[type="checkbox"]) {
+.form-field-container.in-person-eligibility-form
+  .form-group:has(input[type="checkbox"]) {
   display: flex;
   flex-direction: row-reverse;
   justify-content: start;
@@ -96,6 +97,8 @@ input[type="password"]:focus,
 }
 
 .form-field-container.in-person-eligibility-form {
+  display: flex;
+  flex-direction: column;
   gap: 1rem;
 }
 

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -568,6 +568,12 @@ footer .footer-links li a.footer-link:visited {
   letter-spacing: calc(var(--font-size-14px) * var(--letter-spacing-5));
 }
 
+.form-field-container.eligibility-verification-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
 /* Forms: Radio Buttons */
 
 :root {


### PR DESCRIPTION
fixes #2608 

## What this PR does
- Form class: Passing in a class declares a class on `div.form-field-container`
- CSS refactor: Instead of adding styles on the last field, use `.form-group:has(input[type="checkbox"])` to select any parent div that has a checkbox in it.  
- A11y: Makes an Aria fix

## Code design goals
- It is confusing to have to read both Admin's CSS and Transit User's CSS style pages to figure out what is going on. We want to make it easier for the developer to know what exact form they are working on, and where the styles are coming from.
- I removed all Bootstrap utility classes in `form.html`. The form container now only has: `form-field-container` (which has all of our app style _defaults_), and an optional `{{ form.classes }}` that is delcared from the Python form class per form.
- The convention here is to only pass in 1 class, and the class be named something extremely specific so we don't get confused between Admin vs. Not Admin. For now, I chose: `in-person-eligibility-form` and `eligibility-verification-form` (perhaps the latter could be even more specific to indicate it's for transit users? Very open to better name suggestions!).
- Declare all styles in this class, in the proper styles.css file for whichever app you are on.
- Even though we are passing in form-specific classes, still strive to write code that is as general and agnostic as possible. Try not to rely on helpers like `last-of` or `first` etc. to select your target.

This branch vs. Dev
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/0007b6f3-c73b-40ff-8082-27bf8f1f0075" />
