### PR TITLE
Feat: field/add permissions for PemData model

### DIFF
--- a/benefits/core/admin/common.py
+++ b/benefits/core/admin/common.py
@@ -1,8 +1,20 @@
 from django.contrib import admin
+from django.http import HttpRequest
 
 from benefits.core import models
 
 
 @admin.register(models.PemData)
 class PemDataAdmin(admin.ModelAdmin):
-    list_display = ("label",)
+
+    def has_view_permission(self, request: HttpRequest, obj=None):
+        if request.user and request.user.is_superuser:
+            return True
+        else:
+            return False
+
+    def has_add_permission(self, request: HttpRequest, obj=None):
+        if request.user and request.user.is_superuser:
+            return True
+        else:
+            return False

--- a/tests/pytest/core/admin/test_common.py
+++ b/tests/pytest/core/admin/test_common.py
@@ -1,0 +1,43 @@
+import pytest
+
+from django.contrib import admin
+
+from benefits.core import models
+from benefits.core.admin.common import PemDataAdmin
+
+
+@pytest.fixture
+def admin_model():
+    return PemDataAdmin(models.PemData, admin.site)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "user_type,expected",
+    [("staff", False), ("super", True)],
+)
+def test_has_view_permission(
+    admin_user_request,
+    admin_model,
+    user_type,
+    expected,
+):
+    request = admin_user_request(user_type)
+
+    assert admin_model.has_view_permission(request) == expected
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "user_type,expected",
+    [("staff", False), ("super", True)],
+)
+def test_has_add_permission(
+    admin_user_request,
+    admin_model,
+    user_type,
+    expected,
+):
+    request = admin_user_request(user_type)
+
+    assert admin_model.has_add_permission(request) == expected


### PR DESCRIPTION
Closes #2666

This PR sets visible/nonvisible and editable/readonly permissions on the fields of `PemData` for `superuser` and `Cal-ITP` group members, and does not allow `Cal-ITP` group members to add instances of the `PemData` model.

## Reviewing

Log in to the admin interface as a `superuser` and verify the checklist for `superuser` shown below. 

Log in to the admin interface as a `Cal-ITP` group member (the easiest way to set up a `Cal-ITP` group member is to remove the `superuser` attribute from the `benefits-admin` user and to add it to the `Cal-ITP` group) and verify the checklist for `Cal-ITP` group member shown below.

For the verification, ensure model and field permissions match the permissions in the [Benefits admin configuration](https://docs.google.com/spreadsheets/d/1lPp_LJTfJoWCyOkRC4RaljABGG_jPWOgm4gaAHJigMU/edit) spreadsheet for model/field permissions for each user level (`Admin`, `Cal-ITP`, `Transit agency`). Note that in this spreadsheet, each field indicate the _lowest_ level user type, e.g. if a field is marked as readable by `Cal-ITP`, then it should also be readable by a `superuser`.

### `superuser`

- [ ] Confirm all fields of `PemData` are visible and editable as before
- [ ] Confirm `PemData` can be added as before

### `Cal-ITP` group member

- [ ] Confirm correct fields are visible/nonvisible, and editable/readonly
- [ ] Confirm new instances of the `PemData` model cannot be added