### PR TITLE
Feat: CBV mixin enforces flow in session

### DIFF
--- a/benefits/core/mixins.py
+++ b/benefits/core/mixins.py
@@ -21,3 +21,21 @@ class AgencySessionRequiredMixin:
         else:
             logger.warning("Session not configured with an active agency")
             return user_error(request)
+
+
+class FlowSessionRequiredMixin:
+    """Mixin intended for use with a class-based view as the first in the MRO.
+
+    Gets the current `EnrollmentFlow` out of session and sets an attribute on `self`.
+
+    If the session is not configured with a flow, return a user error.
+    """
+
+    def dispatch(self, request, *args, **kwargs):
+        flow = session.flow(request)
+        if flow:
+            self.flow = flow
+            return super().dispatch(request, *args, **kwargs)
+        else:
+            logger.warning("Session not configured with enrollment flow")
+            return user_error(request)

--- a/tests/pytest/core/test_mixins.py
+++ b/tests/pytest/core/test_mixins.py
@@ -3,18 +3,16 @@ from django.views import View
 import pytest
 
 from benefits.core.middleware import TEMPLATE_USER_ERROR
-from benefits.core.mixins import AgencySessionRequiredMixin
-
-
-class SampleView(AgencySessionRequiredMixin, View):
-    pass
+from benefits.core.mixins import AgencySessionRequiredMixin, FlowSessionRequiredMixin
 
 
 class TestAgencySessionRequiredMixin:
+    class SampleView(AgencySessionRequiredMixin, View):
+        pass
 
     @pytest.fixture
     def view(self, app_request):
-        v = SampleView()
+        v = self.SampleView()
         v.setup(app_request)
         return v
 
@@ -36,3 +34,32 @@ class TestAgencySessionRequiredMixin:
         view.dispatch(app_request)
 
         assert view.agency == {"agency": "123"}
+
+
+class TestFlowSessionRequiredMixin:
+    class SampleView(FlowSessionRequiredMixin, View):
+        pass
+
+    @pytest.fixture
+    def view(self, app_request):
+        v = self.SampleView()
+        v.setup(app_request)
+        return v
+
+    def test_dispatch_without_flow(self, view, app_request, mocker):
+        mock_session = mocker.patch("benefits.core.mixins.session")
+        mock_session.flow.return_value = False
+
+        response = view.dispatch(app_request)
+
+        assert not hasattr(view, "flow")
+        assert response.status_code == 200
+        assert response.template_name == TEMPLATE_USER_ERROR
+
+    def test_dispatch_with_flow(self, view, app_request, mocker):
+        mock_session = mocker.patch("benefits.core.mixins.session")
+        mock_session.flow.return_value = {"flow": "123"}
+
+        view.dispatch(app_request)
+
+        assert view.flow == {"flow": "123"}


### PR DESCRIPTION
Closes #2874 

Modeled after existing middleware class [`FlowSessionRequired`](https://github.com/cal-itp/benefits/blob/main/benefits/core/middleware.py#L85), and will eventually replace this entirely once all dependent views are refactored to CBV.