### PR TITLE
Chore: update pillow to 11.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "requests==2.32.3",
     "sentry-sdk==2.25.1",
     "six==1.17.0",
-    "pillow==11.2.0",
+    "pillow==11.2.1",
     "django-multiselectfield==0.1.13",
 ]
 


### PR DESCRIPTION
dependabot upgraded [Pillow](https://github.com/python-pillow/Pillow) to [11.2.0](https://github.com/cal-itp/benefits/pull/2807) but upon further inspection, pillow 11.2.0 was never released in the [GitHub repo](https://github.com/python-pillow/Pillow/releases) nor in [PyPI](https://pypi.org/project/pillow/#history). This caused the `client` image build to fail locally as well as in our [CI](https://github.com/cal-itp/benefits/actions/runs/14437112114/job/40480010017). This version upgrade fixes this issue by upgrading to version [11.2.1](https://pypi.org/project/pillow/) which was published in PyPI.
