### PR TITLE
Feat(session): set config for cdt_identity when setting flow

### DIFF
--- a/benefits/core/session.py
+++ b/benefits/core/session.py
@@ -8,6 +8,7 @@ import logging
 import time
 import uuid
 
+from cdt_identity.session import Session as OAuthSession
 from django.urls import reverse
 
 from benefits.routes import routes
@@ -279,6 +280,9 @@ def update(
         request.session[_ORIGIN] = origin
     if flow is not None and isinstance(flow, models.EnrollmentFlow):
         request.session[_FLOW] = flow.id
+        oauth_session = OAuthSession(request)
+        oauth_session.client_config = flow.oauth_config
+        oauth_session.claims_request = flow.claims_request
 
 
 def flow(request) -> models.EnrollmentFlow | None:

--- a/tests/pytest/core/test_session.py
+++ b/tests/pytest/core/test_session.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta, timezone
 import time
 
+from cdt_identity.session import Session as OAuthSession
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.urls import reverse
 import pytest
@@ -435,12 +436,15 @@ def test_update_origin(app_request):
 
 
 @pytest.mark.django_db
-def test_update_flow(app_request):
-    flow = models.EnrollmentFlow.objects.first()
-
+def test_update_flow(app_request, model_EnrollmentFlow_with_scope_and_claim: models.EnrollmentFlow):
+    flow = model_EnrollmentFlow_with_scope_and_claim
     session.update(app_request, flow=flow)
 
     assert session.flow(app_request) == flow
+
+    oauth_session = OAuthSession(app_request)
+    assert oauth_session.client_config == flow.oauth_config
+    assert oauth_session.claims_request == flow.claims_request
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Part of #2722 

This PR adds the session flow's `oauth_config` and `claims_request` to the session as well.
