### PR TITLE
Feat: OAuth hooks for `post_logout` view

### DIFF
--- a/benefits/oauth/hooks.py
+++ b/benefits/oauth/hooks.py
@@ -28,6 +28,14 @@ class OAuthHooks(DefaultHooks):
         session.logout(request)
 
     @classmethod
+    def post_logout(cls, request):
+        super().post_logout(request)
+        analytics.finished_sign_out(request)
+
+        origin = session.origin(request)
+        return redirect(origin)
+
+    @classmethod
     def system_error(cls, request, exception, operation):
         super().system_error(request, exception, operation)
         analytics.error(request, message=str(exception), operation=str(operation))

--- a/tests/pytest/oauth/test_hooks.py
+++ b/tests/pytest/oauth/test_hooks.py
@@ -42,6 +42,17 @@ def test_pre_logout(app_request, mocked_analytics_module):
     assert not session.logged_in(app_request)
 
 
+@pytest.mark.parametrize("origin", [routes.ELIGIBILITY_START, routes.INDEX])
+def test_post_logout(app_request, mocked_analytics_module, origin):
+    session.update(app_request, origin=origin)
+
+    result = OAuthHooks.post_logout(app_request)
+
+    assert result.status_code == 302
+    assert result.url == reverse(origin)
+    mocked_analytics_module.finished_sign_out.assert_called_once_with(app_request)
+
+
 @pytest.mark.parametrize("operation", Operation)
 def test_system_error(app_request, mocked_analytics_module, mocked_sentry_sdk_module, operation):
     result = OAuthHooks.system_error(app_request, Exception("some exception"), operation)


### PR DESCRIPTION
Part of #2723 

Built on top of #2769 

This PR implements the hooks for the `post_logout` view.

 - [`post_logout`](https://github.com/Office-of-Digital-Services/django-cdt-identity/blob/main/cdt_identity/views.py#L201) - https://github.com/cal-itp/benefits/blob/270492d228c0541e8952fe7719d971e61ad560c1/benefits/oauth/views.py#L196-L199