### PR TITLE
Feat: OAuth hooks for `login` view

### DIFF
--- a/benefits/oauth/hooks.py
+++ b/benefits/oauth/hooks.py
@@ -1,0 +1,5 @@
+from cdt_identity.hooks import DefaultHooks
+
+
+class OAuthHooks(DefaultHooks):
+    pass

--- a/benefits/oauth/hooks.py
+++ b/benefits/oauth/hooks.py
@@ -1,5 +1,10 @@
 from cdt_identity.hooks import DefaultHooks
 
+from . import analytics
+
 
 class OAuthHooks(DefaultHooks):
-    pass
+    @classmethod
+    def pre_login(cls, request):
+        super().pre_login(request)
+        analytics.started_sign_in(request)

--- a/benefits/oauth/hooks.py
+++ b/benefits/oauth/hooks.py
@@ -1,5 +1,8 @@
 from cdt_identity.hooks import DefaultHooks
+from django.shortcuts import redirect
+import sentry_sdk
 
+from benefits.routes import routes
 from . import analytics
 
 
@@ -8,3 +11,10 @@ class OAuthHooks(DefaultHooks):
     def pre_login(cls, request):
         super().pre_login(request)
         analytics.started_sign_in(request)
+
+    @classmethod
+    def system_error(cls, request, exception):
+        super().system_error(request, exception)
+        analytics.error(request, message=str(exception), operation="authorize_redirect")
+        sentry_sdk.capture_exception(exception)
+        return redirect(routes.OAUTH_SYSTEM_ERROR)

--- a/benefits/oauth/hooks.py
+++ b/benefits/oauth/hooks.py
@@ -13,8 +13,8 @@ class OAuthHooks(DefaultHooks):
         analytics.started_sign_in(request)
 
     @classmethod
-    def system_error(cls, request, exception):
-        super().system_error(request, exception)
-        analytics.error(request, message=str(exception), operation="authorize_redirect")
+    def system_error(cls, request, exception, operation):
+        super().system_error(request, exception, operation)
+        analytics.error(request, message=str(exception), operation=str(operation))
         sentry_sdk.capture_exception(exception)
         return redirect(routes.OAUTH_SYSTEM_ERROR)

--- a/tests/pytest/oauth/test_hooks.py
+++ b/tests/pytest/oauth/test_hooks.py
@@ -1,5 +1,8 @@
+from django.urls import reverse
+
 import pytest
 
+from benefits.routes import routes
 from benefits.oauth.hooks import OAuthHooks
 import benefits.oauth.hooks
 
@@ -9,7 +12,21 @@ def mocked_analytics_module(mocked_analytics_module):
     return mocked_analytics_module(benefits.oauth.hooks)
 
 
+@pytest.fixture
+def mocked_sentry_sdk_module(mocker):
+    return mocker.patch.object(benefits.oauth.hooks, "sentry_sdk")
+
+
 def test_pre_login(app_request, mocked_analytics_module):
     OAuthHooks.pre_login(app_request)
 
     mocked_analytics_module.started_sign_in.assert_called_once()
+
+
+def test_system_error(app_request, mocked_analytics_module, mocked_sentry_sdk_module):
+    result = OAuthHooks.system_error(app_request, Exception("some exception"))
+
+    assert result.status_code == 302
+    assert result.url == reverse(routes.OAUTH_SYSTEM_ERROR)
+    mocked_analytics_module.error.assert_called_once()
+    mocked_sentry_sdk_module.capture_exception.assert_called_once()

--- a/tests/pytest/oauth/test_hooks.py
+++ b/tests/pytest/oauth/test_hooks.py
@@ -1,0 +1,15 @@
+import pytest
+
+from benefits.oauth.hooks import OAuthHooks
+import benefits.oauth.hooks
+
+
+@pytest.fixture
+def mocked_analytics_module(mocked_analytics_module):
+    return mocked_analytics_module(benefits.oauth.hooks)
+
+
+def test_pre_login(app_request, mocked_analytics_module):
+    OAuthHooks.pre_login(app_request)
+
+    mocked_analytics_module.started_sign_in.assert_called_once()

--- a/tests/pytest/oauth/test_hooks.py
+++ b/tests/pytest/oauth/test_hooks.py
@@ -1,5 +1,5 @@
+from cdt_identity.hooks import Operation
 from django.urls import reverse
-
 import pytest
 
 from benefits.routes import routes
@@ -23,8 +23,9 @@ def test_pre_login(app_request, mocked_analytics_module):
     mocked_analytics_module.started_sign_in.assert_called_once()
 
 
-def test_system_error(app_request, mocked_analytics_module, mocked_sentry_sdk_module):
-    result = OAuthHooks.system_error(app_request, Exception("some exception"))
+@pytest.mark.parametrize("operation", Operation)
+def test_system_error(app_request, mocked_analytics_module, mocked_sentry_sdk_module, operation):
+    result = OAuthHooks.system_error(app_request, Exception("some exception"), operation)
 
     assert result.status_code == 302
     assert result.url == reverse(routes.OAUTH_SYSTEM_ERROR)


### PR DESCRIPTION
Part of #2723 

This PR implements the hook methods that are called in the `django-cdt-identity` [`login`](https://github.com/Office-of-Digital-Services/django-cdt-identity/blob/main/cdt_identity/views.py#L117) view.

Here are the lines in the existing Benefits `login` view that correspond with each hook:
- https://github.com/cal-itp/benefits/blob/af0ec2cb2980978820856149cb374cb8b6e1af1f/benefits/oauth/views.py#L66 --> [`pre_login`](https://github.com/Office-of-Digital-Services/django-cdt-identity/blob/main/cdt_identity/views.py#L130) hook 
- https://github.com/cal-itp/benefits/blob/af0ec2cb2980978820856149cb374cb8b6e1af1f/benefits/oauth/views.py#L81-L83 --> [`system_error`](https://github.com/Office-of-Digital-Services/django-cdt-identity/blob/main/cdt_identity/views.py#L151) hook
- none --> [`post_login`](https://github.com/Office-of-Digital-Services/django-cdt-identity/blob/main/cdt_identity/views.py#L153) hook