### PR TITLE
Refactor: web perf - load Bootstrap CSS asynchronously

### DIFF
--- a/benefits/core/templates/core/includes/bootstrap-css.html
+++ b/benefits/core/templates/core/includes/bootstrap-css.html
@@ -3,5 +3,4 @@
       integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
       crossorigin="anonymous"
       media="print"
-      onload="this.media='all'"
-      nonce="{{ request.csp_nonce }}">
+      onload="this.media='all'">

--- a/benefits/core/templates/core/includes/bootstrap-css.html
+++ b/benefits/core/templates/core/includes/bootstrap-css.html
@@ -1,4 +1,7 @@
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
       rel="stylesheet"
       integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
-      crossorigin="anonymous">
+      crossorigin="anonymous"
+      media="print"
+      onload="this.media='all'"
+      nonce="{{ request.csp_nonce }}">

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -340,6 +340,8 @@ if sentry.SENTRY_CSP_REPORT_URI:
 
 CSP_SCRIPT_SRC = [
     "'self'",
+    "'unsafe-hashes'",
+    "'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='",  # hash of 'this.media='all'
     "https://cdn.amplitude.com/libs/",
     "https://cdn.jsdelivr.net/",
     "*.littlepay.com",


### PR DESCRIPTION
Part of #2493 

This PR loads the Bootstrap CSS resource asynchronously with the goal of reducing the time that page rendering is blocked.

We can use this PR to examine the code changes needed to do this and the effects of this change on other web performance metrics.

### Code changes needed

<details>

Trying out the approach in https://www.filamentgroup.com/lab/load-css-simpler, we simply need to add `media="print" onload="this.media='all'"` to the `link` element that is loading CSS.

However, then we see that Bootstrap CSS is not loading at all:

<img src="https://github.com/user-attachments/assets/9c19da9c-8f0f-4713-a2ac-9e4edb321d6a" width="400">

   
This is because our CSP `script-src` directive is blocking the inline Javascript in the `onload` event handler from executing:

![Screenshot from 2025-01-17 12-09-48](https://github.com/user-attachments/assets/3cdfe91c-6aa3-4f5f-9c10-04162bd628c0)

#### Modifying our CSP to allow the `onload` code

Adding the `unsafe-inline` keyword to our `script-src` would be the simplest way to allow the event handler, but we see that is also blocked:

![image](https://github.com/user-attachments/assets/2122ebd0-da40-425b-9404-8447477a4bdc)

This is because:
> If a directive contains nonce or hash expressions, then the unsafe-inline keyword is ignored by browsers.

_from https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP#inline_javascript_

So then let's try out the `unsafe-hashes` keywords, which requires that we also provide the hash of the Javascript we're wanting to execute. We can get the hash by running:
```
>  echo -n "this.media='all'" | openssl dgst -sha256 -binary | openssl base64
MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc=
```
Then we add it to the `script-src` directive in `settings.py` -- see [lines 343 and 344](https://github.com/cal-itp/benefits/pull/2636/files#diff-d71405aa44f1e899a9cd920e5187aa1d02affdbd0da472eca95f814b0a8c1210R343-R344).

This works:

![image](https://github.com/user-attachments/assets/f300648e-7101-4ed8-9496-9b736e4f0c25)

One final note: `unsafe-nonce` does not work with inline event handlers -- see https://stackoverflow.com/questions/56399872/content-security-policy-nonce-does-not-apply-to-event-handler-attributes.

Screenshot of attempt to use `nonce` to allow event handler to execute:
<img src="https://github.com/user-attachments/assets/8d27ec08-62dd-4275-820d-df878bb54433" width="400">

</details>

### Effects on web performance

Running Lighthouse reports on the app before and after the code changes, we see that `bootstrap.min.css` is no longer blocking page rendering. See the Diagnostic results below:

| Before | After |
| - | - |
|![image](https://github.com/user-attachments/assets/12f74a60-f130-4701-864a-7b0ddf342128)  |![image](https://github.com/user-attachments/assets/4279e7ce-f058-41ff-9512-29fad4de9ee1) |

However, the overall Performance score is worse because loading the CSS asynchronously causes a layout shift.
![image](https://github.com/user-attachments/assets/d724bd70-b498-4517-82fe-f306e229ca30)


**Lighthouse Performance metrics _before_ code changes**

| Run | Performance score | First Contentful Paint (s) | Largest Contentful Paint (s) | Total Blocking Time (ms) | Cumulative Layout Shift | Speed Index (s) |
| --- | ----------------- | -------------------------- | ---------------------------- | ------------------------ | ----------------------------- | --------------- |
| 1   | 97                | 1.9                        | 2.3                          | 10                       | 0                             | 1.9             |
| 2   | 93                | 1.7                        | 3.2                          | 0                        | 0                             | 1.7             |
| 3   | 93                | 1.9                        | 3.1                          | 0                        | 0                             | 1.9             |
| 4   | 97                | 1.7                        | 2.3                          | 0                        | 0                             | 1.7             |
| 5   | 94                | 2.3                        | 2.7                          | 0                        | 0                             | 2.3             |

<details><summary>Screenshots</summary>

| Run | Screenshot |
| - | - |
| 1 | ![Screenshot from 2025-01-17 13-35-38](https://github.com/user-attachments/assets/d21c5610-8b5e-4074-a317-a18743737dae) |
| 2 | ![Screenshot from 2025-01-17 13-36-06](https://github.com/user-attachments/assets/1e9a3d36-9273-4c21-9217-a8e9c984691d) |
| 3 | ![Screenshot from 2025-01-17 13-36-30](https://github.com/user-attachments/assets/9647acd0-fbd9-4b6c-b837-20818f0f4312) |
| 4 | ![Screenshot from 2025-01-17 13-36-44](https://github.com/user-attachments/assets/dc8431d0-4e8b-4887-85dc-d32764b47bdd) |
| 5 | ![Screenshot from 2025-01-17 13-37-00](https://github.com/user-attachments/assets/3538c7ac-149e-4d2e-bcd9-4dc914fe00c9) |
</details>


**Lighthouse Performance metrics _after_ code changes**

| Run | Performance score | First Contentful Paint (s) | Largest Contentful Paint (s) | Total Blocking Time (ms) | Cumulative Layout Shift | Speed Index (s) |
| --- | ----------------- | -------------------------- | ---------------------------- | ------------------------ | ----------------------------- | --------------- |
| 1   | 76                | 1.7                        | 3.0                          | 0                        | 0.365                         | 1.7             |
| 2   | 78                | 2.3                        | 2.3                          | 30                       | 0.365                         | 2.3             |
| 3   | 76                | 2.3                        | 2.7                          | 60                       | 0.365                         | 2.3             |
| 4   | 80                | 1.8                        | 2.2                          | 40                       | 0.365                         | 1.8             |
| 5   | 78                | 2.3                        | 2.3                          | 60                       | 0.365                         | 2.3             |

<details><summary>Screenshots</summary>

| Run | Screenshot |
| - | - |
| 1| ![Screenshot from 2025-01-17 13-38-51](https://github.com/user-attachments/assets/a08a3c94-bf6f-430e-a899-13418f3a42dd) |
| 2 | ![Screenshot from 2025-01-17 13-39-01](https://github.com/user-attachments/assets/c3ddb83f-0855-4f54-9816-301283ea0b33) |
| 3 | ![Screenshot from 2025-01-17 13-39-14](https://github.com/user-attachments/assets/e4008579-aaa3-4f65-a176-3fedd0fe929e) |
| 4 | ![Screenshot from 2025-01-17 13-39-29](https://github.com/user-attachments/assets/5c47c4b3-c7f4-424b-a44c-137397a20f76) |
| 5 | ![Screenshot from 2025-01-17 13-40-22](https://github.com/user-attachments/assets/a01fd975-b0f1-46ca-8d8f-c27ecb91dbbc) | 

</details>

