### PR TITLE
Chore: reformat all templates to 2 spaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ metadata.json
 *.tfbackend
 *.tmp
 *.egg-info
+node_modules/
 static/
 !benefits/static
 benefits/static/sha.txt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,4 +62,5 @@ repos:
   - repo: https://github.com/Riverside-Healthcare/djLint
     rev: v1.36.4
     hooks:
+      - id: djlint-reformat-django
       - id: djlint-django

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,10 @@
 {
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
+  "djlint.useEditorIndentation": false,
   "[django-html][html]": {
     "editor.defaultFormatter": "monosans.djlint",
+    "editor.tabSize": 2,
     "djlint.enableLinting": true,
     "djlint.profile": "django"
   },

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -55,8 +55,16 @@
       <div id="header-container" class="navbar navbar-expand-sm navbar-dark bg-primary justify-content-between">
         <div class="container">
           <span class="navbar-brand p-0">
-            <img class="sm d-lg-none" src="{% static "img/logo-sm.svg" %}" width="90" height="51.3" alt="{% translate "California Integrated Travel Project: Benefits logo (small)" context "image alt text" %}" />
-            <img class="lg d-none d-lg-block" src="{% static "img/logo-lg.svg" %}" width="220" height="50" alt="{% translate "California Integrated Travel Project: Benefits logo (large)" context "image alt text" %}" />
+            <img class="sm d-lg-none"
+                 src="{% static "img/logo-sm.svg" %}"
+                 width="90"
+                 height="51.3"
+                 alt="{% translate "California Integrated Travel Project: Benefits logo (small)" context "image alt text" %}" />
+            <img class="lg d-none d-lg-block"
+                 src="{% static "img/logo-lg.svg" %}"
+                 width="220"
+                 height="50"
+                 alt="{% translate "California Integrated Travel Project: Benefits logo (large)" context "image alt text" %}" />
           </span>
           <div class="form-inline">{% include "core/includes/lang-selector.html" %}</div>
         </div>

--- a/benefits/core/templates/core/includes/agency-links.html
+++ b/benefits/core/templates/core/includes/agency-links.html
@@ -1,9 +1,9 @@
 <p class="h4 mt-4 d-block">{{ agency_name | default:agency.long_name }}</p>
 <ul class="ps-0 d-flex flex-column gap-1 mt-1">
-    <li class="list-unstyled">
-        <a href="tel:{{ phone | default:agency.phone }}">{{ phone | default:agency.phone }}</a>
-    </li>
-    <li class="list-unstyled">
-        <a href="{{ info_url | default:agency.info_url }}" target="_blank" rel="noopener noreferrer">{{ info_url | default:agency.info_url }}</a>
-    </li>
+  <li class="list-unstyled">
+    <a href="tel:{{ phone | default:agency.phone }}">{{ phone | default:agency.phone }}</a>
+  </li>
+  <li class="list-unstyled">
+    <a href="{{ info_url | default:agency.info_url }}" target="_blank" rel="noopener noreferrer">{{ info_url | default:agency.info_url }}</a>
+  </li>
 </ul>

--- a/benefits/core/templates/core/includes/alert-box.html
+++ b/benefits/core/templates/core/includes/alert-box.html
@@ -1,12 +1,12 @@
 {% block alert-wrapper %}
-    <div class="alert-box border-start p-3 text-body {{ alert_class }}">
-        {% block alert-heading-wrapper %}
-            <{{ heading_tag|default:"h3" }} class="alert-box--heading lh-base ls-base mb-1">
-            {% block alert-heading %}
-            {% endblock alert-heading %}
-            </{{ heading_tag|default:"h3" }}>
-        {% endblock alert-heading-wrapper %}
-        {% block alert-body %}
-        {% endblock alert-body %}
-    </div>
+  <div class="alert-box border-start p-3 text-body {{ alert_class }}">
+    {% block alert-heading-wrapper %}
+      <{{ heading_tag|default:"h3" }} class="alert-box--heading lh-base ls-base mb-1">
+      {% block alert-heading %}
+      {% endblock alert-heading %}
+      </{{ heading_tag|default:"h3" }}>
+    {% endblock alert-heading-wrapper %}
+    {% block alert-body %}
+    {% endblock alert-body %}
+  </div>
 {% endblock alert-wrapper %}

--- a/benefits/core/templates/core/includes/eligibility-item.html
+++ b/benefits/core/templates/core/includes/eligibility-item.html
@@ -1,8 +1,8 @@
 <li>
-    <h2 class="h3 pb-1">
-        {% block heading %}
-        {% endblock heading %}
-    </h2>
-    {% block body %}
-    {% endblock body %}
+  <h2 class="h3 pb-1">
+    {% block heading %}
+    {% endblock heading %}
+  </h2>
+  {% block body %}
+  {% endblock body %}
 </li>

--- a/benefits/core/templates/core/includes/help--calfresh.html
+++ b/benefits/core/templates/core/includes/help--calfresh.html
@@ -1,41 +1,41 @@
 {% load i18n %}
 
 <h2 class="h2-sm pt-4 pt-lg-8" id="calfresh-transit-benefit">
-    {% translate "How do I know if I’m eligible for the transit benefit for CalFresh Cardholders?" %}
+  {% translate "How do I know if I’m eligible for the transit benefit for CalFresh Cardholders?" %}
 </h2>
 <p class="pt-2 pt-lg-4">
-    {% blocktranslate trimmed %}
-        We verify your eligibility as a CalFresh Cardholder by confirming you have received funds in your
-        CalFresh account at any point in the last three months. This means you are eligible for a transit
-        benefit even if you did not receive funds in your CalFresh account this month or last month.
-    {% endblocktranslate %}
+  {% blocktranslate trimmed %}
+    We verify your eligibility as a CalFresh Cardholder by confirming you have received funds in your
+    CalFresh account at any point in the last three months. This means you are eligible for a transit
+    benefit even if you did not receive funds in your CalFresh account this month or last month.
+  {% endblocktranslate %}
 </p>
 
 <h2 class="h2-sm pt-4 pt-lg-8" id="calfresh-transit-benefit-no-account-changes">
-    {% translate "Will this transit benefit change my CalFresh account?" %}
+  {% translate "Will this transit benefit change my CalFresh account?" %}
 </h2>
 <p class="pt-2 pt-lg-4">
-    {% blocktranslate trimmed %}
-        No. Your monthly CalFresh allotment will not change.
-    {% endblocktranslate %}
+  {% blocktranslate trimmed %}
+    No. Your monthly CalFresh allotment will not change.
+  {% endblocktranslate %}
 </p>
 
 <h2 class="h2-sm pt-4 pt-lg-8" id="calfresh-transit-benefit-enrollment">
-    {% translate "Do I need my Golden State Advantage card to enroll?" %}
+  {% translate "Do I need my Golden State Advantage card to enroll?" %}
 </h2>
 <p class="pt-2 pt-lg-4">
-    {% blocktranslate trimmed %}
-        No, you do not need your physical EBT card to enroll. We use information from Login.gov and the California
-        Department of Social Services to enroll you in the benefit.
-    {% endblocktranslate %}
+  {% blocktranslate trimmed %}
+    No, you do not need your physical EBT card to enroll. We use information from Login.gov and the California
+    Department of Social Services to enroll you in the benefit.
+  {% endblocktranslate %}
 </p>
 
 <h2 class="h2-sm pt-4 pt-lg-8" id="calfresh-transit-benefit-payment">
-    {% translate "Can I use my Golden State Advantage card to pay for transit rides?" %}
+  {% translate "Can I use my Golden State Advantage card to pay for transit rides?" %}
 </h2>
 <p class="pt-2 pt-lg-4">
-    {% blocktranslate trimmed %}
-        No. You can not use your EBT or P-EBT card to pay for public transportation. When you tap to ride, use your personal
-        contactless debit or credit card to pay for public transportation.
-    {% endblocktranslate %}
+  {% blocktranslate trimmed %}
+    No. You can not use your EBT or P-EBT card to pay for public transportation. When you tap to ride, use your personal
+    contactless debit or credit card to pay for public transportation.
+  {% endblocktranslate %}
 </p>

--- a/benefits/core/templates/core/includes/help--medicare.html
+++ b/benefits/core/templates/core/includes/help--medicare.html
@@ -1,37 +1,37 @@
 {% load i18n %}
 
 <h2 class="h2-sm pt-4 pt-lg-8" id="medicare-transit-benefit">
-    {% translate "How do I know if I qualify for the Medicare Cardholder option?" %}
+  {% translate "How do I know if I qualify for the Medicare Cardholder option?" %}
 </h2>
 <p class="pt-2 pt-lg-4">
-    {% blocktranslate trimmed %}
-        You qualify for this option if you have a Medicare card. To enroll you will need an account with Medicare.gov. You will need to sign up for a Medicare.gov account if you do not currently have one. Deceased Medicare cardholders do not qualify.
-    {% endblocktranslate %}
+  {% blocktranslate trimmed %}
+    You qualify for this option if you have a Medicare card. To enroll you will need an account with Medicare.gov. You will need to sign up for a Medicare.gov account if you do not currently have one. Deceased Medicare cardholders do not qualify.
+  {% endblocktranslate %}
 </p>
 
 <h2 class="h2-sm pt-4 pt-lg-8" id="medicare-transit-benefit-enrollment">
-    {% translate "Do I need my Medicare card to enroll?" %}
+  {% translate "Do I need my Medicare card to enroll?" %}
 </h2>
 <p class="pt-2 pt-lg-4">
-    {% blocktranslate trimmed %}
-        No, you do not need your physical Medicare card to enroll in a transit benefit. You will need the information on your card to create an account at Medicare.gov if you do not currently have an online account.
-    {% endblocktranslate %}
+  {% blocktranslate trimmed %}
+    No, you do not need your physical Medicare card to enroll in a transit benefit. You will need the information on your card to create an account at Medicare.gov if you do not currently have an online account.
+  {% endblocktranslate %}
 </p>
 
 <h2 class="h2-sm pt-4 pt-lg-8" id="medicare-transit-benefit-payment">
-    {% translate "Do I need to bring my Medicare card when I ride public transportation?" %}
+  {% translate "Do I need to bring my Medicare card when I ride public transportation?" %}
 </h2>
 <p class="pt-2 pt-lg-4">
-    {% blocktranslate trimmed %}
-        No, you do not need your physical Medicare card to use your transit benefit on public transportation. Once you have enrolled you can use your contactless debit or credit card to tap to ride with a reduced fare.
-    {% endblocktranslate %}
+  {% blocktranslate trimmed %}
+    No, you do not need your physical Medicare card to use your transit benefit on public transportation. Once you have enrolled you can use your contactless debit or credit card to tap to ride with a reduced fare.
+  {% endblocktranslate %}
 </p>
 
 <h2 class="h2-sm pt-4 pt-lg-8" id="medicare-transit-benefit-recommended">
-    {% translate "What if I qualify for more than one option?" %}
+  {% translate "What if I qualify for more than one option?" %}
 </h2>
 <p class="pt-2 pt-lg-4">
-    {% blocktranslate trimmed %}
+  {% blocktranslate trimmed %}
     You can enroll in any option you qualify for. We recommend enrolling in the Medicare Cardholder option if you qualify for it.
-    {% endblocktranslate %}
+  {% endblocktranslate %}
 </p>

--- a/benefits/core/templates/core/includes/help--sbmtd-mobility-pass.html
+++ b/benefits/core/templates/core/includes/help--sbmtd-mobility-pass.html
@@ -2,7 +2,7 @@
 
 <h2 class="h2-sm pt-4 pt-lg-8" id="mst-courtesy-card">{% translate "What is a Reduced Fare Mobility ID?" %}</h2>
 <p class="pt-2 pt-lg-4">
-    {% blocktranslate trimmed %}
-        The Santa Barbara Metropolitan Transit District issues Reduced Fare Mobility ID cards to eligible riders. This transit benefit may need to be renewed in the future based on the expiration date of the Reduced Fare Mobility ID. Learn more at the <a href="https://sbmtd.gov/fares-passes/" target="_blank" rel="noopener noreferrer">SBMTD Fares & Passes</a>.
-    {% endblocktranslate %}
+  {% blocktranslate trimmed %}
+    The Santa Barbara Metropolitan Transit District issues Reduced Fare Mobility ID cards to eligible riders. This transit benefit may need to be renewed in the future based on the expiration date of the Reduced Fare Mobility ID. Learn more at the <a href="https://sbmtd.gov/fares-passes/" target="_blank" rel="noopener noreferrer">SBMTD Fares & Passes</a>.
+  {% endblocktranslate %}
 </p>

--- a/benefits/core/templates/core/includes/modal--agency-selector.html
+++ b/benefits/core/templates/core/includes/modal--agency-selector.html
@@ -3,28 +3,28 @@
 {% load static %}
 
 {% block modal-content %}
-    <div class="container text-center">
-        <h3 id="{{ aria_labelledby_id }}" class="modal-title h1 p-0 mb-4 pb-lg-2s text-center">
-            {% translate "Please choose your transit provider:" %}
-        </h3>
-        <div class="card-row row d-flex flex-column flex-lg-row text-start text-lg-center justify-content-center">
-            {% for agency in active_agencies %}
-                <a href="{{ agency.eligibility_index_url }}" class="card m-0 d-inline-block">
-                    <div class="card-body d-flex flex-row-reverse flex-lg-column justify-content-center align-items-center">
-                        <img class="sm d-lg-none ms-auto"
-                             src="{{ agency.logo_small_url }}"
-                             width="52"
-                             height="36"
-                             alt="{% blocktranslate with agency=agency.short_name %}{{ agency }} logo{% endblocktranslate %}">
-                        <img class="lg d-none d-lg-block"
-                             src="{{ agency.logo_large_url }}"
-                             width="148"
-                             height="72"
-                             alt="{% blocktranslate with agency=agency.short_name %}{{ agency }} logo{% endblocktranslate %}">
-                        <h4 class="mt-lg-2 mb-0">{{ agency.long_name }}</h4>
-                    </div>
-                </a>
-            {% endfor %}
-        </div>
+  <div class="container text-center">
+    <h3 id="{{ aria_labelledby_id }}" class="modal-title h1 p-0 mb-4 pb-lg-2s text-center">
+      {% translate "Please choose your transit provider:" %}
+    </h3>
+    <div class="card-row row d-flex flex-column flex-lg-row text-start text-lg-center justify-content-center">
+      {% for agency in active_agencies %}
+        <a href="{{ agency.eligibility_index_url }}" class="card m-0 d-inline-block">
+          <div class="card-body d-flex flex-row-reverse flex-lg-column justify-content-center align-items-center">
+            <img class="sm d-lg-none ms-auto"
+                 src="{{ agency.logo_small_url }}"
+                 width="52"
+                 height="36"
+                 alt="{% blocktranslate with agency=agency.short_name %}{{ agency }} logo{% endblocktranslate %}">
+            <img class="lg d-none d-lg-block"
+                 src="{{ agency.logo_large_url }}"
+                 width="148"
+                 height="72"
+                 alt="{% blocktranslate with agency=agency.short_name %}{{ agency }} logo{% endblocktranslate %}">
+            <h4 class="mt-lg-2 mb-0">{{ agency.long_name }}</h4>
+          </div>
+        </a>
+      {% endfor %}
     </div>
+  </div>
 {% endblock modal-content %}

--- a/benefits/core/templates/core/includes/modal.html
+++ b/benefits/core/templates/core/includes/modal.html
@@ -1,16 +1,16 @@
 <!-- Modal -->
 {% with id|add:"-modal-label" as aria_labelledby_id %}
-    <div class="modal fade" id="{{ id }}" tabindex="-1" aria-labelledby="{{ aria_labelledby_id }}" aria-hidden="true">
-        <div class="modal-dialog w-auto h-auto {{ size }} modal-dialog-centered modal-dialog-scrollable">
-            <div class="modal-content">
-                <div class="modal-header border-0 {{ header }}">
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                </div>
-                <div class="modal-body {{ body }}">
-                    {% block modal-content %}
-                    {% endblock modal-content %}
-                </div>
-            </div>
+  <div class="modal fade" id="{{ id }}" tabindex="-1" aria-labelledby="{{ aria_labelledby_id }}" aria-hidden="true">
+    <div class="modal-dialog w-auto h-auto {{ size }} modal-dialog-centered modal-dialog-scrollable">
+      <div class="modal-content">
+        <div class="modal-header border-0 {{ header }}">
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
+        <div class="modal-body {{ body }}">
+          {% block modal-content %}
+          {% endblock modal-content %}
+        </div>
+      </div>
     </div>
+  </div>
 {% endwith %}

--- a/benefits/core/templates/core/index--sbmtd.html
+++ b/benefits/core/templates/core/index--sbmtd.html
@@ -2,5 +2,5 @@
 {% load i18n %}
 
 {% block headline %}
-    {% translate "Get a reduced fare on Santa Barbara MTD buses when you tap to ride" %}
+  {% translate "Get a reduced fare on Santa Barbara MTD buses when you tap to ride" %}
 {% endblock headline %}

--- a/benefits/core/templates/core/widgets/flow-radio-select-option.html
+++ b/benefits/core/templates/core/widgets/flow-radio-select-option.html
@@ -2,11 +2,11 @@
 <input class="radio-input rounded-circle flex-grow-0 flex-shrink-0"
        type="{{ widget.type }}"
        name="{{ widget.name }}"
-       {% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}
+       {% if widget.value != None %}value="{{ widget.value|stringformat:'s' }}"{% endif %}
        {% include "django/forms/widgets/attrs.html" %}>
 
 {% if widget.wrap_label %}
-  <label{% if widget.attrs.id %} for="{{ widget.attrs.id }}" class="radio-label"{% endif %}>
+  <label {% if widget.attrs.id %}for="{{ widget.attrs.id }}" class="radio-label"{% endif %}>
     {% include widget.selection_label_template %}
   </label>
 {% endif %}

--- a/benefits/eligibility/templates/eligibility/includes/eligibility-item--contactless-card--start.html
+++ b/benefits/eligibility/templates/eligibility/includes/eligibility-item--contactless-card--start.html
@@ -2,15 +2,15 @@
 {% load i18n %}
 
 {% block heading %}
-    {% translate "Your contactless card details" %}
+  {% translate "Your contactless card details" %}
 {% endblock heading %}
 
 {% block body %}
-    <p>
-        {% translate "Your contactless card must be a debit or credit card by Visa or Mastercard." %}
-        {% translate "Learn more about contactless cards" as text %}
-        {% include "core/includes/modal-trigger.html" with modal="modal--contactless" text=text period=True %}
-    </p>
+  <p>
+    {% translate "Your contactless card must be a debit or credit card by Visa or Mastercard." %}
+    {% translate "Learn more about contactless cards" as text %}
+    {% include "core/includes/modal-trigger.html" with modal="modal--contactless" text=text period=True %}
+  </p>
 
-    {% include "eligibility/includes/modal--contactless.html" with id="modal--contactless" size="modal-lg" header="p-md-2 p-3" body="pb-md-3 mb-md-3 mx-md-3 py-0 pt-0 absolute-top" %}
+  {% include "eligibility/includes/modal--contactless.html" with id="modal--contactless" size="modal-lg" header="p-md-2 p-3" body="pb-md-3 mb-md-3 mx-md-3 py-0 pt-0 absolute-top" %}
 {% endblock body %}

--- a/benefits/eligibility/templates/eligibility/includes/eligibility-item--identification--start--sbmtd-agency-card.html
+++ b/benefits/eligibility/templates/eligibility/includes/eligibility-item--identification--start--sbmtd-agency-card.html
@@ -3,9 +3,9 @@
 {% load i18n %}
 
 {% block heading %}
-    {% translate "Your current Reduced Fare Mobility ID number" %}
+  {% translate "Your current Reduced Fare Mobility ID number" %}
 {% endblock heading %}
 
 {% block body %}
-    <p>{% translate "You do not need to have your physical card, but you will need to know the number." %}</p>
+  <p>{% translate "You do not need to have your physical card, but you will need to know the number." %}</p>
 {% endblock body %}

--- a/benefits/eligibility/templates/eligibility/includes/modal--calfresh.html
+++ b/benefits/eligibility/templates/eligibility/includes/modal--calfresh.html
@@ -3,40 +3,40 @@
 {% load static %}
 
 {% block modal-content %}
-    <h2 class="me-4 me-md-0">{% translate "Learn more about the transit benefit for CalFresh Cardholders" %}</h2>
-    <div class="row">
-        <h3 class="pt-4">{% translate "How do I know if I’m eligible for the transit benefit for CalFresh Cardholders?" %}</h3>
-        <p class="pt-1">
-            {% blocktranslate trimmed %}
-                We verify your eligibility as a CalFresh Cardholder by confirming you have received funds in your
-                CalFresh account at any point in the last three months. This means you are eligible for a transit
-                benefit even if you did not receive funds in your CalFresh account this month or last month.
-            {% endblocktranslate %}
-        </p>
+  <h2 class="me-4 me-md-0">{% translate "Learn more about the transit benefit for CalFresh Cardholders" %}</h2>
+  <div class="row">
+    <h3 class="pt-4">{% translate "How do I know if I’m eligible for the transit benefit for CalFresh Cardholders?" %}</h3>
+    <p class="pt-1">
+      {% blocktranslate trimmed %}
+        We verify your eligibility as a CalFresh Cardholder by confirming you have received funds in your
+        CalFresh account at any point in the last three months. This means you are eligible for a transit
+        benefit even if you did not receive funds in your CalFresh account this month or last month.
+      {% endblocktranslate %}
+    </p>
 
-        <h3 class="pt-4">{% translate "Will this transit benefit change my CalFresh account?" %}</h3>
-        <p class="pt-1">
-            {% blocktranslate trimmed %}
-                No. Your monthly CalFresh allotment will not change.
-            {% endblocktranslate %}
-        </p>
-        <h3 class="pt-4">{% translate "Do I need my Golden State Advantage card to enroll?" %}</h3>
-        <p class="pt-1">
-            {% blocktranslate trimmed %}
-                No, you do not need your physical EBT card to enroll. We use information from Login.gov and the California
-                Department of Social Services to enroll you in the benefit.
-            {% endblocktranslate %}
-        </p>
-        <h3 class="pt-4">{% translate "Can I use my Golden State Advantage card to pay for transit rides?" %}</h3>
-        <p class="pt-1">
-            {% blocktranslate trimmed %}
-                No. You can not use your EBT or P-EBT card to pay for public transportation. When you tap to ride, use your personal
-                contactless debit or credit card to pay for public transportation.
-            {% endblocktranslate %}
-        </p>
+    <h3 class="pt-4">{% translate "Will this transit benefit change my CalFresh account?" %}</h3>
+    <p class="pt-1">
+      {% blocktranslate trimmed %}
+        No. Your monthly CalFresh allotment will not change.
+      {% endblocktranslate %}
+    </p>
+    <h3 class="pt-4">{% translate "Do I need my Golden State Advantage card to enroll?" %}</h3>
+    <p class="pt-1">
+      {% blocktranslate trimmed %}
+        No, you do not need your physical EBT card to enroll. We use information from Login.gov and the California
+        Department of Social Services to enroll you in the benefit.
+      {% endblocktranslate %}
+    </p>
+    <h3 class="pt-4">{% translate "Can I use my Golden State Advantage card to pay for transit rides?" %}</h3>
+    <p class="pt-1">
+      {% blocktranslate trimmed %}
+        No. You can not use your EBT or P-EBT card to pay for public transportation. When you tap to ride, use your personal
+        contactless debit or credit card to pay for public transportation.
+      {% endblocktranslate %}
+    </p>
 
-        <p class="pt-4 d-block d-sm-none">
-            <a href="#" data-bs-dismiss="modal" aria-label="Close">{% translate "Go back" %}</a>
-        </p>
-    </div>
+    <p class="pt-4 d-block d-sm-none">
+      <a href="#" data-bs-dismiss="modal" aria-label="Close">{% translate "Go back" %}</a>
+    </p>
+  </div>
 {% endblock modal-content %}

--- a/benefits/eligibility/templates/eligibility/includes/modal--login-gov-help.html
+++ b/benefits/eligibility/templates/eligibility/includes/modal--login-gov-help.html
@@ -5,7 +5,11 @@
 {% block modal-content %}
   <h2 class="me-4 me-md-0">
     {% translate "Learn more about" %}
-    <img class="icon" width="197" height="26" src="{% static "img/login-gov-logo.svg" %}" alt="{% translate "Login.gov" context "image alt text" %}" />
+    <img class="icon"
+         width="197"
+         height="26"
+         src="{% static "img/login-gov-logo.svg" %}"
+         alt="{% translate "Login.gov" context "image alt text" %}" />
   </h2>
   <div class="row">
     <h3 class="pt-4">{% translate "What is Login.gov?" %}</h3>

--- a/benefits/eligibility/templates/eligibility/includes/modal--login-gov-start-help.html
+++ b/benefits/eligibility/templates/eligibility/includes/modal--login-gov-start-help.html
@@ -5,7 +5,11 @@
 {% block modal-content %}
   <h2 class="me-4 me-md-0">
     {% translate "Verify your identity with " %}
-    <img class="icon" width="197" height="26" src="{% static "img/login-gov-logo.svg" %}" alt="{% translate "Login.gov" context "image alt text" %}" />
+    <img class="icon"
+         width="197"
+         height="26"
+         src="{% static "img/login-gov-logo.svg" %}"
+         alt="{% translate "Login.gov" context "image alt text" %}" />
   </h2>
   <div class="row">
     <p class="pt-3">

--- a/benefits/eligibility/templates/eligibility/includes/modal--medicare.html
+++ b/benefits/eligibility/templates/eligibility/includes/modal--medicare.html
@@ -3,36 +3,36 @@
 {% load static %}
 
 {% block modal-content %}
-    <h2 class="me-4 me-md-0">{% translate "Learn more about the option for Medicare Cardholders" %}</h2>
-    <div class="row">
-        <h3 class="pt-4">{% translate "How do I know if I qualify for the Medicare Cardholder option?" %}</h3>
-        <p class="pt-1">
-            {% blocktranslate trimmed %}
-                You qualify for this option if you have a Medicare card. To enroll you will need an account with Medicare.gov. You will need to sign up for a Medicare.gov account if you do not currently have one. Deceased Medicare cardholders do not qualify.
-            {% endblocktranslate %}
-        </p>
+  <h2 class="me-4 me-md-0">{% translate "Learn more about the option for Medicare Cardholders" %}</h2>
+  <div class="row">
+    <h3 class="pt-4">{% translate "How do I know if I qualify for the Medicare Cardholder option?" %}</h3>
+    <p class="pt-1">
+      {% blocktranslate trimmed %}
+        You qualify for this option if you have a Medicare card. To enroll you will need an account with Medicare.gov. You will need to sign up for a Medicare.gov account if you do not currently have one. Deceased Medicare cardholders do not qualify.
+      {% endblocktranslate %}
+    </p>
 
-        <h3 class="pt-4">{% translate "Do I need my Medicare card to enroll?" %}</h3>
-        <p class="pt-1">
-            {% blocktranslate trimmed %}
-                No, you do not need your physical Medicare card to enroll in a transit benefit. You will need the information on your card to create an account at Medicare.gov if you do not currently have an online account.
-            {% endblocktranslate %}
-        </p>
-        <h3 class="pt-4">{% translate "Do I need to bring my Medicare card when I ride public transportation?" %}</h3>
-        <p class="pt-1">
-            {% blocktranslate trimmed %}
-                No, you do not need your physical Medicare card to use your transit benefit on public transportation. Once you have enrolled you can use your contactless debit or credit card to tap to ride with a reduced fare.
-            {% endblocktranslate %}
-        </p>
-        <h3 class="pt-4">{% translate "What if I qualify for more than one option?" %}</h3>
-        <p class="pt-1">
-            {% blocktranslate trimmed %}
-                You can enroll in any option you qualify for. We recommend enrolling in the Medicare Cardholder option if you qualify for it.
-            {% endblocktranslate %}
-        </p>
+    <h3 class="pt-4">{% translate "Do I need my Medicare card to enroll?" %}</h3>
+    <p class="pt-1">
+      {% blocktranslate trimmed %}
+        No, you do not need your physical Medicare card to enroll in a transit benefit. You will need the information on your card to create an account at Medicare.gov if you do not currently have an online account.
+      {% endblocktranslate %}
+    </p>
+    <h3 class="pt-4">{% translate "Do I need to bring my Medicare card when I ride public transportation?" %}</h3>
+    <p class="pt-1">
+      {% blocktranslate trimmed %}
+        No, you do not need your physical Medicare card to use your transit benefit on public transportation. Once you have enrolled you can use your contactless debit or credit card to tap to ride with a reduced fare.
+      {% endblocktranslate %}
+    </p>
+    <h3 class="pt-4">{% translate "What if I qualify for more than one option?" %}</h3>
+    <p class="pt-1">
+      {% blocktranslate trimmed %}
+        You can enroll in any option you qualify for. We recommend enrolling in the Medicare Cardholder option if you qualify for it.
+      {% endblocktranslate %}
+    </p>
 
-        <p class="pt-4 d-block d-sm-none">
-            <a href="#" data-bs-dismiss="modal" aria-label="Close">{% translate "Go back" %}</a>
-        </p>
-    </div>
+    <p class="pt-4 d-block d-sm-none">
+      <a href="#" data-bs-dismiss="modal" aria-label="Close">{% translate "Go back" %}</a>
+    </p>
+  </div>
 {% endblock modal-content %}

--- a/benefits/eligibility/templates/eligibility/includes/selection-label--calfresh.html
+++ b/benefits/eligibility/templates/eligibility/includes/selection-label--calfresh.html
@@ -2,17 +2,17 @@
 {% load i18n %}
 
 {% block label %}
-    {% translate "CalFresh Cardholder" %}
+  {% translate "CalFresh Cardholder" %}
 {% endblock label %}
 
 {% block description %}
-    {% translate "You must have" %}
-    {% translate "recently received CalFresh funds" as calfresh_modal_link %}
-    {% include "core/includes/modal-trigger.html" with modal="modal--calfresh" text=calfresh_modal_link period=True %}
-    {% include "eligibility/includes/modal--calfresh.html" with id="modal--calfresh" size="modal-lg" header="p-md-2 p-3" body="pb-md-3 mb-md-3 mx-md-3 py-0 pt-0 absolute-top" %}
+  {% translate "You must have" %}
+  {% translate "recently received CalFresh funds" as calfresh_modal_link %}
+  {% include "core/includes/modal-trigger.html" with modal="modal--calfresh" text=calfresh_modal_link period=True %}
+  {% include "eligibility/includes/modal--calfresh.html" with id="modal--calfresh" size="modal-lg" header="p-md-2 p-3" body="pb-md-3 mb-md-3 mx-md-3 py-0 pt-0 absolute-top" %}
 
-    {% translate "This transit benefit will remain active for one year. You will need to verify your identity with" %}
-    {% include "core/includes/modal-trigger.html" with classes="border-0 bg-transparent p-0 login" modal="modal--login-gov-veteran" login=True period=True %}
-    {% include "eligibility/includes/modal--login-gov-help.html" with id="modal--login-gov-calfresh" size="modal-lg" header="p-md-2 p-3" body="pb-md-3 mb-md-3 mx-md-3 py-0 pt-0 absolute-top" %}
+  {% translate "This transit benefit will remain active for one year. You will need to verify your identity with" %}
+  {% include "core/includes/modal-trigger.html" with classes="border-0 bg-transparent p-0 login" modal="modal--login-gov-veteran" login=True period=True %}
+  {% include "eligibility/includes/modal--login-gov-help.html" with id="modal--login-gov-calfresh" size="modal-lg" header="p-md-2 p-3" body="pb-md-3 mb-md-3 mx-md-3 py-0 pt-0 absolute-top" %}
 
 {% endblock description %}

--- a/benefits/eligibility/templates/eligibility/includes/selection-label--cst-agency-card.html
+++ b/benefits/eligibility/templates/eligibility/includes/selection-label--cst-agency-card.html
@@ -2,9 +2,9 @@
 {% load i18n %}
 
 {% block label %}
-    {% translate "Agency Cardholder" %}
+  {% translate "Agency Cardholder" %}
 {% endblock label %}
 
 {% block description %}
-    {% translate "This option is for people who have a current CST Agency Card or a CST Paratransit Eligibility Card." %}
+  {% translate "This option is for people who have a current CST Agency Card or a CST Paratransit Eligibility Card." %}
 {% endblock description %}

--- a/benefits/eligibility/templates/eligibility/includes/selection-label--medicare.html
+++ b/benefits/eligibility/templates/eligibility/includes/selection-label--medicare.html
@@ -2,12 +2,12 @@
 {% load i18n %}
 
 {% block label %}
-    {% translate "Medicare Cardholder" %}
+  {% translate "Medicare Cardholder" %}
 {% endblock label %}
 
 {% block description %}
-    {% translate "You must be" %}
-    {% translate "currently enrolled in Medicare" as medicare_modal_link %}
-    {% include "core/includes/modal-trigger.html" with modal="modal--medicare" text=medicare_modal_link period=True %}
-    {% include "eligibility/includes/modal--medicare.html" with id="modal--medicare" size="modal-lg" header="p-md-2 p-3" body="pb-md-3 mb-md-3 mx-md-3 py-0 pt-0 absolute-top" %}
+  {% translate "You must be" %}
+  {% translate "currently enrolled in Medicare" as medicare_modal_link %}
+  {% include "core/includes/modal-trigger.html" with modal="modal--medicare" text=medicare_modal_link period=True %}
+  {% include "eligibility/includes/modal--medicare.html" with id="modal--medicare" size="modal-lg" header="p-md-2 p-3" body="pb-md-3 mb-md-3 mx-md-3 py-0 pt-0 absolute-top" %}
 {% endblock description %}

--- a/benefits/eligibility/templates/eligibility/includes/selection-label--mst-agency-card.html
+++ b/benefits/eligibility/templates/eligibility/includes/selection-label--mst-agency-card.html
@@ -2,9 +2,9 @@
 {% load i18n %}
 
 {% block label %}
-    {% translate "Courtesy Card" %}
+  {% translate "Courtesy Card" %}
 {% endblock label %}
 
 {% block description %}
-    {% translate "This option is for people who have a current MST Courtesy Card or an MST RIDES eligibility card." %}
+  {% translate "This option is for people who have a current MST Courtesy Card or an MST RIDES eligibility card." %}
 {% endblock description %}

--- a/benefits/eligibility/templates/eligibility/includes/selection-label--sbmtd-agency-card.html
+++ b/benefits/eligibility/templates/eligibility/includes/selection-label--sbmtd-agency-card.html
@@ -2,9 +2,9 @@
 {% load i18n %}
 
 {% block label %}
-    {% translate "Reduced Fare Mobility ID" %}
+  {% translate "Reduced Fare Mobility ID" %}
 {% endblock label %}
 
 {% block description %}
-    {% translate "This option is for people who have a current SBMTD Reduced Fare Mobility ID, which used to be called a Mobility Pass. " %}
+  {% translate "This option is for people who have a current SBMTD Reduced Fare Mobility ID, which used to be called a Mobility Pass. " %}
 {% endblock description %}

--- a/benefits/eligibility/templates/eligibility/includes/selection-label.html
+++ b/benefits/eligibility/templates/eligibility/includes/selection-label.html
@@ -1,8 +1,8 @@
 <span class="d-block h3">
-    {% block label %}
-    {% endblock label %}
+  {% block label %}
+  {% endblock label %}
 </span>
 <span class="d-block pt-1">
-    {% block description %}
-    {% endblock description %}
+  {% block description %}
+  {% endblock description %}
 </span>

--- a/benefits/eligibility/templates/eligibility/index--sbmtd.html
+++ b/benefits/eligibility/templates/eligibility/index--sbmtd.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block form-text %}
-    <p class="pt-4 pb-4">
-        {% translate "Cal-ITP doesn’t save any of your information. All SBMTD transit benefits reduce fares by 50% for bus service on fixed routes." %}
-    </p>
+  <p class="pt-4 pb-4">
+    {% translate "Cal-ITP doesn’t save any of your information. All SBMTD transit benefits reduce fares by 50% for bus service on fixed routes." %}
+  </p>
 {% endblock form-text %}

