### PR TITLE
Feat: Cal-ITP staff can add EnrollmentFlow

### DIFF
--- a/benefits/core/admin/enrollment.py
+++ b/benefits/core/admin/enrollment.py
@@ -53,16 +53,6 @@ class SortableEnrollmentFlowAdmin(SortableAdminMixin, admin.ModelAdmin):
     def get_exclude(self, request, obj=None):
         fields = []
 
-        if not is_staff_member_or_superuser(request.user):
-            fields.extend(
-                [
-                    "claims_scope",
-                    "claims_eligibility_claim",
-                    "claims_scheme_override",
-                    "eligibility_api_url",
-                    "eligibility_form_class",
-                ]
-            )
         if not request.user.is_superuser:
             fields.extend(
                 [
@@ -80,16 +70,6 @@ class SortableEnrollmentFlowAdmin(SortableAdminMixin, admin.ModelAdmin):
     def get_readonly_fields(self, request, obj=None):
         fields = []
 
-        if not is_staff_member_or_superuser(request.user):
-            fields.extend(
-                [
-                    "system_name",
-                    "transit_agency",
-                    "supported_enrollment_methods",
-                    "claims_provider",
-                    "supports_expiration",
-                ]
-            )
         if not request.user.is_superuser:
             fields.extend(
                 [

--- a/benefits/core/admin/enrollment.py
+++ b/benefits/core/admin/enrollment.py
@@ -1,4 +1,6 @@
+from django import forms
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.contrib import admin
 from django.http import HttpRequest
 
@@ -46,9 +48,60 @@ class EnrollmentEventAdmin(admin.ModelAdmin):
             return False
 
 
+class EnrollmentFlowForm(forms.ModelForm):
+    def clean(self):
+        cleaned_data = super().clean()
+
+        field_errors = {}
+        non_field_errors = []
+
+        supports_expiration = cleaned_data.get("supports_expiration")
+
+        if supports_expiration:
+            expiration_days = cleaned_data.get("expiration_days")
+            expiration_reenrollment_days = cleaned_data.get("expiration_reenrollment_days")
+            reenrollment_error_template = cleaned_data.get("reenrollment_error_template")
+
+            message = "When support_expiration is True, this value must be greater than 0."
+            if expiration_days is None or expiration_days <= 0:
+                field_errors.update(expiration_days=ValidationError(message))
+            if expiration_reenrollment_days is None or expiration_reenrollment_days <= 0:
+                field_errors.update(expiration_reenrollment_days=ValidationError(message))
+            if not reenrollment_error_template:
+                field_errors.update(reenrollment_error_template=ValidationError("Required when supports expiration is True."))
+
+        transit_agency = cleaned_data.get("transit_agency")
+
+        if transit_agency:
+            if cleaned_data.get("claims_provider"):
+                message = "Required for claims verification."
+                needed = dict(
+                    claims_scope=cleaned_data.get("claims_scope"),
+                    claims_eligibility_claim=cleaned_data.get("claims_eligibility_claim"),
+                )
+                field_errors.update({k: ValidationError(message) for k, v in needed.items() if not v})
+            elif cleaned_data.get("eligibility_api_url") and cleaned_data.get("eligibility_form_class"):
+                message = "Required for Eligibility API verification."
+                needed = dict(
+                    eligibility_api_auth_header=cleaned_data.get("eligibility_api_auth_header"),
+                    eligibility_api_auth_key_secret_name=cleaned_data.get("eligibility_api_auth_key_secret_name"),
+                    eligibility_api_jwe_cek_enc=cleaned_data.get("eligibility_api_jwe_cek_enc"),
+                    eligibility_api_jwe_encryption_alg=cleaned_data.get("eligibility_api_jwe_encryption_alg"),
+                    eligibility_api_jws_signing_alg=cleaned_data.get("eligibility_api_jws_signing_alg"),
+                    eligibility_api_public_key=cleaned_data.get("eligibility_api_public_key"),
+                )
+                field_errors.update({k: ValidationError(message) for k, v in needed.items() if not v})
+
+        if field_errors:
+            raise ValidationError(field_errors)
+        if non_field_errors:
+            raise ValidationError(non_field_errors)
+
+
 @admin.register(models.EnrollmentFlow)
 class SortableEnrollmentFlowAdmin(SortableAdminMixin, admin.ModelAdmin):
     list_display = ("label", "transit_agency", "supported_enrollment_methods")
+    form = EnrollmentFlowForm
 
     def get_exclude(self, request, obj=None):
         fields = []

--- a/benefits/core/admin/enrollment.py
+++ b/benefits/core/admin/enrollment.py
@@ -72,7 +72,7 @@ class EnrollmentFlowForm(forms.ModelForm):
         if supports_expiration:
             expiration_days = cleaned_data.get("expiration_days")
             expiration_reenrollment_days = cleaned_data.get("expiration_reenrollment_days")
-            reenrollment_error_template = cleaned_data.get("reenrollment_error_template")
+            reenrollment_error_template = self.get(cleaned_data, "reenrollment_error_template")
 
             message = "When support_expiration is True, this value must be greater than 0."
             if expiration_days is None or expiration_days <= 0:
@@ -80,7 +80,12 @@ class EnrollmentFlowForm(forms.ModelForm):
             if expiration_reenrollment_days is None or expiration_reenrollment_days <= 0:
                 field_errors.update(expiration_reenrollment_days=ValidationError(message))
             if not reenrollment_error_template:
-                field_errors.update(reenrollment_error_template=ValidationError("Required when supports expiration is True."))
+                message = "Required when supports expiration is True"
+                field_name = "reenrollment_error_template"
+                if self.has_field(field_name):
+                    field_errors.update(reenrollment_error_template=ValidationError(f"{message}."))
+                else:
+                    non_field_errors.append(ValidationError(f"{message}: {field_name}"))
 
         transit_agency = cleaned_data.get("transit_agency")
 

--- a/benefits/core/admin/enrollment.py
+++ b/benefits/core/admin/enrollment.py
@@ -90,16 +90,16 @@ class EnrollmentFlowForm(forms.ModelForm):
             eligibility_form_class = self.get(cleaned_data, "eligibility_form_class")
 
             if cleaned_data.get("claims_provider"):
-                message = "Required for claims verification."
+                message = "Required for claims verification"
                 needed = dict(
                     claims_scope=cleaned_data.get("claims_scope"),
                     claims_eligibility_claim=cleaned_data.get("claims_eligibility_claim"),
                 )
                 for k, v in needed.items():
                     if self.has_field(k) and not v:
-                        field_errors.update({k: ValidationError(message)})
+                        field_errors.update({k: ValidationError(f"{message}.")})
                     elif not v:
-                        non_field_errors.append(ValidationError(message))
+                        non_field_errors.append(ValidationError(f"{message}: {k}"))
             elif eligibility_api_url and eligibility_form_class:
                 message = "Required for Eligibility API verification."
                 needed = dict(
@@ -112,9 +112,9 @@ class EnrollmentFlowForm(forms.ModelForm):
                 )
                 for k, v in needed.items():
                     if self.has_field(k) and not v:
-                        field_errors.update({k: ValidationError(message)})
+                        field_errors.update({k: ValidationError(f"{message}.")})
                     elif not v:
-                        non_field_errors.append(ValidationError(message))
+                        non_field_errors.append(ValidationError(f"{message}: {k}"))
             else:
                 message = (
                     "Must configure either claims verification or Eligibility API verification before"

--- a/benefits/core/admin/enrollment.py
+++ b/benefits/core/admin/enrollment.py
@@ -49,6 +49,18 @@ class EnrollmentEventAdmin(admin.ModelAdmin):
 
 
 class EnrollmentFlowForm(forms.ModelForm):
+    def has_field(self, field_name):
+        return self.fields.get(field_name) is not None
+
+    def get(self, cleaned_data, field_name):
+        """
+        If the field is present on the form, simply get the value from the cleaned_data.
+
+        If the field is not present on the form, that means the user doesn't have access to the field,
+        so get the value from the form's instance of the object.
+        """
+        return cleaned_data.get(field_name) if self.has_field(field_name) else getattr(self.instance, field_name)
+
     def clean(self):
         cleaned_data = super().clean()
 
@@ -73,14 +85,22 @@ class EnrollmentFlowForm(forms.ModelForm):
         transit_agency = cleaned_data.get("transit_agency")
 
         if transit_agency:
+            # these fields might not be on the form, so use helper method to correctly get the value
+            eligibility_api_url = self.get(cleaned_data, "eligibility_api_url")
+            eligibility_form_class = self.get(cleaned_data, "eligibility_form_class")
+
             if cleaned_data.get("claims_provider"):
                 message = "Required for claims verification."
                 needed = dict(
                     claims_scope=cleaned_data.get("claims_scope"),
                     claims_eligibility_claim=cleaned_data.get("claims_eligibility_claim"),
                 )
-                field_errors.update({k: ValidationError(message) for k, v in needed.items() if not v})
-            elif cleaned_data.get("eligibility_api_url") and cleaned_data.get("eligibility_form_class"):
+                for k, v in needed.items():
+                    if self.has_field(k) and not v:
+                        field_errors.update({k: ValidationError(message)})
+                    elif not v:
+                        non_field_errors.append(ValidationError(message))
+            elif eligibility_api_url and eligibility_form_class:
                 message = "Required for Eligibility API verification."
                 needed = dict(
                     eligibility_api_auth_header=cleaned_data.get("eligibility_api_auth_header"),
@@ -90,7 +110,17 @@ class EnrollmentFlowForm(forms.ModelForm):
                     eligibility_api_jws_signing_alg=cleaned_data.get("eligibility_api_jws_signing_alg"),
                     eligibility_api_public_key=cleaned_data.get("eligibility_api_public_key"),
                 )
-                field_errors.update({k: ValidationError(message) for k, v in needed.items() if not v})
+                for k, v in needed.items():
+                    if self.has_field(k) and not v:
+                        field_errors.update({k: ValidationError(message)})
+                    elif not v:
+                        non_field_errors.append(ValidationError(message))
+            else:
+                message = (
+                    "Must configure either claims verification or Eligibility API verification before"
+                    + " adding to a transit agency."
+                )
+                non_field_errors.append(ValidationError(message))
 
         if field_errors:
             raise ValidationError(field_errors)

--- a/benefits/core/admin/enrollment.py
+++ b/benefits/core/admin/enrollment.py
@@ -9,7 +9,7 @@ from .users import is_staff_member_or_superuser
 
 
 @admin.register(models.EnrollmentEvent)
-class EnrollmentEventAdmin(admin.ModelAdmin):  # pragma: no cover
+class EnrollmentEventAdmin(admin.ModelAdmin):
     list_display = ("enrollment_datetime", "transit_agency", "enrollment_flow", "enrollment_method", "verified_by")
 
     def get_readonly_fields(self, request: HttpRequest, obj=None):
@@ -47,36 +47,70 @@ class EnrollmentEventAdmin(admin.ModelAdmin):  # pragma: no cover
 
 
 @admin.register(models.EnrollmentFlow)
-class SortableEnrollmentFlowAdmin(SortableAdminMixin, admin.ModelAdmin):  # pragma: no cover
+class SortableEnrollmentFlowAdmin(SortableAdminMixin, admin.ModelAdmin):
     list_display = ("label", "transit_agency", "supported_enrollment_methods")
 
     def get_exclude(self, request, obj=None):
+        fields = []
+
+        if not is_staff_member_or_superuser(request.user):
+            fields.extend(
+                [
+                    "claims_scope",
+                    "claims_eligibility_claim",
+                    "claims_scheme_override",
+                    "eligibility_api_url",
+                    "eligibility_form_class",
+                ]
+            )
         if not request.user.is_superuser:
-            return [
-                "eligibility_api_auth_header",
-                "eligibility_api_auth_key_secret_name",
-                "eligibility_api_public_key",
-                "eligibility_api_jwe_cek_enc",
-                "eligibility_api_jwe_encryption_alg",
-                "eligibility_api_jws_signing_alg",
-                "eligibility_form_class",
-            ]
-        else:
-            return super().get_exclude(request, obj)
+            fields.extend(
+                [
+                    "eligibility_api_auth_header",
+                    "eligibility_api_auth_key_secret_name",
+                    "eligibility_api_public_key",
+                    "eligibility_api_jwe_cek_enc",
+                    "eligibility_api_jwe_encryption_alg",
+                    "eligibility_api_jws_signing_alg",
+                ]
+            )
+
+        return fields or super().get_exclude(request, obj)
 
     def get_readonly_fields(self, request, obj=None):
+        fields = []
+
+        if not is_staff_member_or_superuser(request.user):
+            fields.extend(
+                [
+                    "system_name",
+                    "transit_agency",
+                    "supported_enrollment_methods",
+                    "claims_provider",
+                    "supports_expiration",
+                ]
+            )
         if not request.user.is_superuser:
-            return [
-                "claims_provider",
-                "eligibility_api_url",
-                "eligibility_start_template_override",
-                "eligibility_unverified_template_override",
-                "help_template",
-                "selection_label_template_override",
-                "claims_scheme_override",
-                "enrollment_index_template",
-                "reenrollment_error_template",
-                "enrollment_success_template_override",
-            ]
+            fields.extend(
+                [
+                    "eligibility_api_url",
+                    "eligibility_form_class",
+                    "selection_label_template_override",
+                    "eligibility_start_template_override",
+                    "eligibility_unverified_template_override",
+                    "help_template",
+                    "enrollment_index_template_override",
+                    "reenrollment_error_template",
+                    "enrollment_success_template_override",
+                ]
+            )
+
+        return fields or super().get_readonly_fields(request, obj)
+
+    def has_add_permission(self, request: HttpRequest, obj=None):
+        if settings.RUNTIME_ENVIRONMENT() != settings.RUNTIME_ENVS.PROD:
+            return True
+        elif request.user and is_staff_member_or_superuser(request.user):
+            return True
         else:
-            return super().get_readonly_fields(request, obj)
+            return False

--- a/benefits/core/admin/enrollment.py
+++ b/benefits/core/admin/enrollment.py
@@ -103,12 +103,12 @@ class EnrollmentFlowForm(forms.ModelForm):
             elif eligibility_api_url and eligibility_form_class:
                 message = "Required for Eligibility API verification."
                 needed = dict(
-                    eligibility_api_auth_header=cleaned_data.get("eligibility_api_auth_header"),
-                    eligibility_api_auth_key_secret_name=cleaned_data.get("eligibility_api_auth_key_secret_name"),
-                    eligibility_api_jwe_cek_enc=cleaned_data.get("eligibility_api_jwe_cek_enc"),
-                    eligibility_api_jwe_encryption_alg=cleaned_data.get("eligibility_api_jwe_encryption_alg"),
-                    eligibility_api_jws_signing_alg=cleaned_data.get("eligibility_api_jws_signing_alg"),
-                    eligibility_api_public_key=cleaned_data.get("eligibility_api_public_key"),
+                    eligibility_api_auth_header=self.get(cleaned_data, "eligibility_api_auth_header"),
+                    eligibility_api_auth_key_secret_name=self.get(cleaned_data, "eligibility_api_auth_key_secret_name"),
+                    eligibility_api_jwe_cek_enc=self.get(cleaned_data, "eligibility_api_jwe_cek_enc"),
+                    eligibility_api_jwe_encryption_alg=self.get(cleaned_data, "eligibility_api_jwe_encryption_alg"),
+                    eligibility_api_jws_signing_alg=self.get(cleaned_data, "eligibility_api_jws_signing_alg"),
+                    eligibility_api_public_key=self.get(cleaned_data, "eligibility_api_public_key"),
                 )
                 for k, v in needed.items():
                     if self.has_field(k) and not v:

--- a/benefits/core/models/enrollment.py
+++ b/benefits/core/models/enrollment.py
@@ -213,6 +213,11 @@ class EnrollmentFlow(models.Model):
         return self.claims_provider is not None and bool(self.claims_scope) and bool(self.claims_eligibility_claim)
 
     @property
+    def uses_api_verification(self):
+        """True if this flow verifies via the Eligibility API. False otherwise."""
+        return bool(self.eligibility_api_url) and bool(self.eligibility_form_class)
+
+    @property
     def claims_scheme(self):
         return self.claims_scheme_override or self.claims_provider.scheme
 
@@ -275,7 +280,7 @@ class EnrollmentFlow(models.Model):
                     claims_eligibility_claim=self.claims_eligibility_claim,
                 )
                 field_errors.update({k: ValidationError(message) for k, v in needed.items() if not v})
-            else:
+            elif self.uses_api_verification:
                 message = "Required for Eligibility API verification."
                 needed = dict(
                     eligibility_api_auth_header=self.eligibility_api_auth_header,
@@ -284,8 +289,6 @@ class EnrollmentFlow(models.Model):
                     eligibility_api_jwe_encryption_alg=self.eligibility_api_jwe_encryption_alg,
                     eligibility_api_jws_signing_alg=self.eligibility_api_jws_signing_alg,
                     eligibility_api_public_key=self.eligibility_api_public_key,
-                    eligibility_api_url=self.eligibility_api_url,
-                    eligibility_form_class=self.eligibility_form_class,
                 )
                 field_errors.update({k: ValidationError(message) for k, v in needed.items() if not v})
 

--- a/benefits/core/models/enrollment.py
+++ b/benefits/core/models/enrollment.py
@@ -165,10 +165,10 @@ class EnrollmentFlow(models.Model):
 
     @property
     def agency_card_name(self):
-        if self.uses_claims_verification:
-            return ""
-        else:
+        if self.uses_api_verification:
             return f"{self.transit_agency.slug}-agency-card"
+        else:
+            return ""
 
     @property
     def eligibility_api_auth_key(self):
@@ -186,26 +186,26 @@ class EnrollmentFlow(models.Model):
     @property
     def selection_label_template(self):
         prefix = "eligibility/includes/selection-label"
-        if self.uses_claims_verification:
-            return self.selection_label_template_override or f"{prefix}--{self.system_name}.html"
-        else:
+        if self.uses_api_verification:
             return self.selection_label_template_override or f"{prefix}--{self.agency_card_name}.html"
+        else:
+            return self.selection_label_template_override or f"{prefix}--{self.system_name}.html"
 
     @property
     def eligibility_start_template(self):
         prefix = "eligibility/start"
-        if self.uses_claims_verification:
-            return self.eligibility_start_template_override or f"{prefix}--{self.system_name}.html"
-        else:
+        if self.uses_api_verification:
             return self.eligibility_start_template_override or f"{prefix}--{self.agency_card_name}.html"
+        else:
+            return self.eligibility_start_template_override or f"{prefix}--{self.system_name}.html"
 
     @property
     def eligibility_unverified_template(self):
         prefix = "eligibility/unverified"
-        if self.uses_claims_verification:
-            return self.eligibility_unverified_template_override or f"{prefix}.html"
-        else:
+        if self.uses_api_verification:
             return self.eligibility_unverified_template_override or f"{prefix}--{self.agency_card_name}.html"
+        else:
+            return self.eligibility_unverified_template_override or f"{prefix}.html"
 
     @property
     def uses_claims_verification(self):
@@ -242,18 +242,18 @@ class EnrollmentFlow(models.Model):
     @property
     def enrollment_index_template(self):
         prefix = "enrollment/index"
-        if self.uses_claims_verification:
-            return self.enrollment_index_template_override or f"{prefix}.html"
-        else:
+        if self.uses_api_verification:
             return self.enrollment_index_template_override or f"{prefix}--agency-card.html"
+        else:
+            return self.enrollment_index_template_override or f"{prefix}.html"
 
     @property
     def enrollment_success_template(self):
         prefix = "enrollment/success"
-        if self.uses_claims_verification:
-            return self.enrollment_success_template_override or f"{prefix}--{self.transit_agency.slug}.html"
-        else:
+        if self.uses_api_verification:
             return self.enrollment_success_template_override or f"{prefix}--{self.agency_card_name}.html"
+        else:
+            return self.enrollment_success_template_override or f"{prefix}--{self.transit_agency.slug}.html"
 
     def clean(self):
         field_errors = {}
@@ -316,7 +316,7 @@ class EnrollmentFlow(models.Model):
 
     def eligibility_form_instance(self, *args, **kwargs):
         """Return an instance of this flow's EligibilityForm, or None."""
-        if not bool(self.eligibility_form_class):
+        if not self.uses_api_verification:
             return None
 
         # inspired by https://stackoverflow.com/a/30941292

--- a/benefits/core/models/enrollment.py
+++ b/benefits/core/models/enrollment.py
@@ -256,42 +256,9 @@ class EnrollmentFlow(models.Model):
             return self.enrollment_success_template_override or f"{prefix}--{self.transit_agency.slug}.html"
 
     def clean(self):
-        field_errors = {}
         template_errors = []
 
-        if self.supports_expiration:
-            expiration_days = self.expiration_days
-            expiration_reenrollment_days = self.expiration_reenrollment_days
-            reenrollment_error_template = self.reenrollment_error_template
-
-            message = "When support_expiration is True, this value must be greater than 0."
-            if expiration_days is None or expiration_days <= 0:
-                field_errors.update(expiration_days=ValidationError(message))
-            if expiration_reenrollment_days is None or expiration_reenrollment_days <= 0:
-                field_errors.update(expiration_reenrollment_days=ValidationError(message))
-            if not reenrollment_error_template:
-                field_errors.update(reenrollment_error_template=ValidationError("Required when supports expiration is True."))
-
         if self.transit_agency:
-            if self.claims_provider:
-                message = "Required for claims verification."
-                needed = dict(
-                    claims_scope=self.claims_scope,
-                    claims_eligibility_claim=self.claims_eligibility_claim,
-                )
-                field_errors.update({k: ValidationError(message) for k, v in needed.items() if not v})
-            elif self.uses_api_verification:
-                message = "Required for Eligibility API verification."
-                needed = dict(
-                    eligibility_api_auth_header=self.eligibility_api_auth_header,
-                    eligibility_api_auth_key_secret_name=self.eligibility_api_auth_key_secret_name,
-                    eligibility_api_jwe_cek_enc=self.eligibility_api_jwe_cek_enc,
-                    eligibility_api_jwe_encryption_alg=self.eligibility_api_jwe_encryption_alg,
-                    eligibility_api_jws_signing_alg=self.eligibility_api_jws_signing_alg,
-                    eligibility_api_public_key=self.eligibility_api_public_key,
-                )
-                field_errors.update({k: ValidationError(message) for k, v in needed.items() if not v})
-
             templates = [
                 self.selection_label_template,
                 self.eligibility_start_template,
@@ -309,8 +276,6 @@ class EnrollmentFlow(models.Model):
                 if not template_path(t):
                     template_errors.append(ValidationError(f"Template not found: {t}"))
 
-        if field_errors:
-            raise ValidationError(field_errors)
         if template_errors:
             raise ValidationError(template_errors)
 

--- a/benefits/core/models/transit.py
+++ b/benefits/core/models/transit.py
@@ -201,12 +201,6 @@ class TransitAgency(models.Model):
         template_errors = []
 
         if self.active:
-            for flow in self.enrollment_flows.all():
-                try:
-                    flow.clean()
-                except ValidationError:
-                    raise ValidationError(f"Invalid EnrollmentFlow: {flow.label}")
-
             message = "This field is required for active transit agencies."
             needed = dict(
                 short_name=self.short_name,

--- a/tests/pytest/core/admin/test_enrollment.py
+++ b/tests/pytest/core/admin/test_enrollment.py
@@ -165,3 +165,18 @@ class TestEnrollmentFlowAdmin:
         request = admin_user_request(user_type)
 
         assert flow_admin_model.has_add_permission(request) == expected
+
+    def test_EnrollmentFlowForm_staff_member_no_transit_agency(self, admin_user_request, flow_admin_model):
+        request = admin_user_request()
+
+        # get the Form class that's used in the admin add view as the user would see it
+        form_class = flow_admin_model.get_form(request)
+
+        request.POST = dict(
+            system_name="testflow",
+            supported_enrollment_methods=[models.EnrollmentMethods.DIGITAL, models.EnrollmentMethods.IN_PERSON],
+        )
+
+        form = form_class(request.POST)
+        assert not form.errors
+        assert form.is_valid()

--- a/tests/pytest/core/admin/test_enrollment.py
+++ b/tests/pytest/core/admin/test_enrollment.py
@@ -201,5 +201,13 @@ class TestEnrollmentFlowAdmin:
         )
 
         form = form_class(request.POST)
-        assert form.errors
+
+        errors = form.errors
+        assert len(errors) == 1
+
+        error = list(errors.values())[0][0]
+        assert (
+            error
+            == "Must configure either claims verification or Eligibility API verification before adding to a transit agency."
+        )
         assert not form.is_valid()

--- a/tests/pytest/core/admin/test_enrollment.py
+++ b/tests/pytest/core/admin/test_enrollment.py
@@ -1,0 +1,185 @@
+import pytest
+
+from django.contrib import admin
+from django.conf import settings
+
+from benefits.core import models
+from benefits.core.admin.enrollment import EnrollmentEventAdmin, SortableEnrollmentFlowAdmin
+
+
+@pytest.fixture
+def event_admin_model():
+    return EnrollmentEventAdmin(models.EnrollmentEvent, admin.site)
+
+
+@pytest.fixture
+def flow_admin_model():
+    return SortableEnrollmentFlowAdmin(models.EnrollmentFlow, admin.site)
+
+
+@pytest.mark.django_db
+class TestEnrollmentEventAdmin:
+
+    def test_get_readonly_fields(self, admin_request, event_admin_model):
+        request = admin_request(is_superuser=False, is_staff_member=False)
+        assert event_admin_model.get_readonly_fields(request) == ["id"]
+
+    @pytest.mark.parametrize(
+        "runtime_env,user_type,expected",
+        [
+            (settings.RUNTIME_ENVS.PROD, "staff", False),
+            (settings.RUNTIME_ENVS.PROD, "super", False),
+            (settings.RUNTIME_ENVS.DEV, "staff", True),
+            (settings.RUNTIME_ENVS.DEV, "super", True),
+        ],
+    )
+    def test_has_add_permission(
+        self,
+        admin_request,
+        event_admin_model,
+        settings,
+        runtime_env,
+        user_type,
+        expected,
+    ):
+        settings.RUNTIME_ENVIRONMENT = lambda: runtime_env
+
+        if user_type == "staff":
+            request = admin_request(is_superuser=False, is_staff_member=True)
+        elif user_type == "super":
+            request = admin_request(is_superuser=True, is_staff_member=False)
+
+        assert event_admin_model.has_add_permission(request) == expected
+
+    @pytest.mark.parametrize(
+        "runtime_env,user_type,expected",
+        [
+            (settings.RUNTIME_ENVS.PROD, "staff", False),
+            (settings.RUNTIME_ENVS.PROD, "super", False),
+            (settings.RUNTIME_ENVS.TEST, "staff", False),
+            (settings.RUNTIME_ENVS.TEST, "super", True),
+        ],
+    )
+    def test_has_change_permission(
+        self,
+        admin_request,
+        event_admin_model,
+        settings,
+        runtime_env,
+        user_type,
+        expected,
+    ):
+        settings.RUNTIME_ENVIRONMENT = lambda: runtime_env
+
+        if user_type == "staff":
+            request = admin_request(is_superuser=False, is_staff_member=True)
+        elif user_type == "super":
+            request = admin_request(is_superuser=True, is_staff_member=False)
+
+        assert event_admin_model.has_change_permission(request) == expected
+
+    @pytest.mark.parametrize(
+        "user_type,expected",
+        [
+            ("staff", True),
+            ("super", True),
+        ],
+    )
+    def test_has_view_permission(self, admin_request, event_admin_model, user_type, expected):
+        if user_type == "staff":
+            request = admin_request(is_superuser=False, is_staff_member=True)
+        elif user_type == "super":
+            request = admin_request(is_superuser=True, is_staff_member=False)
+
+        assert event_admin_model.has_view_permission(request) == expected
+
+
+@pytest.mark.django_db
+class TestEnrollmentFlowAdmin:
+
+    @pytest.mark.parametrize(
+        "user_type,expected",
+        [
+            (
+                "staff",
+                [
+                    "eligibility_api_auth_header",
+                    "eligibility_api_auth_key_secret_name",
+                    "eligibility_api_public_key",
+                    "eligibility_api_jwe_cek_enc",
+                    "eligibility_api_jwe_encryption_alg",
+                    "eligibility_api_jws_signing_alg",
+                ],
+            ),
+            ("super", None),
+        ],
+    )
+    def test_get_exclude(self, admin_request, flow_admin_model, user_type, expected):
+        if user_type == "staff":
+            request = admin_request(is_superuser=False, is_staff_member=True)
+        elif user_type == "super":
+            request = admin_request(is_superuser=True, is_staff_member=False)
+
+        excluded = flow_admin_model.get_exclude(request)
+
+        if expected:
+            assert set(excluded) == set(expected)
+        else:
+            assert excluded is None
+
+    @pytest.mark.parametrize(
+        "user_type,expected",
+        [
+            (
+                "staff",
+                [
+                    "eligibility_api_url",
+                    "eligibility_form_class",
+                    "eligibility_start_template_override",
+                    "eligibility_unverified_template_override",
+                    "selection_label_template_override",
+                    "reenrollment_error_template",
+                    "help_template",
+                    "enrollment_index_template_override",
+                    "enrollment_success_template_override",
+                ],
+            ),
+            ("super", ()),
+        ],
+    )
+    def test_get_readonly_fields(self, admin_request, flow_admin_model, user_type, expected):
+        if user_type == "staff":
+            request = admin_request(is_superuser=False, is_staff_member=True)
+        elif user_type == "super":
+            request = admin_request(is_superuser=True, is_staff_member=False)
+
+        readonly = flow_admin_model.get_readonly_fields(request)
+
+        assert set(readonly) == set(expected)
+
+    @pytest.mark.parametrize(
+        "runtime_env,user_type,expected",
+        [
+            (settings.RUNTIME_ENVS.PROD, "staff", True),
+            (settings.RUNTIME_ENVS.PROD, "super", True),
+            (settings.RUNTIME_ENVS.DEV, "staff", True),
+            (settings.RUNTIME_ENVS.DEV, "super", True),
+        ],
+    )
+    def test_has_add_permission(
+        self,
+        admin_request,
+        flow_admin_model,
+        settings,
+        runtime_env,
+        user_type,
+        expected,
+    ):
+        settings.RUNTIME_ENVIRONMENT = lambda: runtime_env
+
+        if user_type == "staff":
+            request = admin_request(is_superuser=False, is_staff_member=True)
+        else:
+            request = admin_request(is_superuser=True, is_staff_member=False)
+
+        assert flow_admin_model.has_add_permission(request) == expected

--- a/tests/pytest/core/admin/test_enrollment.py
+++ b/tests/pytest/core/admin/test_enrollment.py
@@ -186,6 +186,7 @@ class TestEnrollmentFlowAdmin:
         self, admin_user_request, flow_admin_model, model_TransitAgency, active
     ):
         model_TransitAgency.active = active
+        model_TransitAgency.slug = "mst"  # use value that will map to existing templates
         model_TransitAgency.save()
 
         request = admin_user_request()
@@ -194,7 +195,7 @@ class TestEnrollmentFlowAdmin:
         form_class = flow_admin_model.get_form(request)
 
         request.POST = dict(
-            system_name="testflow",
+            system_name="senior",  # use value that will map to existing templates
             supported_enrollment_methods=[models.EnrollmentMethods.DIGITAL, models.EnrollmentMethods.IN_PERSON],
             transit_agency=model_TransitAgency.id,
         )

--- a/tests/pytest/core/admin/test_enrollment.py
+++ b/tests/pytest/core/admin/test_enrollment.py
@@ -180,3 +180,25 @@ class TestEnrollmentFlowAdmin:
         form = form_class(request.POST)
         assert not form.errors
         assert form.is_valid()
+
+    @pytest.mark.parametrize("active", [True, False])
+    def test_EnrollmentFlowForm_staff_member_with_transit_agency(
+        self, admin_user_request, flow_admin_model, model_TransitAgency, active
+    ):
+        model_TransitAgency.active = active
+        model_TransitAgency.save()
+
+        request = admin_user_request()
+
+        # get the Form class that's used in the admin add view as the user would see it
+        form_class = flow_admin_model.get_form(request)
+
+        request.POST = dict(
+            system_name="testflow",
+            supported_enrollment_methods=[models.EnrollmentMethods.DIGITAL, models.EnrollmentMethods.IN_PERSON],
+            transit_agency=model_TransitAgency.id,
+        )
+
+        form = form_class(request.POST)
+        assert form.errors
+        assert not form.is_valid()

--- a/tests/pytest/core/admin/test_enrollment.py
+++ b/tests/pytest/core/admin/test_enrollment.py
@@ -20,8 +20,8 @@ def flow_admin_model():
 @pytest.mark.django_db
 class TestEnrollmentEventAdmin:
 
-    def test_get_readonly_fields(self, admin_request, event_admin_model):
-        request = admin_request(is_superuser=False, is_staff_member=False)
+    def test_get_readonly_fields(self, admin_user_request, event_admin_model):
+        request = admin_user_request()
         assert event_admin_model.get_readonly_fields(request) == ["id"]
 
     @pytest.mark.parametrize(
@@ -35,7 +35,7 @@ class TestEnrollmentEventAdmin:
     )
     def test_has_add_permission(
         self,
-        admin_request,
+        admin_user_request,
         event_admin_model,
         settings,
         runtime_env,
@@ -44,10 +44,7 @@ class TestEnrollmentEventAdmin:
     ):
         settings.RUNTIME_ENVIRONMENT = lambda: runtime_env
 
-        if user_type == "staff":
-            request = admin_request(is_superuser=False, is_staff_member=True)
-        elif user_type == "super":
-            request = admin_request(is_superuser=True, is_staff_member=False)
+        request = admin_user_request(user_type)
 
         assert event_admin_model.has_add_permission(request) == expected
 
@@ -62,7 +59,7 @@ class TestEnrollmentEventAdmin:
     )
     def test_has_change_permission(
         self,
-        admin_request,
+        admin_user_request,
         event_admin_model,
         settings,
         runtime_env,
@@ -71,10 +68,7 @@ class TestEnrollmentEventAdmin:
     ):
         settings.RUNTIME_ENVIRONMENT = lambda: runtime_env
 
-        if user_type == "staff":
-            request = admin_request(is_superuser=False, is_staff_member=True)
-        elif user_type == "super":
-            request = admin_request(is_superuser=True, is_staff_member=False)
+        request = admin_user_request(user_type)
 
         assert event_admin_model.has_change_permission(request) == expected
 
@@ -85,11 +79,8 @@ class TestEnrollmentEventAdmin:
             ("super", True),
         ],
     )
-    def test_has_view_permission(self, admin_request, event_admin_model, user_type, expected):
-        if user_type == "staff":
-            request = admin_request(is_superuser=False, is_staff_member=True)
-        elif user_type == "super":
-            request = admin_request(is_superuser=True, is_staff_member=False)
+    def test_has_view_permission(self, admin_user_request, event_admin_model, user_type, expected):
+        request = admin_user_request(user_type)
 
         assert event_admin_model.has_view_permission(request) == expected
 
@@ -114,11 +105,8 @@ class TestEnrollmentFlowAdmin:
             ("super", None),
         ],
     )
