### PR TITLE
Feat: Switchio API module

### DIFF
--- a/benefits/enrollment_switchio/api.py
+++ b/benefits/enrollment_switchio/api.py
@@ -50,13 +50,13 @@ class Client:
         self.client_certificate = client_certificate
         self.ca_certificate = ca_certificate
 
-    def _signature_input_string(self, timestamp, method, request_path, body=None):
+    def _signature_input_string(self, timestamp: str, method: str, request_path: str, body: str = None):
         if body is None:
             body = ""
 
         return f"{timestamp}{method}{request_path}{body}"
 
-    def _stp_signature(self, api_secret, timestamp, method, request_path, body=None):
+    def _stp_signature(self, api_secret: str, timestamp: str, method: str, request_path, body: str = None):
         input_string = self._signature_input_string(timestamp, method, request_path, body)
 
         # must encode inputs for hashing, according to https://stackoverflow.com/a/66958131

--- a/benefits/enrollment_switchio/api.py
+++ b/benefits/enrollment_switchio/api.py
@@ -56,11 +56,11 @@ class Client:
 
         return f"{timestamp}{method}{request_path}{body}"
 
-    def _stp_signature(self, api_secret: str, timestamp: str, method: str, request_path, body: str = None):
+    def _stp_signature(self, timestamp: str, method: str, request_path, body: str = None):
         input_string = self._signature_input_string(timestamp, method, request_path, body)
 
         # must encode inputs for hashing, according to https://stackoverflow.com/a/66958131
-        byte_key = api_secret.encode("utf-8")
+        byte_key = self.api_secret.encode("utf-8")
         message = input_string.encode("utf-8")
         stp_signature = hmac.new(byte_key, message, hashlib.sha256).hexdigest()
 
