### PR TITLE
Admin: Header and Theme Toggle

### DIFF
--- a/benefits/locale/en/LC_MESSAGES/django.po
+++ b/benefits/locale/en/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2025-03-14 16:12-0700\n"
+"POT-Creation-Date: 2025-03-18 16:00-0700\n"
 "Language: English\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/benefits/locale/es/LC_MESSAGES/django.po
+++ b/benefits/locale/es/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/cal-itp/benefits/issues \n"
-"POT-Creation-Date: 2025-03-14 16:12-0700\n"
+"POT-Creation-Date: 2025-03-18 16:00-0700\n"
 "Language: Español\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/benefits/static/css/admin/overrides.css
+++ b/benefits/static/css/admin/overrides.css
@@ -15,3 +15,7 @@
 table {
   caption-side: top;
 }
+
+#user-tools {
+  letter-spacing: 0;
+}

--- a/benefits/static/css/admin/overrides.css
+++ b/benefits/static/css/admin/overrides.css
@@ -8,7 +8,8 @@
   margin: 12px 0 20px 0;
 }
 
-#content-related h3 {
+#content-related h3,
+#changelist-filter-extra-actions h3 {
   font-size: 0.875rem;
 }
 

--- a/benefits/static/css/admin/overrides.css
+++ b/benefits/static/css/admin/overrides.css
@@ -1,6 +1,4 @@
-.theme-toggle {
-  display: none;
-}
+/* Django dashboard overriding Bootstrap */
 
 #content-start h1 {
   font-size: 1rem;
@@ -19,4 +17,18 @@ table {
 
 #user-tools {
   letter-spacing: 0;
+}
+
+/* Log out link on Password change page */
+#logout-form button {
+  border: 0;
+  font-size: 1rem;
+  text-transform: capitalize;
+  text-decoration: underline;
+  text-decoration-color: var(--bs-white);
+}
+
+/* Theme toggle on Password change page */
+.theme-toggle {
+  display: none;
 }

--- a/benefits/static/css/admin/overrides.css
+++ b/benefits/static/css/admin/overrides.css
@@ -1,0 +1,17 @@
+.theme-toggle {
+  display: none;
+}
+
+#content-start h1 {
+  font-size: 1rem;
+  font-weight: 700;
+  margin: 12px 0 20px 0;
+}
+
+#content-related h3 {
+  font-size: 0.875rem;
+}
+
+table {
+  caption-side: top;
+}

--- a/benefits/static/css/admin/styles.css
+++ b/benefits/static/css/admin/styles.css
@@ -5,13 +5,14 @@
 html[data-theme="light"],
 :root {
   --primary: #ffffff;
-  --secondary: var(--dark-color);
-  --link-fg: #ffffff;
-  --body-quiet-color: var(--dark-color);
+  --bs-body-font-size: 1rem;
   --button-bg: #ffffff;
+  --bs-body-color: #212121; /* Body text color */
+  --bs-dark-rgb: 33, 33, 33; /* Background color for Header */
+  --bs-heading-color: #212121; /* Header text color */
   --bs-secondary-bg-subtle: #f1f1f1; /* Background color for Admin, lighter than bs-secondary, used with bg-secondary-subtle */
   --bs-secondary-rgb:
-    197, 196, 196; /* Border color for Admin, used with border-secondary */
+    210, 210, 210; /* Border color for Admin, used with border-secondary */
   --bs-secondary: #c5c4c4;
 }
 

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -14,6 +14,14 @@ html {
   scroll-padding-top: 101px; /* Header Height (80px) + Skip Nav Height (21px) = 101px */
 }
 
