### PR TITLE
Fix: have Django serve media files even when DEBUG=False

### DIFF
--- a/benefits/urls.py
+++ b/benefits/urls.py
@@ -30,15 +30,16 @@ urlpatterns = [
     path("in_person/", include("benefits.in_person.urls")),
 ]
 
-# serve user-uploaded media files
-#
-# the helper function `django.conf.urls.static.static` mentioned in
-# https://docs.djangoproject.com/en/5.1/howto/static-files/#serving-files-uploaded-by-a-user-during-development
-# only works when settings.DEBUG = True, so here we add the URL pattern ourselves so it works regardless of DEBUG.
-prefix = settings.MEDIA_URL
-urlpatterns.extend(
-    [re_path(r"^%s(?P<path>.*)$" % re.escape(prefix.lstrip("/")), serve, {"document_root": settings.MEDIA_ROOT})]
-)
+if settings.RUNTIME_ENVIRONMENT() == settings.RUNTIME_ENVS.LOCAL:
+    # serve user-uploaded media files
+    #
+    # the helper function `django.conf.urls.static.static` mentioned in
+    # https://docs.djangoproject.com/en/5.1/howto/static-files/#serving-files-uploaded-by-a-user-during-development
+    # only works when settings.DEBUG = True, so here we add the URL pattern ourselves so it works regardless of DEBUG.
+    prefix = settings.MEDIA_URL
+    urlpatterns.extend(
+        [re_path(r"^%s(?P<path>.*)$" % re.escape(prefix.lstrip("/")), serve, {"document_root": settings.MEDIA_ROOT})]
+    )
 
 if settings.DEBUG:
     # based on

--- a/benefits/urls.py
+++ b/benefits/urls.py
@@ -6,12 +6,13 @@ The `urlpatterns` list routes URLs to views. For more information please see:
 """
 
 import logging
+import re
 
 from django.conf import settings
 from django.contrib import admin
 from django.http import HttpResponse
-from django.urls import include, path
-from django.conf.urls.static import static
+from django.urls import include, path, re_path
+from django.views.static import serve
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +30,16 @@ urlpatterns = [
     path("in_person/", include("benefits.in_person.urls")),
 ]
 
+# serve user-uploaded media files
+#
+# the helper function `django.conf.urls.static.static` mentioned in
+# https://docs.djangoproject.com/en/5.1/howto/static-files/#serving-files-uploaded-by-a-user-during-development
+# only works when settings.DEBUG = True, so here we add the URL pattern ourselves so it works regardless of DEBUG.
+prefix = settings.MEDIA_URL
+urlpatterns.extend(
+    [re_path(r"^%s(?P<path>.*)$" % re.escape(prefix.lstrip("/")), serve, {"document_root": settings.MEDIA_ROOT})]
+)
+
 if settings.DEBUG:
     # based on
     # https://docs.sentry.io/platforms/python/guides/django/#verify
@@ -37,10 +48,6 @@ if settings.DEBUG:
         raise RuntimeError("Test error")
 
     urlpatterns.append(path("error/", trigger_error))
-
-    # serve user-uploaded media files
-    # https://docs.djangoproject.com/en/5.1/howto/static-files/#serving-files-uploaded-by-a-user-during-development
-    urlpatterns.extend(static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT))
 
     # simple route to read a pre-defined "secret"
     # this "secret" does not contain sensitive information


### PR DESCRIPTION
Closes #2618 

The reason why the images were not being served is because when DEBUG was false, there was no URL mapping from `/media` to the `django.views.static.serve` view.

If we simply move `urlpatterns.extend(static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT))` outside of the `if settings.DEBUG` block, the URL mapping still is not added because the `static` helper function only works when [DEBUG is true](https://github.com/django/django/blob/main/django/conf/urls/static.py#L23-L25). So to get around this, we can just add the URL mapping ourselves.

This URL mapping does not affect the way media images are served by the `client` container because we configured NGINX to [handle the `/media` path](https://github.com/cal-itp/benefits/blob/main/appcontainer/nginx.conf#L75-L80).