### PR TITLE
Feat: default descending sort on date for enrollments list

### DIFF
--- a/benefits/core/admin/enrollment.py
+++ b/benefits/core/admin/enrollment.py
@@ -13,6 +13,7 @@ from .users import is_staff_member_or_superuser
 @admin.register(models.EnrollmentEvent)
 class EnrollmentEventAdmin(admin.ModelAdmin):
     list_display = ("enrollment_datetime", "transit_agency", "enrollment_flow", "enrollment_method", "verified_by")
+    ordering = ("-enrollment_datetime",)
 
     def has_add_permission(self, request: HttpRequest, obj=None):
         if settings.RUNTIME_ENVIRONMENT() == settings.RUNTIME_ENVS.PROD:


### PR DESCRIPTION
Closes #2809

There is now a default descending sort on the date when viewing enrollments in the admin.

We do this by setting [`ModelAdmin.ordering`](https://docs.djangoproject.com/en/5.1/ref/contrib/admin/#django.contrib.admin.ModelAdmin.ordering) on `EnrollmentEventAdmin`.

> To indicate descending order with the `ordering` argument you can use a hyphen prefix on the field name.

_from https://docs.djangoproject.com/en/5.1/ref/contrib/admin/_

### Screenshot of default descending sort
![Screenshot from 2025-04-04 15-13-44](https://github.com/user-attachments/assets/d39ac063-818e-4aad-a084-736442e5775f)
