### PR TITLE
Feat: helper function checks if user is staff or superuser

### DIFF
--- a/benefits/core/admin/__init__.py
+++ b/benefits/core/admin/__init__.py
@@ -12,7 +12,7 @@ from .users import (
     add_transit_agency_staff_user_to_group,
     add_google_sso_userinfo,
     is_staff_member,
-    is_staff_or_superuser,
+    is_staff_member_or_superuser,
     pre_login_user,
 )
 
@@ -28,6 +28,6 @@ __all__ = [
     "add_transit_agency_staff_user_to_group",
     "add_google_sso_userinfo",
     "is_staff_member",
-    "is_staff_or_superuser",
+    "is_staff_member_or_superuser",
     "pre_login_user",
 ]

--- a/benefits/core/admin/__init__.py
+++ b/benefits/core/admin/__init__.py
@@ -12,6 +12,7 @@ from .users import (
     add_transit_agency_staff_user_to_group,
     add_google_sso_userinfo,
     is_staff_member,
+    is_staff_or_superuser,
     pre_login_user,
 )
 
@@ -27,5 +28,6 @@ __all__ = [
     "add_transit_agency_staff_user_to_group",
     "add_google_sso_userinfo",
     "is_staff_member",
+    "is_staff_or_superuser",
     "pre_login_user",
 ]

--- a/benefits/core/admin/enrollment.py
+++ b/benefits/core/admin/enrollment.py
@@ -5,7 +5,7 @@ from django.http import HttpRequest
 from adminsortable2.admin import SortableAdminMixin
 
 from benefits.core import models
-from .users import is_staff_member
+from .users import is_staff_or_superuser
 
 
 @admin.register(models.EnrollmentEvent)
@@ -18,7 +18,7 @@ class EnrollmentEventAdmin(admin.ModelAdmin):  # pragma: no cover
     def has_add_permission(self, request: HttpRequest, obj=None):
         if settings.RUNTIME_ENVIRONMENT() == settings.RUNTIME_ENVS.PROD:
             return False
-        elif request.user and (request.user.is_superuser or is_staff_member(request.user)):
+        elif request.user and is_staff_or_superuser(request.user):
             return True
         else:
             return False
@@ -34,13 +34,13 @@ class EnrollmentEventAdmin(admin.ModelAdmin):  # pragma: no cover
     def has_delete_permission(self, request: HttpRequest, obj=None):
         if settings.RUNTIME_ENVIRONMENT() == settings.RUNTIME_ENVS.PROD:
             return False
-        elif request.user and (request.user.is_superuser or is_staff_member(request.user)):
+        elif request.user and is_staff_or_superuser(request.user):
             return True
         else:
             return False
 
     def has_view_permission(self, request: HttpRequest, obj=None):
-        if request.user and (request.user.is_superuser or is_staff_member(request.user)):
+        if request.user and is_staff_or_superuser(request.user):
             return True
         else:
             return False

--- a/benefits/core/admin/enrollment.py
+++ b/benefits/core/admin/enrollment.py
@@ -5,7 +5,7 @@ from django.http import HttpRequest
 from adminsortable2.admin import SortableAdminMixin
 
 from benefits.core import models
-from .users import is_staff_or_superuser
+from .users import is_staff_member_or_superuser
 
 
 @admin.register(models.EnrollmentEvent)
@@ -18,7 +18,7 @@ class EnrollmentEventAdmin(admin.ModelAdmin):  # pragma: no cover
     def has_add_permission(self, request: HttpRequest, obj=None):
         if settings.RUNTIME_ENVIRONMENT() == settings.RUNTIME_ENVS.PROD:
             return False
-        elif request.user and is_staff_or_superuser(request.user):
+        elif request.user and is_staff_member_or_superuser(request.user):
             return True
         else:
             return False
