### PR TITLE
Feat: OAuth hooks for `logout` view

### DIFF
--- a/benefits/oauth/hooks.py
+++ b/benefits/oauth/hooks.py
@@ -3,6 +3,7 @@ from django.shortcuts import redirect
 import sentry_sdk
 
 from benefits.routes import routes
+from benefits.core import session
 from . import analytics
 
 
@@ -17,6 +18,14 @@ class OAuthHooks(DefaultHooks):
         super().cancel_login(request)
         analytics.canceled_sign_in(request)
         return redirect(routes.ELIGIBILITY_UNVERIFIED)
+
+    @classmethod
+    def pre_logout(cls, request):
+        super().pre_logout(request)
+        analytics.started_sign_out(request)
+
+        # the user is signed out of the app
+        session.logout(request)
 
     @classmethod
     def system_error(cls, request, exception, operation):

--- a/tests/pytest/oauth/test_hooks.py
+++ b/tests/pytest/oauth/test_hooks.py
@@ -5,6 +5,7 @@ import pytest
 from benefits.routes import routes
 from benefits.oauth.hooks import OAuthHooks
 import benefits.oauth.hooks
+from benefits.core import session
 
 
 @pytest.fixture
@@ -29,6 +30,16 @@ def test_cancel_login(app_request, mocked_analytics_module):
     assert result.status_code == 302
     assert result.url == reverse(routes.ELIGIBILITY_UNVERIFIED)
     mocked_analytics_module.canceled_sign_in.assert_called_once_with(app_request)
+
+
+def test_pre_logout(app_request, mocked_analytics_module):
+    session.update(app_request, oauth_authorized=True)
+    assert session.logged_in(app_request)
+
+    OAuthHooks.pre_logout(app_request)
+
+    mocked_analytics_module.started_sign_out.assert_called_once_with(app_request)
+    assert not session.logged_in(app_request)
 
 
 @pytest.mark.parametrize("operation", Operation)


### PR DESCRIPTION
Part of #2723 

This PR implements the hooks for the `logout` view.

- [`pre_logout`](https://github.com/Office-of-Digital-Services/django-cdt-identity/blob/main/cdt_identity/views.py#L171) - https://github.com/cal-itp/benefits/blob/270492d228c0541e8952fe7719d971e61ad560c1/benefits/oauth/views.py#L177-L180
- [`system_error`](https://github.com/Office-of-Digital-Services/django-cdt-identity/blob/main/cdt_identity/views.py#L187) - already handled by #2757 