### PR TITLE
Perf: load Bootstrap JS asynchronously

### DIFF
--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -143,7 +143,8 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
             integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
-            crossorigin="anonymous"></script>
+            crossorigin="anonymous"
+            async></script>
 
     <script nonce="{{ request.csp_nonce }}">
       $(function() {


### PR DESCRIPTION
Part of #2493 

Goes with this recommendation:
![image](https://github.com/user-attachments/assets/b0b834b2-73e3-45bc-bb07-62952ebe8dbd)
and belongs to the category of **Load external Javascript in a non-blocking manner**.

We can use `async` to load Bootstrap JS because it doesn't need to be loaded before or after any other scripts. I tested the performance of `defer` vs. `async` with Lighthouse, and below are the results.

Also, side note: while reading about [Lightouse report variability](https://developer.chrome.com/docs/lighthouse/performance/performance-scoring/#fluctuations), I noticed this line about the [median of 5 runs](https://github.com/GoogleChrome/lighthouse/blob/main/docs/variability.md#run-lighthouse-multiple-times) being a more stable score, so I'm going to start using Median instead of Average. Here I've included Average and 90th percentile just because I had already calculated them.

**Before any changes**

|                     | Performance score | First Contentful Paint (s) | Largest Contentful Paint (s) | Total blocking time (ms) | Cumulative Layout Shift | Speed Index (s) |
| ------------------- | ----------------- | -------------------------- | ---------------------------- | ------------------------ | ----------------------- | --------------- |
|                     | 98                | 1.7                        | 2.2                          | 0                        | 0                       | 1.7             |
|                     | 88                | 2.3                        | 3.6                          | 0                        | 0                       | 2.3             |
|                     | 93                | 2.3                        | 2.8                          | 0                        | 0                       | 2.3             |
|                     | 88                | 2.3                        | 3.6                          | 10                       | 0                       | 2.3             |
|                     | 88                | 2.3                        | 3.6                          | 0                        | 0                       | 2.3             |
| **Average**         | **91**            | **2.18**                   | **3.16**                     | **2**                    | **0**                   | **2.18**        |
| **Median**          | **88**            | **2.3**                    | **3.6**                      | **0**                    | **0**                   | **2.3**         |
| **90th Percentile** | **96**            | **2.3**                    | **3.6**                      | **6**                    | **0**                   | **2.3**         |

**With `defer` for Bootstrap JS**

|                     | Performance score | First Contentful Paint (s) | Largest Contentful Paint (s) | Total blocking time (ms) | Cumulative Layout Shift | Speed Index (s) |
| ------------------- | ----------------- | -------------------------- | ---------------------------- | ------------------------ | ----------------------- | --------------- |
|                     | 98                | 1.8                        | 2.1                          | 0                        | 0                       | 1.8             |
|                     | 97                | 1.8                        | 2.3                          | 10                       | 0                       | 1.8             |
|                     | 93                | 2.3                        | 2.8                          | 0                        | 0                       | 2.3             |
|                     | 93                | 2.3                        | 2.8                          | 0                        | 0                       | 2.3             |
|                     | 93                | 2.3                        | 2.8                          | 0                        | 0                       | 2.3             |
| **Average**         | **94.8**          | **2.1**                    | **2.56**                     | **2**                    | **0**                   | **2.1**         |
| **Median**          | **93**            | **2.3**                    | **2.8**                      | **0**                    | **0**                   | **2.3**         |
| **90th Percentile** | **97.6**          | **2.3**                    | **2.8**                      | **6**                    | **0**                   | **2.3**         |

**With `async` for Bootstrap JS**

|                     | Performance score | First Contentful Paint (s) | Largest Contentful Paint (s) | Total blocking time (ms) | Cumulative Layout Shift | Speed Index (s) |
| ------------------- | ----------------- | -------------------------- | ---------------------------- | ------------------------ | ----------------------- | --------------- |
|                     | 94                | 2.4                        | 2.6                          | 0                        | 0                       | 2.4             |
|                     | 94                | 2.3                        | 2.7                          | 0                        | 0                       | 2.3             |
|                     | 94                | 2.3                        | 2.7                          | 0                        | 0                       | 2.3             |
|                     | 95                | 2.3                        | 2.5                          | 0                        | 0                       | 2.3             |
|                     | 93                | 2.3                        | 2.8                          | 0                        | 0                       | 2.3             |
| **Average**         | **94**            | **2.32**                   | **2.66**                     | **0**                    | **0**                   | **2.32**        |
| **Median**          | **94**            | **2.3**                    | **2.7**                      | **0**                    | **0**                   | **2.3**         |
| **90th Percentile** | **94.6**          | **2.36**                   | **2.76**                     | **0**                    | **0**                   | **2.36**        |

I ran reports for `defer` vs. `async` another time to get more data to decide between the two.

**With `defer` for Bootstrap JS**

|                     | Performance score | First Contentful Paint (s) | Largest Contentful Paint (s) | Total blocking time (ms) | Cumulative Layout Shift | Speed Index (s) |
| ------------------- | ----------------- | -------------------------- | ---------------------------- | ------------------------ | ----------------------- | --------------- |
|                     | 98                | 1.8                        | 2.3                          | 20                       | 0                       | 1.8             |
|                     | 93                | 2.3                        | 2.7                          | 0                        | 0                       | 2.3             |
|                     | 94                | 2.3                        | 2.7                          | 0                        | 0                       | 2.3             |
|                     | 97                | 1.8                        | 2.3                          | 30                       | 0                       | 1.8             |
|                     | 94                | 2.3                        | 2.7                          | 0                        | 0                       | 2.3             |
| **Average**         | **95.2**          | **2.1**                    | **2.54**                     | **10**                   | **0**                   | **2.1**         |
| **Median**          | **94**            | **2.3**                    | **2.7**                      | **0**                    | **0**                   | **2.3**         |
| **90th Percentile** | **97.6**          | **2.3**                    | **2.7**                      | **26**                   | **0**                   | **2.3**         |

**With `async` for Bootstrap JS**

|                     | Performance score | First Contentful Paint (s) | Largest Contentful Paint (s) | Total blocking time (ms) | Cumulative Layout Shift | Speed Index (s) |
| ------------------- | ----------------- | -------------------------- | ---------------------------- | ------------------------ | ----------------------- | --------------- |
|                     | 97                | 1.7                        | 2.3                          | 30                       | 0                       | 1.7             |
|                     | 94                | 2.3                        | 2.7                          | 0                        | 0                       | 2.3             |
|                     | 94                | 2.3                        | 2.7                          | 0                        | 0                       | 2.3             |
|                     | 97                | 1.8                        | 2.3                          | 40                       | 0                       | 1.8             |
|                     | 97                | 1.9                        | 2.3                          | 10                       | 0                       | 1.9             |
| **Average**         | **95.8**          | **2**                      | **2.46**                     | **16**                   | **0**                   | **2**           |
| **Median**          | **97**            | **1.9**                    | **2.3**                      | **10**                   | **0**                   | **1.9**         |
| **90th Percentile** | **97**            | **2.3**                    | **2.7**                      | **36**                   | **0**                   | **2.3**         |

Seems like `async` has slightly better performance, so went with that.
