### PR TITLE
Chore: run pre-commit on all files

### DIFF
--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -122,10 +122,12 @@ a[target="_blank"]::after {
   content: " ";
   background-color: currentColor;
 
-  mask-image: url("/static/img/external-link.svg"),
+  mask-image:
+    url("/static/img/external-link.svg"),
     linear-gradient(transparent, transparent);
   mask-position: center center;
-  -webkit-mask-image: url("/static/img/external-link.svg"),
+  -webkit-mask-image:
+    url("/static/img/external-link.svg"),
     linear-gradient(transparent, transparent);
   -webkit-mask-position: center center;
 

--- a/benefits/static/css/variables.css
+++ b/benefits/static/css/variables.css
@@ -11,9 +11,9 @@
   --medium-font-weight: 500;
   --bold-font-weight: 700;
   --bs-body-font-size: calc(18rem / 16);
-  --bs-font-sans-serif: Roboto, system-ui, -apple-system, "Segoe UI",
-    sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
-    "Noto Color Emoji";
+  --bs-font-sans-serif:
+    Roboto, system-ui, -apple-system, "Segoe UI", sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --bs-body-font-family: var(--bs-font-sans-serif);
   --bs-body-line-height: 1.5; /* Displayed as 150% on Figma */
   --heading-line-height: 1.3; /* Displayed as 130% on Figma */


### PR DESCRIPTION
We're not sure what changed to cause the prettier pre-commit hook to fail on `styles.css` and `variables.css`. It keeps getting re-run on our PRs like #2691 and #2689 and [even on merges into `main`](https://results.pre-commit.ci/run/github/285501392/1739894951.TJKhBB2dS7e70pbofhCPNA), so let's just apply the re-formatting so it stops re-running.

Ran `pre-commit run --all-files`:

<img src="https://github.com/user-attachments/assets/57534cb1-e31e-48fc-a5b3-a1ed8fbb199f" width=500>
