### PR TITLE
Feat: OAuth hooks for `cancel` view

### DIFF
--- a/benefits/oauth/hooks.py
+++ b/benefits/oauth/hooks.py
@@ -13,6 +13,12 @@ class OAuthHooks(DefaultHooks):
         analytics.started_sign_in(request)
 
     @classmethod
+    def cancel_login(cls, request):
+        super().cancel_login(request)
+        analytics.canceled_sign_in(request)
+        return redirect(routes.ELIGIBILITY_UNVERIFIED)
+
+    @classmethod
     def system_error(cls, request, exception, operation):
         super().system_error(request, exception, operation)
         analytics.error(request, message=str(exception), operation=str(operation))

--- a/tests/pytest/oauth/test_hooks.py
+++ b/tests/pytest/oauth/test_hooks.py
@@ -23,6 +23,14 @@ def test_pre_login(app_request, mocked_analytics_module):
     mocked_analytics_module.started_sign_in.assert_called_once()
 
 
+def test_cancel_login(app_request, mocked_analytics_module):
+    result = OAuthHooks.cancel_login(app_request)
+
+    assert result.status_code == 302
+    assert result.url == reverse(routes.ELIGIBILITY_UNVERIFIED)
+    mocked_analytics_module.canceled_sign_in.assert_called_once_with(app_request)
+
+
 @pytest.mark.parametrize("operation", Operation)
 def test_system_error(app_request, mocked_analytics_module, mocked_sentry_sdk_module, operation):
     result = OAuthHooks.system_error(app_request, Exception("some exception"), operation)


### PR DESCRIPTION
Part of #2723 

This PR implements the `cancel_login` hook method that is called in the django-cdt-identity [`cancel`](https://github.com/Office-of-Digital-Services/django-cdt-identity/blob/main/cdt_identity/views.py#L110) view.

- [`cancel_login`](https://github.com/Office-of-Digital-Services/django-cdt-identity/blob/main/cdt_identity/views.py#L114): https://github.com/cal-itp/benefits/blob/270492d228c0541e8952fe7719d971e61ad560c1/benefits/oauth/views.py#L157-L159