### PR TITLE
Feat: prevent agency from being saved if it doesn't have copy for index

### DIFF
--- a/tests/pytest/core/models/test_transit.py
+++ b/tests/pytest/core/models/test_transit.py
@@ -179,6 +179,17 @@ def test_TransitAgency_clean(model_TransitAgency_inactive, model_TransitProcesso
 
 
 @pytest.mark.django_db
+def test_TransitAgency_clean_index_context_missing(model_TransitAgency_inactive):
+    model_TransitAgency_inactive.slug = "new_slug_we_forgot_to_add_copy_for"
+    # agency is inactive, OK to have missing index context
+    model_TransitAgency_inactive.clean()
+
+    model_TransitAgency_inactive.active = True
+    with pytest.raises(ValidationError, match="Agency Index copy is missing"):
+        model_TransitAgency_inactive.clean()
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize("template_attribute", ["eligibility_index_template_override"])
 def test_TransitAgency_clean_templates(model_TransitAgency_inactive, template_attribute):
     setattr(model_TransitAgency_inactive, template_attribute, "does/not/exist.html")


### PR DESCRIPTION
While working on #2705, I realized that it would help prevent errors if `TransitAgency.clean` checks that the agency has all the copy it will need. That is, the `clean` method should try to call each `@property` method for getting the context dictionary for whatever page and make sure calling that method doesn't raise an error. 

This is similar to how [`EnrollmentFlow.clean`](https://github.com/cal-itp/benefits/blob/main/benefits/core/models/enrollment.py#L292) checks that the flow is able to get its `in_person_eligibility_context` if it is an in-person flow.

Basically if somehow we've forgotten to add copy for some slug, or if we accidentally remove copy from one of the mappings, then upon saving, we'll realize it.