--- a/benefits/eligibility/templates/eligibility/start--medicare.html
+++ b/benefits/eligibility/templates/eligibility/start--medicare.html
@@ -2,17 +2,17 @@
 {% load i18n %}
 
 {% block page-title %}
-    {% translate "Medicare benefit overview" %}
+  {% translate "Medicare benefit overview" %}
 {% endblock page-title %}
 
 {% block headline-text %}
-    {% translate "You selected a Medicare Cardholder transit benefit." %}
+  {% translate "You selected a Medicare Cardholder transit benefit." %}
 {% endblock headline-text %}
 
 {% block eligibility-item %}
-    {% include "eligibility/includes/eligibility-item--identification--start--medicare.html" %}
+  {% include "eligibility/includes/eligibility-item--identification--start--medicare.html" %}
 {% endblock eligibility-item %}
 
 {% block call-to-action-button %}
-    <a href="{% url routes.OAUTH_LOGIN %}" class="btn btn-lg btn-primary" role="button">{% translate "Continue to Medicare.gov" %}</a>
+  <a href="{% url routes.OAUTH_LOGIN %}" class="btn btn-lg btn-primary" role="button">{% translate "Continue to Medicare.gov" %}</a>
 {% endblock call-to-action-button %}

--- a/benefits/eligibility/templates/eligibility/start--sbmtd-agency-card.html
+++ b/benefits/eligibility/templates/eligibility/start--sbmtd-agency-card.html
@@ -2,17 +2,17 @@
 {% load i18n %}
 
 {% block page-title %}