+/* Admin overrides */
+
+.theme-toggle {
+  display: none;
+}
+
+/* Overrides only */
+
 /* reCAPTCHA: Do not display badge */
 .grecaptcha-badge {
   display: none;

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -14,14 +14,6 @@ html {
   scroll-padding-top: 101px; /* Header Height (80px) + Skip Nav Height (21px) = 101px */
 }
 
-/* Admin overrides */
-
-.theme-toggle {
-  display: none;
-}
-
-/* Overrides only */
-
 /* reCAPTCHA: Do not display badge */
 .grecaptcha-badge {
   display: none;

--- a/benefits/templates/admin/agency-base.html
+++ b/benefits/templates/admin/agency-base.html
@@ -1,9 +1,6 @@
 {% extends "admin/base.html" %}
 {% load i18n static %}
 
-{% block dark-mode-vars %}
-{% endblock dark-mode-vars %}
-
 {% block extrastyle %}
   {% include "admin/includes/favicon.html" %}
   {% include "core/includes/bootstrap-css.html" %}

--- a/benefits/templates/admin/agency-base.html
+++ b/benefits/templates/admin/agency-base.html
@@ -1,13 +1,13 @@
 {% extends "admin/base.html" %}
 {% load i18n static %}
 
-{% block extrastyle %}
+{% block extrahead %}
   {% include "admin/includes/favicon.html" %}
   {% include "core/includes/bootstrap-css.html" %}
   {% include "admin/includes/style-admin.html" %}
   {% include "core/includes/ready-js.html" %}
   {% include "core/includes/analytics.html" with api_key=analytics.api_key uid=analytics.uid did=analytics.did %}
-{% endblock extrastyle %}
+{% endblock extrahead %}
 
 {% block coltype %}
   w-100

--- a/benefits/templates/admin/agency-base.html
+++ b/benefits/templates/admin/agency-base.html
@@ -9,30 +9,6 @@
   {% include "core/includes/analytics.html" with api_key=analytics.api_key uid=analytics.uid did=analytics.did %}
 {% endblock extrastyle %}
 
-{% block branding %}
-  <div id="header-container" class="navbar navbar-expand-sm navbar-dark justify-content-between">
-    <div class="container">
-      <span class="navbar-brand p-0">
-        <img class="sm d-lg-none"
-             src="{% static "img/logo-sm.svg" %}"
-             width="90"
-             height="51.3"
-             alt="California Integrated Travel Project: Benefits logo (small)" />
-        <img class="lg d-none d-lg-block"
-             src="{% static "img/logo-lg.svg" %}"
-             width="220"
-             height="50"
-             alt="California Integrated Travel Project: Benefits logo (large)" />
-      </span>
-    </div>
-    <h1 class="p-0 m-0 text-white">{{ site_header }}</h1>
-  </div>
-{% endblock branding %}
-
-{% block usertools %}
-  {% include "admin/includes/usertools.html" %}
-{% endblock usertools %}
-
 {% block coltype %}
   w-100
 {% endblock coltype %}

--- a/benefits/templates/admin/agency-dashboard-index.html
+++ b/benefits/templates/admin/agency-dashboard-index.html
@@ -8,7 +8,7 @@
 {% block content %}
   <div class="row">
     <div class="col-lg-7">
-      <h1 class="p-0 text-start">{{ agency.long_name }}</h1>
+      <h1 class="pt-3 pb-2 text-start fs-6 fw-bold">{{ agency.long_name }}</h1>
       {% if has_permission_for_in_person %}
         <div class="bg-white border border-1 border-secondary p-3">
           <h2 class="fs-6 fw-bold pt-0 pb-2 text-start">In-person enrollment</h2>
@@ -16,7 +16,7 @@
           {% url routes.IN_PERSON_ELIGIBILITY as url_eligibility %}
           <div class="row pt-4">
             <div class="col-lg-6">
-              <a href="{{ url_eligibility }}" class="btn fs-6 btn-lg btn-primary d-block">New enrollment</a>
+              <a href="{{ url_eligibility }}" class="btn fs-6 btn-lg btn-primary d-block text-white">New enrollment</a>
             </div>
           </div>
         </div>

--- a/benefits/templates/admin/agency-dashboard-index.html
+++ b/benefits/templates/admin/agency-dashboard-index.html
@@ -8,25 +8,28 @@
 {% block content %}
   <div class="row">
     <div class="col-lg-7">
-      <h1 class="pt-0 pb-3 text-start">{{ agency.long_name }}</h1>
+      <h1 class="p-0 text-start">{{ agency.long_name }}</h1>
       {% if has_permission_for_in_person %}
         <div class="bg-white border border-1 border-secondary p-3">
-          <h2 class="pt-0 pb-2 text-start">In-person enrollment</h2>
+          <h2 class="fs-6 fw-bold pt-0 pb-2 text-start">In-person enrollment</h2>
           <p>Verify transit benefit eligibility using agency criteria and complete a rider’s open-loop card enrollment.</p>
           {% url routes.IN_PERSON_ELIGIBILITY as url_eligibility %}
           <div class="row pt-4">
             <div class="col-lg-6">
-              <a href="{{ url_eligibility }}" class="btn btn-lg btn-primary d-block">New enrollment</a>
+              <a href="{{ url_eligibility }}" class="btn fs-6 btn-lg btn-primary d-block">New enrollment</a>
             </div>
           </div>
         </div>
         {% if transit_processor_portal_url %}
           <div class="bg-white border border-1 border-secondary p-3 mt-4">
-            <h2 class="pt-0 pb-2 text-start">Transit Processor</h2>
+            <h2 class="fs-6 fw-bold pt-0 pb-2 text-start">Transit Processor</h2>
             <p>Manage fare-calculation, view rider transactions, and process refunds.</p>
             <div class="row pt-4">
               <div class="col-lg-6">
-                <a href="{{ transit_processor_portal_url }}" target="_blank" rel="noopener noreferrer" class="btn btn-lg btn-outline-primary">Launch Littlepay Control Portal</a>
+                <a href="{{ transit_processor_portal_url }}"
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   class="btn fs-6 btn-lg btn-outline-primary">Launch Littlepay Control Portal</a>
               </div>
             </div>
           </div>

--- a/benefits/templates/admin/base.html
+++ b/benefits/templates/admin/base.html
@@ -29,24 +29,24 @@
       {% if has_permission %}
         <div id="user-tools" class="fs-6 text-white text-capitalize">
           {% block welcome-msg %}
-            {% translate "Welcome," %}
+            Welcome,
             <strong class="fw-bold">{% firstof user.get_short_name user.get_username %}</strong>.
           {% endblock welcome-msg %}
           {% block userlinks %}
             {% if user.is_active and user.is_staff %}
               {% url 'django-admindocs-docroot' as docsroot %}
               {% if docsroot %}
-                <a class="fs-6 border border-0 text-decoration-underline link-underline-primary link-underline-light" href="{{ docsroot }}">{% translate "Documentation" %}</a> /
+                <a class="fs-6 border border-0 text-decoration-underline link-underline-primary link-underline-light" href="{{ docsroot }}">Documentation</a> /
               {% endif %}
             {% endif %}
             {% if user.has_usable_password %}
               <a class="fs-6 border border-0 text-decoration-underline link-underline-primary link-underline-light ms-4"
-                 href="{% url "admin:password_change" %}">{% translate "Change password" %}</a> /
+                 href="{% url "admin:password_change" %}">Change password</a> /
             {% endif %}
             <form id="logout-form" method="post" action="{% url "admin:logout" %}">
               {% csrf_token %}
               <button class="fs-6 border border-0 text-decoration-underline link-underline-primary link-underline-light text-capitalize"
-                      type="submit">{% translate "Log out" %}</button>
+                      type="submit">Log out</button>
             </form>
           {% endblock userlinks %}
         </div>

--- a/benefits/templates/admin/base.html
+++ b/benefits/templates/admin/base.html
@@ -26,7 +26,7 @@
     </div>
     {% block usertools %}
       {% if has_permission %}
-        <div id="user-tools" class="fs-6 text-white">
+        <div id="user-tools" class="fs-6 text-white text-capitalize">
           {% block welcome-msg %}
             {% translate "Welcome," %}
             <strong class="fw-bold">{% firstof user.get_short_name user.get_username %}</strong>.
@@ -44,9 +44,8 @@
             {% endif %}
             <form id="logout-form" method="post" action="{% url "admin:logout" %}">
               {% csrf_token %}
-              <button class="fs-6 border border-0 text-decoration-underline link-underline-primary link-underline-light" type="submit">
-                {% translate "Log out" %}
-              </button>
+              <button class="fs-6 border border-0 text-decoration-underline link-underline-primary link-underline-light text-capitalize"
+                      type="submit">{% translate "Log out" %}</button>
             </form>
           {% endblock userlinks %}
         </div>

--- a/benefits/templates/admin/base.html
+++ b/benefits/templates/admin/base.html
@@ -7,6 +7,7 @@
 {% block extrahead %}
   {% include "admin/includes/favicon.html" %}
   {% include "core/includes/bootstrap-css.html" %}
+  <link href="{% static "css/admin/overrides.css" %}" rel="stylesheet">
 {% endblock extrahead %}
 
 {% block header %}

--- a/benefits/templates/admin/base.html
+++ b/benefits/templates/admin/base.html
@@ -1,8 +1,56 @@
 {% extends "admin/base.html" %}
+{% load i18n static %}
 
 {% block dark-mode-vars %}
 {% endblock dark-mode-vars %}
 
 {% block extrahead %}
   {% include "admin/includes/favicon.html" %}
+  {% include "core/includes/bootstrap-css.html" %}
 {% endblock extrahead %}
+
+{% block header %}
+  <header id="header" class="bg-dark py-3">
+    <div id="branding">
+      <div class="d-flex justify-content-center">
+        <img class="me-3"
+             src="{% static "img/logo-lg.svg" %}"
+             width="141"
+             height="32"
+             alt="California Integrated Travel Project: Benefits logo (large)" />
+      </div>
+
+      <div id="site-name" class="d-flex justify-content-center align-items-center">
+        <h1 class="text-center text-white fs-5 m-0">{{ site_header }}</h1>
+      </div>
+    </div>
+    {% block usertools %}
+      {% if has_permission %}
+        <div id="user-tools" class="fs-6 text-white">
+          {% block welcome-msg %}
+            {% translate "Welcome," %}
+            <strong class="fw-bold">{% firstof user.get_short_name user.get_username %}</strong>.
+          {% endblock welcome-msg %}
+          {% block userlinks %}
+            {% if user.is_active and user.is_staff %}
+              {% url 'django-admindocs-docroot' as docsroot %}
+              {% if docsroot %}
+                <a class="fs-6 border border-0 text-decoration-underline link-underline-primary link-underline-light" href="{{ docsroot }}">{% translate "Documentation" %}</a> /
+              {% endif %}
+            {% endif %}
+            {% if user.has_usable_password %}
+              <a class="fs-6 border border-0 text-decoration-underline link-underline-primary link-underline-light ms-4"
+                 href="{% url "admin:password_change" %}">{% translate "Change password" %}</a> /
+            {% endif %}
+            <form id="logout-form" method="post" action="{% url "admin:logout" %}">
+              {% csrf_token %}
+              <button class="fs-6 border border-0 text-decoration-underline link-underline-primary link-underline-light" type="submit">
+                {% translate "Log out" %}
+              </button>
+            </form>
+          {% endblock userlinks %}
+        </div>
+      {% endif %}
+    {% endblock usertools %}
+  </header>
+{% endblock header %}

--- a/benefits/templates/admin/base.html
+++ b/benefits/templates/admin/base.html
@@ -1,4 +1,7 @@
-{% extends "admin/base_site.html" %}
+{% extends "admin/base.html" %}
+
+{% block dark-mode-vars %}
+{% endblock dark-mode-vars %}
 
 {% block extrahead %}
   {% include "admin/includes/favicon.html" %}

--- a/benefits/templates/admin/flow-base.html
+++ b/benefits/templates/admin/flow-base.html
@@ -12,7 +12,7 @@
   <div class="row">
     <div class="bg-white offset-lg-3 col-lg-5 border border-1 border-secondary px-0">
       <div class="border border-1 border-top-0 border-start-0 border-end-0 border-secondary">
-        <h2 class="p-3 m-0 text-start">In-person enrollment</h2>
+        <h2 class="fs-5 fw-bold p-3 m-0 text-start">In-person enrollment</h2>
       </div>
       {% block flow-content %}
       {% endblock flow-content %}

--- a/benefits/templates/admin/includes/branding-login.html
+++ b/benefits/templates/admin/includes/branding-login.html
@@ -1,13 +1,15 @@
 {% load i18n static %}
 
-<div class="d-flex justify-content-center w-100 bg-primary">
-  <img class="my-3"
-       src="{% static "img/logo-lg.svg" %}"
-       width="220"
-       height="50"
-       alt="California Integrated Travel Project: Benefits logo (large)" />
-</div>
+<header class="bg-dark w-100">
+  <div class="d-flex justify-content-center">
+    <img class="my-3"
+         src="{% static "img/logo-lg.svg" %}"
+         width="212"
+         height="48"
+         alt="California Integrated Travel Project: Benefits logo (large)" />
+  </div>
 
-<div id="site-name">
-  <h1 class="text-center text-white fs-3 py-3 m-0">{{ site_header }}</h1>
-</div>
+  <div id="site-name" class="d-flex justify-content-center">
+    <h1 class="text-center text-white fs-5 pb-3 m-0">{{ site_header }}</h1>
+  </div>
+</header>

--- a/benefits/templates/admin/login.html
+++ b/benefits/templates/admin/login.html
@@ -11,9 +11,9 @@
   {% include "admin/includes/style-admin.html" %}
 {% endblock extrastyle %}
 
-{% block branding %}
+{% block header %}
   {% include "admin/includes/branding-login.html" %}
-{% endblock branding %}
+{% endblock header %}
 
 {% block content %}
   {% if form.errors and not form.non_field_errors %}<p class="errornote">Please correct the error(s) below.</p>{% endif %}

--- a/benefits/templates/admin/login.html
+++ b/benefits/templates/admin/login.html
@@ -4,9 +4,6 @@
   {{ block.super }} bg-secondary-subtle
 {% endblock bodyclass %}
 
-{% block dark-mode-vars %}
-{% endblock dark-mode-vars %}
-
 {% block extrastyle %}
   {% comment %} Overriding instead of extending agency-base here to remove jQuery declaration, which admin/login.html includes on its own {% endcomment %}
   {% include "admin/includes/favicon.html" %}

--- a/benefits/templates/admin/login.html
+++ b/benefits/templates/admin/login.html
@@ -4,12 +4,12 @@
   {{ block.super }} bg-secondary-subtle
 {% endblock bodyclass %}
 
-{% block extrastyle %}
+{% block extrahead %}
   {% comment %} Overriding instead of extending agency-base here to remove jQuery declaration, which admin/login.html includes on its own {% endcomment %}
   {% include "admin/includes/favicon.html" %}
   {% include "core/includes/bootstrap-css.html" %}
   {% include "admin/includes/style-admin.html" %}
-{% endblock extrastyle %}
+{% endblock extrahead %}
 
 {% block header %}
   {% include "admin/includes/branding-login.html" %}

--- a/benefits/templates/registration/logged_out.html
+++ b/benefits/templates/registration/logged_out.html
@@ -14,9 +14,9 @@
   {{ block.super }} login
 {% endblock bodyclass %}
 
-{% block branding %}
+{% block header %}
   {% include "admin/includes/branding-login.html" %}
-{% endblock branding %}
+{% endblock header %}
 
 {% block content %}
 


### PR DESCRIPTION
closes #2738 
closes #2739 

## What this PR does
- Creates a `base.html` that has a `header`. This `header` is used everywhere -- as in, on Agency Base and regular Django admin pages -- except for the Log in/Log out page, which has just a branding logo and title only.
- Removes dark mode variables in 1 spot, `base.html`
- Hides theme toggle button
- Makes some small font and color changes across all of admin, to enhance alignment/uniform-ness/close the gap between Figma and Admin. See below. 
- The Django admin app is now also using Bootstrap CSS. `Overrides.css` was created to write minimal CSS to get rid of any visual anomalies created by Bootstrap on Django admin. Now that this is in place, the whole Admin app, all the parts, are on Bootstrap.

## Overall note

I want to note that this PR is intending to get what I call the Universal header into place, file-wise and code-wise. This PR is not trying to improve the overall CSS/Variable situation - there are a lot of improvements/refactors that can be made, but not at this time. The Universal header was made with trying to use as much Bootstrap CSS utility classes as possible, and it was successful in this. After this PR and the #2742 PR are merged, the Admin users will have a visually aligned experience between the Log in/Log out page, Agency in person flow page, Reset password page, and Django Admin page (used only by Admins).

## What it looks like: This PR vs. Dev site

### Log in
![image](https://github.com/user-attachments/assets/18bfb433-93e5-42c0-8cd2-3d9ff4f418ab)
- Remove the blue, as per Figma
- I looked into see how easy it would be to add the 1px black border that the Log in/Log out pages have on Figma. The div is not accessible from `login.html`, so I opted out of doing it. Would require class-based new CSS. (Which is fine. Just didn't want to include it in this PR).
Note: I do not have reCAPTCHA turned on locally

### Django Dashboard
![image](https://github.com/user-attachments/assets/8c723d23-3ff5-46cf-b113-6430a5d8305e)
- Uses universal header
- The h1 (`Dashboard`) matches the h1 from Agency Dashboard

### Django Dashboard - Class page
![image](https://github.com/user-attachments/assets/330b8d06-c35f-427a-9203-85ccc22676b2)
- The breadcrumb will be changed in the next PR. #2742 

### Django / Agency flow - Change password
![image](https://github.com/user-attachments/assets/78addc70-ac62-4126-b2c8-6d79a834bf41)

### Agency Dashboard
![image](https://github.com/user-attachments/assets/54228417-aae9-46a7-a5a2-25ecc5014966)
- Uses universal header
- Change H1 to match Figma, also matches the H1 on Django Dashboard
- Button font size is smaller, to match Figma
- Font sizes match Figma

### Agency flow 
![image](https://github.com/user-attachments/assets/4f88ff32-3fed-40f9-849c-2b0f05622f99)
- Adds Change Password link to this header
- Clicking Change Password from Agency Flow or Agency Dashboard will take you back to Agency Dashboard

### Log out
![image](https://github.com/user-attachments/assets/b5acd255-dcab-4d7a-a76a-f24df2b06a32)
