### PR TITLE
Admin: Disable sidebar

### DIFF
--- a/benefits/admin.py
+++ b/benefits/admin.py
@@ -32,10 +32,6 @@ class BenefitsAdminSite(AdminSite):
     def login(self, request, extra_context=None):
         return super().login(request, extra_context)
 
-    def __init__(self, name="admin"):
-        super().__init__(name)
-        self.enable_nav_sidebar = False
-
     def index(self, request, extra_context=None):
         """
         Display the main admin index page if the user is a superuser or a "staff_group" user.

--- a/benefits/admin.py
+++ b/benefits/admin.py
@@ -26,6 +26,7 @@ class BenefitsAdminSite(AdminSite):
     site_header = "Administrator"
     index_title = "Dashboard"
     login_form = BenefitsAdminLoginForm
+    enable_nav_sidebar = False
 
     @method_decorator(decorator_from_middleware(RecaptchaEnabled))
     def login(self, request, extra_context=None):

--- a/benefits/admin.py
+++ b/benefits/admin.py
@@ -31,6 +31,10 @@ class BenefitsAdminSite(AdminSite):
     def login(self, request, extra_context=None):
         return super().login(request, extra_context)
 
+    def __init__(self, name="admin"):
+        super().__init__(name)
+        self.enable_nav_sidebar = False
+
     def index(self, request, extra_context=None):
         """
         Display the main admin index page if the user is a superuser or a "staff_group" user.


### PR DESCRIPTION
closes #2740 

We do not want the sidebar to show up across the Django admin app.

This is what the sidebar looks like and how it functions, when open and closed on the Reset Password page:
![image](https://github.com/user-attachments/assets/f90917fa-d0d9-4ce3-b96c-5a3b58d5659f)
![image](https://github.com/user-attachments/assets/951ed3f6-f3ec-4539-9316-943eadca3643)

This PR sets the `enable_nav_sidebar` setting to False, so that it does not appear at all:

![image](https://github.com/user-attachments/assets/2a20db79-a9c2-4b20-bcd9-7b2e85d3f528)