-    {% translate "Agency card overview" %}
+  {% translate "Agency card overview" %}
 {% endblock page-title %}
 
 {% block headline-text %}
-    {% translate "You selected a Reduced Fare Mobility ID transit benefit." %}
+  {% translate "You selected a Reduced Fare Mobility ID transit benefit." %}
 {% endblock headline-text %}
 
 {% block eligibility-item %}
-    {% include "eligibility/includes/eligibility-item--identification--start--sbmtd-agency-card.html" %}
+  {% include "eligibility/includes/eligibility-item--identification--start--sbmtd-agency-card.html" %}
 {% endblock eligibility-item %}
 
 {% block call-to-action-button %}
-    <a href="{% url routes.ELIGIBILITY_CONFIRM %}" class="btn btn-lg btn-primary" role="button">{% translate "Continue" %}</a>
+  <a href="{% url routes.ELIGIBILITY_CONFIRM %}" class="btn btn-lg btn-primary" role="button">{% translate "Continue" %}</a>
 {% endblock call-to-action-button %}

--- a/benefits/eligibility/templates/eligibility/unverified--cst-agency-card.html
+++ b/benefits/eligibility/templates/eligibility/unverified--cst-agency-card.html
@@ -2,5 +2,5 @@
 {% load i18n %}
 
 {% block unverified-body %}
