### PR TITLE
Fix: use `server:main` image

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -35,7 +35,7 @@ services:
       - ./:/calitp/app
 
   server:
-    image: ghcr.io/cal-itp/eligibility-server:dev
+    image: ghcr.io/cal-itp/eligibility-server:main
     env_file: .devcontainer/server/.env.server
     ports:
       - "8000"


### PR DESCRIPTION
The `dev` tag is no longer used as of https://github.com/cal-itp/eligibility-server/pull/414

~The `main` tag is also not being pushed! Need an update in Eligibility Server too.~

The `main` tag is where all new development/features are published, see https://github.com/cal-itp/eligibility-server/pull/519