### PR TITLE
Feat: OAuth hooks for `authorize` view

### DIFF
--- a/benefits/eligibility/verify.py
+++ b/benefits/eligibility/verify.py
@@ -30,10 +30,3 @@ def eligibility_from_api(flow: models.EnrollmentFlow, form, agency: models.Trans
         return True
     else:
         return False
-
-
-def eligibility_from_oauth(flow: models.EnrollmentFlow, oauth_claims):
-    if flow.uses_claims_verification and flow.claims_request.eligibility_claim in oauth_claims:
-        return True
-    else:
-        return False

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -112,7 +112,7 @@ def confirm(request):
             return TemplateResponse(request, TEMPLATE_CONFIRM, context)
         # no type was verified
         elif not is_verified:
-            return redirect(reverse(routes.ELIGIBILITY_UNVERIFIED))
+            return redirect(routes.ELIGIBILITY_UNVERIFIED)
         # type was verified
         else:
             return verified(request)

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -78,16 +78,8 @@ def confirm(request):
     if request.method == "GET" and session.eligible(request):
         return verified(request)
 
-    unverified_view = reverse(routes.ELIGIBILITY_UNVERIFIED)
-
     agency = session.agency(request)
     flow = session.flow(request)
-
-    # GET for OAuth verification
-    if request.method == "GET" and flow.uses_claims_verification:
-        analytics.started_eligibility(request, flow)
-
-        return redirect(unverified_view)
 
     form = flow.eligibility_form_instance()
 
@@ -120,7 +112,7 @@ def confirm(request):
             return TemplateResponse(request, TEMPLATE_CONFIRM, context)
         # no type was verified
         elif not is_verified:
-            return redirect(unverified_view)
+            return redirect(reverse(routes.ELIGIBILITY_UNVERIFIED))
         # type was verified
         else:
             return verified(request)

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -87,12 +87,7 @@ def confirm(request):
     if request.method == "GET" and flow.uses_claims_verification:
         analytics.started_eligibility(request, flow)
 
-        is_verified = verify.eligibility_from_oauth(flow, session.oauth_claims(request))
-
-        if is_verified:
-            return verified(request)
-        else:
-            return redirect(unverified_view)
+        return redirect(unverified_view)
 
     form = flow.eligibility_form_instance()
 

--- a/benefits/oauth/hooks.py
+++ b/benefits/oauth/hooks.py
@@ -1,7 +1,6 @@
 from cdt_identity.hooks import DefaultHooks
 from django.shortcuts import redirect
 from django.utils.decorators import method_decorator, decorator_from_middleware
-from django.urls import reverse
 import sentry_sdk
 
 from benefits.routes import routes
@@ -70,7 +69,7 @@ class OAuthHooks(DefaultHooks):
         flow = session.flow(request)
         eligibility_analytics.started_eligibility(request, flow)
 
-        return redirect(reverse(routes.ELIGIBILITY_UNVERIFIED))
+        return redirect(routes.ELIGIBILITY_UNVERIFIED)
 
     @classmethod
     def system_error(cls, request, exception, operation):

--- a/benefits/oauth/hooks.py
+++ b/benefits/oauth/hooks.py
@@ -42,6 +42,12 @@ class OAuthHooks(DefaultHooks):
         return redirect(routes.ELIGIBILITY_CONFIRM)
 
     @classmethod
+    def claims_verified_not_eligible(cls, request, claims_request, claims_result):
+        super().claims_verified_not_eligible(request, claims_request, claims_result)
+        analytics.finished_sign_in(request, error=claims_result.errors)
+        return redirect(routes.ELIGIBILITY_CONFIRM)
+
+    @classmethod
     def system_error(cls, request, exception, operation):
         super().system_error(request, exception, operation)
         analytics.error(request, message=str(exception), operation=str(operation))

--- a/benefits/oauth/hooks.py
+++ b/benefits/oauth/hooks.py
@@ -36,6 +36,12 @@ class OAuthHooks(DefaultHooks):
         return redirect(origin)
 
     @classmethod
+    def claims_verified_eligible(cls, request, claims_request, claims_result):
+        super().claims_verified_eligible(request, claims_request, claims_result)
+        analytics.finished_sign_in(request)
+        return redirect(routes.ELIGIBILITY_CONFIRM)
+
+    @classmethod
     def system_error(cls, request, exception, operation):
         super().system_error(request, exception, operation)
         analytics.error(request, message=str(exception), operation=str(operation))

--- a/tests/pytest/eligibility/test_verify.py
+++ b/tests/pytest/eligibility/test_verify.py
@@ -1,7 +1,7 @@
 import pytest
 
 from benefits.eligibility.forms import EligibilityVerificationForm
-from benefits.eligibility.verify import eligibility_from_api, eligibility_from_oauth
+from benefits.eligibility.verify import eligibility_from_api
 
 
 @pytest.fixture
@@ -51,35 +51,3 @@ def test_eligibility_from_api_no_verified_types(
     response = eligibility_from_api(model_EnrollmentFlow_with_eligibility_api, form, model_TransitAgency)
 
     assert response is False
-
-
-@pytest.mark.django_db
-def test_eligibility_from_oauth_does_not_use_claims_verification(mocked_session_flow_does_not_use_claims_verification):
-    # mocked_session_flow_does_not_use_claims_verification is Mocked version of the session.flow() function
-    flow = mocked_session_flow_does_not_use_claims_verification.return_value
-
-    response = eligibility_from_oauth(flow, ["claim"])
-
-    assert response is False
-
-
-@pytest.mark.django_db
-def test_eligibility_from_oauth_claim_mismatch(mocked_session_flow_uses_claims_verification):
-    # mocked_session_flow_uses_claims_verification is Mocked version of the session.flow() function
-    flow = mocked_session_flow_uses_claims_verification.return_value
-    flow.claims_eligibility_claim = "claim"
-
-    response = eligibility_from_oauth(flow, ["some_other_claim"])
-
-    assert response is False
-
-
-@pytest.mark.django_db
-def test_eligibility_from_oauth_claim_match(mocked_session_flow_uses_claims_verification):
-    # mocked_session_flow_uses_claims_verification is Mocked version of the session.flow() function
-    flow = mocked_session_flow_uses_claims_verification.return_value
-    flow.claims_eligibility_claim = "claim"
-
-    response = eligibility_from_oauth(flow, ["claim"])
-
-    assert response is True

--- a/tests/pytest/eligibility/test_views.py
+++ b/tests/pytest/eligibility/test_views.py
@@ -262,22 +262,6 @@ def test_confirm_get_verified(client, mocked_session_update):
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures(
-    "mocked_session_agency", "mocked_session_flow_uses_claims_verification", "mocked_session_oauth_authorized"
-)
-def test_confirm_get_oauth_verified(mocker, client, mocked_session_update, mocked_analytics_module):
-    mocker.patch("benefits.eligibility.verify.eligibility_from_oauth", return_value=True)
-
-    path = reverse(routes.ELIGIBILITY_CONFIRM)
-    response = client.get(path)
-
-    mocked_session_update.assert_called_once()
-    mocked_analytics_module.returned_success.assert_called_once()
-    assert response.status_code == 302
-    assert response.url == reverse(routes.ENROLLMENT_INDEX)
-
-
-@pytest.mark.django_db
-@pytest.mark.usefixtures(
     "mocked_session_agency",
     "mocked_session_flow_uses_claims_verification",
     "mocked_session_oauth_authorized",

--- a/tests/pytest/eligibility/test_views.py
+++ b/tests/pytest/eligibility/test_views.py
@@ -261,23 +261,6 @@ def test_confirm_get_verified(client, mocked_session_update):
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures(
-    "mocked_session_agency",
-    "mocked_session_flow_uses_claims_verification",
-    "mocked_session_oauth_authorized",
-    "mocked_session_update",
-)
-def test_confirm_get_oauth_unverified(mocker, client):
-    mocker.patch("benefits.eligibility.verify.eligibility_from_oauth", return_value=[])
-
-    path = reverse(routes.ELIGIBILITY_CONFIRM)
-    response = client.get(path)
-
-    assert response.status_code == 302
-    assert response.url == reverse(routes.ELIGIBILITY_UNVERIFIED)
-
-
-@pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_eligibility_auth_request", "model_EnrollmentFlow_with_form_class")
 def test_confirm_post_invalid_form(client, invalid_form_data, mocked_analytics_module):
     path = reverse(routes.ELIGIBILITY_CONFIRM)

--- a/tests/pytest/oauth/test_hooks.py
+++ b/tests/pytest/oauth/test_hooks.py
@@ -63,6 +63,15 @@ def test_claims_verified_eligible(app_request, mocked_analytics_module):
     mocked_analytics_module.finished_sign_in.assert_called_once_with(app_request)
 
 
+def test_claims_verified_not_eligible(app_request, mocked_analytics_module):
+    claims_result = ClaimsResult(errors={"some_claim": "error message"})
+    result = OAuthHooks.claims_verified_not_eligible(app_request, ClaimsVerificationRequest(), claims_result)
+
+    assert result.status_code == 302
+    assert result.url == reverse(routes.ELIGIBILITY_CONFIRM)
+    mocked_analytics_module.finished_sign_in.assert_called_once_with(app_request, error=claims_result.errors)
+
+
 @pytest.mark.parametrize("operation", Operation)
 def test_system_error(app_request, mocked_analytics_module, mocked_sentry_sdk_module, operation):
     result = OAuthHooks.system_error(app_request, Exception("some exception"), operation)

--- a/tests/pytest/oauth/test_hooks.py
+++ b/tests/pytest/oauth/test_hooks.py
@@ -1,4 +1,6 @@
+from cdt_identity.claims import ClaimsResult
 from cdt_identity.hooks import Operation
+from cdt_identity.models import ClaimsVerificationRequest
 from django.urls import reverse
 import pytest
 
@@ -51,6 +53,14 @@ def test_post_logout(app_request, mocked_analytics_module, origin):
     assert result.status_code == 302
     assert result.url == reverse(origin)
     mocked_analytics_module.finished_sign_out.assert_called_once_with(app_request)
+
+
+def test_claims_verified_eligible(app_request, mocked_analytics_module):
+    result = OAuthHooks.claims_verified_eligible(app_request, ClaimsVerificationRequest(), ClaimsResult())
+
+    assert result.status_code == 302
+    assert result.url == reverse(routes.ELIGIBILITY_CONFIRM)
+    mocked_analytics_module.finished_sign_in.assert_called_once_with(app_request)
 
 
 @pytest.mark.parametrize("operation", Operation)

--- a/tests/pytest/oauth/test_hooks.py
+++ b/tests/pytest/oauth/test_hooks.py
@@ -4,6 +4,8 @@ from cdt_identity.models import ClaimsVerificationRequest
 from django.urls import reverse
 import pytest
 
+import benefits.eligibility
+import benefits.eligibility.views
 from benefits.routes import routes
 from benefits.oauth.hooks import OAuthHooks
 import benefits.oauth.hooks
@@ -11,8 +13,13 @@ from benefits.core import session
 
 
 @pytest.fixture
-def mocked_analytics_module(mocked_analytics_module):
+def mocked_oauth_analytics_module(mocked_analytics_module):
     return mocked_analytics_module(benefits.oauth.hooks)
+
+
+@pytest.fixture
+def mocked_eligibility_analytics_module(mocked_analytics_module):
+    return mocked_analytics_module(benefits.eligibility.views)
 
 
 @pytest.fixture
@@ -20,63 +27,71 @@ def mocked_sentry_sdk_module(mocker):
     return mocker.patch.object(benefits.oauth.hooks, "sentry_sdk")
 
 
-def test_pre_login(app_request, mocked_analytics_module):
+def test_pre_login(app_request, mocked_oauth_analytics_module):
     OAuthHooks.pre_login(app_request)
 
-    mocked_analytics_module.started_sign_in.assert_called_once()
+    mocked_oauth_analytics_module.started_sign_in.assert_called_once()
 
 
-def test_cancel_login(app_request, mocked_analytics_module):
+def test_cancel_login(app_request, mocked_oauth_analytics_module):
     result = OAuthHooks.cancel_login(app_request)
 
     assert result.status_code == 302
     assert result.url == reverse(routes.ELIGIBILITY_UNVERIFIED)
-    mocked_analytics_module.canceled_sign_in.assert_called_once_with(app_request)
+    mocked_oauth_analytics_module.canceled_sign_in.assert_called_once_with(app_request)
 
 
-def test_pre_logout(app_request, mocked_analytics_module):
+def test_pre_logout(app_request, mocked_oauth_analytics_module):
     session.update(app_request, oauth_authorized=True)
     assert session.logged_in(app_request)
 
     OAuthHooks.pre_logout(app_request)
 
-    mocked_analytics_module.started_sign_out.assert_called_once_with(app_request)
+    mocked_oauth_analytics_module.started_sign_out.assert_called_once_with(app_request)
     assert not session.logged_in(app_request)
 
 
 @pytest.mark.parametrize("origin", [routes.ELIGIBILITY_START, routes.INDEX])
-def test_post_logout(app_request, mocked_analytics_module, origin):
+def test_post_logout(app_request, mocked_oauth_analytics_module, origin):
     session.update(app_request, origin=origin)
 
     result = OAuthHooks.post_logout(app_request)
 
     assert result.status_code == 302
     assert result.url == reverse(origin)
-    mocked_analytics_module.finished_sign_out.assert_called_once_with(app_request)
+    mocked_oauth_analytics_module.finished_sign_out.assert_called_once_with(app_request)
 
 
-def test_claims_verified_eligible(app_request, mocked_analytics_module):
+@pytest.mark.django_db
+@pytest.mark.usefixtures(
+    "mocked_session_agency", "mocked_session_flow_uses_claims_verification", "mocked_session_oauth_authorized"
+)
+def test_claims_verified_eligible(
+    app_request, mocked_oauth_analytics_module, mocked_session_update, mocked_eligibility_analytics_module
+):
     result = OAuthHooks.claims_verified_eligible(app_request, ClaimsVerificationRequest(), ClaimsResult())
 
     assert result.status_code == 302
-    assert result.url == reverse(routes.ELIGIBILITY_CONFIRM)
-    mocked_analytics_module.finished_sign_in.assert_called_once_with(app_request)
+    assert result.url == reverse(routes.ENROLLMENT_INDEX)
+    mocked_oauth_analytics_module.finished_sign_in.assert_called_once_with(app_request)
+    mocked_session_update.assert_called_once()
+    mocked_eligibility_analytics_module.returned_success.assert_called_once()
 
 
-def test_claims_verified_not_eligible(app_request, mocked_analytics_module):
+def test_claims_verified_not_eligible(app_request, mocked_oauth_analytics_module):
     claims_result = ClaimsResult(errors={"some_claim": "error message"})
     result = OAuthHooks.claims_verified_not_eligible(app_request, ClaimsVerificationRequest(), claims_result)
 
     assert result.status_code == 302
     assert result.url == reverse(routes.ELIGIBILITY_CONFIRM)
-    mocked_analytics_module.finished_sign_in.assert_called_once_with(app_request, error=claims_result.errors)
+    mocked_oauth_analytics_module.finished_sign_in.assert_called_once_with(app_request, error=claims_result.errors)
 
 
 @pytest.mark.parametrize("operation", Operation)
-def test_system_error(app_request, mocked_analytics_module, mocked_sentry_sdk_module, operation):
+def test_system_error(app_request, mocked_oauth_analytics_module, mocked_sentry_sdk_module, operation):
     result = OAuthHooks.system_error(app_request, Exception("some exception"), operation)
 
     assert result.status_code == 302
     assert result.url == reverse(routes.OAUTH_SYSTEM_ERROR)
-    mocked_analytics_module.error.assert_called_once()
+    mocked_oauth_analytics_module.error.assert_called_once()
     mocked_sentry_sdk_module.capture_exception.assert_called_once()

--- a/tests/pytest/oauth/test_hooks.py
+++ b/tests/pytest/oauth/test_hooks.py
@@ -78,12 +78,16 @@ def test_claims_verified_eligible(
     mocked_eligibility_analytics_module.returned_success.assert_called_once()
 
 
+@pytest.mark.django_db
+@pytest.mark.usefixtures(
+    "mocked_session_agency", "mocked_session_flow_uses_claims_verification", "mocked_session_oauth_authorized"
+)
 def test_claims_verified_not_eligible(app_request, mocked_oauth_analytics_module):
     claims_result = ClaimsResult(errors={"some_claim": "error message"})
     result = OAuthHooks.claims_verified_not_eligible(app_request, ClaimsVerificationRequest(), claims_result)
 
     assert result.status_code == 302
-    assert result.url == reverse(routes.ELIGIBILITY_CONFIRM)
+    assert result.url == reverse(routes.ELIGIBILITY_UNVERIFIED)
     mocked_oauth_analytics_module.finished_sign_in.assert_called_once_with(app_request, error=claims_result.errors)
 
 


### PR DESCRIPTION
Part of #2723 

This PR implements the hook methods that are called in the `django-cdt-identity` [`authorize`](https://github.com/Office-of-Digital-Services/django-cdt-identity/blob/main/cdt_identity/views.py#L53) view.

These are the hooks and the corresponding Benefits code:
- [`pre_authorize`](https://github.com/Office-of-Digital-Services/django-cdt-identity/blob/main/cdt_identity/views.py#L67): none
- [`system_error`](https://github.com/Office-of-Digital-Services/django-cdt-identity/blob/main/cdt_identity/views.py#L83): https://github.com/cal-itp/benefits/blob/270492d228c0541e8952fe7719d971e61ad560c1/benefits/oauth/views.py#L116-L118 (already done by #2757 with [the last two commits](https://github.com/cal-itp/benefits/pull/2757/files/b320e98a699f4ce20f001c5827456eb2d5e4a221..72705baa4bbb74599807456a3f7088dc1d923155))
- [`post_authorize`](https://github.com/Office-of-Digital-Services/django-cdt-identity/blob/main/cdt_identity/views.py#L85): none
- [`pre_claims_verification`](https://github.com/Office-of-Digital-Services/django-cdt-identity/blob/main/cdt_identity/views.py#L90): none
- [`claims_verified_eligible`](https://github.com/Office-of-Digital-Services/django-cdt-identity/blob/main/cdt_identity/views.py#L101): https://github.com/cal-itp/benefits/blob/270492d228c0541e8952fe7719d971e61ad560c1/benefits/oauth/views.py#L148-L150 (the variant with no errors)
- [`claims_verified_not_eligible`](https://github.com/Office-of-Digital-Services/django-cdt-identity/blob/main/cdt_identity/views.py#L107): https://github.com/cal-itp/benefits/blob/270492d228c0541e8952fe7719d971e61ad560c1/benefits/oauth/views.py#L148-L150 (the variant with errors)