### PR TITLE
Feat: additional Littlepay card types

### DIFF
--- a/benefits/enrollment_littlepay/templates/enrollment_littlepay/index.html
+++ b/benefits/enrollment_littlepay/templates/enrollment_littlepay/index.html
@@ -38,13 +38,18 @@
                   $(this).addClass("disabled").attr("aria-disabled", "true").text("{{ loading_text }}");
               });
 
+              // parse the JSON string back into a JS array
+              // the escapejs filter handles e.g. quote conversion
+              let cardTypes = JSON.parse('{{ card_types|escapejs }}');
+
               littlepay({
                   authorization: data.token,
                   element: '#{{ cta_button }}',
                   envUrl: '{{ transit_processor.card_tokenize_env }}',
                   options: {
                       color: '#046b99',
-                      language: '{{ overlay_language }}'
+                      language: '{{ overlay_language }}',
+                      cardTypes: cardTypes
                   },
                   onTokenize: function (response) {
                       /* This function executes when the

--- a/benefits/enrollment_littlepay/views.py
+++ b/benefits/enrollment_littlepay/views.py
@@ -1,5 +1,7 @@
+import json
 import logging
 
+from django.conf import settings
 from django.http import JsonResponse
 from django.urls import reverse
 from django.views.generic import FormView, View
@@ -68,6 +70,10 @@ class IndexView(EligibleSessionRequiredMixin, FormView):
         # mapping from Django's I18N LANGUAGE_CODE to Littlepay's overlay language code
         overlay_language = {"en": "en", "es": "es-419"}.get(request.LANGUAGE_CODE, "en")
 
+        card_types = ["visa", "mastercard"]
+        if settings.LITTLEPAY_ADDITIONAL_CARDTYPES:
+            card_types.extend(["discover", "amex"])
+
         context = {
             "forms": [tokenize_retry_form, tokenize_server_error_form, tokenize_system_error_form, tokenize_success_form],
             "cta_button": "tokenize_card",
@@ -78,6 +84,8 @@ class IndexView(EligibleSessionRequiredMixin, FormView):
             "form_success": tokenize_success_form.id,
             "form_system_error": tokenize_system_error_form.id,
             "overlay_language": overlay_language,
+            # convert the python list to a JSON string for use in JavaScript
+            "card_types": json.dumps(card_types),
         }
 
         enrollment_index_context_dict = flow.enrollment_index_context

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -379,3 +379,6 @@ except Exception:
     REQUESTS_READ_TIMEOUT = 20
 
 REQUESTS_TIMEOUT = (REQUESTS_CONNECT_TIMEOUT, REQUESTS_READ_TIMEOUT)
+
+# Temporary flag for Littlepay card types
+LITTLEPAY_ADDITIONAL_CARDTYPES = os.environ.get("LITTLEPAY_ADDITIONAL_CARDTYPES", "False").lower() == "true"

--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -61,14 +61,14 @@ resource "azurerm_linux_web_app" "main" {
     "DJANGO_STORAGE_DIR"   = "${local.secret_prefix}django-storage-dir)",
     "DJANGO_DEBUG"         = local.is_prod ? null : "${local.secret_prefix}django-debug)",
     "DJANGO_LOG_LEVEL"     = "${local.secret_prefix}django-log-level)",
-
     "DJANGO_RECAPTCHA_SECRET_KEY" = "${local.secret_prefix}django-recaptcha-secret-key)",
     "DJANGO_RECAPTCHA_SITE_KEY"   = "${local.secret_prefix}django-recaptcha-site-key)",
-
     "DJANGO_SECRET_KEY"      = "${local.secret_prefix}django-secret-key)",
     "DJANGO_TRUSTED_ORIGINS" = "${local.secret_prefix}django-trusted-origins)",
 
     "HEALTHCHECK_USER_AGENTS" = local.is_dev ? null : "${local.secret_prefix}healthcheck-user-agents)",
+
+    "LITTLEPAY_ADDITIONAL_CARDTYPES" = "${local.secret_prefix}littlepay-additional-cardtypes)",
 
     # Google SSO for Admin
 

--- a/tests/pytest/enrollment_littlepay/test_views.py
+++ b/tests/pytest/enrollment_littlepay/test_views.py
@@ -209,7 +209,10 @@ class TestIndexView:
 
     @pytest.mark.django_db
     @pytest.mark.usefixtures("mocked_session_agency", "mocked_session_flow")
-    def test_get_context_data(self, view):
+    @pytest.mark.parametrize("additional_cardtypes", [True, False])
+    def test_get_context_data(self, view, settings, additional_cardtypes):
+        settings.LITTLEPAY_ADDITIONAL_CARDTYPES = additional_cardtypes
+
         context = view.get_context_data()
 
         assert "forms" in context
@@ -233,6 +236,13 @@ class TestIndexView:
         assert "website" in transit_processor_context
         assert "card_tokenize_url" in transit_processor_context
         assert "card_tokenize_env" in transit_processor_context
+
+        card_types = context["card_types"]
+        assert "visa" in card_types
+        assert "mastercard" in card_types
+        if additional_cardtypes:
+            assert "discover" in card_types
+            assert "amex" in card_types
 
     def test_form_valid(self, mocker, view):
         mocker.patch("benefits.enrollment_littlepay.views.enroll", return_value=(Status.SUCCESS, None))


### PR DESCRIPTION
Closes #2901 
Closes #2942 

## Reviewing

I wasn't able to see a difference in the Littlepay tokenization overlay with the flag set to `True` -- but I can confirm that the correct list of `cardTypes` is passed as an `option` to the function call:

![image](https://github.com/user-attachments/assets/5f89afd4-5502-4acf-9e09-74cddd12befb)

Easiest way to test is just set `LITTLEPAY_ADDITIONAL_CARDTYPES = True` in your local settings file (e.g. on the very last line in the file).

```python
# other settings...

# Temporary flag for Littlepay card types
LITTLEPAY_ADDITIONAL_CARDTYPES = os.environ.get("LITTLEPAY_ADDITIONAL_CARDTYPES", "False").lower() == "true"
LITTLEPAY_ADDITIONAL_CARDTYPES = True  # <-- quick and dirty override
```