### PR TITLE
Fix: Set important to override bootstrap h4

### DIFF
--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -238,9 +238,11 @@ h3,
 
 h4,
 .h4 {
-  font-size: var(--h4-font-size);
-  letter-spacing: calc(var(--h4-font-size) * var(--h4-letter-spacing-percent));
-  line-height: var(--h4-line-height);
+  font-size: var(--h4-font-size) !important; /* override Bootstrap class */
+  letter-spacing: calc(
+    var(--h4-font-size) * var(--h4-letter-spacing-percent)
+  ) !important;
+  line-height: var(--h4-line-height) !important;
 }
 
 /* Header */


### PR DESCRIPTION
closes #2601 

Bootstrap has a class called `h4`, which has different sizing than what we want.

I could have done a few things:
- Rename the `h4` class in our styles
- Use this `disable-rfs` class that Bootstrap gives you
- Or add `important` to the existing `h4` size declaration

I decided to go with the latter, so that any future use of `h4` will be covered (and not require the dev to know to use `disable-rfs`). I didn't want to rename all the hX classes.