### PR TITLE
Chore: unnecessary read-only field in EnrollmentEventAdmin

### DIFF
--- a/benefits/core/admin/enrollment.py
+++ b/benefits/core/admin/enrollment.py
@@ -14,9 +14,6 @@ from .users import is_staff_member_or_superuser
 class EnrollmentEventAdmin(admin.ModelAdmin):
     list_display = ("enrollment_datetime", "transit_agency", "enrollment_flow", "enrollment_method", "verified_by")
 
-    def get_readonly_fields(self, request: HttpRequest, obj=None):
-        return ["id"]
-
     def has_add_permission(self, request: HttpRequest, obj=None):
         if settings.RUNTIME_ENVIRONMENT() == settings.RUNTIME_ENVS.PROD:
             return False

--- a/tests/pytest/core/admin/test_enrollment.py
+++ b/tests/pytest/core/admin/test_enrollment.py
@@ -21,10 +21,6 @@ def flow_admin_model():
 @pytest.mark.django_db
 class TestEnrollmentEventAdmin:
 
-    def test_get_readonly_fields(self, admin_user_request, event_admin_model):
-        request = admin_user_request()
-        assert event_admin_model.get_readonly_fields(request) == ["id"]
-
     @pytest.mark.parametrize(
         "runtime_env,user_type,expected",
         [


### PR DESCRIPTION
Closes #2683 

This PR cleans up `EnrollmentEventAdmin` so that it no longer specifies `id` as a read-only field. Per the [docs](https://docs.djangoproject.com/en/5.1/ref/models/fields/#primary-key), the `id` field is already read-only since it's a primary key. The cleanup originally occurred in https://github.com/cal-itp/benefits/commit/6540f51370bb599d438484b3b689de713b586991.