-    {% translate "The number and last name must be entered exactly as they appear on your CST Agency Card. Please check your card and try again, or contact your transit agency for help." %}
+  {% translate "The number and last name must be entered exactly as they appear on your CST Agency Card. Please check your card and try again, or contact your transit agency for help." %}
 {% endblock unverified-body %}

--- a/benefits/eligibility/templates/eligibility/unverified--mst-agency-card.html
+++ b/benefits/eligibility/templates/eligibility/unverified--mst-agency-card.html
@@ -2,5 +2,5 @@
 {% load i18n %}
 
 {% block unverified-body %}
-    {% translate "The number and last name must be entered exactly as they appear on your MST Courtesy Card. Please check your card and try again, or contact your transit agency for help." %}
+  {% translate "The number and last name must be entered exactly as they appear on your MST Courtesy Card. Please check your card and try again, or contact your transit agency for help." %}
 {% endblock unverified-body %}

--- a/benefits/eligibility/templates/eligibility/unverified--sbmtd-agency-card.html
+++ b/benefits/eligibility/templates/eligibility/unverified--sbmtd-agency-card.html
@@ -2,5 +2,5 @@
 {% load i18n %}
 
 {% block unverified-body %}
-    {% translate "The number and last name must be entered exactly as they appear on your SBMTD Reduced Fare Mobility ID card. Please check your card and try again, or contact your transit agency for help." %}
+  {% translate "The number and last name must be entered exactly as they appear on your SBMTD Reduced Fare Mobility ID card. Please check your card and try again, or contact your transit agency for help." %}
 {% endblock unverified-body %}

