### PR TITLE
Fix: use correct storage directory for client service

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -10,7 +10,8 @@ services:
     ports:
       - "${DJANGO_LOCAL_PORT:-8000}:8000"
     volumes:
-      - ./:/home/calitp/app/data # matches the path in nginx.conf for media files. set your DJANGO_STORAGE_DIR to `/home/calitp/app/data` so the container can access `django.db` and `uploads/`.
+      - ./django.db:/home/calitp/app/data/django.db # the app container expects the database to already exist
+      - ./uploads/:/home/calitp/app/data/uploads
 
   dev:
     build:

--- a/compose.yml
+++ b/compose.yml
@@ -9,6 +9,8 @@ services:
     env_file: .env
     ports:
       - "${DJANGO_LOCAL_PORT:-8000}:8000"
+    volumes:
+      - ./:/home/calitp/app/data # matches the path in nginx.conf for media files. set your DJANGO_STORAGE_DIR to `/home/calitp/app/data` so the container can access `django.db` and `uploads/`.
 
   dev:
     build:


### PR DESCRIPTION
Closes #2620 

This PR adds volume mappings to bring in `django.db` and the `uploads` folder into `/home/calitp/app/data` inside the `client` service. 

### Explanation
It needs to be this specific path is because the client container needs `DJANGO_STORAGE_DIR` to be `/home/calitp/app/data` so that nginx can serve media files correctly. But then, the client container fails to start because there is no database file at `/home/calitp/app/data`.

This volume mapping gives the container access to the `django.db` file and the `uploads/` directory from the host side of the mapping.