### PR TITLE
Chore: enable debugging of external python modules

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,7 @@
       "program": "${workspaceFolder}/manage.py",
       "args": ["runserver", "--insecure", "0.0.0.0:8000"],
       "django": true,
+      "justMyCode": false,
       "env": {
         "DJANGO_DEBUG": "true",
         "PYTHONWARNINGS": "default"
@@ -23,6 +24,7 @@
       "program": "${workspaceFolder}/manage.py",
       "args": ["runserver", "--insecure", "0.0.0.0:8000"],
       "django": true,
+      "justMyCode": false,
       "env": {
         "DJANGO_DEBUG": "false",
         "DJANGO_STATICFILES_STORAGE": "django.contrib.staticfiles.storage.StaticFilesStorage"


### PR DESCRIPTION
With this option set on the debugger's launch configuration we can set breakpoints in external modules and debug them.
