### PR TITLE
Fix: Admin - Fix secondary button text color

### DIFF
--- a/benefits/in_person/templates/in_person/enrollment/success.html
+++ b/benefits/in_person/templates/in_person/enrollment/success.html
@@ -26,7 +26,7 @@
       </div>
       <div class="col-6">
         {% url routes.ADMIN_INDEX as url_done %}
-        <a href="{{ url_done }}" class="btn btn-lg btn-primary d-block">Done</a>
+        <a href="{{ url_done }}" class="btn btn-lg btn-primary text-white d-block">Done</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
fixes #2867 

![image](https://github.com/user-attachments/assets/dbd4cd2f-472d-4f39-90c5-8dbfac75bb6b)

This PR fixes the button issue by using the same set of classes the button on the Admin dashboard does (btn btn-lg text-white btn-primary d-block). Eventually, when the Benefits design language is ready to be implemented, this should be improved so we don't need a long string of buttons to make the standard button.