--- a/benefits/enrollment/templates/enrollment/includes/alert-box--warning--calfresh.html
+++ b/benefits/enrollment/templates/enrollment/includes/alert-box--warning--calfresh.html
@@ -2,18 +2,18 @@
 {% load i18n %}
 
 {% block alert-wrapper %}
-    {% with alert_class="alert-box--warning" %}{{ block.super }}{% endwith %}
+  {% with alert_class="alert-box--warning" %}{{ block.super }}{% endwith %}
 {% endblock alert-wrapper %}
 
 {% block alert-heading %}
-    {% translate "Do not enter information from your EBT card." %}
+  {% translate "Do not enter information from your EBT card." %}
 {% endblock alert-heading %}
 
 {% block alert-body %}
-    {% translate "Read our guidance on the CalFresh benefit" as calfresh_modal_link %}
-    <p>
-        {% translate "You can’t pay for transit using the CalFresh funds on your Golden State Advantage card. Please provide details from your contactless debit or credit card issued by Visa or Mastercard and use that card to pay for transit." %}
-        {% include "core/includes/modal-trigger.html" with modal="modal--calfresh" text=calfresh_modal_link period=True %}
-    </p>
-    {% include "eligibility/includes/modal--calfresh.html" with id="modal--calfresh" size="modal-lg" header="p-md-2 p-3" body="pb-md-3 mb-md-3 mx-md-3 py-0 pt-0 absolute-top" %}
+  {% translate "Read our guidance on the CalFresh benefit" as calfresh_modal_link %}
+  <p>
+    {% translate "You can’t pay for transit using the CalFresh funds on your Golden State Advantage card. Please provide details from your contactless debit or credit card issued by Visa or Mastercard and use that card to pay for transit." %}
+    {% include "core/includes/modal-trigger.html" with modal="modal--calfresh" text=calfresh_modal_link period=True %}
+  </p>
+  {% include "eligibility/includes/modal--calfresh.html" with id="modal--calfresh" size="modal-lg" header="p-md-2 p-3" body="pb-md-3 mb-md-3 mx-md-3 py-0 pt-0 absolute-top" %}
 {% endblock alert-body %}

--- a/benefits/enrollment/templates/enrollment/reenrollment-error--calfresh.html
+++ b/benefits/enrollment/templates/enrollment/reenrollment-error--calfresh.html
@@ -2,9 +2,9 @@
 {% load i18n %}
 
 {% block paragraphs %}
-    <p>
-        {% translate "Your CalFresh Cardholder transit benefit does not expire until" %} {{ enrollment.expires|date }}.
-        {% translate "You can re-enroll for this benefit beginning on" %} {{ enrollment.reenrollment|date }}.
-        {% translate "Please try again then." %}
-    </p>
+  <p>
+    {% translate "Your CalFresh Cardholder transit benefit does not expire until" %} {{ enrollment.expires|date }}.
+    {% translate "You can re-enroll for this benefit beginning on" %} {{ enrollment.reenrollment|date }}.
+    {% translate "Please try again then." %}
+  </p>
 {% endblock paragraphs %}

--- a/benefits/enrollment/templates/enrollment/success--sbmtd-agency-card.html
+++ b/benefits/enrollment/templates/enrollment/success--sbmtd-agency-card.html
@@ -2,14 +2,14 @@
 {% load i18n %}
 
 {% block success-message %}
-    {% blocktranslate trimmed %}
-        Your contactless card is now enrolled in an SBMTD Reduced Fare Mobility ID transit benefit. When boarding an SBMTD bus, tap this card and you will be
-        charged a reduced fare. You will need to re-enroll if you choose to change the card you use to pay for transit service.
-    {% endblocktranslate %}
+  {% blocktranslate trimmed %}
+    Your contactless card is now enrolled in an SBMTD Reduced Fare Mobility ID transit benefit. When boarding an SBMTD bus, tap this card and you will be
+    charged a reduced fare. You will need to re-enroll if you choose to change the card you use to pay for transit service.
+  {% endblocktranslate %}
 {% endblock success-message %}
 
 {% block thank-you-message %}
-    {% blocktranslate trimmed %}
-        You were not charged anything today. Thank you for using Cal-ITP Benefits!
-    {% endblocktranslate %}
+  {% blocktranslate trimmed %}
+    You were not charged anything today. Thank you for using Cal-ITP Benefits!
+  {% endblocktranslate %}
 {% endblock thank-you-message %}

--- a/benefits/enrollment/templates/enrollment/success--sbmtd.html
+++ b/benefits/enrollment/templates/enrollment/success--sbmtd.html
@@ -2,8 +2,8 @@
 {% load i18n %}
 
 {% block success-message %}
-    {% blocktranslate trimmed %}
-        You were not charged anything today. When boarding an SBMTD bus, tap this card and you will be
-        charged a reduced fare. You will need to re-enroll if you choose to change the card you use to pay for transit service.
-    {% endblocktranslate %}
+  {% blocktranslate trimmed %}
+    You were not charged anything today. When boarding an SBMTD bus, tap this card and you will be
+    charged a reduced fare. You will need to re-enroll if you choose to change the card you use to pay for transit service.
+  {% endblocktranslate %}
 {% endblock success-message %}

--- a/benefits/in_person/templates/error-base.html
+++ b/benefits/in_person/templates/error-base.html
@@ -2,28 +2,28 @@
 {% load static %}
 
 {% block title %}