@@ -34,13 +34,13 @@ class EnrollmentEventAdmin(admin.ModelAdmin):  # pragma: no cover
     def has_delete_permission(self, request: HttpRequest, obj=None):
         if settings.RUNTIME_ENVIRONMENT() == settings.RUNTIME_ENVS.PROD:
             return False
-        elif request.user and is_staff_or_superuser(request.user):
+        elif request.user and is_staff_member_or_superuser(request.user):
             return True
         else:
             return False
 
     def has_view_permission(self, request: HttpRequest, obj=None):
-        if request.user and is_staff_or_superuser(request.user):
+        if request.user and is_staff_member_or_superuser(request.user):
             return True
         else:
             return False

--- a/benefits/core/admin/users.py
+++ b/benefits/core/admin/users.py
@@ -54,7 +54,7 @@ def is_staff_member(user):
     return staff_group.user_set.contains(user)
 
 
-def is_staff_or_superuser(user):
+def is_staff_member_or_superuser(user):
     return user.is_superuser or is_staff_member(user)
 
 

--- a/benefits/core/admin/users.py
+++ b/benefits/core/admin/users.py
@@ -54,6 +54,10 @@ def is_staff_member(user):
     return staff_group.user_set.contains(user)
 
 
+def is_staff_or_superuser(user):
+    return user.is_superuser or is_staff_member(user)
+
+
 def pre_login_user(user, request):
     logger.debug(f"Running pre-login callback for user: {user.username}")
     add_google_sso_userinfo(user, request)

--- a/benefits/core/admin/users.py
+++ b/benefits/core/admin/users.py
@@ -50,11 +50,18 @@ def add_transit_agency_staff_user_to_group(user, request):
 
 
 def is_staff_member(user):
+    """Determine if a user is a member of the staff group of Benefits
+
+    The staff group of Benefits is also called the 'Cal-ITP' group (defined in settings.STAFF_GROUP_NAME)
+    and it is not to be confused with Django's concept of 'staff' which simply means users that can log in to the admin.
+    """
+
     staff_group = Group.objects.get(name=settings.STAFF_GROUP_NAME)
     return staff_group.user_set.contains(user)
 
 
 def is_staff_member_or_superuser(user):
+    """Determine if a user is a member of the staff group of Benefits or if it is a superuser."""
     return user.is_superuser or is_staff_member(user)
 
 

--- a/tests/pytest/core/admin/test_users.py
+++ b/tests/pytest/core/admin/test_users.py
@@ -2,7 +2,7 @@ import pytest
 from django.contrib.auth.models import User, Group
 
 import benefits.core.admin
-from benefits.core.admin.users import GOOGLE_USER_INFO_URL, is_staff_member, is_staff_or_superuser, pre_login_user
+from benefits.core.admin.users import GOOGLE_USER_INFO_URL, is_staff_member, is_staff_member_or_superuser, pre_login_user
 
 
 @pytest.fixture
@@ -46,30 +46,30 @@ def test_is_staff_member_superuser(model_AdminUser, settings):
 
 
 @pytest.mark.django_db
-def test_is_staff_or_superuser_regular_user(model_AdminUser, settings):
+def test_is_staff_member_or_superuser_regular_user(model_AdminUser, settings):
     assert not model_AdminUser.is_superuser
 
     staff_group = Group.objects.get(name=settings.STAFF_GROUP_NAME)
 
     assert not staff_group.user_set.contains(model_AdminUser)
-    assert not is_staff_or_superuser(model_AdminUser)
+    assert not is_staff_member_or_superuser(model_AdminUser)
 
 
 @pytest.mark.django_db
-def test_is_staff_or_superuser_staff_member(model_AdminUser, settings):
+def test_is_staff_member_or_superuser_staff_member(model_AdminUser, settings):
     staff_group = Group.objects.get(name=settings.STAFF_GROUP_NAME)
     staff_group.user_set.add(model_AdminUser)
 
     assert not model_AdminUser.is_superuser
