### PR TITLE
Fix: `EnrollmentFlowForm` test and validation

### DIFF
--- a/benefits/core/admin/enrollment.py
+++ b/benefits/core/admin/enrollment.py
@@ -125,9 +125,11 @@ class EnrollmentFlowForm(forms.ModelForm):
                 non_field_errors.append(ValidationError(message))
 
         if field_errors:
-            raise ValidationError(field_errors)
+            for field_name, validation_error in field_errors.items():
+                self.add_error(field_name, validation_error)
         if non_field_errors:
-            raise ValidationError(non_field_errors)
+            for validation_error in non_field_errors:
+                self.add_error(None, validation_error)
 
 
 @admin.register(models.EnrollmentFlow)

--- a/benefits/core/admin/enrollment.py
+++ b/benefits/core/admin/enrollment.py
@@ -124,12 +124,10 @@ class EnrollmentFlowForm(forms.ModelForm):
                 )
                 non_field_errors.append(ValidationError(message))
 
-        if field_errors:
-            for field_name, validation_error in field_errors.items():
-                self.add_error(field_name, validation_error)
-        if non_field_errors:
-            for validation_error in non_field_errors:
-                self.add_error(None, validation_error)
+        for field_name, validation_error in field_errors.items():
+            self.add_error(field_name, validation_error)
+        for validation_error in non_field_errors:
+            self.add_error(None, validation_error)
 
 
 @admin.register(models.EnrollmentFlow)

--- a/tests/pytest/core/admin/test_enrollment.py
+++ b/tests/pytest/core/admin/test_enrollment.py
@@ -322,7 +322,7 @@ class TestEnrollmentFlowAdmin:
             dict(
                 oauth_config=model_IdentityGatewayConfig.id,
                 claims_scope="scope",
-                claims_claim="claim",
+                claims_eligibility_claim="claim",
             )
         )
 
@@ -350,6 +350,6 @@ class TestEnrollmentFlowAdmin:
         if user_type == "staff":
             non_field_errors = form.errors[forms.NON_FIELD_ERRORS]
             assert len(non_field_errors) == 1
-            assert "Template not found" in non_field_errors[0]
+            assert "Required when supports expiration is True" in non_field_errors[0]
         elif user_type == "super":
             assert "reenrollment_error_template" in error_dict


### PR DESCRIPTION
@lalver1 pointed out that `test_EnrollmentFlowForm_clean_supports_expiration` started failing due to some model refactoring in #2721 and that it was not clear why the test still fails even after making the expected changes to reflect the refactor.

It turns out the test itself had a mistake, namely that the field for the eligibility claim was not correct. 

Correcting that revealed another bug which is that if you had both field-errors and non-field errors during form validation, you would lose the non-field errors.

Lastly, we also noticed that trying to re-use the same test for both `super` and `staff` parameters didn't actually make sense because `staff` users cannot actually POST some fields, like `reenrollment_error_template`. To address this, we decided to split the test out.

These changes are needed for Luis to finish out #2721.