### PR TITLE
Fix: OAuth exception is not overwritten

### DIFF
--- a/benefits/oauth/views.py
+++ b/benefits/oauth/views.py
@@ -74,7 +74,7 @@ def login(request):
 
     if result and result.status_code >= 400:
         exception = Exception(f"authorize_redirect error response [{result.status_code}]: {result.content.decode()}")
-    elif result is None:
+    elif result is None and exception is None:
         exception = Exception("authorize_redirect returned None")
 
     if exception:


### PR DESCRIPTION
ClaimsProvider (oauth_client.authorize_redirect throws an exception)
is not overwritten and is the one that gets bubbled further.
