### PR TITLE
Admin: Fixes to Log In/Out and Agency Dashboard page

### DIFF
--- a/benefits/static/css/admin/styles.css
+++ b/benefits/static/css/admin/styles.css
@@ -185,8 +185,7 @@ iframe.card-collection {
 }
 
 :root {
-  --external-link-icon-size: var(--font-size-24px);
-  --external-link-icon-size-small: var(--font-size-18px);
+  --external-link-icon-size: var(--font-size-16px);
 }
 
 .login a[target="_blank"]::after {
@@ -197,10 +196,12 @@ iframe.card-collection {
     url("/static/img/external-link.svg"),
     linear-gradient(transparent, transparent);
   mask-position: center center;
+  mask-size: contain;
   -webkit-mask-image:
     url("/static/img/external-link.svg"),
     linear-gradient(transparent, transparent);
   -webkit-mask-position: center center;
+  -webkit-mask-size: contain;
 
   display: inline-block;
   position: relative;

--- a/benefits/static/css/admin/styles.css
+++ b/benefits/static/css/admin/styles.css
@@ -1,10 +1,13 @@
 @import "../variables.css";
 
 /* Buttons */
+/* Note: This button style has now diverged from Benefit's */
 /* Primary Button: Use all three classes: btn btn-lg btn-primary */
 /* Outline Primary Button: Use all three classes: btn btn-lg btn-outline-primary */
 /* Set button width in parent with Bootstrap column */
-/* Height: 48px (3rem) on Desktop and Mobile */
+/* Font size: 16px (1rem) */
+/* Height: 48px (3rem - composed of 16px padding top and bottom, 16px font size) */
+/* Sizing same across Desktop and Mobile */
 
 :root {
   --primary-button-padding: 1rem 0;

--- a/benefits/static/css/admin/styles.css
+++ b/benefits/static/css/admin/styles.css
@@ -4,16 +4,10 @@
 /* Primary Button: Use all three classes: btn btn-lg btn-primary */
 /* Outline Primary Button: Use all three classes: btn btn-lg btn-outline-primary */
 /* Set button width in parent with Bootstrap column */
-/* Height: 48px (3rem) on Desktop; 72 on mobile*/
+/* Height: 48px (3rem) on Desktop and Mobile */
 
 :root {
   --primary-button-padding: 1rem 0;
-}
-
-@media (min-width: 992px) {
-  :root {
-    --primary-button-padding: 13px 0;
-  }
 }
 
 .btn.btn-lg.btn-outline-primary:not(:hover) {

--- a/benefits/static/css/admin/styles.css
+++ b/benefits/static/css/admin/styles.css
@@ -4,10 +4,10 @@
 /* Primary Button: Use all three classes: btn btn-lg btn-primary */
 /* Outline Primary Button: Use all three classes: btn btn-lg btn-outline-primary */
 /* Set button width in parent with Bootstrap column */
-/* Height: 60px on Desktop; 72 on mobile*/
+/* Height: 48px (3rem) on Desktop; 72 on mobile*/
 
 :root {
-  --primary-button-padding: 19px 0;
+  --primary-button-padding: 1rem 0;
 }
 
 @media (min-width: 992px) {
@@ -29,12 +29,14 @@
 .login input[type="submit"],
 .btn.btn-lg.btn-outline-primary {
   border-color: var(--primary-color);
+  border-radius: 2px;
   border-width: 2px;
   font-weight: var(--medium-font-weight);
-  font-size: var(--font-size-20px);
-  letter-spacing: calc(var(--font-size-20px) * var(--letter-spacing-2));
+  font-size: var(--font-size-16px);
+  letter-spacing: calc(var(--font-size-16px) * var(--letter-spacing-2));
   width: 100%;
   padding: var(--primary-button-padding);
+  line-height: 1;
 }
 
 .btn.btn-lg.btn-primary:hover,
@@ -64,12 +66,8 @@ input[type="password"]:focus,
 
 .btn-text {
   font-weight: var(--medium-font-weight);
-  font-size: var(--font-size-20px);
-  letter-spacing: calc(var(--font-size-20px) * var(--letter-spacing-2));
-}
-
-.login .submit-row input[type="submit"] {
-  text-transform: unset;
+  font-size: var(--font-size-16px);
+  letter-spacing: calc(var(--font-size-16px) * var(--letter-spacing-2));
 }
 
 /* Eligibility Page:  In-person Enrollment */
@@ -232,17 +230,17 @@ iframe.card-collection {
   border: 1px solid var(--bs-primary);
   background-color: var(--white);
   height: 100%;
-  border-radius: 4px;
+  border-radius: 2px;
   padding: 0;
 }
 
 .login .google-login-btn .btn-content {
-  padding: 13.5px 0;
+  padding: 1rem 0;
   border-radius: 4px;
 }
 
 .login .google-btn-logo {
-  padding-right: 20px;
+  padding-right: 1rem;
   background-color: transparent;
 }
 
@@ -260,5 +258,6 @@ iframe.card-collection {
   color: var(--bs-primary);
   width: auto;
   font-weight: var(--medium-font-weight);
-  font-size: var(--font-size-20px);
+  font-size: var(--font-size-16px);
+  line-height: 1;
 }

--- a/benefits/static/css/admin/theme.css
+++ b/benefits/static/css/admin/theme.css
@@ -126,3 +126,13 @@ div.breadcrumbs {
 .login .main {
   border: 1px solid #000000;
 }
+
+.login .google-btn-logo {
+  height: 1rem;
+  width: 1rem;
+}
+
+.login .google-btn-logo img {
+  height: 1rem;
+  width: 1rem;
+}

--- a/benefits/static/css/admin/theme.css
+++ b/benefits/static/css/admin/theme.css
@@ -60,6 +60,7 @@ div.breadcrumbs {
   font-size: 1rem;
   letter-spacing: 0;
   text-transform: unset;
+  font-weight: 400 !important;
 }
 
 #user-tools a,
@@ -118,7 +119,7 @@ div.breadcrumbs {
 /* Content */
 
 #content {
-  padding: 1rem 2rem;
+  padding: 2rem;
 }
 
 /* Login page */

--- a/benefits/templates/admin/agency-dashboard-index.html
+++ b/benefits/templates/admin/agency-dashboard-index.html
@@ -11,22 +11,20 @@
       <h1 class="pt-0 pb-3 text-start">{{ agency.long_name }}</h1>
       {% if has_permission_for_in_person %}
         <div class="bg-white border border-1 border-secondary p-3">
-          <h2 class="pt-0 pb-2 text-start fs-6 fw-bold">In-person enrollment</h2>
-          <p>
-            Verify a transit rider’s benefit eligibility using physical documentation and register their credit or debit card for reduced fares.
-          </p>
+          <h2 class="pt-0 text-start fs-6 fw-bold">In-person enrollment</h2>
+          <p class="mb-4">Verify transit benefit eligibility using agency criteria and complete a rider’s open-loop card enrollment.</p>
           {% url routes.IN_PERSON_ELIGIBILITY as url_eligibility %}
-          <div class="row pt-4">
+          <div class="row">
             <div class="col-lg-6">
               <a href="{{ url_eligibility }}" class="btn btn-lg text-white btn-primary d-block">New enrollment</a>
             </div>
           </div>
         </div>
         {% if transit_processor_portal_url %}
-          <div class="bg-white border border-1 border-secondary p-3 mt-4">
-            <h2 class="pt-0 pb-2 text-start fs-6 fw-bold">Transit processor</h2>
-            <p>Manage fare-calculation, view rider transactions, and process refunds.</p>
-            <div class="row pt-4">
+          <div class="bg-white border border-1 border-secondary p-3 mt-3">
+            <h2 class="pt-0 text-start fs-6 fw-bold">Transit processor</h2>
+            <p class="mb-4">Manage fare-calculation, view rider transactions, and process refunds.</p>
+            <div class="row">
               <div class="col-lg-6">
                 <a href="{{ transit_processor_portal_url }}" target="_blank" rel="noopener noreferrer" class="btn btn-lg btn-outline-primary">Launch Littlepay Control Portal</a>
               </div>

--- a/benefits/templates/admin/login.html
+++ b/benefits/templates/admin/login.html
@@ -51,7 +51,7 @@
           <a href="{{ password_reset_url }}">Forgotten your login credentials?</a>
         </div>
       {% endif %}
-      <div class="submit-row">
+      <div class="login-submit-row">
         <input type="submit" value="Log in">
       </div>
 


### PR DESCRIPTION
closes #2790 

This PR ended up getting a little bigger than the original issue. The theme of this PR is "small visual fixes" on these 2 pages that are now most prominent to current Agency users. This PR does _not_ touch any of the "flow" pages.

## How to test this PR
- Test this PR with reCAPTCHA turned _on_ to get the reCAPTCHA warning text

## What this PR does
### Log In/Log Out
- CTA Button for Log In/Log Out and Sign in with Google: Border radius, font size, icon size and resulting total button height now match Figma - 3rem (48px) height buttons with 1rem (16px) font size text, centered with border-radius 2px.
<img width="425" alt="image" src="https://github.com/user-attachments/assets/2629f1fe-0d74-47ff-8e3a-7fed18e20891" />

- Make the external link icon 1rem, to match the font size
<img width="404" alt="image" src="https://github.com/user-attachments/assets/b36272a3-1e9a-44c7-939c-555816f789b2" />
<img width="205" alt="image" src="https://github.com/user-attachments/assets/62847c98-3f91-46d6-a33f-24f2160ef5a8" />
<img width="418" alt="image" src="https://github.com/user-attachments/assets/320af3ea-0890-499b-aa15-616c789d5a55" />

### Dashboard page
- CTA Button: Border radius, font size, and resulting total button height now match Figma
- Spacing above the transit agency name now matches Figma
- Spacing above the button now matches Figma
- Header nav text used to have a font weight too light. Now matches Figma.
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/59227b30-6df6-4cf0-b609-1940e37be788" />
