### PR TITLE
Refactor: remove unnecessary usage of `translate`

### DIFF
--- a/benefits/core/templates/core/index--agency.html
+++ b/benefits/core/templates/core/index--agency.html
@@ -6,7 +6,7 @@
 {% endblock title %}
 
 {% block headline %}
-  {% translate headline %}
+  {{ headline }}
 {% endblock headline %}
 
 {% block call-to-action %}

--- a/benefits/eligibility/templates/eligibility/index.html
+++ b/benefits/eligibility/templates/eligibility/index.html
@@ -21,9 +21,9 @@
 {% block inner-content %}
   {% for text in form_text %}
     {% if not forloop.last %}
-      <p class="pt-4">{% translate text %}</p>
+      <p class="pt-4">{{ text }}</p>
     {% else %}
-      <p class="pt-4 pb-4">{% translate text %}</p>
+      <p class="pt-4 pb-4">{{ text }}</p>
     {% endif %}
   {% endfor %}
 

--- a/benefits/eligibility/templates/eligibility/index.html
+++ b/benefits/eligibility/templates/eligibility/index.html
@@ -21,9 +21,9 @@
 {% block inner-content %}
   {% for text in form_text %}
     {% if not forloop.last %}
-      <p class="pt-4">{{ text }}</p>
+      <p class="pt-4">{% translate text %}</p>
     {% else %}
-      <p class="pt-4 pb-4">{{ text }}</p>
+      <p class="pt-4 pb-4">{% translate text %}</p>
     {% endif %}
   {% endfor %}
 

--- a/benefits/eligibility/templates/eligibility/start.html
+++ b/benefits/eligibility/templates/eligibility/start.html
@@ -6,7 +6,7 @@
 {% endblock classes %}
 
 {% block page-title %}
-  {% translate page_title %}
+  {{ page_title }}
 {% endblock page-title %}
 
 {% block nav-buttons %}
@@ -59,10 +59,9 @@
 {% endblock inner-content %}
 
 {% block call-to-action-button %}
-  {% translate call_to_action_button.text as button_text %}
   <a href="{% url call_to_action_button.route %}"
      class="btn btn-lg btn-primary{% if call_to_action_button.extra_classes %} {{ call_to_action_button.extra_classes }}{% endif %}">
-    {{ button_text }}
+    {{ call_to_action_button.text }}
     {% if call_to_action_button.fallback_text %}
       <span class="fallback-text white-logo">{{ call_to_action_button.fallback_text }}</span>
     {% endif %}


### PR DESCRIPTION
Closes #2760 

Removes unneeded `translate`s from Agency Index and Eligibility Start.

The [ones on Eligibility Index](https://github.com/cal-itp/benefits/pull/2824/commits/b246fb8d178c99f29954da8c9bd8e6a3a739e1fe#diff-1e3c02710205416114dcc25094079f5cdd0a6d71b504924fe9c6d0d215612ef1L24-L26) are needed because, for some reason, removing it causes translation to break (i.e. switching to Spanish does not show Spanish copy. The English copy sticks around.) Seems like something to do with the `%` character.