@@ -74,7 +74,6 @@ class Client:
             "STP-APIKEY": self.api_key,
             "STP-TIMESTAMP": timestamp,
             "STP-SIGNATURE": self._stp_signature(
-                api_secret=self.api_secret,
                 timestamp=timestamp,
                 method=method,
                 request_path=request_path,

--- a/benefits/enrollment_switchio/api.py
+++ b/benefits/enrollment_switchio/api.py
@@ -1,0 +1,127 @@
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+import hashlib
+import hmac
+import json
+import requests
+
+
+@dataclass
+class Registration:
+    regId: str
+    gtwUrl: str
+
+
+class EshopResponseMode(Enum):
+    FRAGMENT = "fragment"
+    QUERY = "query"
+    FORM_POST = "form_post"
+    POST_MESSAGE = "post_message"
+
+
+@dataclass
+class RegistrationStatus:
+    regState: str
+    created: datetime
+    mode: str
+    tokens: list[dict]
+    eshopResponseMode: str
+    identifier_type: str = None
+    mask_cin: str = None
+    card_exp: str = None
+
+
+class Client:
+
+    def __init__(
+        self,
+        api_url,
+        api_key,
+        api_secret,
+        private_key,
+        client_certificate,
+        ca_certificate,
+    ):
+        self.api_url = api_url
+        self.api_key = api_key
+        self.api_secret = api_secret
+        self.private_key = private_key
+        self.client_certificate = client_certificate
+        self.ca_certificate = ca_certificate
+
+    def _signature_input_string(self, timestamp, method, request_path, body=None):
+        if body is None:
+            body = ""
+
+        return f"{timestamp}{method}{request_path}{body}"
+
+    def _stp_signature(self, api_secret, timestamp, method, request_path, body=None):
+        input_string = self._signature_input_string(timestamp, method, request_path, body)
+
+        # must encode inputs for hashing, according to https://stackoverflow.com/a/66958131
+        byte_key = api_secret.encode("utf-8")
+        message = input_string.encode("utf-8")
+        stp_signature = hmac.new(byte_key, message, hashlib.sha256).hexdigest()
+
+        return stp_signature
+
+    def _get_headers(self, method, request_path, request_body: dict = None):
+        timestamp = str(int(datetime.now().timestamp()))
+
+        return {
+            "Content-Type": "application/json",
+            "STP-APIKEY": self.api_key,
+            "STP-TIMESTAMP": timestamp,
+            "STP-SIGNATURE": self._stp_signature(
+                api_secret=self.api_secret,
+                timestamp=timestamp,
+                method=method,
+                request_path=request_path,
+                body=json.dumps(request_body) if request_body else None,
+            ),
+        }
+
+    def request_registration(
+        self,
+        eshopRedirectUrl: str,
+        mode: str,
+        eshopResponseMode: EshopResponseMode,
+        timeout=5,
+    ) -> Registration:
+        registration_path = "/api/v1/registration"
+        request_body = {
+            "eshopRedirectUrl": eshopRedirectUrl,
+            "mode": mode,
+            "eshopResponseMode": eshopResponseMode.value,
+        }
+        cert = (self.client_certificate, self.private_key)
+
+        response = requests.post(
+            self.api_url.strip("/") + registration_path,
+            json=request_body,
+            headers=self._get_headers(method="POST", request_path=registration_path, request_body=request_body),
+            cert=cert,
+            verify=self.ca_certificate,
+            timeout=timeout,
+        )
+
+        response.raise_for_status()
+
+        return Registration(**response.json())
+
+    def get_registration_status(self, registration_id, timeout=5) -> RegistrationStatus:
+        request_path = f"/api/v1/registration/{registration_id}"
+        cert = (self.client_certificate, self.private_key)
+
+        response = requests.get(
+            self.api_url.strip("/") + request_path,
+            headers=self._get_headers(method="GET", request_path=request_path),
+            cert=cert,
+            verify=self.ca_certificate,
+            timeout=timeout,
+        )
+
+        response.raise_for_status()
+
+        return RegistrationStatus(**response.json())

--- a/tests/pytest/enrollment_switchio/test_api.py
+++ b/tests/pytest/enrollment_switchio/test_api.py
@@ -1,6 +1,4 @@
 from datetime import datetime
-import hashlib
-import hmac
 import json
 import pytest
 
@@ -15,7 +13,7 @@ def client():
 
 @pytest.mark.parametrize("method", ["GET", "POST"])
 @pytest.mark.parametrize("body", ['{"exampleProperty": "blah"}', None, ""])
-def test_client_signature_input_string_with_body(client, method, body):
+def test_client_signature_input_string(client, method, body):
     timestamp = str(int(datetime.now().timestamp()))
     request_path = "/api/example"
 
@@ -29,19 +27,16 @@ def test_client_signature_input_string_with_body(client, method, body):
     assert input_string == expected
 
 
-@pytest.mark.parametrize("method", ["GET", "POST"])
-@pytest.mark.parametrize("body", ['{"exampleProperty": "blah"}', None, ""])
-def test_client_stp_signature(client, method, body):
-    timestamp = str(int(datetime.now().timestamp()))
+def test_client_stp_signature(client):
+    timestamp = "1748637999"
+    method = "GET"
     request_path = "/api/example"
+    body = '{"exampleProperty": "blah"}'
 
     stp_signature = client._stp_signature(timestamp=timestamp, method=method, request_path=request_path, body=body)
 
-    # calculate the expected value
-    byte_key = client.api_secret.encode("utf-8")
-    input_string = client._signature_input_string(timestamp=timestamp, method=method, request_path=request_path, body=body)
-    message = input_string.encode("utf-8")
-    expected = hmac.new(byte_key, message, hashlib.sha256).hexdigest()
+    # the expected STP-SIGNATURE value based on those inputs
+    expected = "7da3dd8dad6af77d4f0d5b96ff250399f2ffe1dac2fdfbdbfae0c22a86366426"
 
     assert stp_signature == expected
 

--- a/tests/pytest/enrollment_switchio/test_api.py
+++ b/tests/pytest/enrollment_switchio/test_api.py
@@ -5,7 +5,7 @@ import json
 import pytest
 
 import benefits.enrollment_switchio.api
-from benefits.enrollment_switchio.api import Client, EshopResponseMode, Registration
+from benefits.enrollment_switchio.api import Client, EshopResponseMode, Registration, RegistrationStatus
 
 
 @pytest.fixture
@@ -88,3 +88,20 @@ def test_client_request_registration(mocker, client):
     )
 
     assert registration == Registration(**mock_json)
+
+
+def test_client_get_registration_status(mocker, client):
+    mock_response = mocker.Mock()
+    mock_json = dict(
+        regState="created",
+        created="2025-05-28T18:26:03.353",
+        mode="register",
+        tokens=[],
+        eshopResponseMode="form_post",
+    )
+    mock_response.json.return_value = mock_json
+    mocker.patch("benefits.enrollment_switchio.api.requests.get", return_value=mock_response)
+
+    registration_status = client.get_registration_status(registration_id="1234")
+
+    assert registration_status == RegistrationStatus(**mock_json)

--- a/tests/pytest/enrollment_switchio/test_api.py
+++ b/tests/pytest/enrollment_switchio/test_api.py
@@ -1,4 +1,6 @@
 from datetime import datetime
+import hashlib
+import hmac
 import pytest
 
 from benefits.enrollment_switchio.api import Client
@@ -23,3 +25,20 @@ def test_client_signature_input_string_with_body(client, method, body):
         expected = f"{timestamp}{method}{request_path}{body}"
 
     assert input_string == expected
