### PR TITLE
Refactor: use cdt_identity `post_logout` view

### DIFF
--- a/benefits/oauth/urls.py
+++ b/benefits/oauth/urls.py
@@ -19,6 +19,11 @@ urlpatterns = [
     ),
     path("cancel", views.cancel, name=routes.name(routes.OAUTH_CANCEL)),
     path("logout", views.logout, name=routes.name(routes.OAUTH_LOGOUT)),
-    path("post_logout", views.post_logout, name=routes.name(routes.OAUTH_POST_LOGOUT)),
+    path(
+        "post_logout",
+        decorator_from_middleware(FlowUsesClaimsVerificationSessionRequired)(cdt_identity_views.post_logout),
+        {"hooks": hooks.OAuthHooks},
+        name=routes.name(routes.OAUTH_POST_LOGOUT),
+    ),
     path("error", views.system_error, name=routes.name(routes.OAUTH_SYSTEM_ERROR)),
 ]

--- a/benefits/oauth/views.py
+++ b/benefits/oauth/views.py
@@ -124,16 +124,6 @@ def logout(request):
     return redirects.deauthorize_redirect(request, oauth_client, redirect_uri)
 
 
-@decorator_from_middleware(FlowUsesClaimsVerificationSessionRequired)
-def post_logout(request):
-    """View routes the user to their origin after sign out."""
-
-    analytics.finished_sign_out(request)
-
-    origin = session.origin(request)
-    return redirect(origin)
-
-
 @decorator_from_middleware(AgencySessionRequired)
 def system_error(request):
     """View handler for an oauth system error."""


### PR DESCRIPTION
Part of #2788 

Replaces Benefits oauth `post_logout` with cdt_identity `post_logout` view.

## Testing locally

### Hook gets run

Run through a Login.gov flow, and click on any links for logging out. You should see that the `post_logout` hook is called.

### Middleware still works

Choose a non-Login.gov flow (e.g. Agency Card), and then attempt to go to `oauth/post_logout`. The `FlowUsesClaimsVerificationSessionRequired` middleware should get called and end up showing you the user error screen.