-    {{ title }}
+  {{ title }}
 {% endblock title %}
 
 {% block content %}
-    <div class="row justify-content-center">
-        <div class="col-lg-6">
-            <div class="border border-3 p-3">
-                <h2 class="p-0 m-0 text-start">In-person enrollment</h2>
-            </div>
-            <div class="border border-3 border-top-0 p-3 min-vh-60 d-flex flex-column justify-content-between">
-                <div class="d-flex">
-                    <i class="error-icon"></i>
-                    <div class="mt-lg-3">
-                        {% block error-message %}
-                        {% endblock error-message %}
-                    </div>
-                </div>
-                <div class="row">
-                    {% block cta-buttons %}
-                    {% endblock cta-buttons %}
-                </div>
-            </div>
+  <div class="row justify-content-center">
+    <div class="col-lg-6">
+      <div class="border border-3 p-3">
+        <h2 class="p-0 m-0 text-start">In-person enrollment</h2>
+      </div>
+      <div class="border border-3 border-top-0 p-3 min-vh-60 d-flex flex-column justify-content-between">
+        <div class="d-flex">
+          <i class="error-icon"></i>
+          <div class="mt-lg-3">
+            {% block error-message %}
+            {% endblock error-message %}
+          </div>
         </div>
+        <div class="row">
+          {% block cta-buttons %}
+          {% endblock cta-buttons %}
+        </div>
+      </div>
     </div>
+  </div>
 {% endblock content %}

--- a/benefits/in_person/templates/in_person/eligibility.html
+++ b/benefits/in_person/templates/in_person/eligibility.html
@@ -1,30 +1,30 @@
 {% extends "admin/agency-base.html" %}
 
 {% block title %}
-    {{ title }}
+  {{ title }}
 {% endblock title %}
 
 {% block content %}
-    <div class="row justify-content-center">
-        <div class="col-11 col-md-10 col-lg-6 border border-3 px-0">
-            <div class="border border-3 border-top-0 border-start-0 border-end-0">
-                <h2 class="p-3 m-0 text-start">In-person enrollment</h2>
-            </div>
-            <div class="p-3">{% include "core/includes/form.html" with form=form %}</div>
-            <div class="row d-flex justify-content-start p-3 pt-8">
-                <div class="col-6">
-                    {% url form.cancel_url as url_cancel %}
-                    <a href="{{ url_cancel }}" class="btn btn-lg btn-outline-primary d-block">Cancel</a>
-                </div>
-                <div class="col-6">
-                    <button class="btn btn-lg btn-primary d-flex justify-content-center align-items-center"
-                            data-action="submit"
-                            type="submit"
-                            form="{{ form.id }}">
-                        <span class="btn-text">Continue</span>
-                    </button>
-                </div>
-            </div>
+  <div class="row justify-content-center">
+    <div class="col-11 col-md-10 col-lg-6 border border-3 px-0">
+      <div class="border border-3 border-top-0 border-start-0 border-end-0">
+        <h2 class="p-3 m-0 text-start">In-person enrollment</h2>
+      </div>
+      <div class="p-3">{% include "core/includes/form.html" with form=form %}</div>
+      <div class="row d-flex justify-content-start p-3 pt-8">
+        <div class="col-6">
+          {% url form.cancel_url as url_cancel %}
+          <a href="{{ url_cancel }}" class="btn btn-lg btn-outline-primary d-block">Cancel</a>
         </div>
+        <div class="col-6">
+          <button class="btn btn-lg btn-primary d-flex justify-content-center align-items-center"
+                  data-action="submit"
+                  type="submit"
+                  form="{{ form.id }}">
+            <span class="btn-text">Continue</span>
+          </button>
+        </div>
+      </div>
     </div>
+  </div>
 {% endblock content %}

--- a/benefits/in_person/templates/in_person/enrollment/index.html
+++ b/benefits/in_person/templates/in_person/enrollment/index.html
@@ -1,46 +1,46 @@
 {% extends "admin/agency-base.html" %}
 
 {% block title %}
-    {{ title }}
+  {{ title }}
 {% endblock title %}
 
 {% block content %}
 
-    <div class="row justify-content-center">
-        <div class="col-lg-6">
-            <div class="border border-3 p-3">
-                <h2 class="p-0 m-0 text-start">In-person enrollment</h2>
-            </div>
-            <div class="border border-3 border-top-0 p-3">
-                <div class="loading">
-                    <p>
-                        <span class="spinner-border align-middle text-primary" role="status"></span>
-                        <span id="loading-message" class="fw-bold p-2">Please wait...</span>
-                    </p>
-                </div>
-                <div class="invisible">
-                    <p>Provide the rider's contactless debit or credit card details.</p>
-                    <iframe class="card-collection" name="card-collection-iframe"></iframe>
-                </div>
-                <div class="row d-flex justify-content-start p-3 pt-8">
-                    <div class="col-12">
-                        {% url routes.ADMIN_INDEX as url_cancel %}
-                        <a href="{{ url_cancel }}" class="btn btn-lg btn-outline-primary d-block">Cancel</a>
-                    </div>
-                </div>
-            </div>
+  <div class="row justify-content-center">
+    <div class="col-lg-6">
+      <div class="border border-3 p-3">
+        <h2 class="p-0 m-0 text-start">In-person enrollment</h2>
+      </div>
+      <div class="border border-3 border-top-0 p-3">
+        <div class="loading">
+          <p>
+            <span class="spinner-border align-middle text-primary" role="status"></span>
+            <span id="loading-message" class="fw-bold p-2">Please wait...</span>
+          </p>
         </div>
+        <div class="invisible">
+          <p>Provide the rider's contactless debit or credit card details.</p>
+          <iframe class="card-collection" name="card-collection-iframe"></iframe>
+        </div>
+        <div class="row d-flex justify-content-start p-3 pt-8">
+          <div class="col-12">
+            {% url routes.ADMIN_INDEX as url_cancel %}
+            <a href="{{ url_cancel }}" class="btn btn-lg btn-outline-primary d-block">Cancel</a>
+          </div>
+        </div>
+      </div>
     </div>
+  </div>
 
-    <!--
+  <!--
         This hidden button is needed by the card tokenisation function's `element` option.
         The iframe's source isn't set until the button is clicked.
     -->
-    <div class="d-none">
-        <button id="{{ cta_button }}" href="#{{ cta_button }}" class="btn btn-lg btn-primary" role="button">Enroll</button>
-    </div>
+  <div class="d-none">
+    <button id="{{ cta_button }}" href="#{{ cta_button }}" class="btn btn-lg btn-primary" role="button">Enroll</button>
+  </div>
 
-    <script nonce="{{ request.csp_nonce }}">
+  <script nonce="{{ request.csp_nonce }}">
         var startedEvent = "started card tokenization", closedEvent = "finished card tokenization";
 
         $.ajax({ dataType: "script", attrs: { nonce: "{{ request.csp_nonce }}"}, url: "{{ card_tokenize_url }}" })
@@ -131,10 +131,10 @@
           console.log(exception);
         });
 
-    </script>
+  </script>
 
-    {% for f in forms %}
-        {% include "core/includes/form.html" with form=f %}
-    {% endfor %}
+  {% for f in forms %}
+    {% include "core/includes/form.html" with form=f %}
+  {% endfor %}
 
 {% endblock content %}

--- a/benefits/in_person/templates/in_person/enrollment/reenrollment_error.html
+++ b/benefits/in_person/templates/in_person/enrollment/reenrollment_error.html
@@ -1,16 +1,16 @@
 {% extends "error-base.html" %}
 
 {% block error-message %}
-    <h3 class="fw-bold h4">This person is still enrolled in the {{ flow_label }} benefit.</h3>
+  <h3 class="fw-bold h4">This person is still enrolled in the {{ flow_label }} benefit.</h3>
 
-    <p class="my-4">
-        <span class="fw-bold">This rider will enjoy a transit benefit until {{ enrollment.expires|date }}.</span> They can re-enroll for this benefit beginning on {{ enrollment.reenrollment|date }}. Please try again then.
-    </p>
+  <p class="my-4">
+    <span class="fw-bold">This rider will enjoy a transit benefit until {{ enrollment.expires|date }}.</span> They can re-enroll for this benefit beginning on {{ enrollment.reenrollment|date }}. Please try again then.
+  </p>
 {% endblock error-message %}
 
 {% block cta-buttons %}
-    <div class="col-12">
-        {% url routes.ADMIN_INDEX as url_return_to_dashboard %}
-        <a href="{{ url_return_to_dashboard }}" class="btn btn-lg btn-primary d-block">Return to dashboard</a>
-    </div>
+  <div class="col-12">
+    {% url routes.ADMIN_INDEX as url_return_to_dashboard %}
+    <a href="{{ url_return_to_dashboard }}" class="btn btn-lg btn-primary d-block">Return to dashboard</a>
+  </div>
 {% endblock cta-buttons %}

--- a/benefits/in_person/templates/in_person/enrollment/retry.html
+++ b/benefits/in_person/templates/in_person/enrollment/retry.html
@@ -1,20 +1,20 @@
 {% extends "error-base.html" %}
 
 {% block error-message %}
-    <h3 class="fw-bold h4">Card not found.</h3>
+  <h3 class="fw-bold h4">Card not found.</h3>
 
