### PR TITLE
Refactor: install cdt_identity app

### DIFF
--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -57,6 +57,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.staticfiles",
     "adminsortable2",
+    "cdt_identity",
     "django_google_sso",
     "benefits.core",
     "benefits.enrollment",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "azure-keyvault-secrets==4.9.0",
     "azure-identity==1.20.0",
     "Django==5.1.7",
+    "django-cdt-identity @ git+https://github.com/Office-of-Digital-Services/django-cdt-identity.git@main",
     "django-csp==3.8",
     "django-admin-sortable2==2.2.4",
     "django-google-sso==8.0.0",


### PR DESCRIPTION
Closes #2734

This PR installs [django-cdt-identity](https://github.com/Office-of-Digital-Services/django-cdt-identity) using the package's Git URL (`main` branch) while we get it published to PyPI.

## Reviewing

- If you have a running dev container:

  - Switch to this branch
  - Run `pip install -e .` in your dev container's terminal
  - Run `pip freeze` to verify that `django-cdt-identity` is in the list of installed packages. The git URL will display the SHA of the latest commit in [`main`](https://github.com/Office-of-Digital-Services/django-cdt-identity)
  - Run `bin/init.sh` to apply one migration associated with `cdt_identity`
  - Start a debug session and in the `DEBUG CONSOLE` type `from cdt_identity.hooks import DefaultHooks` to verify that you can import from the `cdt_identity` app.

- If you are starting from scratch building a dev container, you can skip most of the steps above and just go through the last step to ensure that you can import from the `cdt_identity` app.