### PR TITLE
Refactor: use cdt_identity `logout` view

### DIFF
--- a/benefits/oauth/urls.py
+++ b/benefits/oauth/urls.py
@@ -28,7 +28,12 @@ urlpatterns = [
         {"hooks": hooks.OAuthHooks},
         name=routes.name(routes.OAUTH_CANCEL),
     ),
-    path("logout", views.logout, name=routes.name(routes.OAUTH_LOGOUT)),
+    path(
+        "logout",
+        decorator_from_middleware(FlowUsesClaimsVerificationSessionRequired)(cdt_identity_views.logout),
+        {"hooks": hooks.OAuthHooks},
+        name=routes.name(routes.OAUTH_LOGOUT),
+    ),
     path(
         "post_logout",
         decorator_from_middleware(FlowUsesClaimsVerificationSessionRequired)(cdt_identity_views.post_logout),

--- a/benefits/oauth/views.py
+++ b/benefits/oauth/views.py
@@ -2,16 +2,14 @@ import logging
 
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
-from django.urls import reverse
 from django.utils.decorators import decorator_from_middleware
 import sentry_sdk
 
 from benefits.routes import routes
 from benefits.core import models, session
 from benefits.core.middleware import AgencySessionRequired
-from . import analytics, redirects
+from . import analytics
 from .client import oauth, create_client
-from .middleware import FlowUsesClaimsVerificationSessionRequired
 
 
 logger = logging.getLogger(__name__)
@@ -42,36 +40,6 @@ def _oauth_client_or_error_redirect(request, flow: models.EnrollmentFlow):
         return redirect(routes.OAUTH_SYSTEM_ERROR)
 
     return oauth_client
-
-
-@decorator_from_middleware(FlowUsesClaimsVerificationSessionRequired)
-def logout(request):
-    """View implementing OIDC and application sign out."""
-    flow = session.flow(request)
-
-    oauth_client_result = _oauth_client_or_error_redirect(request, flow)
-
-    if hasattr(oauth_client_result, "load_server_metadata"):
-        # this looks like an oauth_client since it has the method we need
-        # (called in redirects.deauthorize_redirect)
-        oauth_client = oauth_client_result
-    else:
-        # this does not look like an oauth_client, it's an error redirect
-        return oauth_client_result
-
-    analytics.started_sign_out(request)
-
-    # the user is signed out of the app
-    session.logout(request)
-
-    route = reverse(routes.OAUTH_POST_LOGOUT)
-    redirect_uri = redirects.generate_redirect_uri(request, route)
-
-    logger.debug(f"OAuth end_session_endpoint with redirect_uri: {redirect_uri}")
-
-    # send the user through the end_session_endpoint, redirecting back to
-    # the post_logout route
-    return redirects.deauthorize_redirect(request, oauth_client, redirect_uri)
 
 
 @decorator_from_middleware(AgencySessionRequired)

--- a/tests/pytest/oauth/test_hooks.py
+++ b/tests/pytest/oauth/test_hooks.py
@@ -1,6 +1,7 @@
 from cdt_identity.claims import ClaimsResult
 from cdt_identity.hooks import Operation
 from cdt_identity.models import ClaimsVerificationRequest
+from cdt_identity.session import Session as OAuthSession
 from django.urls import reverse
 import pytest
 
@@ -49,6 +50,9 @@ def test_pre_logout(app_request, mocked_oauth_analytics_module):
 
     mocked_oauth_analytics_module.started_sign_out.assert_called_once_with(app_request)
     assert not session.logged_in(app_request)
+    assert session.enrollment_token(app_request) is False
+    assert session.logged_in(app_request) is False
+    assert OAuthSession(app_request).claims_result == ClaimsResult()
 
 
 @pytest.mark.parametrize("origin", [routes.ELIGIBILITY_START, routes.INDEX])


### PR DESCRIPTION
Closes #2787

As part of the oauth refactor, this PR replaces `benefits.oauth.views.logout` with `cdt_identity.views.logout`.

## Reviewing

Run through a login.gov flow and ensure you can confirm your eligibility. On the eligibility confirmation page, click on `Sign out of Login.gov ` and check that the `cdt_identity` `logout` view is called.  In addition, a `started sign out` analytics event will be created as part of the `pre_logout` hook; and a `finished sign out` analytics event will be created as part of the `post_logout` hook.