-    <p class="my-4">
-        The card information may not have been entered correctly. Please check the details on your card and try again.
-    </p>
+  <p class="my-4">
+    The card information may not have been entered correctly. Please check the details on your card and try again.
+  </p>
 {% endblock error-message %}
 
 {% block cta-buttons %}
-    <div class="col-6">
-        {% url routes.ADMIN_INDEX as url_cancel %}
-        <a href="{{ url_cancel }}" class="btn btn-lg btn-outline-primary d-block">Cancel</a>
-    </div>
-    <div class="col-6">
-        {% url routes.IN_PERSON_ENROLLMENT as url_try_again %}
-        <a href="{{ url_try_again }}" class="btn btn-lg btn-primary d-block">Try again</a>
-    </div>
+  <div class="col-6">
+    {% url routes.ADMIN_INDEX as url_cancel %}
+    <a href="{{ url_cancel }}" class="btn btn-lg btn-outline-primary d-block">Cancel</a>
+  </div>
+  <div class="col-6">
+    {% url routes.IN_PERSON_ENROLLMENT as url_try_again %}
+    <a href="{{ url_try_again }}" class="btn btn-lg btn-primary d-block">Try again</a>
+  </div>
 {% endblock cta-buttons %}

--- a/benefits/in_person/templates/in_person/enrollment/server_error.html
+++ b/benefits/in_person/templates/in_person/enrollment/server_error.html
@@ -1,16 +1,16 @@
 {% extends "error-base.html" %}
 
 {% block error-message %}
-    <h3 class="fw-bold h4">We're working to fix a problem.</h3>
+  <h3 class="fw-bold h4">We're working to fix a problem.</h3>
 
-    <p class="my-4">
-        There is a problem with the application configuration, but we're working to fix it. Please try again in a little while.
-    </p>
+  <p class="my-4">
+    There is a problem with the application configuration, but we're working to fix it. Please try again in a little while.
+  </p>
 {% endblock error-message %}
 
 {% block cta-buttons %}
-    <div class="col-12">
-        {% url routes.ADMIN_INDEX as url_return_to_dashboard %}
-        <a href="{{ url_return_to_dashboard }}" class="btn btn-lg btn-primary d-block">Return to dashboard</a>
-    </div>
+  <div class="col-12">
+    {% url routes.ADMIN_INDEX as url_return_to_dashboard %}
+    <a href="{{ url_return_to_dashboard }}" class="btn btn-lg btn-primary d-block">Return to dashboard</a>
+  </div>
 {% endblock cta-buttons %}

--- a/benefits/in_person/templates/in_person/enrollment/success.html
+++ b/benefits/in_person/templates/in_person/enrollment/success.html
@@ -2,39 +2,39 @@
 {% load static %}
 
 {% block title %}
-    {{ title }}
+  {{ title }}
 {% endblock title %}
 
 {% block content %}
-    <div class="row justify-content-center">
-        <div class="col-lg-6">
-            <div class="border border-3 p-3">
-                <h2 class="p-0 m-0 text-start">In-person enrollment</h2>
-            </div>
-            <div class="border border-3 border-top-0 p-3 min-vh-60 d-flex flex-column justify-content-between">
-                <div class="d-flex">
-                    <i class="success-icon"></i>
-                    <div>
-                        <p>Success! This rider can now use their contactless card to automatically receive a reduced fare when they tap-to-ride.</p>
+  <div class="row justify-content-center">
+    <div class="col-lg-6">
+      <div class="border border-3 p-3">
+        <h2 class="p-0 m-0 text-start">In-person enrollment</h2>
+      </div>
+      <div class="border border-3 border-top-0 p-3 min-vh-60 d-flex flex-column justify-content-between">
+        <div class="d-flex">
+          <i class="success-icon"></i>
+          <div>
+            <p>Success! This rider can now use their contactless card to automatically receive a reduced fare when they tap-to-ride.</p>
 
-                        {% if enrollment.supports_expiration %}
-                            <p>
-                                <span class="fw-bold my-3">This rider will enjoy a transit benefit until {{ enrollment.expires|date }}.</span> They will need to enroll again at that time to continue receiving reduced fares.
-                            </p>
-                        {% endif %}
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col-6">
-                        {% url routes.IN_PERSON_ELIGIBILITY as url_eligibility %}
-                        <a href="{{ url_eligibility }}" class="btn btn-lg btn-outline-primary d-block">New enrollment</a>
-                    </div>
-                    <div class="col-6">
-                        {% url routes.ADMIN_INDEX as url_done %}
-                        <a href="{{ url_done }}" class="btn btn-lg btn-primary d-block">Done</a>
-                    </div>
-                </div>
-            </div>
+            {% if enrollment.supports_expiration %}
+              <p>
+                <span class="fw-bold my-3">This rider will enjoy a transit benefit until {{ enrollment.expires|date }}.</span> They will need to enroll again at that time to continue receiving reduced fares.
+              </p>
+            {% endif %}
+          </div>
         </div>
+        <div class="row">
+          <div class="col-6">
+            {% url routes.IN_PERSON_ELIGIBILITY as url_eligibility %}
+            <a href="{{ url_eligibility }}" class="btn btn-lg btn-outline-primary d-block">New enrollment</a>
+          </div>
+          <div class="col-6">
+            {% url routes.ADMIN_INDEX as url_done %}
+            <a href="{{ url_done }}" class="btn btn-lg btn-primary d-block">Done</a>
+          </div>
+        </div>
+      </div>
     </div>
+  </div>
 {% endblock content %}

--- a/benefits/in_person/templates/in_person/enrollment/system_error.html
+++ b/benefits/in_person/templates/in_person/enrollment/system_error.html
@@ -1,14 +1,14 @@
 {% extends "error-base.html" %}
 
 {% block error-message %}
-    <h3 class="fw-bold h4">The enrollment system isn't working right now.</h3>
+  <h3 class="fw-bold h4">The enrollment system isn't working right now.</h3>
 
-    <p class="my-4">Please wait 24 hours and try to enroll again.</p>
+  <p class="my-4">Please wait 24 hours and try to enroll again.</p>
 {% endblock error-message %}
 
 {% block cta-buttons %}
-    <div class="col-12">
-        {% url routes.ADMIN_INDEX as url_return_to_dashboard %}
-        <a href="{{ url_return_to_dashboard }}" class="btn btn-lg btn-primary d-block">Return to dashboard</a>
-    </div>
+  <div class="col-12">
+    {% url routes.ADMIN_INDEX as url_return_to_dashboard %}
+    <a href="{{ url_return_to_dashboard }}" class="btn btn-lg btn-primary d-block">Return to dashboard</a>
+  </div>
 {% endblock cta-buttons %}

--- a/benefits/templates/admin/agency-base.html
+++ b/benefits/templates/admin/agency-base.html
@@ -5,38 +5,46 @@
 {% endblock dark-mode-vars %}
 
 {% block extrastyle %}
-    {% include "admin/includes/favicon.html" %}
-    <script nonce="{{ request.csp_nonce }}"
-            src="https://cdn.jsdelivr.net/npm/jquery@3.6.1/dist/jquery.min.js"
-            integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ="
-            crossorigin="anonymous"></script>
-    {% include "core/includes/bootstrap-css.html" %}
-    {% include "admin/includes/style-admin.html" %}
-    {% include "core/includes/analytics.html" with api_key=analytics.api_key uid=analytics.uid did=analytics.did %}
+  {% include "admin/includes/favicon.html" %}
+  <script nonce="{{ request.csp_nonce }}"
+          src="https://cdn.jsdelivr.net/npm/jquery@3.6.1/dist/jquery.min.js"
+          integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ="
+          crossorigin="anonymous"></script>
+  {% include "core/includes/bootstrap-css.html" %}
+  {% include "admin/includes/style-admin.html" %}
+  {% include "core/includes/analytics.html" with api_key=analytics.api_key uid=analytics.uid did=analytics.did %}
 {% endblock extrastyle %}
 
 {% block branding %}
-    <div id="header-container" class="navbar navbar-expand-sm navbar-dark justify-content-between">
-        <div class="container">
-            <span class="navbar-brand p-0">
-                <img class="sm d-lg-none" src="{% static "img/logo-sm.svg" %}" width="90" height="51.3" alt="California Integrated Travel Project: Benefits logo (small)" />
-                <img class="lg d-none d-lg-block" src="{% static "img/logo-lg.svg" %}" width="220" height="50" alt="California Integrated Travel Project: Benefits logo (large)" />
-            </span>
-        </div>
-        <h1 class="p-0 m-0 text-white">{{ site_header }}</h1>
+  <div id="header-container" class="navbar navbar-expand-sm navbar-dark justify-content-between">
+    <div class="container">
+      <span class="navbar-brand p-0">
+        <img class="sm d-lg-none"
+             src="{% static "img/logo-sm.svg" %}"
+             width="90"
+             height="51.3"
+             alt="California Integrated Travel Project: Benefits logo (small)" />
+        <img class="lg d-none d-lg-block"
+             src="{% static "img/logo-lg.svg" %}"
+             width="220"
+             height="50"
+             alt="California Integrated Travel Project: Benefits logo (large)" />
+      </span>
     </div>
+    <h1 class="p-0 m-0 text-white">{{ site_header }}</h1>
+  </div>
 {% endblock branding %}
 
 {% block usertools %}
