### PR TITLE
Fix: check if flow uses claims verification

### DIFF
--- a/benefits/core/session.py
+++ b/benefits/core/session.py
@@ -154,12 +154,14 @@ def logout(request):
 
 def oauth_extra_claims(request):
     """Get the extra oauth claims from the request's session, or None"""
-    oauth_session = OAuthSession(request)
-    eligibility_claim = oauth_session.claims_request.eligibility_claim
-    requested_extra_claims = [claim for claim in oauth_session.claims_request.claims_list if claim != eligibility_claim]
+    claims = [claim for claim, value in OAuthSession(request).claims_result.verified.items() if value]
 
-    if oauth_session.claims_result:
-        return [extra_claim for extra_claim in requested_extra_claims if extra_claim in oauth_session.claims_result]
+    if claims:
+        f = flow(request)
+        if f and f.uses_claims_verification:
+            claims.remove(f.claims_request.eligibility_claim)
+            return claims or None
+        raise Exception("Oauth claims but no flow")
     else:
         return None
 

--- a/tests/pytest/core/test_session.py
+++ b/tests/pytest/core/test_session.py
@@ -474,4 +474,11 @@ def test_oauth_extra_claims_no_claims(app_request, model_EnrollmentFlow_with_sco
     session.update(app_request, flow=model_EnrollmentFlow_with_scope_and_claim)
     OAuthSession(app_request).claims_result = ClaimsResult()
 
-    assert session.oauth_extra_claims(app_request) == []
+    assert session.oauth_extra_claims(app_request) is None
+
+
+@pytest.mark.django_db
+def test_oauth_extra_claims_claims_no_flow(app_request):
+    OAuthSession(app_request).claims_result = ClaimsResult(verified={"eligibility_claim": True, "extra_claim": True})
+    with pytest.raises(Exception, match="Oauth claims but no flow"):
+        session.oauth_extra_claims(app_request)


### PR DESCRIPTION
This PR brings back a check to avoid trying to access `eligibility_claim` on a flow that does not use claims verification. Without this fix, an exception would be raised when trying to access `eligibility_claim` on an agency card flow, for example:

![image](https://github.com/user-attachments/assets/f099d539-29aa-4fb2-9817-e1ea8cdb2395)

The exception would occur on [line 74 of enrollment index ](https://github.com/cal-itp/benefits/blob/main/benefits/enrollment/views.py#L74)when `extra_claims` would be requested from the `session`.
## Reviewing

Run through an agency card and a login.gov flow (all the way to the end) and ensure that you can successfully enroll.

