### PR TITLE
Test: introduce admin conftest to use for testing `add` permissions

### DIFF
--- a/tests/pytest/core/admin/conftest.py
+++ b/tests/pytest/core/admin/conftest.py
@@ -1,0 +1,31 @@
+import pytest
+from django.contrib.auth.models import User, Group
+
+
+@pytest.fixture
+def model_AdminUser():
+    return User.objects.create(email="user@calitp.org", first_name="", last_name="", username="")
+
+
+@pytest.fixture
+def staff_group(settings):
+    return Group.objects.get(name=settings.STAFF_GROUP_NAME)
+
+
+@pytest.fixture
+def admin_user_request(model_AdminUser, rf, staff_group):
+    def _admin_user_request(user_type="staff"):
+        request = rf.get("/")
+        request.user = model_AdminUser
+
+        model_AdminUser.is_staff = True  # a user can log in if and only if this is True
+
+        if user_type == "staff":
+            model_AdminUser.is_superuser = False
+            staff_group.user_set.add(model_AdminUser)
+        elif user_type == "super":
+            model_AdminUser.is_superuser = True
+
+        return request
+
+    return _admin_user_request

--- a/tests/pytest/core/admin/test_users.py
+++ b/tests/pytest/core/admin/test_users.py
@@ -5,11 +5,6 @@ import benefits.core.admin
 from benefits.core.admin.users import GOOGLE_USER_INFO_URL, is_staff_member, is_staff_member_or_superuser, pre_login_user
 
 
-@pytest.fixture
-def model_AdminUser():
-    return User.objects.create(email="user@calitp.org", first_name="", last_name="", username="")
-
-
 @pytest.mark.django_db
 def test_admin_registered(client):
     response = client.get("/admin", follow=True)


### PR DESCRIPTION
This PR extracts out the `conftest.py` from #2654. This is so other PRs can be worked on to add and test the `add` permissions for `ClaimsProvider` and `TransitAgency` without having to wait for #2654.

Some guidance for the other PRs:
- Continue using `model_AdminUser`. We can look into switching to `admin_user` as a separate PR after these PRs that add the permissions.
- No need to add or test any `"regular"` user scenarios