### PR TITLE
Admin: Breadcrumb colors

### DIFF
--- a/benefits/static/css/admin/theme.css
+++ b/benefits/static/css/admin/theme.css
@@ -11,6 +11,9 @@ html[data-theme="light"],
   --bs-secondary-rgb:
     210, 210, 210; /* Border color for Admin, used with border-secondary */
   --bs-secondary: #c5c4c4;
+  --breadcrumbs-link-fg: #066b99; /* Breadcrumbs on Django Admin */
+  --breadcrumbs-bg: #ffffff;
+  --breadcrumbs-fg: #212121;
 }
 
 /* Django dashboard overriding Bootstrap */
@@ -31,6 +34,12 @@ table {
 
 .submit-row a.deletelink {
   height: initial !important;
+}
+
+/* Breadcrumbs */
+
+div.breadcrumbs {
+  padding: 10px 2rem;
 }
 
 /* Header - Colors, Type */
@@ -101,7 +110,7 @@ table {
 /* Content */
 
 #content {
-  padding: 2rem;
+  padding: 1rem 2rem;
 }
 
 /* Login page */


### PR DESCRIPTION
closes #2771 

NOTE: This PR depends on #2773 to be merged first

## What this PR does
- Adds breadcrumb theme variables to `theme.css`
- Changes the spacing on the left to match the 2rem spacing of the app, as declared on Figma, in `theme.css`

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/eb5403e0-c4c9-40bc-b1c0-24b1052b26f0" />
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/00e66e64-e866-473d-8829-a5890625a912" />
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/65d5e8bc-3766-4e2f-b645-0cb1143092e9" />