-    def test_get_exclude(self, admin_request, flow_admin_model, user_type, expected):
-        if user_type == "staff":
-            request = admin_request(is_superuser=False, is_staff_member=True)
-        elif user_type == "super":
-            request = admin_request(is_superuser=True, is_staff_member=False)
+    def test_get_exclude(self, admin_user_request, flow_admin_model, user_type, expected):
+        request = admin_user_request(user_type)
 
         excluded = flow_admin_model.get_exclude(request)
 
@@ -147,11 +135,8 @@ class TestEnrollmentFlowAdmin:
             ("super", ()),
         ],
     )
-    def test_get_readonly_fields(self, admin_request, flow_admin_model, user_type, expected):
-        if user_type == "staff":
-            request = admin_request(is_superuser=False, is_staff_member=True)
-        elif user_type == "super":
-            request = admin_request(is_superuser=True, is_staff_member=False)
+    def test_get_readonly_fields(self, admin_user_request, flow_admin_model, user_type, expected):
+        request = admin_user_request(user_type)
 
         readonly = flow_admin_model.get_readonly_fields(request)
 
@@ -168,7 +153,7 @@ class TestEnrollmentFlowAdmin:
     )
     def test_has_add_permission(
         self,
-        admin_request,
+        admin_user_request,
         flow_admin_model,
         settings,
         runtime_env,
@@ -177,9 +162,6 @@ class TestEnrollmentFlowAdmin:
     ):
         settings.RUNTIME_ENVIRONMENT = lambda: runtime_env
 
