### PR TITLE
Refactor: use cdt_identity `cancel` view

### DIFF
--- a/benefits/oauth/urls.py
+++ b/benefits/oauth/urls.py
@@ -17,7 +17,12 @@ urlpatterns = [
         {"hooks": hooks.OAuthHooks},
         name=routes.name(routes.OAUTH_AUTHORIZE),
     ),
-    path("cancel", views.cancel, name=routes.name(routes.OAUTH_CANCEL)),
+    path(
+        "cancel",
+        decorator_from_middleware(FlowUsesClaimsVerificationSessionRequired)(cdt_identity_views.cancel),
+        {"hooks": hooks.OAuthHooks},
+        name=routes.name(routes.OAUTH_CANCEL),
+    ),
     path("logout", views.logout, name=routes.name(routes.OAUTH_LOGOUT)),
     path(
         "post_logout",

--- a/benefits/oauth/views.py
+++ b/benefits/oauth/views.py
@@ -86,15 +86,6 @@ def login(request):
 
 
 @decorator_from_middleware(FlowUsesClaimsVerificationSessionRequired)
-def cancel(request):
-    """View implementing cancellation of OIDC authorization."""
-
-    analytics.canceled_sign_in(request)
-
-    return redirect(routes.ELIGIBILITY_UNVERIFIED)
-
-
-@decorator_from_middleware(FlowUsesClaimsVerificationSessionRequired)
 def logout(request):
     """View implementing OIDC and application sign out."""
     flow = session.flow(request)

--- a/tests/pytest/oauth/test_views.py
+++ b/tests/pytest/oauth/test_views.py
@@ -12,7 +12,6 @@ from benefits.oauth.views import (
     TEMPLATE_SYSTEM_ERROR,
     _oauth_client_or_error_redirect,
     login,
-    cancel,
     logout,
     system_error,
 )
@@ -191,22 +190,24 @@ def test_authorize_no_session_flow(client):
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_session_flow_uses_claims_verification")
-def test_cancel(app_request, mocked_view_analytics_module):
+def test_cancel(client, mocked_hook_analytics_module):
     unverified_route = reverse(routes.ELIGIBILITY_UNVERIFIED)
 
-    result = cancel(app_request)
+    path = reverse(routes.OAUTH_CANCEL)
+    response = client.get(path)
 
-    mocked_view_analytics_module.canceled_sign_in.assert_called_once()
-    assert result.status_code == 302
-    assert result.url == unverified_route
+    mocked_hook_analytics_module.canceled_sign_in.assert_called_once()
+    assert response.status_code == 302
+    assert response.url == unverified_route
 
 
 @pytest.mark.django_db
-def test_cancel_no_session_flow(app_request):
-    result = cancel(app_request)
+def test_cancel_no_session_flow(client):
+    path = reverse(routes.OAUTH_CANCEL)
+    response = client.get(path)
 
-    assert result.status_code == 200
-    assert result.template_name == TEMPLATE_USER_ERROR
+    assert response.status_code == 200
+    assert response.template_name == TEMPLATE_USER_ERROR
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Closes #2788 

~Builds on #2791~

Replaces Benefits oauth `cancel` with cdt_identity `cancel` view.

## Testing locally

### ~Hook gets run~

~Run through a Login.gov flow, and on the Login.gov login screen, click the link that says `‹ Back to Dev Cal-ITP Benefits`. You should see that the `cancel_login` hook is called.~

We can't test this hook locally because the dev IdG redirects to `dev-benefits.calitp.org` when that `‹ Back to Dev Cal-ITP Benefits` link is clicked.

### Middleware still works

Choose a non-Login.gov flow (e.g. Agency Card), and then attempt to go to `oauth/cancel`. The `FlowUsesClaimsVerificationSessionRequired` middleware should get called and end up showing you the user error screen.