### PR TITLE
Fix: check out code first in workflow

### DIFF
--- a/.github/workflows/check-metadata.yml
+++ b/.github/workflows/check-metadata.yml
@@ -13,6 +13,9 @@ jobs:
       matrix:
         agency: [mst, sbmtd]
     steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
       - uses: actions/setup-python@v5
         with:
           python-version-file: .github/workflows/.python-version


### PR DESCRIPTION
Getting runtime errors on the job, e.g. https://github.com/cal-itp/benefits/actions/runs/12655445699

Forgot to checkout the code, so the files aren't available to the workflow... Doh!