### PR TITLE
Chore: remove unused parameter in eligibility_from_oauth

### DIFF
--- a/benefits/eligibility/verify.py
+++ b/benefits/eligibility/verify.py
@@ -32,7 +32,7 @@ def eligibility_from_api(flow: models.EnrollmentFlow, form, agency: models.Trans
         return False
 
 
-def eligibility_from_oauth(flow: models.EnrollmentFlow, oauth_claims, agency: models.TransitAgency):
+def eligibility_from_oauth(flow: models.EnrollmentFlow, oauth_claims):
     if flow.uses_claims_verification and flow.claims_eligibility_claim in oauth_claims:
         return True
     else:

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -85,7 +85,7 @@ def confirm(request):
     if request.method == "GET" and flow.uses_claims_verification:
         analytics.started_eligibility(request, flow)
 
-        is_verified = verify.eligibility_from_oauth(flow, session.oauth_claims(request), agency)
+        is_verified = verify.eligibility_from_oauth(flow, session.oauth_claims(request))
 
         if is_verified:
             return verified(request)

--- a/tests/pytest/eligibility/test_verify.py
+++ b/tests/pytest/eligibility/test_verify.py
@@ -54,34 +54,32 @@ def test_eligibility_from_api_no_verified_types(
 
 
 @pytest.mark.django_db
-def test_eligibility_from_oauth_does_not_use_claims_verification(
-    mocked_session_flow_does_not_use_claims_verification, model_TransitAgency
-):
+def test_eligibility_from_oauth_does_not_use_claims_verification(mocked_session_flow_does_not_use_claims_verification):
     # mocked_session_flow_does_not_use_claims_verification is Mocked version of the session.flow() function
     flow = mocked_session_flow_does_not_use_claims_verification.return_value
 
-    response = eligibility_from_oauth(flow, ["claim"], model_TransitAgency)
+    response = eligibility_from_oauth(flow, ["claim"])
 
     assert response is False
 
 
 @pytest.mark.django_db
-def test_eligibility_from_oauth_claim_mismatch(mocked_session_flow_uses_claims_verification, model_TransitAgency):
+def test_eligibility_from_oauth_claim_mismatch(mocked_session_flow_uses_claims_verification):
     # mocked_session_flow_uses_claims_verification is Mocked version of the session.flow() function
     flow = mocked_session_flow_uses_claims_verification.return_value
     flow.claims_eligibility_claim = "claim"
 
-    response = eligibility_from_oauth(flow, ["some_other_claim"], model_TransitAgency)
+    response = eligibility_from_oauth(flow, ["some_other_claim"])
 
     assert response is False
 
 
 @pytest.mark.django_db
-def test_eligibility_from_oauth_claim_match(mocked_session_flow_uses_claims_verification, model_TransitAgency):
+def test_eligibility_from_oauth_claim_match(mocked_session_flow_uses_claims_verification):
     # mocked_session_flow_uses_claims_verification is Mocked version of the session.flow() function
     flow = mocked_session_flow_uses_claims_verification.return_value
     flow.claims_eligibility_claim = "claim"
 
-    response = eligibility_from_oauth(flow, ["claim"], model_TransitAgency)
+    response = eligibility_from_oauth(flow, ["claim"])
 
     assert response is True


### PR DESCRIPTION
While working on https://github.com/cal-itp/benefits/pull/2700, I noticed that we were not using this parameter anymore. This PR makes this small cleanup.