### PR TITLE
Feat: field/add permissions for Transit models

### DIFF
--- a/benefits/core/admin/transit.py
+++ b/benefits/core/admin/transit.py
@@ -1,48 +1,74 @@
+from django.conf import settings
 from django.contrib import admin
 
 from benefits.core import models
+from .users import is_staff_member_or_superuser
 
 
 @admin.register(models.TransitAgency)
-class TransitAgencyAdmin(admin.ModelAdmin):  # pragma: no cover
+class TransitAgencyAdmin(admin.ModelAdmin):
     def get_exclude(self, request, obj=None):
+        fields = []
+
         if not request.user.is_superuser:
-            return [
-                "eligibility_api_private_key",
-                "eligibility_api_public_key",
-                "transit_processor_client_id",
-                "transit_processor_client_secret_name",
-                "transit_processor_audience",
-            ]
-        else:
-            return super().get_exclude(request, obj)
+            fields.extend(
+                [
+                    "eligibility_api_private_key",
+                    "eligibility_api_public_key",
+                    "sso_domain",
+                    "transit_processor_audience",
+                    "transit_processor_client_id",
+                    "transit_processor_client_secret_name",
+                ]
+            )
+
+        return fields or super().get_exclude(request, obj)
 
     def get_readonly_fields(self, request, obj=None):
+        fields = []
+
         if not request.user.is_superuser:
-            return [
-                "eligibility_api_id",
-                "transit_processor",
-                "index_template_override",
-                "eligibility_index_template_override",
-            ]
+            fields.extend(
+                [
+                    "index_template_override",
+                    "eligibility_index_template_override",
+                    "eligibility_api_id",
+                    "transit_processor",
+                ]
+            )
+
+        return fields or super().get_readonly_fields(request, obj)
+
+    def has_add_permission(self, request):
+        if settings.RUNTIME_ENVIRONMENT() != settings.RUNTIME_ENVS.PROD:
+            return True
+        elif request.user and is_staff_member_or_superuser(request.user):
+            return True
         else:
-            return super().get_readonly_fields(request, obj)
+            return False
 
 
 @admin.register(models.TransitProcessor)
-class TransitProcessorAdmin(admin.ModelAdmin):  # pragma: no cover
-    def get_exclude(self, request, obj=None):
-        if not request.user.is_superuser:
-            return []
-        else:
-            return super().get_exclude(request, obj)
+class TransitProcessorAdmin(admin.ModelAdmin):
 
     def get_readonly_fields(self, request, obj=None):
+        fields = []
+
         if not request.user.is_superuser:
-            return [
-                "card_tokenize_url",
-                "card_tokenize_func",
-                "card_tokenize_env",
-            ]
+            fields.extend(
+                [
+                    "card_tokenize_url",
+                    "card_tokenize_func",
+                    "card_tokenize_env",
+                ]
+            )
+
+        return fields or super().get_readonly_fields(request, obj)
+
+    def has_add_permission(self, request):
+        if settings.RUNTIME_ENVIRONMENT() != settings.RUNTIME_ENVS.PROD:
+            return True
+        elif request.user and request.user.is_superuser:
+            return True
         else:
-            return super().get_readonly_fields(request, obj)
+            return False

--- a/benefits/core/admin/transit.py
+++ b/benefits/core/admin/transit.py
@@ -51,19 +51,13 @@ class TransitAgencyAdmin(admin.ModelAdmin):
 @admin.register(models.TransitProcessor)
 class TransitProcessorAdmin(admin.ModelAdmin):
 
-    def get_readonly_fields(self, request, obj=None):
+    def get_exclude(self, request, obj=None):
         fields = []
 
         if not request.user.is_superuser:
-            fields.extend(
-                [
-                    "card_tokenize_url",
-                    "card_tokenize_func",
-                    "card_tokenize_env",
-                ]
-            )
+            fields.extend(["api_base_url", "card_tokenize_url", "card_tokenize_func", "card_tokenize_env"])
 
-        return fields or super().get_readonly_fields(request, obj)
+        return fields or super().get_exclude(request, obj)
 
     def has_add_permission(self, request):
         if settings.RUNTIME_ENVIRONMENT() != settings.RUNTIME_ENVS.PROD:

--- a/tests/pytest/core/admin/test_transit.py
+++ b/tests/pytest/core/admin/test_transit.py
@@ -87,16 +87,17 @@ class TestTransitProcessorAdmin:
     @pytest.mark.parametrize(
         "user_type,expected",
         [
-            ("staff", ["card_tokenize_url", "card_tokenize_func", "card_tokenize_env"]),
+            ("staff", ["api_base_url", "card_tokenize_url", "card_tokenize_func", "card_tokenize_env"]),
             ("super", ()),
         ],
     )
-    def test_get_readonly_fields(self, admin_user_request, processor_admin_model, user_type, expected):
+    def test_get_exclude(self, admin_user_request, processor_admin_model, user_type, expected):
         request = admin_user_request(user_type)
 
-        readonly = processor_admin_model.get_readonly_fields(request)
+        excluded = processor_admin_model.get_exclude(request)
 