-        if user_type == "staff":
-            request = admin_request(is_superuser=False, is_staff_member=True)
-        else:
-            request = admin_request(is_superuser=True, is_staff_member=False)
+        request = admin_user_request(user_type)
 
         assert flow_admin_model.has_add_permission(request) == expected

--- a/tests/pytest/core/admin/test_enrollment.py
+++ b/tests/pytest/core/admin/test_enrollment.py
@@ -212,17 +212,14 @@ class TestEnrollmentFlowAdmin:
         )
         assert not form.is_valid()
 
+    @pytest.mark.parametrize("user_type", ["staff", "super"])
     def test_EnrollmentFlowForm_clean_claims_verification(
-        self,
-        admin_user_request,
-        flow_admin_model,
-        model_TransitAgency,
-        model_ClaimsProvider,
+        self, admin_user_request, flow_admin_model, model_TransitAgency, model_ClaimsProvider, user_type
     ):
         model_TransitAgency.slug = "mst"  # use value that will map to existing templates
         model_TransitAgency.save()
 
-        request = admin_user_request()
+        request = admin_user_request(user_type)
 
         # fill out the form without a transit agency
         request.POST = dict(

--- a/tests/pytest/core/models/test_enrollment.py
+++ b/tests/pytest/core/models/test_enrollment.py
@@ -255,6 +255,9 @@ def test_EnrollmentFlow_clean_eligibility_api_verification(model_EnrollmentFlow_
 
     # reassign agency
     model_EnrollmentFlow_with_eligibility_api.transit_agency = model_TransitAgency
+    # and fields indicating eligibility API verification
+    model_EnrollmentFlow_with_eligibility_api.eligibility_api_url = "https://example.com"
+    model_EnrollmentFlow_with_eligibility_api.eligibility_form_class = "FormClass"
     with pytest.raises(ValidationError) as e:
         model_EnrollmentFlow_with_eligibility_api.clean()
 
@@ -265,8 +268,6 @@ def test_EnrollmentFlow_clean_eligibility_api_verification(model_EnrollmentFlow_
     assert "eligibility_api_jwe_encryption_alg" in error_dict
     assert "eligibility_api_jws_signing_alg" in error_dict
     assert "eligibility_api_public_key" in error_dict
-    assert "eligibility_api_url" in error_dict
-    assert "eligibility_form_class" in error_dict
 
 
 @pytest.mark.django_db

--- a/tests/pytest/core/models/test_enrollment.py
+++ b/tests/pytest/core/models/test_enrollment.py
@@ -218,59 +218,6 @@ def test_EnrollmentFlow_template_overrides_eligibility_api(model_EnrollmentFlow_
 
 
 @pytest.mark.django_db
-def test_EnrollmentFlow_clean_claims_verification(model_EnrollmentFlow_with_scope_and_claim, model_TransitAgency):
-    # remove agency
-    model_EnrollmentFlow_with_scope_and_claim.transit_agency = None
-    # and required fields
-    model_EnrollmentFlow_with_scope_and_claim.claims_scope = ""
-    model_EnrollmentFlow_with_scope_and_claim.claims_eligibility_claim = ""
-    # clean is OK
-    model_EnrollmentFlow_with_scope_and_claim.clean()
-
-    # reassign agency
-    model_EnrollmentFlow_with_scope_and_claim.transit_agency = model_TransitAgency
-    with pytest.raises(ValidationError) as e:
-        model_EnrollmentFlow_with_scope_and_claim.clean()
-
-    error_dict = e.value.error_dict
-    assert "claims_scope" in error_dict
-    assert "claims_eligibility_claim" in error_dict
-
-
-@pytest.mark.django_db
-def test_EnrollmentFlow_clean_eligibility_api_verification(model_EnrollmentFlow_with_eligibility_api, model_TransitAgency):
-    # remove agency
-    model_EnrollmentFlow_with_eligibility_api.transit_agency = None
-    # and required fields
-    model_EnrollmentFlow_with_eligibility_api.eligibility_api_auth_header = ""
-    model_EnrollmentFlow_with_eligibility_api.eligibility_api_auth_key_secret_name = ""
-    model_EnrollmentFlow_with_eligibility_api.eligibility_api_jwe_cek_enc = ""
-    model_EnrollmentFlow_with_eligibility_api.eligibility_api_jwe_encryption_alg = ""
-    model_EnrollmentFlow_with_eligibility_api.eligibility_api_jws_signing_alg = ""
-    model_EnrollmentFlow_with_eligibility_api.eligibility_api_public_key = None
-    model_EnrollmentFlow_with_eligibility_api.eligibility_api_url = ""
-    model_EnrollmentFlow_with_eligibility_api.eligibility_form_class = ""
-    # clean is OK
-    model_EnrollmentFlow_with_eligibility_api.clean()
-
-    # reassign agency
-    model_EnrollmentFlow_with_eligibility_api.transit_agency = model_TransitAgency
-    # and fields indicating eligibility API verification
-    model_EnrollmentFlow_with_eligibility_api.eligibility_api_url = "https://example.com"
-    model_EnrollmentFlow_with_eligibility_api.eligibility_form_class = "FormClass"
-    with pytest.raises(ValidationError) as e:
-        model_EnrollmentFlow_with_eligibility_api.clean()
-
-    error_dict = e.value.error_dict
-    assert "eligibility_api_auth_header" in error_dict
-    assert "eligibility_api_auth_key_secret_name" in error_dict
-    assert "eligibility_api_jwe_cek_enc" in error_dict
-    assert "eligibility_api_jwe_encryption_alg" in error_dict
-    assert "eligibility_api_jws_signing_alg" in error_dict
-    assert "eligibility_api_public_key" in error_dict
-
-
-@pytest.mark.django_db
 def test_EnrollmentFlow_clean_supports_expiration(model_EnrollmentFlow_supports_expiration, model_ClaimsProvider):
     # fake a valid claims configuration
     model_EnrollmentFlow_supports_expiration.claims_provider = model_ClaimsProvider
@@ -281,18 +228,6 @@ def test_EnrollmentFlow_clean_supports_expiration(model_EnrollmentFlow_supports_
 
     with pytest.raises(ValidationError, match="Template not found: does/not/exist.html"):
         model_EnrollmentFlow_supports_expiration.clean()
-
-    model_EnrollmentFlow_supports_expiration.expiration_days = 0
-    model_EnrollmentFlow_supports_expiration.expiration_reenrollment_days = 0
-    model_EnrollmentFlow_supports_expiration.reenrollment_error_template = ""
-
-    with pytest.raises(ValidationError) as e:
-        model_EnrollmentFlow_supports_expiration.clean()
-
-    error_dict = e.value.error_dict
-    assert "expiration_days" in error_dict
-    assert "expiration_reenrollment_days" in error_dict
-    assert "reenrollment_error_template" in error_dict
 
 
 @pytest.mark.django_db

--- a/tests/pytest/core/models/test_transit.py
+++ b/tests/pytest/core/models/test_transit.py
@@ -192,16 +192,3 @@ def test_TransitAgency_clean_templates(model_TransitAgency_inactive, template_at
     model_TransitAgency_inactive.active = True
     with pytest.raises(ValidationError, match="Template not found: does/not/exist.html"):
         model_TransitAgency_inactive.clean()
-
-
-@pytest.mark.django_db
-def test_TransitAgency_clean_dirty_flow(model_TransitAgency, model_EnrollmentFlow, model_ClaimsProvider):
-    # partially setup the EnrollmentFlow
-    # missing scope and claims
-    model_EnrollmentFlow.claims_provider = model_ClaimsProvider
-    model_EnrollmentFlow.transit_agency = model_TransitAgency
-    model_EnrollmentFlow.save()
-
-    # clean the agency, and expect an invalid EnrollmentFlow error
-    with pytest.raises(ValidationError, match=f"Invalid EnrollmentFlow: {model_EnrollmentFlow.label}"):
-        model_TransitAgency.clean()

--- a/tests/pytest/core/models/test_transit.py
+++ b/tests/pytest/core/models/test_transit.py
@@ -200,6 +200,7 @@ def test_TransitAgency_clean_dirty_flow(model_TransitAgency, model_EnrollmentFlo
     # missing scope and claims
     model_EnrollmentFlow.claims_provider = model_ClaimsProvider
     model_EnrollmentFlow.transit_agency = model_TransitAgency
+    model_EnrollmentFlow.save()
 
     # clean the agency, and expect an invalid EnrollmentFlow error
     with pytest.raises(ValidationError, match=f"Invalid EnrollmentFlow: {model_EnrollmentFlow.label}"):

--- a/tests/pytest/eligibility/test_views.py
+++ b/tests/pytest/eligibility/test_views.py
@@ -65,11 +65,11 @@ class SampleVerificationForm(EligibilityVerificationForm):
 
 
 @pytest.fixture
-def model_EnrollmentFlow_with_form_class(mocker, model_EnrollmentFlow):
-    model_EnrollmentFlow.eligibility_form_class = f"{__name__}.SampleVerificationForm"
-    model_EnrollmentFlow.save()
-    mocker.patch("benefits.eligibility.views.session.flow", return_value=model_EnrollmentFlow)
-    return model_EnrollmentFlow
+def model_EnrollmentFlow_with_form_class(mocker, model_EnrollmentFlow_with_eligibility_api):
+    model_EnrollmentFlow_with_eligibility_api.eligibility_form_class = f"{__name__}.SampleVerificationForm"
+    model_EnrollmentFlow_with_eligibility_api.save()
+    mocker.patch("benefits.eligibility.views.session.flow", return_value=model_EnrollmentFlow_with_eligibility_api)
+    return model_EnrollmentFlow_with_eligibility_api
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Part of #2201

Closes #2664 

Allows Cal-ITP staff members to add new `EnrollmentFlow` objects.

## Testing

### Staff member
Login into Benefits Admin as `calitp-user` from our LastPass shared credentials.

- Cal-ITP staff member can add a new `EnrollmentFlow`:
   - [ ] can add an `EnrollmentFlow` with claims verification to a transit agency
   - [ ] can start creation of an `EnrollmentFlow` with API verification; they have to ask an engineer to finish out configuration of the Eligibility API fields before the flow can be added to a transit agency
- Cal-ITP staff member should not be able to add incomplete `EnrollmentFlow` to a transit agency
   - [ ] incomplete - none of the fields for claims or API verification have been filled out
   - [ ] incomplete - some but not all fields for claims verification have been filled out
   - [ ] incomplete - some but not all fields for expiration have been filled out
   - ~~[ ] incomplete - some but not all fields for API verification have been filled out~~ - not possible for staff member to do by themselves

### Some screenshots

>  Cal-ITP staff member should not be able to add incomplete `EnrollmentFlow` to a transit agency

<details><summary>Incomplete - none of the fields for claims or API verification have been filled out</summary>

![image](https://github.com/user-attachments/assets/ba8ce0d3-8e01-4d14-88df-3ee9c45ea1e8)

</details>

<details><summary>Incomplete - some but not all fields for expiration have been filled out</summary>

![image](https://github.com/user-attachments/assets/f380bd28-0029-4643-832a-b2075725804c)

</details>