-    assert is_staff_or_superuser(model_AdminUser)
+    assert is_staff_member_or_superuser(model_AdminUser)
 
 
 @pytest.mark.django_db
-def test_is_staff_or_superuser_superuser(model_AdminUser):
+def test_is_staff_member_or_superuser_superuser(model_AdminUser):
     model_AdminUser.is_superuser = True
     model_AdminUser.save()
 
-    assert is_staff_or_superuser(model_AdminUser)
+    assert is_staff_member_or_superuser(model_AdminUser)
 
 
 @pytest.mark.django_db

--- a/tests/pytest/core/admin/test_users.py
+++ b/tests/pytest/core/admin/test_users.py
@@ -2,7 +2,7 @@ import pytest
 from django.contrib.auth.models import User, Group
 
 import benefits.core.admin
-from benefits.core.admin.users import GOOGLE_USER_INFO_URL, pre_login_user
+from benefits.core.admin.users import GOOGLE_USER_INFO_URL, is_staff_member, is_staff_or_superuser, pre_login_user
 
 
 @pytest.fixture
@@ -19,6 +19,57 @@ def test_admin_registered(client):
     assert ("/admin/login/?next=/admin/", 302) in response.redirect_chain
     assert response.request["PATH_INFO"] == "/admin/login/"
     assert "google_sso/login.html" in response.template_name
+
+
+@pytest.mark.django_db
+def test_is_staff_member_regular_user(model_AdminUser, settings):
+    staff_group = Group.objects.get(name=settings.STAFF_GROUP_NAME)
+    assert not staff_group.user_set.contains(model_AdminUser)
+    assert not is_staff_member(model_AdminUser)
+
+
+@pytest.mark.django_db
+def test_is_staff_member_staff_user(model_AdminUser, settings):
+    staff_group = Group.objects.get(name=settings.STAFF_GROUP_NAME)
+    staff_group.user_set.add(model_AdminUser)
+    assert staff_group.user_set.contains(model_AdminUser)
+    assert is_staff_member(model_AdminUser)
+
+
+@pytest.mark.django_db
+def test_is_staff_member_superuser(model_AdminUser, settings):
+    model_AdminUser.is_superuser = True
+    model_AdminUser.save()
+    staff_group = Group.objects.get(name=settings.STAFF_GROUP_NAME)
+    assert not staff_group.user_set.contains(model_AdminUser)
+    assert not is_staff_member(model_AdminUser)
+
+
+@pytest.mark.django_db
+def test_is_staff_or_superuser_regular_user(model_AdminUser, settings):
+    assert not model_AdminUser.is_superuser
+
+    staff_group = Group.objects.get(name=settings.STAFF_GROUP_NAME)
+
+    assert not staff_group.user_set.contains(model_AdminUser)
+    assert not is_staff_or_superuser(model_AdminUser)
+
+
+@pytest.mark.django_db
+def test_is_staff_or_superuser_staff_member(model_AdminUser, settings):
+    staff_group = Group.objects.get(name=settings.STAFF_GROUP_NAME)
+    staff_group.user_set.add(model_AdminUser)
+
+    assert not model_AdminUser.is_superuser
+    assert is_staff_or_superuser(model_AdminUser)
+
+
+@pytest.mark.django_db
+def test_is_staff_or_superuser_superuser(model_AdminUser):
+    model_AdminUser.is_superuser = True
+    model_AdminUser.save()
+
+    assert is_staff_or_superuser(model_AdminUser)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Part of #2201

Following our [approach](https://github.com/cal-itp/benefits/pull/2638#issuecomment-2622595676) to breaking up [Refactor: Admin permissions for Cal-ITP Staff](https://github.com/cal-itp/benefits/pull/2638) into smaller PRs, this PR adds the `is_staff_or_superuser` helper function to check if user is staff or superuser and adds more tests for the helper functions in  `benefits/core/admin/users.py`.