### PR TITLE
Feat: field/add permissions for ClaimsProvider model

### DIFF
--- a/benefits/core/admin/claims.py
+++ b/benefits/core/admin/claims.py
@@ -2,7 +2,6 @@ from django.conf import settings
 from django.contrib import admin
 
 from benefits.core import models
-from .users import is_staff_member_or_superuser
 
 
 @admin.register(models.ClaimsProvider)
@@ -33,7 +32,7 @@ class ClaimsProviderAdmin(admin.ModelAdmin):
     def has_add_permission(self, request):
         if settings.RUNTIME_ENVIRONMENT() != settings.RUNTIME_ENVS.PROD:
             return True
-        elif request.user and is_staff_member_or_superuser(request.user):
+        elif request.user and request.user.is_superuser:
             return True
         else:
             return False

--- a/benefits/core/admin/claims.py
+++ b/benefits/core/admin/claims.py
@@ -1,23 +1,39 @@
+from django.conf import settings
 from django.contrib import admin
 
 from benefits.core import models
+from .users import is_staff_member_or_superuser
 
 
 @admin.register(models.ClaimsProvider)
-class ClaimsProviderAdmin(admin.ModelAdmin):  # pragma: no cover
+class ClaimsProviderAdmin(admin.ModelAdmin):
     def get_exclude(self, request, obj=None):
+        fields = []
+
         if not request.user.is_superuser:
-            return ["client_id_secret_name"]
-        else:
-            return super().get_exclude(request, obj)
+            fields.extend(["client_id_secret_name"])
+
+        return fields or super().get_exclude(request, obj)
 
     def get_readonly_fields(self, request, obj=None):
+        fields = []
+
         if not request.user.is_superuser:
-            return [
-                "sign_out_button_template",
-                "sign_out_link_template",
-                "authority",
-                "scheme",
-            ]
+            fields.extend(
+                [
+                    "sign_out_button_template",
+                    "sign_out_link_template",
+                    "authority",
+                    "scheme",
+                ]
+            )
+
+        return fields or super().get_readonly_fields(request, obj)
+
+    def has_add_permission(self, request):
+        if settings.RUNTIME_ENVIRONMENT() != settings.RUNTIME_ENVS.PROD:
+            return True
+        elif request.user and is_staff_member_or_superuser(request.user):
+            return True
         else:
-            return super().get_readonly_fields(request, obj)
+            return False

--- a/tests/pytest/core/admin/test_claims.py
+++ b/tests/pytest/core/admin/test_claims.py
@@ -1,0 +1,62 @@
+import pytest
+
+from django.conf import settings
+from django.contrib import admin
+
+from benefits.core import models
+from benefits.core.admin.claims import ClaimsProviderAdmin
+
+
+@pytest.fixture
+def admin_model():
+    return ClaimsProviderAdmin(models.ClaimsProvider, admin.site)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "user_type,expected",
+    [("staff", ["client_id_secret_name"]), ("super", None)],
+)
+def test_get_exclude(admin_model, admin_user_request, user_type, expected):
+    request = admin_user_request(user_type)
+
+    exclude = admin_model.get_exclude(request)
+
+    if expected:
+        assert set(exclude) == set(expected)
+    else:
+        assert exclude is None
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "user_type,expected",
+    [
+        ("staff", ["sign_out_button_template", "sign_out_link_template", "authority", "scheme"]),
+        ("super", ()),
+    ],
+)
+def test_get_readonly_fields(admin_model, admin_user_request, user_type, expected):
+    request = admin_user_request(user_type)
+
+    readonly = admin_model.get_readonly_fields(request)
+
+    assert set(readonly) == set(expected)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "runtime_env,user_type,expected",
+    [
+        (settings.RUNTIME_ENVS.PROD, "staff", True),
+        (settings.RUNTIME_ENVS.PROD, "super", True),
+        (settings.RUNTIME_ENVS.DEV, "staff", True),
+        (settings.RUNTIME_ENVS.DEV, "super", True),
+    ],
+)
+def test_has_add_permission(admin_model, admin_user_request, settings, runtime_env, user_type, expected):
+    settings.RUNTIME_ENVIRONMENT = lambda: runtime_env
+
+    request = admin_user_request(user_type)
+
+    assert admin_model.has_add_permission(request) == expected

--- a/tests/pytest/core/admin/test_claims.py
+++ b/tests/pytest/core/admin/test_claims.py
@@ -48,7 +48,7 @@ def test_get_readonly_fields(admin_model, admin_user_request, user_type, expecte
 @pytest.mark.parametrize(
     "runtime_env,user_type,expected",
     [
-        (settings.RUNTIME_ENVS.PROD, "staff", True),
+        (settings.RUNTIME_ENVS.PROD, "staff", False),
         (settings.RUNTIME_ENVS.PROD, "super", True),
         (settings.RUNTIME_ENVS.DEV, "staff", True),
         (settings.RUNTIME_ENVS.DEV, "super", True),


### PR DESCRIPTION
Closes #2663

This PR sets visible/nonvisible and editable/readonly permissions on the fields of `ClaimsProvider` for `superuser` and `Cal-ITP` group members, and lets `Cal-ITP` group members add instances of the `ClaimsProvider` model.

## Reviewing

Set `DJANGO_ALLOWED_HOSTS=benefits.calitp.org,localhost` in your `.env` file (and don't forget to `source .env` in the dev container's terminal) so that you can see the add `ClaimsProvider` model behavior as it would run on `prod`. Otherwise, you will always be able to add the `ClaimsProvider` model because of

```python
def has_add_permission(self, request):
        if settings.RUNTIME_ENVIRONMENT() != settings.RUNTIME_ENVS.PROD:
            return True
```

Log in to the admin interface as a `superuser` and verify the checklist for `superuser` shown below. 

Log in to the admin interface as a `Cal-ITP` group member (the easiest way to set up a `Cal-ITP` group member is to remove the `superuser` attribute from the `benefits-admin` user and to add it to the `Cal-ITP` group) and verify the checklist for `Cal-ITP` group member shown below.

For the verification, ensure model and field permissions match the permissions in the [Benefits admin configuration](https://docs.google.com/spreadsheets/d/1lPp_LJTfJoWCyOkRC4RaljABGG_jPWOgm4gaAHJigMU/edit) spreadsheet for model/field permissions for each user level (`Admin`, `Cal-ITP`, `Transit agency`). Note that in this spreadsheet, each field indicate the _lowest_ level user type, e.g. if a field is marked as readable by `Cal-ITP`, then it should also be readable by a `superuser`.

### `superuser`

- [ ] Confirm all fields of `ClaimsProvider` are visible and editable as before
- [ ] Confirm `ClaimsProvider` can be added as before

### `Cal-ITP` group member

- [ ] Confirm correct fields are visible/nonvisible, and editable/readonly
- [ ] Confirm new instances of the `ClaimsProvider` model can be added AND saved