### PR TITLE
Fix: port forwarding in VS Code

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
   "service": "dev",
   "runServices": ["dev", "docs", "server"],
   "forwardPorts": ["docs:8001", "server:8000"],
+  "otherPortsAttributes": { "onAutoForward": "ignore" },
   "workspaceFolder": "/calitp/app",
   "postStartCommand": ["/bin/bash", "bin/reset_db.sh"],
   "postAttachCommand": ["/bin/bash", ".devcontainer/postAttach.sh"],


### PR DESCRIPTION
Closes #2642

This PR changes the behavior of the dev container to only auto forward the ports associated with the `docs` and `server` services in the compose file. By setting `"otherPortsAttributes": { "onAutoForward": "ignore" }`, [any other ports should not be auto-forwarded at all](https://containers.dev/implementors/json_reference/#port-attributes).

## Reviewing
1. Exit your current dev container
2. Switch to this branch
3. Rebuild and reopen the dev container
4. Start the debugger
5. Verify that the app is always reachable from your browser at `localhost:DJANGO_LOCAL_PORT/` (open the benefits app, submit the eligibility form, navigate to the admin, etc.) and that the `PORTS` tab in VS Code always only shows 2 ports, the `server` and `docs` ports