### PR TITLE
Perf: improve Google Web Font performance

### DIFF
--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -20,7 +20,7 @@
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous">
-    <link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet" type="text/css">
+    <link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" rel="stylesheet" type="text/css">
     {% include "core/includes/bootstrap-css.html" %}
     <link href="{% static "css/styles.css" %}" rel="stylesheet">
     <link href="{% static "img/favicon.ico" %}" rel="icon" type="image/x-icon" />

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -18,6 +18,8 @@
     {% block preload %}
     {% endblock preload %}
 
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous">
     <link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet" type="text/css">
     {% include "core/includes/bootstrap-css.html" %}
     <link href="{% static "css/styles.css" %}" rel="stylesheet">


### PR DESCRIPTION
Closes #2492 
This PR audits and improves how the Google Web Font is loaded.

## Background
In [`base.html`](https://github.com/cal-itp/benefits/blob/933cd572b6b5731665f877b40da677ccad8c5ee1/benefits/core/templates/core/base.html#L21), the external font (Roboto) is loaded first, and the local font (Public Sans) is loaded after. Since there are no conflicts, Roboto takes precedence. Then, Roboto is set for [`--bs-font-sans-serif`](https://github.com/cal-itp/benefits/blob/933cd572b6b5731665f877b40da677ccad8c5ee1/benefits/static/css/variables.css#L14) so it is used throughout the site. The local font is only used for [login.gov buttons](https://github.com/cal-itp/benefits/blob/933cd572b6b5731665f877b40da677ccad8c5ee1/benefits/static/css/styles.css#L423).

## Audit
- [x] Double-check that we are using all [3 Roboto weights](https://github.com/cal-itp/benefits/blob/933cd572b6b5731665f877b40da677ccad8c5ee1/benefits/core/templates/core/base.html#L21): 400 normal, 500 normal, 700 normal. _We are using all 3 weights._
- [x] Use [`font-display: swap`](https://developer.chrome.com/docs/lighthouse/performance/font-display/?utm_source=lighthouse&utm_medium=devtools#google_fonts_example) and ~[`preload`](https://web.dev/learn/performance/optimize-web-fonts#preload). _Lighthouse reports an improvement in performance from 92 to 97 when using these attributes on `<link>`._~
- [x] Ensure there is a good fall-back default font. _The [first fallback font](https://github.com/cal-itp/benefits/blob/933cd572b6b5731665f877b40da677ccad8c5ee1/benefits/static/css/variables.css#L14) is `system-ui` which is a good fallback._

