### PR TITLE
Fix: rename test route to `testerror/`

### DIFF
--- a/benefits/urls.py
+++ b/benefits/urls.py
@@ -48,7 +48,7 @@ if settings.DEBUG:
     def trigger_error(request):
         raise RuntimeError("Test error")
 
-    urlpatterns.append(path("error/", trigger_error))
+    urlpatterns.append(path("testerror/", trigger_error))
 
     # simple route to read a pre-defined "secret"
     # this "secret" does not contain sensitive information


### PR DESCRIPTION
I needed this change while testing #2694.

In [746f322](https://github.com/cal-itp/benefits/commit/746f32246847aeacad52490a1183344788b5a753#diff-0a52f0f149d58e26a1c8fc3a6c333e6557c065bad6b9259e48c8531ee4728b54R53), we introduced an `error/` route to core's URLconf. We overlooked that in the root URLconf, there already was an `error/` route if `DEBUG=True`, which is for the purpose of testing Sentry.

That change was in May 2024, so I'm not sure how we've been able to test Sentry updates since then. For example, in [November 2024](https://github.com/cal-itp/benefits/pull/2532#pullrequestreview-2459325168), I was somehow able to hit the root `error/` and trigger the `RuntimeError("Test error")`.

Today, what I saw was that when I go to `error/`, I hit the core `error/` and see the Error page. No Sentry notification is sent:

<img src="https://github.com/user-attachments/assets/dff4b902-ee80-426b-95f6-f669c8d8892b" width=450>

I had to change the route name to something else in order to hit the root path and then [a Sentry notification was sent](https://cal-itp.slack.com/archives/C022HHSEE3F/p1740516871713039):

<img src="https://github.com/user-attachments/assets/9e472e6c-0af5-483e-b694-dc05da007d02" width=450>



