### PR TITLE
Fix: use headline-text for block

### DIFF
--- a/benefits/eligibility/templates/eligibility/start--sbmtd-agency-card.html
+++ b/benefits/eligibility/templates/eligibility/start--sbmtd-agency-card.html
@@ -5,9 +5,9 @@
     {% translate "Agency card overview" %}
 {% endblock page-title %}
 
-{% block headline %}
+{% block headline-text %}
     {% translate "You selected a Reduced Fare Mobility ID transit benefit." %}
-{% endblock headline %}
+{% endblock headline-text %}
 
 {% block eligibility-item %}
     {% include "eligibility/includes/eligibility-item--identification--start--sbmtd-agency-card.html" %}


### PR DESCRIPTION
closes https://github.com/cal-itp/benefits/issues/2630

This PR fixes a small bug in `benefits/eligibility/templates/eligibility/start--sbmtd-agency-card.html` , where `block` should be `headline-text` instead of `headline` to render the title properly.
