### PR TITLE
Feat: CBV mixin enforces agency in session

### DIFF
--- a/benefits/core/mixins.py
+++ b/benefits/core/mixins.py
@@ -1,0 +1,23 @@
+import logging
+
+from . import session
+from .middleware import user_error
+
+logger = logging.getLogger(__name__)
+
+
+class AgencySessionRequiredMixin:
+    """Mixin intended for use with a class-based view as the first in the MRO.
+
+    Gets the active `TransitAgency` out of session and sets an attribute on `self`.
+
+    If the session is not configured with an agency, return a user error.
+    """
+
+    def dispatch(self, request, *args, **kwargs):
+        if session.active_agency(request):
+            self.agency = session.agency(request)
+            return super().dispatch(request, *args, **kwargs)
+        else:
+            logger.warning("Session not configured with an active agency")
+            return user_error(request)

--- a/tests/pytest/core/test_mixins.py
+++ b/tests/pytest/core/test_mixins.py
@@ -1,0 +1,38 @@
+from django.views import View
+
+import pytest
+
+from benefits.core.middleware import TEMPLATE_USER_ERROR
+from benefits.core.mixins import AgencySessionRequiredMixin
+
+
+class SampleView(AgencySessionRequiredMixin, View):
+    pass
+
+
+class TestAgencySessionRequiredMixin:
+
+    @pytest.fixture
+    def view(self, app_request):
+        v = SampleView()
+        v.setup(app_request)
+        return v
+
+    def test_dispatch_without_active_agency(self, view, app_request, mocker):
+        mock_session = mocker.patch("benefits.core.mixins.session")
+        mock_session.active_agency.return_value = False
+
+        response = view.dispatch(app_request)
+
+        assert not hasattr(view, "agency")
+        assert response.status_code == 200
+        assert response.template_name == TEMPLATE_USER_ERROR
+
+    def test_dispatch_with_active_agency(self, view, app_request, mocker):
+        mock_session = mocker.patch("benefits.core.mixins.session")
+        mock_session.active_agency.return_value = True
+        mock_session.agency.return_value = {"agency": "123"}
+
+        view.dispatch(app_request)
+
+        assert view.agency == {"agency": "123"}


### PR DESCRIPTION
Closes #2873 

Modeled after existing middleware class [`AgencySessionRequired`](https://github.com/cal-itp/benefits/blob/main/benefits/core/middleware.py#L29), and will eventually replace this entirely once all dependent views are refactored to CBV.

