### PR TITLE
Refactor: OAuth URLconf

### DIFF
--- a/benefits/oauth/urls.py
+++ b/benefits/oauth/urls.py
@@ -1,6 +1,7 @@
 from cdt_identity import views as cdt_identity_views
 from cdt_identity.routes import Routes
 from cdt_identity.urls import app_name as cdt_app_name
+
 from django.utils.decorators import decorator_from_middleware
 from django.urls import path
 
@@ -8,40 +9,19 @@ from benefits.routes import routes
 from . import views, hooks
 from .middleware import FlowUsesClaimsVerificationSessionRequired
 
+
+decorator = decorator_from_middleware(FlowUsesClaimsVerificationSessionRequired)
+kwargs = {"hooks": hooks.OAuthHooks}
+
 # use cdt_identity app name so that the URL namespace matches what cdt_identity expects.
 # (e.g. when cdt_identity reverses routes.)
 app_name = cdt_app_name
 urlpatterns = [
     # /oauth
-    path(
-        Routes.login,
-        decorator_from_middleware(FlowUsesClaimsVerificationSessionRequired)(cdt_identity_views.login),
-        {"hooks": hooks.OAuthHooks},
-        name=routes.name(routes.OAUTH_LOGIN),
-    ),
-    path(
-        Routes.authorize,
-        decorator_from_middleware(FlowUsesClaimsVerificationSessionRequired)(cdt_identity_views.authorize),
-        {"hooks": hooks.OAuthHooks},
-        name=routes.name(routes.OAUTH_AUTHORIZE),
-    ),
-    path(
-        Routes.cancel,
-        decorator_from_middleware(FlowUsesClaimsVerificationSessionRequired)(cdt_identity_views.cancel),
-        {"hooks": hooks.OAuthHooks},
-        name=routes.name(routes.OAUTH_CANCEL),
-    ),
-    path(
-        Routes.logout,
-        decorator_from_middleware(FlowUsesClaimsVerificationSessionRequired)(cdt_identity_views.logout),
-        {"hooks": hooks.OAuthHooks},
-        name=routes.name(routes.OAUTH_LOGOUT),
-    ),
-    path(
-        Routes.post_logout,
-        decorator_from_middleware(FlowUsesClaimsVerificationSessionRequired)(cdt_identity_views.post_logout),
-        {"hooks": hooks.OAuthHooks},
-        name=routes.name(routes.OAUTH_POST_LOGOUT),
-    ),
+    path(Routes.login, decorator(cdt_identity_views.login), kwargs, name=routes.name(routes.OAUTH_LOGIN)),
+    path(Routes.authorize, decorator(cdt_identity_views.authorize), kwargs, name=routes.name(routes.OAUTH_AUTHORIZE)),
+    path(Routes.cancel, decorator(cdt_identity_views.cancel), kwargs, name=routes.name(routes.OAUTH_CANCEL)),
+    path(Routes.logout, decorator(cdt_identity_views.logout), kwargs, name=routes.name(routes.OAUTH_LOGOUT)),
+    path(Routes.post_logout, decorator(cdt_identity_views.post_logout), kwargs, name=routes.name(routes.OAUTH_POST_LOGOUT)),
     path("error", views.system_error, name=routes.name(routes.OAUTH_SYSTEM_ERROR)),
 ]

--- a/benefits/oauth/urls.py
+++ b/benefits/oauth/urls.py
@@ -1,4 +1,6 @@
 from cdt_identity import views as cdt_identity_views
+from cdt_identity.routes import Routes
+from cdt_identity.urls import app_name as cdt_app_name
 from django.utils.decorators import decorator_from_middleware
 from django.urls import path
 
@@ -6,36 +8,37 @@ from benefits.routes import routes
 from . import views, hooks
 from .middleware import FlowUsesClaimsVerificationSessionRequired
 