+
+
+@pytest.mark.parametrize("method", ["GET", "POST"])
+@pytest.mark.parametrize("body", ['{"exampleProperty": "blah"}', None, ""])
+def test_client_stp_signature(client, method, body):
+    timestamp = str(int(datetime.now().timestamp()))
+    request_path = "/api/example"
+
+    stp_signature = client._stp_signature(timestamp=timestamp, method=method, request_path=request_path, body=body)
+
+    # calculate the expected value
+    byte_key = client.api_secret.encode("utf-8")
+    input_string = client._signature_input_string(timestamp=timestamp, method=method, request_path=request_path, body=body)
+    message = input_string.encode("utf-8")
+    expected = hmac.new(byte_key, message, hashlib.sha256).hexdigest()
+
+    assert stp_signature == expected

--- a/tests/pytest/enrollment_switchio/test_api.py
+++ b/tests/pytest/enrollment_switchio/test_api.py
@@ -1,8 +1,10 @@
 from datetime import datetime
 import hashlib
 import hmac
+import json
 import pytest
 
+import benefits.enrollment_switchio.api
 from benefits.enrollment_switchio.api import Client
 
 
@@ -42,3 +44,34 @@ def test_client_stp_signature(client, method, body):
     expected = hmac.new(byte_key, message, hashlib.sha256).hexdigest()
 
     assert stp_signature == expected
+
+
+@pytest.mark.parametrize("method", ["GET", "POST"])
+@pytest.mark.parametrize("body", [{"exampleProperty": "blah"}, None])
+def test_get_headers(mocker, client, method, body):
+    timestamp = 1516867520
+
+    # mock datetime.now()
+    datetime_mock = mocker.Mock()
+    datetime_mock.now.return_value = datetime.fromtimestamp(timestamp)
+    mocker.patch.object(benefits.enrollment_switchio.api, "datetime", datetime_mock)
+
+    request_path = "/api/example"
+
+    headers = client._get_headers(method=method, request_path=request_path, request_body=body)
+
+    # calculate the expected value
+    timestamp = str(timestamp)
+    expected = {
+        "Content-Type": "application/json",
+        "STP-APIKEY": client.api_key,
+        "STP-TIMESTAMP": timestamp,
+        "STP-SIGNATURE": client._stp_signature(
+            timestamp=timestamp,
+            method=method,
+            request_path=request_path,
+            body=json.dumps(body) if body else None,
+        ),
+    }
+
+    assert headers == expected

--- a/tests/pytest/enrollment_switchio/test_api.py
+++ b/tests/pytest/enrollment_switchio/test_api.py
@@ -5,7 +5,7 @@ import json
 import pytest
 
 import benefits.enrollment_switchio.api
-from benefits.enrollment_switchio.api import Client
+from benefits.enrollment_switchio.api import Client, EshopResponseMode, Registration
 
 
 @pytest.fixture
@@ -75,3 +75,16 @@ def test_get_headers(mocker, client, method, body):
     }
 
     assert headers == expected
+
+
+def test_client_request_registration(mocker, client):
+    mock_response = mocker.Mock()
+    mock_json = dict(regId="1234", gtwUrl="https://example.com/cst/?regId=1234")
+    mock_response.json.return_value = mock_json
+    mocker.patch("benefits.enrollment_switchio.api.requests.post", return_value=mock_response)
+
+    registration = client.request_registration(
+        eshopRedirectUrl="https://localhost/enrollment", mode="register", eshopResponseMode=EshopResponseMode.FORM_POST
+    )
+
+    assert registration == Registration(**mock_json)

--- a/tests/pytest/enrollment_switchio/test_api.py
+++ b/tests/pytest/enrollment_switchio/test_api.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+import pytest
+
+from benefits.enrollment_switchio.api import Client
+
+
+@pytest.fixture
+def client():
+    return Client("https://example.com", "api key", "api secret", None, None, None)
+
+
+@pytest.mark.parametrize("method", ["GET", "POST"])
+@pytest.mark.parametrize("body", ['{"exampleProperty": "blah"}', None, ""])
+def test_client_signature_input_string_with_body(client, method, body):
+    timestamp = str(int(datetime.now().timestamp()))
+    request_path = "/api/example"
+
+    input_string = client._signature_input_string(timestamp=timestamp, method=method, request_path=request_path, body=body)
+
+    if body is None:
+        expected = f"{timestamp}{method}{request_path}"
+    else:
+        expected = f"{timestamp}{method}{request_path}{body}"
+
+    assert input_string == expected


### PR DESCRIPTION
Closes #2903

This PR introduces a `Client` class that encapsulates interaction with the Switchio registration API. This API is responsible for managing the back-end state of a card tokenization session. The two API endpoints allow you to
- establish a session and get back an ID and corresponding URL (`Client.request_registration`)
- get the status of a session, by ID (`Client.get_registration_status`)

Note about their naming: "registration" here is not "enrollment". If it helps at all, think of "registration" here as "card tokenization" or a "card tokenization session".