### PR TITLE
Refactor: Class-based views - Eligibility index

### DIFF
--- a/benefits/eligibility/urls.py
+++ b/benefits/eligibility/urls.py
@@ -11,7 +11,7 @@ from . import views
 app_name = "eligibility"
 urlpatterns = [
     # /eligibility
-    path("", views.index, name=routes.name(routes.ELIGIBILITY_INDEX)),
+    path("", views.IndexView.as_view(), name=routes.name(routes.ELIGIBILITY_INDEX)),
     path("start", views.start, name=routes.name(routes.ELIGIBILITY_START)),
     path("confirm", views.confirm, name=routes.name(routes.ELIGIBILITY_CONFIRM)),
     path("unverified", views.unverified, name=routes.name(routes.ELIGIBILITY_UNVERIFIED)),

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -25,11 +25,6 @@ class IndexView(AgencySessionRequiredMixin, RecaptchaEnabledMixin, FormView):
     template_name = "eligibility/index.html"
     form_class = forms.EnrollmentFlowSelectionForm
 
-    def setup(self, request, *args, **kwargs):
-        """Initialize view attributes."""
-        super().setup(request, *args, **kwargs)
-        self.agency = session.agency(request)
-
     def get_form_kwargs(self):
         """Return the keyword arguments for instantiating the form."""
         kwargs = super().get_form_kwargs()

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -60,8 +60,7 @@ class IndexView(AgencySessionRequiredMixin, RecaptchaEnabledMixin, FormView):
     def get_context_data(self, **kwargs):
         """Add agency-specific context data."""
         context = super().get_context_data(**kwargs)
-        if self.agency:
-            context.update(self.agency.eligibility_index_context)
+        context.update(self.agency.eligibility_index_context)
         return context
 
 

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -33,14 +33,16 @@ class IndexView(AgencySessionRequiredMixin, RecaptchaEnabledMixin, FormView):
 
     def dispatch(self, request, *args, **kwargs):
         """Initialize session state before handling the request."""
-        if not self.agency:
-            return TemplateResponse(request, "200-user-error.html")
+
+        # Run super.dispatch() here to
+        # Ensure all mixins run before dispatch logic
+        # so that self.agency is available from AgencySessionRequiredMixin
+        response = super().dispatch(request, *args, **kwargs)
 
         session.update(request, eligible=False, origin=self.agency.index_url)
-        # clear any prior OAuth token as the user is choosing their desired flow
-        # this may or may not require OAuth, with a different set of scope/claims than what is already stored
         session.logout(request)
-        return super().dispatch(request, *args, **kwargs)
+
+        return response
 
     def form_valid(self, form):
         """If the form is valid, set enrollment flow and redirect."""

--- a/tests/pytest/eligibility/test_views.py
+++ b/tests/pytest/eligibility/test_views.py
@@ -120,7 +120,7 @@ def test_index_get_agency_multiple_flows(mocker, model_TransitAgency, model_Enro
     response = client.get(path)
 
     assert response.status_code == 200
-    assert response.template_name == "eligibility/index.html"
+    assert "eligibility/index.html" in response.template_name
     assert "form" in response.context_data
     assert isinstance(response.context_data["form"], EnrollmentFlowSelectionForm)
 
@@ -143,7 +143,7 @@ def test_index_get_agency_single_flow(mocker, model_TransitAgency, model_Enrollm
     response = client.get(path)
 
     assert response.status_code == 200
-    assert response.template_name == "eligibility/index.html"
+    assert "eligibility/index.html" in response.template_name
     assert "form" in response.context_data
     assert isinstance(response.context_data["form"], EnrollmentFlowSelectionForm)
 


### PR DESCRIPTION
closes #2868 

This PR converts the Eligibility Index view method from a function-based view into a class-based view (CBV, reference here https://ccbv.co.uk/). This PR uses both mixins from #2875 and #2882.

## What this PR does
- uses a FormView https://ccbv.co.uk/projects/Django/5.2/django.views.generic.edit/FormView/ https://docs.djangoproject.com/en/5.2/ref/class-based-views/generic-editing/#django.views.generic.edit.FormView 
- uses both AgencySessionRequiredMixin and RecaptchaEnabledMixin in class-based index view (from https://github.com/cal-itp/benefits/pull/2887)
- updates url to reflect this change.

## Notes
- I kept the comments there for posterity. Do we still want/need them?
- I updated one test. One part of a spec was failing because it now was returning like this: `assert ['eligibility/index.html'] == 'eligibility/index.html'`, b/c `FormView` returns a list of template names, instead of a string. I changed the test to match what FormView now does, instead of changing FormView itself to return a string like the test expects.
