### PR TITLE
Refactor: web perf - load recaptcha script only where it's needed

### DIFF
--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -161,9 +161,5 @@
         });
       });
     </script>
-
-    {% if request.recaptcha %}
-      <script nonce="{{ request.csp_nonce }}" src="{{ request.recaptcha.script_api }}"></script>
-    {% endif %}
   </body>
 </html>

--- a/benefits/core/templates/core/includes/form.html
+++ b/benefits/core/templates/core/includes/form.html
@@ -79,6 +79,8 @@
     </script>
 
     {% if request.recaptcha %}
+      <script nonce="{{ request.csp_nonce }}" src="{{ request.recaptcha.script_api }}"></script>
+
       {% comment %}
         Adapted from https://stackoverflow.com/a/63290578/453168
       {% endcomment %}


### PR DESCRIPTION
Part of #2493

This PR moves the loading of the reCAPTCHA script to only where it's actually used. This is a small change that belongs to the category of **Identify inline Javascript that doesn't need to be on every page**.