### PR TITLE
Refactor: add enrollment_littlepay token view

### DIFF
--- a/benefits/enrollment/urls.py
+++ b/benefits/enrollment/urls.py
@@ -6,14 +6,12 @@ from django.urls import path
 
 from benefits.routes import routes
 from . import views
-from benefits.enrollment_littlepay.views import TokenView
 
 
 app_name = "enrollment"
 urlpatterns = [
     # /enrollment
     path("", views.index, name=routes.name(routes.ENROLLMENT_INDEX)),
-    path("token", TokenView.as_view(), name=routes.name(routes.ENROLLMENT_TOKEN)),
     path("error/reenrollment", views.reenrollment_error, name=routes.name(routes.ENROLLMENT_REENROLLMENT_ERROR)),
     path("retry", views.retry, name=routes.name(routes.ENROLLMENT_RETRY)),
     path("success", views.success, name=routes.name(routes.ENROLLMENT_SUCCESS)),

--- a/benefits/enrollment/urls.py
+++ b/benefits/enrollment/urls.py
@@ -6,13 +6,14 @@ from django.urls import path
 
 from benefits.routes import routes
 from . import views
+from benefits.enrollment_littlepay.views import token
 
 
 app_name = "enrollment"
 urlpatterns = [
     # /enrollment
     path("", views.index, name=routes.name(routes.ENROLLMENT_INDEX)),
-    path("token", views.token, name=routes.name(routes.ENROLLMENT_TOKEN)),
+    path("token", token, name=routes.name(routes.ENROLLMENT_TOKEN)),
     path("error/reenrollment", views.reenrollment_error, name=routes.name(routes.ENROLLMENT_REENROLLMENT_ERROR)),
     path("retry", views.retry, name=routes.name(routes.ENROLLMENT_RETRY)),
     path("success", views.success, name=routes.name(routes.ENROLLMENT_SUCCESS)),

--- a/benefits/enrollment/urls.py
+++ b/benefits/enrollment/urls.py
@@ -6,14 +6,14 @@ from django.urls import path
 
 from benefits.routes import routes
 from . import views
-from benefits.enrollment_littlepay.views import token
+from benefits.enrollment_littlepay.views import TokenView
 
 
 app_name = "enrollment"
 urlpatterns = [
     # /enrollment
     path("", views.index, name=routes.name(routes.ENROLLMENT_INDEX)),
-    path("token", token, name=routes.name(routes.ENROLLMENT_TOKEN)),
+    path("token", TokenView.as_view(), name=routes.name(routes.ENROLLMENT_TOKEN)),
     path("error/reenrollment", views.reenrollment_error, name=routes.name(routes.ENROLLMENT_REENROLLMENT_ERROR)),
     path("retry", views.retry, name=routes.name(routes.ENROLLMENT_RETRY)),
     path("success", views.success, name=routes.name(routes.ENROLLMENT_SUCCESS)),

--- a/benefits/enrollment_littlepay/templates/enrollment_littlepay/index.html
+++ b/benefits/enrollment_littlepay/templates/enrollment_littlepay/index.html
@@ -15,7 +15,7 @@
 
       $.ajax({ dataType: "script", attrs: { nonce: "{{ request.csp_nonce }}"}, url: "{{ transit_processor.card_tokenize_url }}" })
           .done(function() {
-          $.get("{% url routes.ENROLLMENT_TOKEN %}", function(data) {
+          $.get("{% url routes.ENROLLMENT_LITTLEPAY_TOKEN %}", function(data) {
               if (data.redirect) {
                 // https://stackoverflow.com/a/42469170
                 // use 'assign' because 'replace' was giving strange Back button behavior

--- a/benefits/enrollment_littlepay/urls.py
+++ b/benefits/enrollment_littlepay/urls.py
@@ -1,0 +1,11 @@
+from django.urls import path
+
+from benefits.routes import routes
+from benefits.enrollment_littlepay.views import TokenView
+
+
+app_name = "littlepay"
+urlpatterns = [
+    # /littlepay
+    path("token", TokenView.as_view(), name=routes.name(routes.ENROLLMENT_LITTLEPAY_TOKEN)),
+]

--- a/benefits/enrollment_littlepay/views.py
+++ b/benefits/enrollment_littlepay/views.py
@@ -2,11 +2,9 @@ import logging
 
 from django.http import JsonResponse
 from django.urls import reverse
-from django.utils.decorators import decorator_from_middleware
-from django.views.generic import FormView
+from django.views.generic import FormView, View
 import sentry_sdk
 
-from benefits.core.middleware import EligibleSessionRequired
 from benefits.routes import routes
 from benefits.core import models, session
 from benefits.core.mixins import EligibleSessionRequiredMixin
@@ -14,38 +12,38 @@ from benefits.core.mixins import EligibleSessionRequiredMixin
 from benefits.enrollment import analytics, forms
 from benefits.enrollment.enrollment import Status
 from benefits.enrollment_littlepay.enrollment import enroll, request_card_tokenization_access
-from benefits.enrollment_littlepay.session import Session as LittlepaySession
+from benefits.enrollment_littlepay.session import Session
 
 logger = logging.getLogger(__name__)
 
 
-@decorator_from_middleware(EligibleSessionRequired)
-def token(request):
-    """View handler for the enrollment auth token."""
-    session = LittlepaySession(request)
+class TokenView(EligibleSessionRequiredMixin, View):
+    """View handler for the card tokenization access token."""
 
-    if not session.access_token_valid():
-        response = request_card_tokenization_access(request)
+    def get(self, request, *args, **kwargs):
+        session = Session(request)
 
-        if response.status is Status.SUCCESS:
-            session.access_token = response.access_token
-            session.access_token_expiry = response.expires_at
-        elif response.status is Status.SYSTEM_ERROR or response.status is Status.EXCEPTION:
-            logger.debug("Error occurred while requesting access token", exc_info=response.exception)
-            sentry_sdk.capture_exception(response.exception)
-            analytics.failed_access_token_request(request, response.status_code)
+        if not session.access_token_valid():
+            response = request_card_tokenization_access(request)
 
-            if response.status is Status.SYSTEM_ERROR:
-                redirect = reverse(routes.ENROLLMENT_SYSTEM_ERROR)
-            else:
-                redirect = reverse(routes.SERVER_ERROR)
+            if response.status is Status.SUCCESS:
+                session.access_token = response.access_token
+                session.access_token_expiry = response.expires_at
+            elif response.status is Status.SYSTEM_ERROR or response.status is Status.EXCEPTION:
+                logger.debug("Error occurred while requesting access token", exc_info=response.exception)
+                sentry_sdk.capture_exception(response.exception)
+                analytics.failed_access_token_request(request, response.status_code)
 
-            data = {"redirect": redirect}
-            return JsonResponse(data)
+                if response.status is Status.SYSTEM_ERROR:
+                    redirect = reverse(routes.ENROLLMENT_SYSTEM_ERROR)
+                else:
+                    redirect = reverse(routes.SERVER_ERROR)
 
-    data = {"token": session.access_token}
+                data = {"redirect": redirect}
+                return JsonResponse(data)
 
-    return JsonResponse(data)
+        data = {"token": session.access_token}
+        return JsonResponse(data)
 
 
 class IndexView(EligibleSessionRequiredMixin, FormView):

--- a/benefits/routes.py
+++ b/benefits/routes.py
@@ -85,9 +85,9 @@ class Routes:
         return "enrollment:index"
 
     @property
-    def ENROLLMENT_TOKEN(self):
-        """Acquire a TransitProcessor API token for enrollment."""
-        return "enrollment:token"
+    def ENROLLMENT_LITTLEPAY_TOKEN(self):
+        """Acquire a Littlepay card tokenization access token for enrollment."""
+        return "littlepay:token"
 
     @property
     def ENROLLMENT_SUCCESS(self):

--- a/benefits/urls.py
+++ b/benefits/urls.py
@@ -28,6 +28,7 @@ urlpatterns = [
     path("i18n/", include("django.conf.urls.i18n")),
     path("oauth/", include("benefits.oauth.urls")),
     path("in_person/", include("benefits.in_person.urls")),
+    path("littlepay/", include("benefits.enrollment_littlepay.urls")),
 ]
 
 if settings.RUNTIME_ENVIRONMENT() == settings.RUNTIME_ENVS.LOCAL:

--- a/tests/pytest/enrollment_littlepay/test_views.py
+++ b/tests/pytest/enrollment_littlepay/test_views.py
@@ -36,7 +36,7 @@ def mocked_enrollment_result_handler():
 
 @pytest.mark.django_db
 def test_token_ineligible(client):
-    path = reverse(routes.ENROLLMENT_TOKEN)
+    path = reverse(routes.ENROLLMENT_LITTLEPAY_TOKEN)
 
     response = client.get(path)
 
@@ -62,7 +62,7 @@ def test_token_refresh(mocker, client):
         ),
     )
 
-    path = reverse(routes.ENROLLMENT_TOKEN)
+    path = reverse(routes.ENROLLMENT_LITTLEPAY_TOKEN)
     response = client.get(path)
 
     assert response.status_code == 200
@@ -77,7 +77,7 @@ def test_token_valid(mocker, client):
     mocker.patch.object(Session, "access_token", "enrollment_token")
     mocker.patch("benefits.enrollment_littlepay.session.Session.access_token_valid", return_value=True)
 
-    path = reverse(routes.ENROLLMENT_TOKEN)
+    path = reverse(routes.ENROLLMENT_LITTLEPAY_TOKEN)
     response = client.get(path)
 
     assert response.status_code == 200
@@ -103,7 +103,7 @@ def test_token_system_error(mocker, client, mocked_analytics_module, mocked_sent
         ),
     )
 
-    path = reverse(routes.ENROLLMENT_TOKEN)
+    path = reverse(routes.ENROLLMENT_LITTLEPAY_TOKEN)
     response = client.get(path)
 
     assert response.status_code == 200
@@ -133,7 +133,7 @@ def test_token_http_error_400(mocker, client, mocked_analytics_module, mocked_se
         ),
     )
 
-    path = reverse(routes.ENROLLMENT_TOKEN)
+    path = reverse(routes.ENROLLMENT_LITTLEPAY_TOKEN)
     response = client.get(path)
 
     assert response.status_code == 200
@@ -160,7 +160,7 @@ def test_token_misconfigured_client_id(mocker, client, mocked_analytics_module, 
         ),
     )
 
-    path = reverse(routes.ENROLLMENT_TOKEN)
+    path = reverse(routes.ENROLLMENT_LITTLEPAY_TOKEN)
     response = client.get(path)
 
     assert response.status_code == 200
@@ -186,7 +186,7 @@ def test_token_connection_error(mocker, client, mocked_analytics_module, mocked_
         ),
     )
 
-    path = reverse(routes.ENROLLMENT_TOKEN)
+    path = reverse(routes.ENROLLMENT_LITTLEPAY_TOKEN)
     response = client.get(path)
 
     assert response.status_code == 200

--- a/tests/pytest/enrollment_littlepay/test_views.py
+++ b/tests/pytest/enrollment_littlepay/test_views.py
@@ -1,7 +1,29 @@
-import pytest
+import time
 
+import pytest
+from authlib.integrations.base_client.errors import UnsupportedTokenTypeError
+from django.urls import reverse
+from requests import HTTPError
+
+from benefits.routes import routes
+from benefits.core.middleware import TEMPLATE_USER_ERROR
 from benefits.enrollment.enrollment import Status
+from benefits.enrollment_littlepay.session import Session
+from benefits.enrollment_littlepay.enrollment import CardTokenizationAccessResponse
+import benefits.enrollment_littlepay.views
+
+
 from benefits.enrollment_littlepay.views import IndexView
+
+
+@pytest.fixture
+def mocked_analytics_module(mocked_analytics_module):
+    return mocked_analytics_module(benefits.enrollment_littlepay.views)
+
+
+@pytest.fixture
+def mocked_sentry_sdk_module(mocker):
+    return mocker.patch.object(benefits.enrollment_littlepay.views, "sentry_sdk")
 
 
 @pytest.fixture
@@ -10,6 +32,170 @@ def mocked_enrollment_result_handler():
         return "success"
 
     return handler
+
+
+@pytest.mark.django_db
+def test_token_ineligible(client):
+    path = reverse(routes.ENROLLMENT_TOKEN)
+
+    response = client.get(path)
+
+    assert response.status_code == 200
+    assert response.template_name == TEMPLATE_USER_ERROR
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("mocked_session_agency", "mocked_session_eligible")
+def test_token_refresh(mocker, client):
+    mocker.patch("benefits.enrollment_littlepay.session.Session.access_token_valid", return_value=False)
+
+    mock_token = {}
+    mock_token["access_token"] = "access_token"
+    mock_token["expires_at"] = time.time() + 10000
+
+    mocker.patch(
+        "benefits.enrollment_littlepay.views.request_card_tokenization_access",
+        return_value=CardTokenizationAccessResponse(
+            Status.SUCCESS,
+            access_token=mock_token["access_token"],
+            expires_at=mock_token["expires_at"],
+        ),
+    )
+
+    path = reverse(routes.ENROLLMENT_TOKEN)
+    response = client.get(path)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "token" in data
+    assert data["token"] == mock_token["access_token"]
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("mocked_session_agency", "mocked_session_eligible")
+def test_token_valid(mocker, client):
+    mocker.patch.object(Session, "access_token", "enrollment_token")
+    mocker.patch("benefits.enrollment_littlepay.session.Session.access_token_valid", return_value=True)
+
+    path = reverse(routes.ENROLLMENT_TOKEN)
+    response = client.get(path)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "token" in data
+    assert data["token"] == "enrollment_token"
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("mocked_session_agency", "mocked_session_eligible")
+def test_token_system_error(mocker, client, mocked_analytics_module, mocked_sentry_sdk_module):
+    mocker.patch("benefits.enrollment_littlepay.session.Session.access_token_valid", return_value=False)
+
+    mock_error = {"message": "Mock error message"}
+    mock_error_response = mocker.Mock(status_code=500, **mock_error)
+    mock_error_response.json.return_value = mock_error
+    http_error = HTTPError(response=mock_error_response)
+
+    mocker.patch(
+        "benefits.enrollment_littlepay.views.request_card_tokenization_access",
+        return_value=CardTokenizationAccessResponse(
+            Status.SYSTEM_ERROR, access_token=None, expires_at=None, exception=http_error, status_code=500
+        ),
+    )
+
+    path = reverse(routes.ENROLLMENT_TOKEN)
+    response = client.get(path)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "token" not in data
+    assert "redirect" in data
+    assert data["redirect"] == reverse(routes.ENROLLMENT_SYSTEM_ERROR)
+    mocked_analytics_module.failed_access_token_request.assert_called_once()
+    assert 500 in mocked_analytics_module.failed_access_token_request.call_args.args
+    mocked_sentry_sdk_module.capture_exception.assert_called_once()
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("mocked_session_agency", "mocked_session_eligible")
+def test_token_http_error_400(mocker, client, mocked_analytics_module, mocked_sentry_sdk_module):
+    mocker.patch("benefits.enrollment_littlepay.session.Session.access_token_valid", return_value=False)
+
+    mock_error = {"message": "Mock error message"}
+    mock_error_response = mocker.Mock(status_code=400, **mock_error)
+    mock_error_response.json.return_value = mock_error
+    http_error = HTTPError(response=mock_error_response)
+
+    mocker.patch(
+        "benefits.enrollment_littlepay.views.request_card_tokenization_access",
+        return_value=CardTokenizationAccessResponse(
+            Status.EXCEPTION, access_token=None, expires_at=None, exception=http_error, status_code=400
+        ),
+    )
+
+    path = reverse(routes.ENROLLMENT_TOKEN)
+    response = client.get(path)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "token" not in data
+    assert "redirect" in data
+    assert data["redirect"] == reverse(routes.SERVER_ERROR)
+    mocked_analytics_module.failed_access_token_request.assert_called_once()
+    assert 400 in mocked_analytics_module.failed_access_token_request.call_args.args
+    mocked_sentry_sdk_module.capture_exception.assert_called_once()
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("mocked_session_agency", "mocked_session_eligible")
+def test_token_misconfigured_client_id(mocker, client, mocked_analytics_module, mocked_sentry_sdk_module):
+    mocker.patch("benefits.enrollment_littlepay.session.Session.access_token_valid", return_value=False)
+
+    exception = UnsupportedTokenTypeError()
+
+    mocker.patch(
+        "benefits.enrollment_littlepay.views.request_card_tokenization_access",
+        return_value=CardTokenizationAccessResponse(
+            Status.EXCEPTION, access_token=None, expires_at=None, exception=exception, status_code=None
+        ),
+    )
+
+    path = reverse(routes.ENROLLMENT_TOKEN)
+    response = client.get(path)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "token" not in data
+    assert "redirect" in data
+    assert data["redirect"] == reverse(routes.SERVER_ERROR)
+    mocked_analytics_module.failed_access_token_request.assert_called_once()
+    mocked_sentry_sdk_module.capture_exception.assert_called_once()
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("mocked_session_agency", "mocked_session_eligible")
+def test_token_connection_error(mocker, client, mocked_analytics_module, mocked_sentry_sdk_module):
+    mocker.patch("benefits.enrollment_littlepay.session.Session.access_token_valid", return_value=False)
+
+    exception = ConnectionError()
+
+    mocker.patch(
+        "benefits.enrollment_littlepay.views.request_card_tokenization_access",
+        return_value=CardTokenizationAccessResponse(
+            Status.EXCEPTION, access_token=None, expires_at=None, exception=exception, status_code=None
+        ),
+    )
+
+    path = reverse(routes.ENROLLMENT_TOKEN)
+    response = client.get(path)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "token" not in data
+    assert "redirect" in data
+    assert data["redirect"] == reverse(routes.SERVER_ERROR)
+    mocked_analytics_module.failed_access_token_request.assert_called_once()
+    mocked_sentry_sdk_module.capture_exception.assert_called_once()
 
 
 class TestIndexView:


### PR DESCRIPTION
Part of #2907 

This PR moves the entire `token` view from `benefits.enrollment.views` into `benefits.enrollment_littlepay.views`. It also refactors the view into a class-based view.

The URL for the view was moved under `enrollment_littlepay` with a namespace of `littlepay` so that the URL is something like `<base URL>/littlepay/token`. The route was updated as well so that all consumers of the route use the new URL.

## Reviewing
Enrollment with Littlepay should still work.

## Screenshot

![image](https://github.com/user-attachments/assets/005df476-d854-4096-b701-ef2dbcc4ea93)
