### PR TITLE
Fix: Admin - Header: Log out hover bug

### DIFF
--- a/benefits/static/css/admin/theme.css
+++ b/benefits/static/css/admin/theme.css
@@ -75,6 +75,11 @@ div.breadcrumbs {
   display: none;
 }
 
+#logout-form button:active,
+#logout-form button:hover {
+  margin-bottom: 0 !important; /* Fix logout link hover bug */
+}
+
 /* Header - Branding by page */
 
 #logo {


### PR DESCRIPTION
closes #2789 

Fixes a bug where the Log out link moves up/down when hovering over it.

<img width="587" alt="image" src="https://github.com/user-attachments/assets/d057e812-de4f-49d6-82e4-b758b43e8f3c" />

Fixed by applying a `margin-bottom: 0` to links that, the `base.css` (default Django style) adds a `margin-bottom: 1px` to. 