### PR TITLE
Refactor: use cdt_identity `login` view

### DIFF
--- a/benefits/oauth/urls.py
+++ b/benefits/oauth/urls.py
@@ -10,7 +10,12 @@ from .middleware import FlowUsesClaimsVerificationSessionRequired
 app_name = "oauth"
 urlpatterns = [
     # /oauth
-    path("login", views.login, name=routes.name(routes.OAUTH_LOGIN)),
+    path(
+        "login",
+        decorator_from_middleware(FlowUsesClaimsVerificationSessionRequired)(cdt_identity_views.login),
+        {"hooks": hooks.OAuthHooks},
+        name=routes.name(routes.OAUTH_LOGIN),
+    ),
     path(
         "authorize",
         decorator_from_middleware(FlowUsesClaimsVerificationSessionRequired)(cdt_identity_views.authorize),

--- a/benefits/urls.py
+++ b/benefits/urls.py
@@ -27,6 +27,7 @@ urlpatterns = [
     path("enrollment/", include("benefits.enrollment.urls")),
     path("i18n/", include("django.conf.urls.i18n")),
     path("oauth/", include("benefits.oauth.urls")),
+    path("oauth/", include("cdt_identity.urls")),
     path("in_person/", include("benefits.in_person.urls")),
 ]
 


### PR DESCRIPTION
Closes #2786 

As part of the oauth refactor, this PR replaces `benefits.oauth.views.login` with `cdt_identity.views.login`.

## Reviewing

Run through a login.gov flow and ensure you can confirm your eligibility. Also notice that when you click on the `Get started with LOGIN.GOV` CTA button, the `cdt_identity` `login` view is called.  In addition, a `started sign in` analytics event will be created as part of the `pre_login` hook.
