### PR TITLE
Docs: update syntax for non-markdown numbering

### DIFF
--- a/docs/development/application-logic.md
+++ b/docs/development/application-logic.md
@@ -107,16 +107,16 @@ flowchart LR
     next>"`_Next phase_`"]
     style next stroke-width:2px
 
-    start -- "1a. Lands on index" --> pick_agency
-    start -- "1b. Lands on agency index" --> agency
+    start -- "1a: Lands on index" --> pick_agency
+    start -- "1b: Lands on agency index" --> agency
     %% invisible links help with diagram layout
     start ~~~ session
     start ~~~ agency
 
-    pick_agency -- 2. Chooses agency --> agency
-    agency -- 3. Chooses enrollment pathway --> eligibility
+    pick_agency -- "2: Chooses agency" --> agency
+    agency -- "3: Chooses enrollment pathway" --> eligibility
 
-    eligibility -- 4. continue --> next
+    eligibility -- "4: continue" --> next
 
     agency -. update -.-o session
     eligibility -. update -.-o session
@@ -165,17 +165,17 @@ flowchart LR
     verification_`"]
     style next stroke-width:2px
 
-    start -- 1. Clicks login button --> benefits
+    start -- "1: Clicks login button" --> benefits
     %% invisible links help with diagram layout
     start ~~~ session
 
-    benefits -- 2. OIDC authorize_redirect --> idg
+    benefits -- "2: OIDC authorize_redirect" --> idg
     benefits -. started sign in  -.-o analytics
 
-    idg <-. "3. PII exchange" .-> logingov
-    idg -- 4. OIDC token authorization --> claims
+    idg <-. "3: PII exchange" .-> logingov
+    idg -- "4: OIDC token authorization" --> claims
 
-    claims -- 5. continue --> next
+    claims -- "5: continue" --> next
     claims -. update .-o session
     claims -. finished sign in -.-o analytics
 ```


### PR DESCRIPTION
Getting `Unsupported markdown: list` error in these charts

https://docs.calitp.org/benefits/development/application-logic

![image](https://github.com/user-attachments/assets/cc67bb02-a537-4fa9-bf7a-ba696087a8fa)

With this change

https://benefits-2645--cal-itp-previews.netlify.app/development/application-logic/

![image](https://github.com/user-attachments/assets/7b179326-cae7-4529-9ff7-b0f305b2f3b2)

Related:

- https://github.com/mermaid-js/mermaid/issues/5824
- https://github.com/mermaid-js/mermaid/issues/6099