-
-app_name = "oauth"
+# use cdt_identity app name so that the URL namespace matches what cdt_identity expects.
+# (e.g. when cdt_identity reverses routes.)
+app_name = cdt_app_name
 urlpatterns = [
     # /oauth
     path(
-        "login",
+        Routes.login,
         decorator_from_middleware(FlowUsesClaimsVerificationSessionRequired)(cdt_identity_views.login),
         {"hooks": hooks.OAuthHooks},
         name=routes.name(routes.OAUTH_LOGIN),
     ),
     path(
-        "authorize",
+        Routes.authorize,
         decorator_from_middleware(FlowUsesClaimsVerificationSessionRequired)(cdt_identity_views.authorize),
         {"hooks": hooks.OAuthHooks},
         name=routes.name(routes.OAUTH_AUTHORIZE),
     ),
     path(
-        "cancel",
+        Routes.cancel,
         decorator_from_middleware(FlowUsesClaimsVerificationSessionRequired)(cdt_identity_views.cancel),
         {"hooks": hooks.OAuthHooks},
         name=routes.name(routes.OAUTH_CANCEL),
     ),
     path(
-        "logout",
+        Routes.logout,
         decorator_from_middleware(FlowUsesClaimsVerificationSessionRequired)(cdt_identity_views.logout),
         {"hooks": hooks.OAuthHooks},
         name=routes.name(routes.OAUTH_LOGOUT),
     ),
     path(
-        "post_logout",
+        Routes.post_logout,
         decorator_from_middleware(FlowUsesClaimsVerificationSessionRequired)(cdt_identity_views.post_logout),
         {"hooks": hooks.OAuthHooks},
         name=routes.name(routes.OAUTH_POST_LOGOUT),

--- a/benefits/routes.py
+++ b/benefits/routes.py
@@ -1,3 +1,6 @@
+from cdt_identity.routes import Routes as OAuthRoutes
+
+
 class Routes:
     """Django routes in the form of `app:name` for the Benefits application."""
 
@@ -44,32 +47,32 @@ class Routes:
     @property
     def OAUTH_LOGIN(self):
         """Start of the identity proofing phase for claims verification."""
-        return "oauth:login"
+        return OAuthRoutes.route_login
 
     @property
     def OAUTH_CANCEL(self):
         """OAuth cancel login."""
-        return "oauth:cancel"
+        return OAuthRoutes.route_cancel
 
     @property
     def OAUTH_AUTHORIZE(self):
         """OAuth authorize access token for claims verification."""
-        return "oauth:authorize"
+        return OAuthRoutes.route_authorize
 
     @property
     def OAUTH_LOGOUT(self):
         """OAuth initiate logout."""
-        return "oauth:logout"
+        return OAuthRoutes.route_logout
 
     @property
     def OAUTH_POST_LOGOUT(self):
         """OAuth complete logout."""
-        return "oauth:post_logout"
+        return OAuthRoutes.route_post_logout
 
     @property
     def OAUTH_SYSTEM_ERROR(self):
         """OAuth error not caused by the user."""
-        return "oauth:system_error"
+        return OAuthRoutes.route("system_error")
 
     @property
     def ELIGIBILITY_INDEX(self):

--- a/benefits/urls.py
+++ b/benefits/urls.py
@@ -27,7 +27,6 @@ urlpatterns = [
     path("enrollment/", include("benefits.enrollment.urls")),
     path("i18n/", include("django.conf.urls.i18n")),
     path("oauth/", include("benefits.oauth.urls")),
-    path("oauth/", include("cdt_identity.urls")),
     path("in_person/", include("benefits.in_person.urls")),
 ]
 


### PR DESCRIPTION
Closes #2813 

~Builds off #2819~

In https://github.com/cal-itp/benefits/pull/2793, we uncovered a need for the `oauth/authorize` route to have a namespace of `cdt`. See https://github.com/cal-itp/benefits/pull/2793#discussion_r2023782407 for more details. The temporary solution was to add a duplicate URL pattern that pointed to `cdt_identity.urls`.

@thekaveman, @lalver1, and I took a closer look at this today and figured out a cleaner solution, which is to make the URL patterns in `benefits.oauth.urls` have a namespace of `cdt`. Then there is no need for the duplicate.

We also cleaned up duplication in `benefits.oauth.urls` by extracting repeated values into variables.