-    {% include "admin/includes/usertools.html" %}
+  {% include "admin/includes/usertools.html" %}
 {% endblock usertools %}
 
 {% block coltype %}
-    w-100
+  w-100
 {% endblock coltype %}
 
 {% block bodyclass %}
-    {{ block.super }} dashboard
+  {{ block.super }} dashboard
 {% endblock bodyclass %}
 
 {% block nav-breadcrumbs %}

--- a/benefits/templates/admin/agency-dashboard-index.html
+++ b/benefits/templates/admin/agency-dashboard-index.html
@@ -2,37 +2,37 @@
 {% load i18n static %}
 
 {% block title %}
-    {{ title }}
+  {{ title }}
 {% endblock title %}
 
 {% block content %}
-    <div class="row">
-        <div class="col-lg-12">
-            <h1 class="pt-0 pb-3 text-start">{{ agency.long_name }}</h1>
-            {% if has_permission_for_in_person %}
-                <div class="border border-3 p-3">
-                    <h2 class="pt-0 pb-2 text-start">In-person enrollment</h2>
-                    <p>Verify transit benefit eligibility using agency criteria and complete a rider’s open-loop card enrollment.</p>
-                    {% url routes.IN_PERSON_ELIGIBILITY as url_eligibility %}
-                    <div class="row pt-4">
-                        <div class="col-lg-2">
-                            <a href="{{ url_eligibility }}" class="btn btn-lg btn-primary d-block">New enrollment</a>
-                        </div>
-                    </div>
-                </div>
-                {% if transit_processor_portal_url %}
-                    <div class="border border-3 p-3 mt-4">
-                        <h2 class="pt-0 pb-2 text-start">Transit Processor</h2>
-                        <p>Manage fare-calculation, view rider transactions, and process refunds.</p>
-                        <div class="row pt-4">
-                            <div class="col-lg-3">
-                                <a href="{{ transit_processor_portal_url }}" target="_blank" rel="noopener noreferrer" class="btn btn-lg btn-outline-primary">Launch Littlepay Control Portal</a>
-                            </div>
-                        </div>
-                    </div>
-                {% endif %}
-            {% endif %}
+  <div class="row">
+    <div class="col-lg-12">
+      <h1 class="pt-0 pb-3 text-start">{{ agency.long_name }}</h1>
+      {% if has_permission_for_in_person %}
+        <div class="border border-3 p-3">
+          <h2 class="pt-0 pb-2 text-start">In-person enrollment</h2>
+          <p>Verify transit benefit eligibility using agency criteria and complete a rider’s open-loop card enrollment.</p>
+          {% url routes.IN_PERSON_ELIGIBILITY as url_eligibility %}
+          <div class="row pt-4">
+            <div class="col-lg-2">
+              <a href="{{ url_eligibility }}" class="btn btn-lg btn-primary d-block">New enrollment</a>
+            </div>
+          </div>
         </div>
+        {% if transit_processor_portal_url %}
+          <div class="border border-3 p-3 mt-4">
+            <h2 class="pt-0 pb-2 text-start">Transit Processor</h2>
+            <p>Manage fare-calculation, view rider transactions, and process refunds.</p>
+            <div class="row pt-4">
+              <div class="col-lg-3">
+                <a href="{{ transit_processor_portal_url }}" target="_blank" rel="noopener noreferrer" class="btn btn-lg btn-outline-primary">Launch Littlepay Control Portal</a>
+              </div>
+            </div>
+          </div>
+        {% endif %}
+      {% endif %}
     </div>
+  </div>
 
 {% endblock content %}

--- a/benefits/templates/admin/base_site.html
+++ b/benefits/templates/admin/base_site.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
 
 {% block extrahead %}
-    {% include "admin/includes/favicon.html" %}
+  {% include "admin/includes/favicon.html" %}
 {% endblock extrahead %}

--- a/benefits/templates/admin/includes/branding-login.html
+++ b/benefits/templates/admin/includes/branding-login.html
@@ -1,9 +1,13 @@
 {% load i18n static %}
 
 <div class="d-flex justify-content-center w-100 bg-primary">
-    <img class="my-3" src="{% static "img/logo-lg.svg" %}" width="220" height="50" alt="California Integrated Travel Project: Benefits logo (large)" />
+  <img class="my-3"
+       src="{% static "img/logo-lg.svg" %}"
+       width="220"
+       height="50"
+       alt="California Integrated Travel Project: Benefits logo (large)" />
 </div>
 
 <div id="site-name">
-    <h1 class="text-center text-white fs-3 py-3 m-0">{{ site_header }}</h1>
+  <h1 class="text-center text-white fs-3 py-3 m-0">{{ site_header }}</h1>
 </div>

--- a/benefits/templates/admin/includes/usertools.html
+++ b/benefits/templates/admin/includes/usertools.html
@@ -1,23 +1,23 @@
 {% load i18n static %}
 
 {% if has_permission %}
-    <div id="user-tools">
-        {% block welcome-msg %}
-            <span class="text-uppercase text-white">
-                Welcome,
-                <span class="fw-bold">{% firstof user.get_short_name user.get_username %}</span>.
-            </span>
-        {% endblock welcome-msg %}
-        {% block userlinks %}
-            {% if user.is_active and user.is_staff %}
-                {% url 'django-admindocs-docroot' as docsroot %}
-                {% if docsroot %}<a href="{{ docsroot }}">Documentation</a> /{% endif %}
-            {% endif %}
-            <img class="icon" width="15" height="15" src="{% static "img/icon/box-arrow-right.svg" %}" alt="" />
-            <form id="logout-form" method="post" action="{% url 'admin:logout' %}">
-                {% csrf_token %}
-                <button type="submit" class="border-0">Log out</button>
-            </form>
-        {% endblock userlinks %}
-    </div>
+  <div id="user-tools">
+    {% block welcome-msg %}
+      <span class="text-uppercase text-white">
+        Welcome,
+        <span class="fw-bold">{% firstof user.get_short_name user.get_username %}</span>.
+      </span>
+    {% endblock welcome-msg %}
+    {% block userlinks %}
+      {% if user.is_active and user.is_staff %}
+        {% url 'django-admindocs-docroot' as docsroot %}
+        {% if docsroot %}<a href="{{ docsroot }}">Documentation</a> /{% endif %}
+      {% endif %}
+      <img class="icon" width="15" height="15" src="{% static "img/icon/box-arrow-right.svg" %}" alt="" />
+      <form id="logout-form" method="post" action="{% url 'admin:logout' %}">
+        {% csrf_token %}
+        <button type="submit" class="border-0">Log out</button>
+      </form>
+    {% endblock userlinks %}
+  </div>
 {% endif %}

--- a/benefits/templates/admin/login.html
+++ b/benefits/templates/admin/login.html
@@ -5,12 +5,12 @@
 {% endblock dark-mode-vars %}
 
 {% block extrastyle %}
-    {% comment %} Overriding instead of extending agency-base here to remove jQuery declaration, which admin/login.html includes on its own {% endcomment %}
-    {% include "admin/includes/favicon.html" %}
-    {% include "core/includes/bootstrap-css.html" %}
-    {% include "admin/includes/style-admin.html" %}
+  {% comment %} Overriding instead of extending agency-base here to remove jQuery declaration, which admin/login.html includes on its own {% endcomment %}
+  {% include "admin/includes/favicon.html" %}
+  {% include "core/includes/bootstrap-css.html" %}
+  {% include "admin/includes/style-admin.html" %}
 {% endblock extrastyle %}
 
 {% block branding %}
-    {% include "admin/includes/branding-login.html" %}
+  {% include "admin/includes/branding-login.html" %}
 {% endblock branding %}

--- a/benefits/templates/registration/logged_out.html
+++ b/benefits/templates/registration/logged_out.html
@@ -2,28 +2,28 @@
 {% load static %}
 
 {% block title %}
-    Logged out | {{ site_title }}
+  Logged out | {{ site_title }}
 {% endblock title %}
 
 {% block extrastyle %}
-    {{ block.super }}
-    <link rel="stylesheet" href="{% static "admin/css/login.css" %}">
+  {{ block.super }}
+  <link rel="stylesheet" href="{% static "admin/css/login.css" %}">
 {% endblock extrastyle %}
 
 {% block bodyclass %}
-    {{ block.super }} login
+  {{ block.super }} login
 {% endblock bodyclass %}
 
 {% block branding %}
-    {% include "admin/includes/branding-login.html" %}
+  {% include "admin/includes/branding-login.html" %}
 {% endblock branding %}
 
 {% block content %}
 
-    <div id="content-main">
-        <p class="text-center mt-4">You have logged out successfully.</p>
+  <div id="content-main">
+    <p class="text-center mt-4">You have logged out successfully.</p>
 
-        <a class="btn btn-lg btn-outline-primary d-block my-5" href="{% url 'admin:index' %}">Log in again</a>
-    </div>
+    <a class="btn btn-lg btn-outline-primary d-block my-5" href="{% url 'admin:index' %}">Log in again</a>
+  </div>
 
 {% endblock content %}


### PR DESCRIPTION
Closes #2591

This PR:

- Sets the default number of spaces to 2 for `html` files
- Modifies the pre-commit config to run the `djlint-reformat-django` pre-commit job before linting
- Reformats all templates to 2 spaces (ran `pre-commit run --all --all-files` in the dev container)
- Adds `node_modules/` to `.gitignore`