### PR TITLE
Refactor: reduce usage of jQuery

### DIFF
--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -23,6 +23,16 @@
     <link href="{% static "css/styles.css" %}" rel="stylesheet">
     <link href="{% static "img/favicon.ico" %}" rel="icon" type="image/x-icon" />
 
+    <script nonce="{{ request.csp_nonce }}">
+      // critical JS - function for running a callback when document is ready.
+      function ready(callback) {
+        if (document.readyState != "loading") {
+          callback();
+        } else {
+          document.addEventListener("DOMContentLoaded", callback);
+        }
+      };
+    </script>
     <script nonce="{{ request.csp_nonce }}"
             src="https://cdn.jsdelivr.net/npm/jquery@3.6.1/dist/jquery.min.js"
             integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ="

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -157,17 +157,17 @@
             async></script>
 
     <script nonce="{{ request.csp_nonce }}">
-      $(function() {
+      ready(function() {
         document.cookie = "testcookie"
         if (document.cookie.indexOf("testcookie") < 0) {
-          $(".nocookies").removeClass("d-none");
+          document.querySelector(".nocookies").classList.remove("d-none");
         }
         else {
           document.cookie = "testcookie; expires=Thu, 01-Jan-1970 00:00:01 GMT";
-          $(".nocookies").addClass("d-none");
+          document.querySelector(".nocookies").classList.add("d-none");
         }
 
-        $("a[href^='https'], a[href^='tel'], [href*='#']").on("click", function(e) {
+        document.querySelector("a[href^='https'], a[href^='tel'], [href*='#']").addEventListener("click", function(e) {
           amplitude.getInstance().logEvent('clicked link', {'href': e.target.href, 'path': window.location.pathname});
         });
       });

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -33,10 +33,6 @@
         }
       };
     </script>
-    <script nonce="{{ request.csp_nonce }}"
-            src="https://cdn.jsdelivr.net/npm/jquery@3.6.1/dist/jquery.min.js"
-            integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ="
-            crossorigin="anonymous"></script>
 
     {% include "core/includes/analytics.html" with api_key=analytics.api_key uid=analytics.uid did=analytics.did %}
   </head>

--- a/benefits/core/templates/core/base.html
+++ b/benefits/core/templates/core/base.html
@@ -23,17 +23,7 @@
     <link href="{% static "css/styles.css" %}" rel="stylesheet">
     <link href="{% static "img/favicon.ico" %}" rel="icon" type="image/x-icon" />
 
-    <script nonce="{{ request.csp_nonce }}">
-      // critical JS - function for running a callback when document is ready.
-      function ready(callback) {
-        if (document.readyState != "loading") {
-          callback();
-        } else {
-          document.addEventListener("DOMContentLoaded", callback);
-        }
-      };
-    </script>
-
+    {% include "core/includes/ready-js.html" %}
     {% include "core/includes/analytics.html" with api_key=analytics.api_key uid=analytics.uid did=analytics.did %}
   </head>
   <body>

--- a/benefits/core/templates/core/includes/form.html
+++ b/benefits/core/templates/core/includes/form.html
@@ -108,22 +108,27 @@
           // form is client-side valid; taking over the remainder of processing
           $event.preventDefault();
 
+          // assign to a variable since `$event.currentTarget` will be null inside the `grecaptcha.execute` Promise.
+          // https://developer.mozilla.org/en-US/docs/Web/API/Event/currentTarget
+          let currentTarget = $event.currentTarget;
+
           grecaptcha.ready(function() {
             grecaptcha.execute("{{ request.recaptcha.site_key }}", { action: "submit" }).then(function(token) {
                 // add the token to hidden form element
-                $event.currentTarget.form.elements["{{ request.recaptcha.data_field }}"].value = token;
+                currentTarget.form.elements["{{ request.recaptcha.data_field }}"].value = token;
                 // trigger the custom "submitting" event
                 // since calling .submit() does not trigger the "submit" event
                 // hence the normal handler won't apply
-                $($event.currentTarget.form).trigger("submitting");
+                const customEvent = new CustomEvent("submitting");
+                currentTarget.form.dispatchEvent(customEvent);
                 // submit the form to server
-                $event.currentTarget.form.submit($event.currentTarget);
+                currentTarget.form.submit(currentTarget);
             });
           });
         };
 
         // bind the above handler to button click
-        $("button[type=submit]", "#{{ form.id }}").on("click", recaptchaSubmit);
+        document.querySelector("#{{ form.id }} button[type=submit]").addEventListener("click", recaptchaSubmit);
       </script>
     {% endif %}
   </form>

--- a/benefits/core/templates/core/includes/form.html
+++ b/benefits/core/templates/core/includes/form.html
@@ -100,17 +100,17 @@
       <div class="pt-8">{% include "core/includes/recaptcha-text.html" %}</div>
 
       <script nonce="{{ request.csp_nonce }}">
-        function recaptchaSubmit($event) {
+        function recaptchaSubmit(event) {
           // checks the validity of the form. Return if invalid; HTML5 validation errors should display
-          if (!$event.currentTarget.form.checkValidity()) {
+          if (!event.currentTarget.form.checkValidity()) {
             return;
           }
           // form is client-side valid; taking over the remainder of processing
-          $event.preventDefault();
+          event.preventDefault();
 
-          // assign to a variable since `$event.currentTarget` will be null inside the `grecaptcha.execute` Promise.
+          // assign to a variable since `event.currentTarget` will be null inside the `grecaptcha.execute` Promise.
           // https://developer.mozilla.org/en-US/docs/Web/API/Event/currentTarget
-          let currentTarget = $event.currentTarget;
+          let currentTarget = event.currentTarget;
 
           grecaptcha.ready(function() {
             grecaptcha.execute("{{ request.recaptcha.site_key }}", { action: "submit" }).then(function(token) {

--- a/benefits/core/templates/core/includes/form.html
+++ b/benefits/core/templates/core/includes/form.html
@@ -63,23 +63,22 @@
         });
 
         {% if form.use_custom_validity %}
-        const validate = function(input_element) {
-          input_element.setCustomValidity(""); // clearing message sets input_element.validity.customError back to false
+        const validate = function(inputElement) {
+          inputElement.setCustomValidity(""); // clearing message sets inputElement.validity.customError back to false
 
-          const valid = input_element.checkValidity();
+          const valid = inputElement.checkValidity();
           if (!valid) {
-            input_element.setCustomValidity(input_element.dataset.customValidity);
+            inputElement.setCustomValidity(inputElement.dataset.customValidity);
           }
         }
 
-        $("button[type=submit]", "#{{ form.id }}").add("button[type=submit][form={{ form.id }}]").on("click", function(e) {
-            // revalidate all fields
-            $("[data-custom-validity]").each(function() {
-              let input_element = $(this)[0];
-              if (input_element) {
-                validate(input_element);
-              }
-            });
+        button.addEventListener("click", function(e) {
+          // revalidate all fields
+          document.querySelectorAll("[data-custom-validity]").forEach((element) => {
+            if (element) {
+              validate(element);
+            }
+          });
         });
 
         {% endif %}

--- a/benefits/core/templates/core/includes/form.html
+++ b/benefits/core/templates/core/includes/form.html
@@ -57,8 +57,9 @@
         });
 
         // on normal form submit, trigger the custom "submitting" event
-        $("#{{ form.id }}").on("submit", function(e) {
-          $(this).trigger("submitting");
+        form.addEventListener("submit", function(e) {
+          const event = new CustomEvent("submitting");
+          form.dispatchEvent(event);
         });
 
         {% if form.use_custom_validity %}

--- a/benefits/core/templates/core/includes/form.html
+++ b/benefits/core/templates/core/includes/form.html
@@ -37,15 +37,22 @@
 
     <script nonce="{{ request.csp_nonce }}">
       ready(function() {
+        let form = document.querySelector("#{{ form.id }}");
+
+        let button = document.querySelector("#{{ form.id }} button[type=submit]");
+        if (!button) {
+          button = document.querySelector("button[type=submit][form={{ form.id }}]")
+        }
+
         // listen for a custom "submitting" event on the form, for button interactions
-        $("#{{ form.id }}").on("submitting", function(e) {
+        form.addEventListener("submitting", function(e) {
           if ("{{ form.submitting_value }}" !== "") {
-            $("button[type=submit]", this)
-              .removeClass("spinner-hidden")
-              .addClass("disabled")
-              .attr("role", "status")
-              .attr("disabled", "true")
-              .children().first().text("{{ form.submitting_value }}");
+            let buttonClasses = button.classList;
+            buttonClasses.remove("spinner-hidden");
+            buttonClasses.add("disabled");
+            button.setAttribute("role", "status");
+            button.setAttribute("disabled", "true");
+            button.children[0].textContent = "{{ form.submitting_value }}";
           }
         });
 

--- a/benefits/core/templates/core/includes/form.html
+++ b/benefits/core/templates/core/includes/form.html
@@ -36,7 +36,7 @@
     {% endif %}
 
     <script nonce="{{ request.csp_nonce }}">
-      $(function() {
+      ready(function() {
         // listen for a custom "submitting" event on the form, for button interactions
         $("#{{ form.id }}").on("submitting", function(e) {
           if ("{{ form.submitting_value }}" !== "") {

--- a/benefits/core/templates/core/includes/ready-js.html
+++ b/benefits/core/templates/core/includes/ready-js.html
@@ -1,0 +1,10 @@
+<script nonce="{{ request.csp_nonce }}">
+  // critical JS - function for running a callback when document is ready.
+  function ready(callback) {
+    if (document.readyState != "loading") {
+      callback();
+    } else {
+      document.addEventListener("DOMContentLoaded", callback);
+    }
+  };
+</script>

--- a/benefits/eligibility/templates/eligibility/index.html
+++ b/benefits/eligibility/templates/eligibility/index.html
@@ -23,11 +23,13 @@
   {% endblock form-text %}
   {% include "core/includes/form.html" with form=form %}
   <script nonce="{{ request.csp_nonce }}">
-    $(".modal").on("click", function(event) {
-      if (!(event.target instanceof HTMLAnchorElement)) {
-          event.preventDefault();
-          event.stopPropagation();
-      }
+    document.querySelectorAll(".modal").forEach((modal) => {
+      modal.addEventListener("click", function(event) {
+        if (!(event.target instanceof HTMLAnchorElement)) {
+            event.preventDefault();
+            event.stopPropagation();
+        }
+      });
     });
   </script>
 {% endblock inner-content %}

--- a/benefits/enrollment/templates/enrollment/includes/jquery.html
+++ b/benefits/enrollment/templates/enrollment/includes/jquery.html
@@ -1,0 +1,4 @@
+<script nonce="{{ request.csp_nonce }}"
+        src="https://cdn.jsdelivr.net/npm/jquery@3.6.1/dist/jquery.min.js"
+        integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ="
+        crossorigin="anonymous"></script>

--- a/benefits/enrollment/templates/enrollment/index.html
+++ b/benefits/enrollment/templates/enrollment/index.html
@@ -35,6 +35,12 @@
     come before the forms, which are rendered at just before the {% endblock inner-content %}
   {% endcomment %}
   {% translate "Please wait..." as loading_text %}
+
+  <script nonce="{{ request.csp_nonce }}"
+          src="https://cdn.jsdelivr.net/npm/jquery@3.6.1/dist/jquery.min.js"
+          integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ="
+          crossorigin="anonymous"></script>
+
   <script nonce="{{ request.csp_nonce }}">
       var startedEvent = "started card tokenization", closedEvent = "finished card tokenization";
 

--- a/benefits/enrollment/templates/enrollment/index.html
+++ b/benefits/enrollment/templates/enrollment/index.html
@@ -36,10 +36,7 @@
   {% endcomment %}
   {% translate "Please wait..." as loading_text %}
 
-  <script nonce="{{ request.csp_nonce }}"
-          src="https://cdn.jsdelivr.net/npm/jquery@3.6.1/dist/jquery.min.js"
-          integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ="
-          crossorigin="anonymous"></script>
+  {% include "enrollment/includes/jquery.html" %}
 
   <script nonce="{{ request.csp_nonce }}">
       var startedEvent = "started card tokenization", closedEvent = "finished card tokenization";

--- a/benefits/in_person/templates/in_person/enrollment/index.html
+++ b/benefits/in_person/templates/in_person/enrollment/index.html
@@ -40,6 +40,11 @@
     <button id="{{ cta_button }}" href="#{{ cta_button }}" class="btn btn-lg btn-primary" role="button">Enroll</button>
   </div>
 
+  <script nonce="{{ request.csp_nonce }}"
+          src="https://cdn.jsdelivr.net/npm/jquery@3.6.1/dist/jquery.min.js"
+          integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ="
+          crossorigin="anonymous"></script>
+
   <script nonce="{{ request.csp_nonce }}">
         var startedEvent = "started card tokenization", closedEvent = "finished card tokenization";
 

--- a/benefits/in_person/templates/in_person/enrollment/index.html
+++ b/benefits/in_person/templates/in_person/enrollment/index.html
@@ -40,10 +40,7 @@
     <button id="{{ cta_button }}" href="#{{ cta_button }}" class="btn btn-lg btn-primary" role="button">Enroll</button>
   </div>
 
-  <script nonce="{{ request.csp_nonce }}"
-          src="https://cdn.jsdelivr.net/npm/jquery@3.6.1/dist/jquery.min.js"
-          integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ="
-          crossorigin="anonymous"></script>
+  {% include "enrollment/includes/jquery.html" %}
 
   <script nonce="{{ request.csp_nonce }}">
         var startedEvent = "started card tokenization", closedEvent = "finished card tokenization";

--- a/benefits/templates/admin/agency-base.html
+++ b/benefits/templates/admin/agency-base.html
@@ -6,10 +6,6 @@
 
 {% block extrastyle %}
   {% include "admin/includes/favicon.html" %}
-  <script nonce="{{ request.csp_nonce }}"
-          src="https://cdn.jsdelivr.net/npm/jquery@3.6.1/dist/jquery.min.js"
-          integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ="
-          crossorigin="anonymous"></script>
   {% include "core/includes/bootstrap-css.html" %}
   {% include "admin/includes/style-admin.html" %}
   {% include "core/includes/analytics.html" with api_key=analytics.api_key uid=analytics.uid did=analytics.did %}

--- a/benefits/templates/admin/agency-base.html
+++ b/benefits/templates/admin/agency-base.html
@@ -8,6 +8,7 @@
   {% include "admin/includes/favicon.html" %}
   {% include "core/includes/bootstrap-css.html" %}
   {% include "admin/includes/style-admin.html" %}
+  {% include "core/includes/ready-js.html" %}
   {% include "core/includes/analytics.html" with api_key=analytics.api_key uid=analytics.uid did=analytics.did %}
 {% endblock extrastyle %}
 


### PR DESCRIPTION
Part of #2493 

This PR makes it so we only use jQuery for enrollment. This allows us to stop loading jQuery on every page.

### Context:

I originally set out to extract inline Javascript as separate files to be loaded in with `async` or `defer`. A lot of them would have to be `defer` since they depend on `jQuery` being loaded and available.

I tried it out and saw that the performance change was negligible. There was basically no difference.

It seemed then that a more impactful change would be to reduce the need for jQuery. A lot of what we were doing with jQuery can be done with plain Javascript that is well-supported by all modern browsers.

Using https://youmightnotneedjquery.com/ and https://tobiasahlin.com/blog/move-from-jquery-to-vanilla-javascript/#document-ready as reference and testing each change thoroughly, I was able to convert over all inline Javascript except for the ones on `core/enrollment/index.html` and `in_person/enrollment/index.html` since the code there involves making AJAX requests and is more difficult to convert over.

This change showed performance improvement, specifically with First Contentful Paint and Largest Contentful Paint times, according to Lighthouse. If we want to optimize further, another PR could extract inline Javascript out to separate files and load them with `async` now that they don't depend on jQuery.

<details><summary>Before</summary>

![Screenshot from 2025-01-27 20-30-42](https://github.com/user-attachments/assets/7652e8ad-eb87-4274-81de-b01f7cfbde06) 
![Screenshot from 2025-01-27 20-30-57](https://github.com/user-attachments/assets/ee43d23e-46ad-411a-9308-6f8efbae32e0)

</details>

<details><summary>After</summary>

![Screenshot from 2025-01-27 20-31-17](https://github.com/user-attachments/assets/7fe7a16c-524f-4e70-860a-603b9d4d6439)

![Screenshot from 2025-01-27 20-31-33](https://github.com/user-attachments/assets/5da02c28-d407-4518-909f-1fcacd4f0de7)

</details>




