### PR TITLE
Refactor: Class-based views - Eligibility Start

### DIFF
--- a/benefits/eligibility/urls.py
+++ b/benefits/eligibility/urls.py
@@ -12,7 +12,7 @@ app_name = "eligibility"
 urlpatterns = [
     # /eligibility
     path("", views.index, name=routes.name(routes.ELIGIBILITY_INDEX)),
-    path("start", views.start, name=routes.name(routes.ELIGIBILITY_START)),
+    path("start", views.StartView.as_view(), name=routes.name(routes.ELIGIBILITY_START)),
     path("confirm", views.confirm, name=routes.name(routes.ELIGIBILITY_CONFIRM)),
     path("unverified", views.unverified, name=routes.name(routes.ELIGIBILITY_UNVERIFIED)),
 ]

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -7,9 +7,11 @@ from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.decorators import decorator_from_middleware
+from django.views.generic.base import TemplateView
 
 from benefits.routes import routes
 from benefits.core import recaptcha, session
+from benefits.core.mixins import AgencySessionRequiredMixin, FlowSessionRequiredMixin
 from benefits.core.middleware import AgencySessionRequired, RecaptchaEnabled, FlowSessionRequired
 from benefits.core.models import EnrollmentFlow
 from . import analytics, forms, verify
@@ -56,15 +58,18 @@ def index(request):
     return response
 
 
-@decorator_from_middleware(AgencySessionRequired)
-@decorator_from_middleware(FlowSessionRequired)
-def start(request):
-    """View handler for the eligibility verification getting started screen."""
-    session.update(request, eligible=False, origin=reverse(routes.ELIGIBILITY_START))
+class StartView(AgencySessionRequiredMixin, FlowSessionRequiredMixin, TemplateView):
+    """CBV for the eligibility verification getting started screen."""
 
-    flow = session.flow(request)
+    template_name = "eligibility/start.html"
 
-    return TemplateResponse(request, "eligibility/start.html", flow.eligibility_start_context)
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        session.update(self.request, eligible=False, origin=reverse(routes.ELIGIBILITY_START))
+        flow = session.flow(self.request)
+        context.update(flow.eligibility_start_context)
+
+        return context
 
 
 @decorator_from_middleware(AgencySessionRequired)

--- a/tests/pytest/eligibility/test_views.py
+++ b/tests/pytest/eligibility/test_views.py
@@ -191,6 +191,34 @@ def test_index_calls_session_logout(client, session_logout_spy):
     session_logout_spy.assert_called_once()
 
 
+class TestStartView:
+    @pytest.fixture
+    def view(self, app_request):
+        """Fixture to create an instance of StartView."""
+        v = benefits.eligibility.views.StartView()
+        v.setup(app_request)
+
+        return v
+
+    @pytest.mark.django_db
+    def test_get_context_data_flow_uses_claims_verification_logged_in(
+        self, mocker, app_request, view, mocked_session_flow_uses_claims_verification
+    ):
+        mock_session = mocker.patch("benefits.core.session")
+        mock_session.logged_in.return_value = True
+        mock_session.flow.return_value = mocked_session_flow_uses_claims_verification(None)
+
+        context = view.get_context_data()
+
+        assert benefits.eligibility.views.session._ELIGIBLE in app_request.session
+        assert app_request.session[benefits.eligibility.views.session._ELIGIBLE] is False
+        assert app_request.session[benefits.eligibility.views.session._ORIGIN] == reverse(routes.ELIGIBILITY_START)
+        # remove the "view" context key added by ContextMixin in
+        # https://github.com/django/django/blob/5.2/django/views/generic/base.py#L30
+        # before assertion
+        assert set({k: v for k, v in context.items() if k not in "view"}) == set(mock_session.flow().eligibility_start_context)
+
+
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_session_agency", "mocked_flow_selection_form")
 def test_start_flow_uses_claims_verification_logged_in(mocker, client, mocked_session_flow_uses_claims_verification):
@@ -227,16 +255,6 @@ def test_start_flow_does_not_use_claims_verification(mocker, client, mocked_sess
     response = client.get(path)
 
     assert response.status_code == 200
-
-
-@pytest.mark.django_db
-@pytest.mark.usefixtures("mocked_session_agency")
-def test_start_without_flow(client):
-    path = reverse(routes.ELIGIBILITY_START)
-
-    response = client.get(path)
-    assert response.status_code == 200
-    assert response.template_name == TEMPLATE_USER_ERROR
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
WIP(tests) - determine if TestStartView is required. Removed
test_start_without_flow since TestFlowSessionRequiredMixin seems
to be testing the same functionality. Note that the CBV is still
completely covered by the original tests.