-        assert set(readonly) == set(expected)
+        if expected:
+            assert set(excluded) == set(expected)
 
     @pytest.mark.parametrize(
         "runtime_env,user_type,expected",

--- a/tests/pytest/core/admin/test_transit.py
+++ b/tests/pytest/core/admin/test_transit.py
@@ -1,0 +1,115 @@
+import pytest
+
+from django.conf import settings
+from django.contrib import admin
+
+from benefits.core.admin.transit import TransitAgencyAdmin, TransitProcessorAdmin
+from benefits.core import models
+
+
+@pytest.fixture
+def agency_admin_model():
+    return TransitAgencyAdmin(models.TransitAgency, admin.site)
+
+
+@pytest.fixture
+def processor_admin_model():
+    return TransitProcessorAdmin(models.TransitProcessor, admin.site)
+
+
+@pytest.mark.django_db
+class TestTransitAgencyAdmin:
+
+    @pytest.mark.parametrize(
+        "user_type,expected",
+        [
+            (
+                "staff",
+                [
+                    "eligibility_api_private_key",
+                    "eligibility_api_public_key",
+                    "sso_domain",
+                    "transit_processor_audience",
+                    "transit_processor_client_id",
+                    "transit_processor_client_secret_name",
+                ],
+            ),
+            ("super", None),
+        ],
+    )
+    def test_get_exclude(self, admin_user_request, agency_admin_model, user_type, expected):
+        request = admin_user_request(user_type)
+
+        excluded = agency_admin_model.get_exclude(request)
+
+        if expected:
+            assert set(excluded) == set(expected)
+        else:
+            assert excluded is None
+
+    @pytest.mark.parametrize(
+        "user_type,expected",
+        [
+            (
+                "staff",
+                ["index_template_override", "eligibility_index_template_override", "eligibility_api_id", "transit_processor"],
+            ),
+            ("super", ()),
+        ],
+    )
+    def test_get_readonly_fields(self, admin_user_request, agency_admin_model, user_type, expected):
+        request = admin_user_request(user_type)
+
+        readonly = agency_admin_model.get_readonly_fields(request)
+
+        assert set(readonly) == set(expected)
+
+    @pytest.mark.parametrize(
+        "runtime_env,user_type,expected",
+        [
+            (settings.RUNTIME_ENVS.PROD, "staff", True),
+            (settings.RUNTIME_ENVS.PROD, "super", True),
+            (settings.RUNTIME_ENVS.DEV, "staff", True),
+            (settings.RUNTIME_ENVS.DEV, "super", True),
+        ],
+    )
+    def test_has_add_permission(self, admin_user_request, agency_admin_model, settings, runtime_env, user_type, expected):
+        settings.RUNTIME_ENVIRONMENT = lambda: runtime_env
+
+        request = admin_user_request(user_type)
+
+        assert agency_admin_model.has_add_permission(request) == expected
+
+
+@pytest.mark.django_db
+class TestTransitProcessorAdmin:
+
+    @pytest.mark.parametrize(
+        "user_type,expected",
+        [
+            ("staff", ["card_tokenize_url", "card_tokenize_func", "card_tokenize_env"]),
+            ("super", ()),
+        ],
+    )
+    def test_get_readonly_fields(self, admin_user_request, processor_admin_model, user_type, expected):
+        request = admin_user_request(user_type)
+
+        readonly = processor_admin_model.get_readonly_fields(request)
+
+        assert set(readonly) == set(expected)
+
+    @pytest.mark.parametrize(
+        "runtime_env,user_type,expected",
+        [
+            (settings.RUNTIME_ENVS.PROD, "staff", False),
+            (settings.RUNTIME_ENVS.PROD, "super", True),
+            (settings.RUNTIME_ENVS.DEV, "staff", True),
+            (settings.RUNTIME_ENVS.DEV, "super", True),
+        ],
+    )
+    def test_has_add_permission(self, admin_user_request, processor_admin_model, settings, runtime_env, user_type, expected):
+        settings.RUNTIME_ENVIRONMENT = lambda: runtime_env
+
+        request = admin_user_request(user_type)
+
+        assert processor_admin_model.has_add_permission(request) == expected


### PR DESCRIPTION
Closes #2665

This PR sets visible/nonvisible and editable/readonly permissions on the fields of `TransitAgency` and `TransitProcessor` models for `superuser` and `Cal-ITP` group members, and lets `Cal-ITP` group members add `TransitAgency` models.

## Reviewing

Set `DJANGO_ALLOWED_HOSTS=benefits.calitp.org,localhost` in your `.env` file (and don't forget to `source .env` in the dev container's terminal) so that you can see the add `TransitProcessor` and `TransitAgency` model behavior as it would run on `prod`. Otherwise, you will always be able to add the `TransitProcessor` model because of

```python
def has_add_permission(self, request):
        if settings.RUNTIME_ENVIRONMENT() != settings.RUNTIME_ENVS.PROD:
            return True
```

Log in to the admin interface as a `superuser` and verify the checklist for `superuser` shown below. 

Log in to the admin interface as a `Cal-ITP` group member (the easiest way to set up a `Cal-ITP` group member is to remove the `superuser` attribute from the `benefits-admin` user and to add it to the `Cal-ITP` group) and verify the checklist for `Cal-ITP` group member shown below.

For the verification, ensure model and field permissions match the permissions in the [Benefits admin configuration](https://docs.google.com/spreadsheets/d/1lPp_LJTfJoWCyOkRC4RaljABGG_jPWOgm4gaAHJigMU/edit) spreadsheet for model/field permissions for each user level (`Admin`, `Cal-ITP`, `Transit agency`). Note that in this spreadsheet, each field indicate the _lowest_ level user type, e.g. if a field is marked as readable by `Cal-ITP`, then it should also be readable by a `superuser`.

### `superuser`

- [ ] Confirm all fields of `TransitAgency` and `TransitProcessor` models are visible and editable as before
- [ ] Confirm `TransitAgency` and `TransitProcessor` models can be added as before

### `Cal-ITP` group member

- [ ] Confirm correct fields are visible/nonvisible, and editable/readonly
- [ ] Confirm new instances of the `TransitAgency` model can be added AND saved