### PR TITLE
Test: ensure core_context.agency_index contains all AgencySlugs

### DIFF
--- a/tests/pytest/core/context/test_agency.py
+++ b/tests/pytest/core/context/test_agency.py
@@ -1,0 +1,8 @@
+import pytest
+
+from benefits.core import context as core_context
+
+
+@pytest.mark.parametrize("slug", core_context.AgencySlug)
+def test_agency_index(slug):
+    assert core_context.agency_index[slug.value]


### PR DESCRIPTION
This will protect us from forgetting to add Agency Index copy.

Other PRs (like #2705) can add their own tests.