### PR TITLE
Chore: add fixture for Cal-ITP Staff account

### DIFF
--- a/benefits/core/migrations/local_fixtures.json
+++ b/benefits/core/migrations/local_fixtures.json
@@ -194,6 +194,24 @@
     }
   },
   {
+    "model": "auth.user",
+    "pk": 4,
+    "fields": {
+      "password": "pbkdf2_sha256$870000$UOTPdUZcVa1vrGNjw7BEv5$91er7Bp+yGI49FDS6DdWI5MutLwEegEMRHgIOZCfrYs=",
+      "last_login": null,
+      "is_superuser": false,
+      "username": "calitp-user",
+      "first_name": "CalITP",
+      "last_name": "User",
+      "email": "user@calitp.org",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2024-09-17T18:54:46Z",
+      "groups": [1],
+      "user_permissions": []
+    }
+  },
+  {
     "model": "core.enrollmentevent",
     "pk": "49328a98-f829-4009-a16a-d71ece9e51e3",
     "fields": {


### PR DESCRIPTION
Closes #2675

This PR adds to the database a `calitp-user` to make local testing and QA a little simpler without having to manually set up user accounts.

## Reviewing
Reset your database using the new fixture file in this PR, log in to the admin area, confirm that you can use the `calitp-user` credentials that are stored in the shared LastPass area, and that the permissions match the `Cal-ITP` staff group.
