### PR TITLE
Feat: Buildkit caching for Docker builds

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,7 +13,10 @@ USER $USER
 
 COPY . .
 # install devcontainer requirements
-RUN pip install -e .[dev,test]
+# this RUN command uses pipcache; this layer is rebuilt if 'COPY . .' changes,
+# but pip will use its cache for downloads
+RUN --mount=type=cache,id=pipcache,target=${HOME}/.cache/pip pip install -e .[dev,test]
 
 # docs requirements are in a separate file for the GitHub Action
-RUN pip install -r docs/requirements.txt
+# this RUN command uses pipcache, pip will use its cache for downloads
+RUN --mount=type=cache,id=pipcache,target=${HOME}/.cache/pip pip install -r docs/requirements.txt

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,13 +1,16 @@
 FROM benefits_client:latest
 
-# install Azure CLI
-# https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt
 USER root
-RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 
-# install webp CLI
-# https://developers.google.com/speed/webp/download
-RUN apt install webp -y
+# install apt packages using the archives and lists cache
+RUN --mount=type=cache,id=apt-archives,sharing=locked,target=/var/cache/apt/archives \
+    --mount=type=cache,id=apt-lists,sharing=locked,target=/var/lib/apt/lists \
+    # install Azure CLI
+    # https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt
+    curl -sL https://aka.ms/InstallAzureCLIDeb | bash && \
+    # install webp CLI
+    # https://developers.google.com/speed/webp/download
+    apt install webp -y
 
 USER $USER
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,12 +11,20 @@ RUN apt install webp -y
 
 USER $USER
 
-COPY . .
-# install devcontainer requirements
-# this RUN command uses pipcache; this layer is rebuilt if 'COPY . .' changes,
-# but pip will use its cache for downloads
-RUN --mount=type=cache,id=pipcache,target=${HOME}/.cache/pip pip install -e .[dev,test]
+# copy only minimal files needed for dev dependency installs
+COPY .git .git
+COPY pyproject.toml pyproject.toml
+
+# this RUN command uses pipcache
+# setting uid,gid here is critical, as otherwise the Buildkit cache is mounted as root
+# even though we are running in the context of non-root $USER
+RUN --mount=type=cache,id=pipcache,target=${PIP_CACHE_DIR},uid=${USER_UID},gid=${USER_GID} \
+     pip install -e .[dev,test]
 
 # docs requirements are in a separate file for the GitHub Action
-# this RUN command uses pipcache, pip will use its cache for downloads
-RUN --mount=type=cache,id=pipcache,target=${HOME}/.cache/pip pip install -r docs/requirements.txt
+COPY docs/requirements.txt docs/requirements.txt
+# this RUN command uses pipcache
+# setting uid,gid here is critical, as otherwise the Buildkit cache is mounted as root
+# even though we are running in the context of non-root $USER
+RUN --mount=type=cache,id=pipcache,target=${PIP_CACHE_DIR},uid=${USER_UID},gid=${USER_GID} \
+    pip install -r docs/requirements.txt

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,16 @@
 **/__pycache__/
 node_modules/
+.github/
+.pytest_cache/
 static/
+terraform/
+tests/
 .coverage
 *.db
 *.egg-info
+.flake8
+.pre-commit-config.yaml
+compose.yml
 *.log
 *.mo
 .DS_Store

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,6 @@ node_modules/
 .pytest_cache/
 static/
 terraform/
-tests/
 .coverage
 *.db
 *.egg-info

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,13 +73,22 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Cache Parameters
+        id: cache_params
+        run: |
+          CACHE_SCOPE="cal-itp"
+          MAIN_BRANCH_REF="refs/heads/main"
+
+          echo "cache_from_args=type=gha,scope=${CACHE_SCOPE},ref=${MAIN_BRANCH_REF}" >> $GITHUB_OUTPUT
+          echo "cache_to_args=type=gha,scope=${CACHE_SCOPE},mode=max,ref=${MAIN_BRANCH_REF}" >> $GITHUB_OUTPUT
+
       - name: Build, tag, and push image to GitHub Container Registry
         uses: docker/build-push-action@v6
         with:
           builder: ${{ steps.buildx.outputs.name }}
           build-args: GIT-SHA=${{ github.sha }}
-          cache-from: type=gha,scope=cal-itp
-          cache-to: type=gha,scope=cal-itp,mode=max
+          cache-from: ${{ steps.cache_params.outputs.cache_from_args }}
+          cache-to: ${{ steps.cache_params.outputs.cache_to_args }}
           context: .
           file: appcontainer/Dockerfile
           push: true

--- a/appcontainer/Dockerfile
+++ b/appcontainer/Dockerfile
@@ -81,18 +81,22 @@ ENV PYTHONUNBUFFERED=${PYTHONUNBUFFERED} \
     # https://pip.pypa.io/en/stable/cli/pip/#cmdoption-cache-dir
     PIP_CACHE_DIR="/home/${USER}/.cache/pip"
 
+USER $USER
+
+# copy mostly-static runtime files
+COPY LICENSE LICENSE
+COPY manage.py manage.py
 # overwrite default nginx.conf
 COPY appcontainer/nginx.conf /etc/nginx/nginx.conf
 COPY appcontainer/proxy.conf /calitp/run/proxy.conf
+
 # copy runtime files
-COPY manage.py manage.py
 COPY bin bin
 COPY benefits benefits
 
-USER root
-COPY LICENSE LICENSE
 #ensure $USER can compile messages in the locale directories
-RUN chmod -R 777 benefits/locale
+USER root
+RUN chown -R $USER:$USER benefits
 USER $USER
 
 # copy the wheel built in the previous stage

--- a/appcontainer/Dockerfile
+++ b/appcontainer/Dockerfile
@@ -107,7 +107,7 @@ COPY --from=build_wheel /build/dist /build/dist
 # this Docker layer will be rebuilt, but pip will use its cache for downloads
 RUN --mount=type=cache,id=pipcache,target=${PIP_CACHE_DIR},uid=${USER_UID},gid=${USER_GID} \
     python -m pip install --user --upgrade pip && \
-    pip install $(find /build/dist -name benefits*.whl)
+    pip install --user $(find /build/dist -name benefits*.whl)
 
 # configure container executable
 ENTRYPOINT ["/bin/bash"]

--- a/appcontainer/Dockerfile
+++ b/appcontainer/Dockerfile
@@ -1,16 +1,46 @@
+# declare default build args for later stages
+ARG PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    USER=calitp \
+    USER_UID=1000 \
+    USER_GID=1000
+
 # multi-stage build
 #
 # stage 1: builds the benefits package from source
 #          using the git metadata for version info
 FROM ghcr.io/cal-itp/docker-python-web:main AS build_wheel
 
+# renew top-level args in this stage
+ARG PYTHONDONTWRITEBYTECODE \
+    PYTHONUNBUFFERED \
+    USER \
+    USER_UID \
+    USER_GID
+
+# set env vars for the user, including HOME
+ENV PYTHONUNBUFFERED=${PYTHONUNBUFFERED} \
+    PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE} \
+    HOME=/home/${USER} \
+    USER=${USER} \
+    PATH="/home/${USER}/.local/bin:$PATH" \
+    # update env for local pip installs
+    # see https://docs.python.org/3/using/cmdline.html#envvar-PYTHONUSERBASE
+    # since all `pip install` commands are in the context of $USER
+    # $PYTHONUSERBASE is the location used by default
+    PYTHONUSERBASE="/home/${USER}/.local" \
+    # where to store the pip cache (use the default)
+    # https://pip.pypa.io/en/stable/cli/pip/#cmdoption-cache-dir
+    PIP_CACHE_DIR="/home/${USER}/.cache/pip"
+
 WORKDIR /build
 
 # upgrade pip and install build package
 # this RUN command benefits from the pipcache for downloading/installing 'build'
 # the layer for this command will be cached by Docker if 'pip' and 'build' requirements don't change
-RUN --mount=type=cache,id=pipcache,target=${HOME}/.cache/pip python -m pip install --upgrade pip && \
-    pip install build
+RUN --mount=type=cache,id=pipcache,target=${PIP_CACHE_DIR},uid=${USER_UID},gid=${USER_GID} \
+    python -m pip install --user --upgrade pip && \
+    pip install --user build
 
 # copy all source files; changes here will invalidate subsequent Docker layers
 COPY . .
@@ -18,7 +48,8 @@ RUN git config --global --add safe.directory /build
 
 # build the wheel, using pipcache for any build-time dependencies
 # this layer is rebuilt if 'COPY . .' changes
-RUN --mount=type=cache,id=pipcache,target=${HOME}/.cache/pip python -m build
+RUN --mount=type=cache,id=pipcache,target=${PIP_CACHE_DIR},uid=${USER_UID},gid=${USER_GID} \
+    python -m build
 
 # multi-stage build
 #
@@ -26,27 +57,53 @@ RUN --mount=type=cache,id=pipcache,target=${HOME}/.cache/pip python -m build
 #          using the pre-built package, and copying only needed source
 FROM ghcr.io/cal-itp/docker-python-web:main AS appcontainer
 
+# renew top-level args in this stage
+ARG PYTHONDONTWRITEBYTECODE \
+    PYTHONUNBUFFERED \
+    USER \
+    USER_UID \
+    USER_GID
+
+# set env vars from args so they persist into running containers
+ENV PYTHONUNBUFFERED=${PYTHONUNBUFFERED} \
+    PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE} \
+    HOME=/home/${USER} \
+    USER=${USER} \
+    USER_UID=${USER_UID} \
+    USER_GID=${USER_GID} \
+    PATH="/home/${USER}/.local/bin:$PATH" \
+    # update env for local pip installs
+    # see https://docs.python.org/3/using/cmdline.html#envvar-PYTHONUSERBASE
+    # since all `pip install` commands are in the context of $USER
+    # $PYTHONUSERBASE is the location used by default
+    PYTHONUSERBASE="/home/${USER}/.local" \
+    # where to store the pip cache (use the default)
+    # https://pip.pypa.io/en/stable/cli/pip/#cmdoption-cache-dir
+    PIP_CACHE_DIR="/home/${USER}/.cache/pip"
+
 # overwrite default nginx.conf
 COPY appcontainer/nginx.conf /etc/nginx/nginx.conf
 COPY appcontainer/proxy.conf /calitp/run/proxy.conf
-
-# copy the wheel built in the previous stage
-COPY --from=build_wheel /build/dist /build/dist
 # copy runtime files
 COPY manage.py manage.py
 COPY bin bin
 COPY benefits benefits
-
-# install the locally built wheel and its dependencies
-# this RUN command uses pipcache; if the wheel file changes (due to code changes),
-# this Docker layer will be rebuilt, but pip will use its cache for downloads
-RUN --mount=type=cache,id=pipcache,target=${HOME}/.cache/pip pip install $(find /build/dist -name benefits*.whl)
 
 USER root
 COPY LICENSE LICENSE
 #ensure $USER can compile messages in the locale directories
 RUN chmod -R 777 benefits/locale
 USER $USER
+
+# copy the wheel built in the previous stage
+COPY --from=build_wheel /build/dist /build/dist
+
+# install the locally built wheel and its dependencies
+# this RUN command uses pipcache; if the wheel file changes (due to code changes),
+# this Docker layer will be rebuilt, but pip will use its cache for downloads
+RUN --mount=type=cache,id=pipcache,target=${PIP_CACHE_DIR},uid=${USER_UID},gid=${USER_GID} \
+    python -m pip install --user --upgrade pip && \
+    pip install $(find /build/dist -name benefits*.whl)
 
 # configure container executable
 ENTRYPOINT ["/bin/bash"]

--- a/appcontainer/Dockerfile
+++ b/appcontainer/Dockerfile
@@ -6,16 +6,19 @@ FROM ghcr.io/cal-itp/docker-python-web:main AS build_wheel
 
 WORKDIR /build
 
-# upgrade pip
-RUN python -m pip install --upgrade pip && \
+# upgrade pip and install build package
+# this RUN command benefits from the pipcache for downloading/installing 'build'
+# the layer for this command will be cached by Docker if 'pip' and 'build' requirements don't change
+RUN --mount=type=cache,id=pipcache,target=${HOME}/.cache/pip python -m pip install --upgrade pip && \
     pip install build
 
-# copy source files
+# copy all source files; changes here will invalidate subsequent Docker layers
 COPY . .
 RUN git config --global --add safe.directory /build
 
-# build package
-RUN python -m build
+# build the wheel, using pipcache for any build-time dependencies
+# this layer is rebuilt if 'COPY . .' changes
+RUN --mount=type=cache,id=pipcache,target=${HOME}/.cache/pip python -m build
 
 # multi-stage build
 #
@@ -27,14 +30,17 @@ FROM ghcr.io/cal-itp/docker-python-web:main AS appcontainer
 COPY appcontainer/nginx.conf /etc/nginx/nginx.conf
 COPY appcontainer/proxy.conf /calitp/run/proxy.conf
 
-# copy runtime files
+# copy the wheel built in the previous stage
 COPY --from=build_wheel /build/dist /build/dist
+# copy runtime files
 COPY manage.py manage.py
 COPY bin bin
 COPY benefits benefits
 
-# install source as a package
-RUN pip install $(find /build/dist -name benefits*.whl)
+# install the locally built wheel and its dependencies
+# this RUN command uses pipcache; if the wheel file changes (due to code changes),
+# this Docker layer will be rebuilt, but pip will use its cache for downloads
+RUN --mount=type=cache,id=pipcache,target=${HOME}/.cache/pip pip install $(find /build/dist -name benefits*.whl)
 
 USER root
 COPY LICENSE LICENSE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "benefits"
 dynamic = ["version"]
 description = "Cal-ITP Benefits is an application that enables automated eligibility verification and enrollment for transit benefits onto customers’ existing contactless bank (credit/debit) cards."
 readme = "README.md"
-license = { file = "LICENSE" }
+license-files = ["LICENSE"]
 classifiers = ["Programming Language :: Python :: 3 :: Only"]
 requires-python = ">=3.9"
 maintainers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,18 +12,18 @@ maintainers = [
 dependencies = [
     "azure-keyvault-secrets==4.10.0",
     "azure-identity==1.23.1",
-    "Django==5.1.7",
-    "django-cdt-identity @ git+https://github.com/Office-of-Digital-Services/django-cdt-identity.git@2025.04.1",
-    "django-csp==3.8",
-    "django-admin-sortable2==2.2.8",
-    "django-google-sso==8.0.0",
-    "eligibility-api==2025.4.1",
     "calitp-littlepay==2025.4.1",
+    "Django==5.1.7",
+    "django-admin-sortable2==2.2.8",
+    "django-cdt-identity @ git+https://github.com/Office-of-Digital-Services/django-cdt-identity.git@c635773a75e7f184a9382748afcef6d5a705b2d6",
+    "django-csp==3.8",
+    "django-google-sso==8.0.0",
+    "django-multiselectfield==1.0.1",
+    "eligibility-api==2025.4.1",
+    "pillow==11.3.0",
     "requests==2.32.4",
     "sentry-sdk==2.34.1",
     "six==1.17.0",
-    "pillow==11.3.0",
-    "django-multiselectfield==1.0.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## What does this PR do?

Uses [Buildkit cache mounts](https://docs.docker.com/build/cache/optimize/#use-cache-mounts) to avoid re-downloading `apt` and `pip` dependencies that haven't changed between builds of both the app container and devcontainer. Some Docker commands were also rearranged to improve [Docker's layer caching](https://docs.docker.com/build/cache/optimize/#order-your-layers).

These changes result in a significant speed-up of image build times, both locally and in the CI/CD pipeline.

## TODO

- [x] Cache `pip install` for local builds (appcontainer and devcontainer)
- [x] Cache `apt install` for local builds (devcontainer only, appcontainer doesn't install anything beyond the [base](https://github.com/cal-itp/docker-python-web/blob/main/appcontainer/Dockerfile))
- [x] Ensure GitHub Actions takes advantage of this caching as well
- [x] Update [base image](https://github.com/cal-itp/docker-python-web/blob/main/appcontainer/Dockerfile) to utilize same caching strategy (the source of the current Lighthouse failure) https://github.com/cal-itp/docker-python-web/pull/56

## Reviewing

https://github.com/cal-itp/docker-python-web/pull/56 has to be merged first.

### Clear local Buildkit cache

This will start your local environment from a clean slate, to ensure caching is working as expected (also, removes a bunch of Docker build assets you may or may not want hanging around!)

Run this in any directory on your local machine:

```console
docker builder prune --all
```

### Build from the cold cache

This will do a full build, downloading and caching all `pip install` libs. It can help to pipe the output to a file to review the full logs.

Run this command _from the parent directory_ of your `benefits` repo, so as not to spoil the Docker context with a new file:

```console
docker compose -f benefits/compose.yml build client > cold_build.txt
```

Examine `cold_build.txt` and confirm `pip install` downloads all libs:

<details>
<summary>cold_build.txt</summary>

```log
# other build steps...

#20 [client appcontainer 10/10] RUN --mount=type=cache,id=pipcache,target=/home/calitp/.cache/pip,uid=1000,gid=1000     python -m pip install --user --upgrade pip &&     pip install $(find /build/dist -name benefits*.whl)
#20 0.611 Requirement already satisfied: pip in /usr/local/lib/python3.12/site-packages (25.1.1)
#20 1.964 Defaulting to user installation because normal site-packages is not writeable
#20 2.006 Processing /build/dist/benefits-2025.4.2.dev138+gb67f8b3f7.d20250602-py3-none-any.whl
#20 2.944 Collecting azure-keyvault-secrets==4.9.0 (from benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 3.803   Downloading azure_keyvault_secrets-4.9.0-py3-none-any.whl.metadata (29 kB)
#20 4.394 Collecting azure-identity==1.21.0 (from benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 4.594   Downloading azure_identity-1.21.0-py3-none-any.whl.metadata (81 kB)
#20 5.244 Collecting calitp-littlepay==2025.4.1 (from benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 5.445   Downloading calitp_littlepay-2025.4.1-py3-none-any.whl.metadata (21 kB)
#20 6.173 Collecting Django==5.1.7 (from benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 6.374   Downloading Django-5.1.7-py3-none-any.whl.metadata (4.1 kB)
#20 6.690 Collecting django-admin-sortable2==2.2.6 (from benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 6.975   Downloading django_admin_sortable2-2.2.6-py3-none-any.whl.metadata (4.1 kB)
#20 6.988 Collecting django-cdt-identity@ git+https://github.com/Office-of-Digital-Services/django-cdt-identity.git@c635773a75e7f184a9382748afcef6d5a705b2d6 (from benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 6.989   Cloning https://github.com/Office-of-Digital-Services/django-cdt-identity.git (to revision c635773a75e7f184a9382748afcef6d5a705b2d6) to /tmp/pip-install-0saaq0wh/django-cdt-identity_9f6ccb5d1c0440bd8eecf565122a0e91
#20 6.992   Running command git clone --filter=blob:none --quiet https://github.com/Office-of-Digital-Services/django-cdt-identity.git /tmp/pip-install-0saaq0wh/django-cdt-identity_9f6ccb5d1c0440bd8eecf565122a0e91
#20 10.68   Running command git rev-parse -q --verify 'sha^c635773a75e7f184a9382748afcef6d5a705b2d6'
#20 10.68   Running command git fetch -q https://github.com/Office-of-Digital-Services/django-cdt-identity.git c635773a75e7f184a9382748afcef6d5a705b2d6
#20 12.05   Running command git checkout -q c635773a75e7f184a9382748afcef6d5a705b2d6
#20 13.35   Resolved https://github.com/Office-of-Digital-Services/django-cdt-identity.git to commit c635773a75e7f184a9382748afcef6d5a705b2d6
#20 13.35   Installing build dependencies: started
#20 15.34   Installing build dependencies: finished with status 'done'
#20 15.34   Getting requirements to build wheel: started
#20 15.88   Getting requirements to build wheel: finished with status 'done'
#20 15.88   Preparing metadata (pyproject.toml): started
#20 16.43   Preparing metadata (pyproject.toml): finished with status 'done'
#20 16.72 Collecting django-csp==3.8 (from benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 17.01   Downloading django_csp-3.8-py3-none-any.whl.metadata (2.7 kB)
#20 17.30 Collecting django-google-sso==8.0.0 (from benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 17.50   Downloading django_google_sso-8.0.0-py3-none-any.whl.metadata (3.9 kB)
#20 17.76 Collecting django-multiselectfield==0.1.13 (from benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 18.04   Downloading django_multiselectfield-0.1.13-py3-none-any.whl.metadata (10 kB)
#20 18.35 Collecting eligibility-api==2025.4.1 (from benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 18.62   Downloading eligibility_api-2025.4.1-py3-none-any.whl.metadata (14 kB)
#20 19.35 Collecting pillow==11.2.1 (from benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 19.57   Downloading pillow-11.2.1-cp312-cp312-manylinux_2_28_x86_64.whl.metadata (8.9 kB)
#20 19.81 Collecting requests==2.32.3 (from benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 20.08   Downloading requests-2.32.3-py3-none-any.whl.metadata (4.6 kB)
#20 20.43 Collecting sentry-sdk==2.25.1 (from benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 20.70   Downloading sentry_sdk-2.25.1-py2.py3-none-any.whl.metadata (10 kB)
#20 21.03 Collecting six==1.17.0 (from benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 21.31   Downloading six-1.17.0-py2.py3-none-any.whl.metadata (1.7 kB)
#20 21.64 Collecting Authlib>=1.4.1 (from django-cdt-identity@ git+https://github.com/Office-of-Digital-Services/django-cdt-identity.git@c635773a75e7f184a9382748afcef6d5a705b2d6->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 21.84   Downloading authlib-1.6.0-py2.py3-none-any.whl.metadata (4.1 kB)
#20 22.10 Collecting azure-core>=1.31.0 (from azure-identity==1.21.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 22.34   Downloading azure_core-1.34.0-py3-none-any.whl.metadata (42 kB)
#20 22.78 Collecting cryptography>=2.5 (from azure-identity==1.21.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 23.05   Downloading cryptography-45.0.3-cp311-abi3-manylinux_2_34_x86_64.whl.metadata (5.7 kB)
#20 23.30 Collecting msal>=1.30.0 (from azure-identity==1.21.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 23.50   Downloading msal-1.32.3-py3-none-any.whl.metadata (11 kB)
#20 23.79 Collecting msal-extensions>=1.2.0 (from azure-identity==1.21.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 23.99   Downloading msal_extensions-1.3.1-py3-none-any.whl.metadata (7.8 kB)
#20 24.24 Collecting typing-extensions>=4.0.0 (from azure-identity==1.21.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 24.49   Downloading typing_extensions-4.13.2-py3-none-any.whl.metadata (3.0 kB)
#20 24.73 Collecting isodate>=0.6.1 (from azure-keyvault-secrets==4.9.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 24.93   Downloading isodate-0.7.2-py3-none-any.whl.metadata (11 kB)
#20 25.22 Collecting PyYAML>=6.0.1 (from calitp-littlepay==2025.4.1->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 25.42   Downloading PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (2.1 kB)
#20 25.66 Collecting asgiref<4,>=3.8.1 (from Django==5.1.7->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 25.87   Downloading asgiref-3.8.1-py3-none-any.whl.metadata (9.3 kB)
#20 26.15 Collecting sqlparse>=0.3.1 (from Django==5.1.7->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 26.35   Downloading sqlparse-0.5.3-py3-none-any.whl.metadata (3.9 kB)
#20 26.63 Collecting google-auth (from django-google-sso==8.0.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 26.84   Downloading google_auth-2.40.2-py2.py3-none-any.whl.metadata (6.2 kB)
#20 27.07 Collecting google-auth-httplib2 (from django-google-sso==8.0.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 27.33   Downloading google_auth_httplib2-0.2.0-py2.py3-none-any.whl.metadata (2.2 kB)
#20 27.58 Collecting google-auth-oauthlib (from django-google-sso==8.0.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 27.87   Downloading google_auth_oauthlib-1.2.2-py3-none-any.whl.metadata (2.7 kB)
#20 28.09 Collecting loguru (from django-google-sso==8.0.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 28.29   Downloading loguru-0.7.3-py3-none-any.whl.metadata (22 kB)
#20 28.70 Collecting jwcrypto>=1.5 (from eligibility-api==2025.4.1->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 28.99   Downloading jwcrypto-1.5.6-py3-none-any.whl.metadata (3.1 kB)
#20 29.34 Collecting charset-normalizer<4,>=2 (from requests==2.32.3->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 29.61   Downloading charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (35 kB)
#20 29.90 Collecting idna<4,>=2.5 (from requests==2.32.3->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 30.10   Downloading idna-3.10-py3-none-any.whl.metadata (10 kB)
#20 30.45 Collecting urllib3<3,>=1.21.1 (from requests==2.32.3->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 30.73   Downloading urllib3-2.4.0-py3-none-any.whl.metadata (6.5 kB)
#20 31.05 Collecting certifi>=2017.4.17 (from requests==2.32.3->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 31.25   Downloading certifi-2025.4.26-py3-none-any.whl.metadata (2.5 kB)
#20 31.60 Collecting cffi>=1.14 (from cryptography>=2.5->azure-identity==1.21.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 31.80   Downloading cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (1.5 kB)
#20 32.03 Collecting pycparser (from cffi>=1.14->cryptography>=2.5->azure-identity==1.21.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 32.27   Downloading pycparser-2.22-py3-none-any.whl.metadata (943 bytes)
#20 32.53 Collecting PyJWT<3,>=1.0.0 (from PyJWT[crypto]<3,>=1.0.0->msal>=1.30.0->azure-identity==1.21.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 32.73   Downloading PyJWT-2.10.1-py3-none-any.whl.metadata (4.0 kB)
#20 32.98 Collecting cachetools<6.0,>=2.0.0 (from google-auth->django-google-sso==8.0.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 33.19   Downloading cachetools-5.5.2-py3-none-any.whl.metadata (5.4 kB)
#20 33.43 Collecting pyasn1-modules>=0.2.1 (from google-auth->django-google-sso==8.0.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 33.70   Downloading pyasn1_modules-0.4.2-py3-none-any.whl.metadata (3.5 kB)
#20 33.94 Collecting rsa<5,>=3.1.4 (from google-auth->django-google-sso==8.0.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 34.22   Downloading rsa-4.9.1-py3-none-any.whl.metadata (5.6 kB)
#20 34.55 Collecting pyasn1>=0.1.3 (from rsa<5,>=3.1.4->google-auth->django-google-sso==8.0.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 34.83   Downloading pyasn1-0.6.1-py3-none-any.whl.metadata (8.4 kB)
#20 35.07 Collecting httplib2>=0.19.0 (from google-auth-httplib2->django-google-sso==8.0.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 35.29   Downloading httplib2-0.22.0-py3-none-any.whl.metadata (2.6 kB)
#20 35.57 Collecting pyparsing!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3,<4,>=2.4.2 (from httplib2>=0.19.0->google-auth-httplib2->django-google-sso==8.0.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 35.85   Downloading pyparsing-3.2.3-py3-none-any.whl.metadata (5.0 kB)
#20 36.09 Collecting requests-oauthlib>=0.7.0 (from google-auth-oauthlib->django-google-sso==8.0.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 36.37   Downloading requests_oauthlib-2.0.0-py2.py3-none-any.whl.metadata (11 kB)
#20 36.68 Collecting oauthlib>=3.0.0 (from requests-oauthlib>=0.7.0->google-auth-oauthlib->django-google-sso==8.0.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 36.88   Downloading oauthlib-3.2.2-py3-none-any.whl.metadata (7.5 kB)
#20 37.12 Downloading azure_identity-1.21.0-py3-none-any.whl (189 kB)
#20 37.70 Downloading azure_keyvault_secrets-4.9.0-py3-none-any.whl (87 kB)
#20 37.91 Downloading calitp_littlepay-2025.4.1-py3-none-any.whl (28 kB)
#20 38.13 Downloading Django-5.1.7-py3-none-any.whl (8.3 MB)
#20 39.98    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 8.3/8.3 MB 4.7 MB/s eta 0:00:00
#20 40.26 Downloading django_admin_sortable2-2.2.6-py3-none-any.whl (90 kB)
#20 40.57 Downloading django_csp-3.8-py3-none-any.whl (17 kB)
#20 40.78 Downloading django_google_sso-8.0.0-py3-none-any.whl (23 kB)
#20 40.99 Downloading django_multiselectfield-0.1.13-py3-none-any.whl (14 kB)
#20 41.20 Downloading eligibility_api-2025.4.1-py3-none-any.whl (13 kB)
#20 41.42 Downloading pillow-11.2.1-cp312-cp312-manylinux_2_28_x86_64.whl (4.6 MB)
#20 42.12    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.6/4.6 MB 6.5 MB/s eta 0:00:00
#20 42.41 Downloading requests-2.32.3-py3-none-any.whl (64 kB)
#20 42.62 Downloading sentry_sdk-2.25.1-py2.py3-none-any.whl (339 kB)
#20 42.92 Downloading six-1.17.0-py2.py3-none-any.whl (11 kB)
#20 43.20 Downloading asgiref-3.8.1-py3-none-any.whl (23 kB)
#20 43.41 Downloading charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (148 kB)
#20 43.64 Downloading idna-3.10-py3-none-any.whl (70 kB)
#20 43.86 Downloading urllib3-2.4.0-py3-none-any.whl (128 kB)
#20 44.09 Downloading authlib-1.6.0-py2.py3-none-any.whl (239 kB)
#20 44.33 Downloading azure_core-1.34.0-py3-none-any.whl (207 kB)
#20 44.65 Downloading certifi-2025.4.26-py3-none-any.whl (159 kB)
#20 44.87 Downloading cryptography-45.0.3-cp311-abi3-manylinux_2_34_x86_64.whl (4.5 MB)
#20 45.53    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.5/4.5 MB 6.7 MB/s eta 0:00:00
#20 45.79 Downloading cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (479 kB)
#20 46.09 Downloading isodate-0.7.2-py3-none-any.whl (22 kB)
#20 46.31 Downloading jwcrypto-1.5.6-py3-none-any.whl (92 kB)
#20 46.52 Downloading msal-1.32.3-py3-none-any.whl (115 kB)
#20 46.75 Downloading PyJWT-2.10.1-py3-none-any.whl (22 kB)
#20 47.02 Downloading msal_extensions-1.3.1-py3-none-any.whl (20 kB)
#20 47.26 Downloading PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (767 kB)
#20 47.35    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 767.5/767.5 kB 6.0 MB/s eta 0:00:00
#20 47.55 Downloading sqlparse-0.5.3-py3-none-any.whl (44 kB)
#20 47.84 Downloading typing_extensions-4.13.2-py3-none-any.whl (45 kB)
#20 48.11 Downloading google_auth-2.40.2-py2.py3-none-any.whl (216 kB)
#20 48.35 Downloading cachetools-5.5.2-py3-none-any.whl (10 kB)
#20 48.64 Downloading rsa-4.9.1-py3-none-any.whl (34 kB)
#20 48.86 Downloading pyasn1-0.6.1-py3-none-any.whl (83 kB)
#20 49.17 Downloading pyasn1_modules-0.4.2-py3-none-any.whl (181 kB)
#20 49.38 Downloading google_auth_httplib2-0.2.0-py2.py3-none-any.whl (9.3 kB)
#20 49.59 Downloading httplib2-0.22.0-py3-none-any.whl (96 kB)
#20 49.80 Downloading pyparsing-3.2.3-py3-none-any.whl (111 kB)
#20 50.03 Downloading google_auth_oauthlib-1.2.2-py3-none-any.whl (19 kB)
#20 50.24 Downloading requests_oauthlib-2.0.0-py2.py3-none-any.whl (24 kB)
#20 50.50 Downloading oauthlib-3.2.2-py3-none-any.whl (151 kB)
#20 50.81 Downloading loguru-0.7.3-py3-none-any.whl (61 kB)
#20 51.11 Downloading pycparser-2.22-py3-none-any.whl (117 kB)
#20 51.17 Building wheels for collected packages: django-cdt-identity
#20 51.17   Building wheel for django-cdt-identity (pyproject.toml): started
#20 51.73   Building wheel for django-cdt-identity (pyproject.toml): finished with status 'done'
#20 51.73   Created wheel for django-cdt-identity: filename=django_cdt_identity-2025.4.1-py3-none-any.whl size=35907 sha256=b09728e898a0e2648d75ba12be7841797d48ecd2c23c6d802dd0552b9ecb2fd4
#20 51.73   Stored in directory: /home/calitp/.cache/pip/wheels/bf/28/62/2b3d31724b1916058924e8e07e4494c6eff777392c134d6c00
#20 51.74 Successfully built django-cdt-identity
#20 51.79 Installing collected packages: urllib3, typing-extensions, sqlparse, six, PyYAML, pyparsing, PyJWT, pycparser, pyasn1, pillow, oauthlib, loguru, isodate, idna, charset-normalizer, certifi, cachetools, asgiref, sentry-sdk, rsa, requests, pyasn1-modules, httplib2, Django, cffi, requests-oauthlib, google-auth, django-multiselectfield, django-csp, django-admin-sortable2, cryptography, azure-core, jwcrypto, google-auth-oauthlib, google-auth-httplib2, azure-keyvault-secrets, Authlib, msal, eligibility-api, django-google-sso, django-cdt-identity, calitp-littlepay, msal-extensions, azure-identity, benefits
#20 54.34 
#20 54.35 Successfully installed Authlib-1.6.0 Django-5.1.7 PyJWT-2.10.1 PyYAML-6.0.2 asgiref-3.8.1 azure-core-1.34.0 azure-identity-1.21.0 azure-keyvault-secrets-4.9.0 benefits-2025.4.2.dev138+gb67f8b3f7.d20250602 cachetools-5.5.2 calitp-littlepay-2025.4.1 certifi-2025.4.26 cffi-1.17.1 charset-normalizer-3.4.2 cryptography-45.0.3 django-admin-sortable2-2.2.6 django-cdt-identity-2025.4.1 django-csp-3.8 django-google-sso-8.0.0 django-multiselectfield-0.1.13 eligibility-api-2025.4.1 google-auth-2.40.2 google-auth-httplib2-0.2.0 google-auth-oauthlib-1.2.2 httplib2-0.22.0 idna-3.10 isodate-0.7.2 jwcrypto-1.5.6 loguru-0.7.3 msal-1.32.3 msal-extensions-1.3.1 oauthlib-3.2.2 pillow-11.2.1 pyasn1-0.6.1 pyasn1-modules-0.4.2 pycparser-2.22 pyparsing-3.2.3 requests-2.32.3 requests-oauthlib-2.0.0 rsa-4.9.1 sentry-sdk-2.25.1 six-1.17.0 sqlparse-0.5.3 typing-extensions-4.13.2 urllib3-2.4.0
#20 DONE 54.5s
```
</details>

### Build from the warm cache

Now that the cache is populated, make a small change to the dependencies, e.g. add `"pandas==2.2.3"` to the list:

```toml
dependencies = [
    "azure-keyvault-secrets==4.9.0",
    "azure-identity==1.21.0",
    "calitp-littlepay==2025.4.1",
    "Django==5.1.7",
    "django-admin-sortable2==2.2.6",
    "django-cdt-identity @ git+https://github.com/Office-of-Digital-Services/django-cdt-identity.git@c635773a75e7f184a9382748afcef6d5a705b2d6",
    "django-csp==3.8",
    "django-google-sso==8.0.0",
    "django-multiselectfield==0.1.13",
    "eligibility-api==2025.4.1",
    "pandas==2.2.3",  # <---- ADDED
    "pillow==11.2.1",
    "requests==2.32.3",
    "sentry-sdk==2.25.1",
    "six==1.17.0"
]
```

Again, run this command _from the parent directory_ of your `benefits` repo, so as not to spoil the Docker context with a new file:

```console
docker compose -f benefits/compose.yml build client > warm_build.txt
```

Examine `warm_build.txt` and confirm `pip install` uses cached libs that were previously downloaded. 

**Note** the new dependency for `pandas` and its dependencies _are downloaded_ since they weren't in the cache for the previous build.

<details>
<summary>warm_build.txt</summary>

```log
# other build steps...

#20 [client appcontainer 10/10] RUN --mount=type=cache,id=pipcache,target=/home/calitp/.cache/pip,uid=1000,gid=1000     python -m pip install --user --upgrade pip &&     pip install $(find /build/dist -name benefits*.whl)
#20 0.598 Requirement already satisfied: pip in /usr/local/lib/python3.12/site-packages (25.1.1)
#20 2.030 Defaulting to user installation because normal site-packages is not writeable
#20 2.075 Processing /build/dist/benefits-2025.4.2.dev138+gb67f8b3f7.d20250602-py3-none-any.whl
#20 3.017 Collecting azure-keyvault-secrets==4.9.0 (from benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 3.018   Using cached azure_keyvault_secrets-4.9.0-py3-none-any.whl.metadata (29 kB)
#20 3.244 Collecting azure-identity==1.21.0 (from benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 3.245   Using cached azure_identity-1.21.0-py3-none-any.whl.metadata (81 kB)
#20 3.455 Collecting calitp-littlepay==2025.4.1 (from benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 3.456   Using cached calitp_littlepay-2025.4.1-py3-none-any.whl.metadata (21 kB)
#20 3.699 Collecting Django==5.1.7 (from benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 3.700   Using cached Django-5.1.7-py3-none-any.whl.metadata (4.1 kB)
#20 3.947 Collecting django-admin-sortable2==2.2.6 (from benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 3.948   Using cached django_admin_sortable2-2.2.6-py3-none-any.whl.metadata (4.1 kB)
#20 3.949 Collecting django-cdt-identity@ git+https://github.com/Office-of-Digital-Services/django-cdt-identity.git@c635773a75e7f184a9382748afcef6d5a705b2d6 (from benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 3.949   Using cached django_cdt_identity-2025.4.1-py3-none-any.whl
#20 4.243 Collecting django-csp==3.8 (from benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 4.244   Using cached django_csp-3.8-py3-none-any.whl.metadata (2.7 kB)
#20 4.552 Collecting django-google-sso==8.0.0 (from benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 4.552   Using cached django_google_sso-8.0.0-py3-none-any.whl.metadata (3.9 kB)
#20 4.854 Collecting django-multiselectfield==0.1.13 (from benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 4.856   Using cached django_multiselectfield-0.1.13-py3-none-any.whl.metadata (10 kB)
#20 5.158 Collecting eligibility-api==2025.4.1 (from benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 5.159   Using cached eligibility_api-2025.4.1-py3-none-any.whl.metadata (14 kB)
#20 6.232 Collecting pandas==2.2.3 (from benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 7.098   Downloading pandas-2.2.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (89 kB)
#20 8.004 Collecting pillow==11.2.1 (from benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 8.005   Using cached pillow-11.2.1-cp312-cp312-manylinux_2_28_x86_64.whl.metadata (8.9 kB)
#20 8.227 Collecting requests==2.32.3 (from benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 8.228   Using cached requests-2.32.3-py3-none-any.whl.metadata (4.6 kB)
#20 8.503 Collecting sentry-sdk==2.25.1 (from benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 8.504   Using cached sentry_sdk-2.25.1-py2.py3-none-any.whl.metadata (10 kB)
#20 8.729 Collecting six==1.17.0 (from benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 8.730   Using cached six-1.17.0-py2.py3-none-any.whl.metadata (1.7 kB)
#20 8.962 Collecting Authlib>=1.4.1 (from django-cdt-identity@ git+https://github.com/Office-of-Digital-Services/django-cdt-identity.git@c635773a75e7f184a9382748afcef6d5a705b2d6->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 8.963   Using cached authlib-1.6.0-py2.py3-none-any.whl.metadata (4.1 kB)
#20 9.198 Collecting azure-core>=1.31.0 (from azure-identity==1.21.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 9.199   Using cached azure_core-1.34.0-py3-none-any.whl.metadata (42 kB)
#20 9.500 Collecting cryptography>=2.5 (from azure-identity==1.21.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 9.501   Using cached cryptography-45.0.3-cp311-abi3-manylinux_2_34_x86_64.whl.metadata (5.7 kB)
#20 9.723 Collecting msal>=1.30.0 (from azure-identity==1.21.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 9.724   Using cached msal-1.32.3-py3-none-any.whl.metadata (11 kB)
#20 9.939 Collecting msal-extensions>=1.2.0 (from azure-identity==1.21.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 9.941   Using cached msal_extensions-1.3.1-py3-none-any.whl.metadata (7.8 kB)
#20 10.16 Collecting typing-extensions>=4.0.0 (from azure-identity==1.21.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 10.16   Using cached typing_extensions-4.13.2-py3-none-any.whl.metadata (3.0 kB)
#20 10.38 Collecting isodate>=0.6.1 (from azure-keyvault-secrets==4.9.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 10.38   Using cached isodate-0.7.2-py3-none-any.whl.metadata (11 kB)
#20 10.67 Collecting PyYAML>=6.0.1 (from calitp-littlepay==2025.4.1->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 10.67   Using cached PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (2.1 kB)
#20 10.90 Collecting asgiref<4,>=3.8.1 (from Django==5.1.7->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 10.90   Using cached asgiref-3.8.1-py3-none-any.whl.metadata (9.3 kB)
#20 11.20 Collecting sqlparse>=0.3.1 (from Django==5.1.7->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 11.20   Using cached sqlparse-0.5.3-py3-none-any.whl.metadata (3.9 kB)
#20 11.46 Collecting google-auth (from django-google-sso==8.0.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 11.46   Using cached google_auth-2.40.2-py2.py3-none-any.whl.metadata (6.2 kB)
#20 11.72 Collecting google-auth-httplib2 (from django-google-sso==8.0.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 11.72   Using cached google_auth_httplib2-0.2.0-py2.py3-none-any.whl.metadata (2.2 kB)
#20 11.94 Collecting google-auth-oauthlib (from django-google-sso==8.0.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 11.95   Using cached google_auth_oauthlib-1.2.2-py3-none-any.whl.metadata (2.7 kB)
#20 12.17 Collecting loguru (from django-google-sso==8.0.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 12.17   Using cached loguru-0.7.3-py3-none-any.whl.metadata (22 kB)
#20 12.43 Collecting jwcrypto>=1.5 (from eligibility-api==2025.4.1->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 12.43   Using cached jwcrypto-1.5.6-py3-none-any.whl.metadata (3.1 kB)
#20 13.06 Collecting numpy>=1.26.0 (from pandas==2.2.3->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 13.35   Downloading numpy-2.2.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (62 kB)
#20 13.60 Collecting python-dateutil>=2.8.2 (from pandas==2.2.3->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 13.60   Using cached python_dateutil-2.9.0.post0-py2.py3-none-any.whl.metadata (8.4 kB)
#20 13.86 Collecting pytz>=2020.1 (from pandas==2.2.3->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 14.06   Downloading pytz-2025.2-py2.py3-none-any.whl.metadata (22 kB)
#20 14.39 Collecting tzdata>=2022.7 (from pandas==2.2.3->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 14.59   Downloading tzdata-2025.2-py2.py3-none-any.whl.metadata (1.4 kB)
#20 14.93 Collecting charset-normalizer<4,>=2 (from requests==2.32.3->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 14.93   Using cached charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (35 kB)
#20 15.20 Collecting idna<4,>=2.5 (from requests==2.32.3->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 15.20   Using cached idna-3.10-py3-none-any.whl.metadata (10 kB)
#20 15.52 Collecting urllib3<3,>=1.21.1 (from requests==2.32.3->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 15.52   Using cached urllib3-2.4.0-py3-none-any.whl.metadata (6.5 kB)
#20 15.80 Collecting certifi>=2017.4.17 (from requests==2.32.3->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 15.80   Using cached certifi-2025.4.26-py3-none-any.whl.metadata (2.5 kB)
#20 16.17 Collecting cffi>=1.14 (from cryptography>=2.5->azure-identity==1.21.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 16.17   Using cached cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (1.5 kB)
#20 16.38 Collecting pycparser (from cffi>=1.14->cryptography>=2.5->azure-identity==1.21.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 16.38   Using cached pycparser-2.22-py3-none-any.whl.metadata (943 bytes)
#20 16.64 Collecting PyJWT<3,>=1.0.0 (from PyJWT[crypto]<3,>=1.0.0->msal>=1.30.0->azure-identity==1.21.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 16.64   Using cached PyJWT-2.10.1-py3-none-any.whl.metadata (4.0 kB)
#20 16.93 Collecting cachetools<6.0,>=2.0.0 (from google-auth->django-google-sso==8.0.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 16.93   Using cached cachetools-5.5.2-py3-none-any.whl.metadata (5.4 kB)
#20 17.15 Collecting pyasn1-modules>=0.2.1 (from google-auth->django-google-sso==8.0.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 17.15   Using cached pyasn1_modules-0.4.2-py3-none-any.whl.metadata (3.5 kB)
#20 17.37 Collecting rsa<5,>=3.1.4 (from google-auth->django-google-sso==8.0.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 17.37   Using cached rsa-4.9.1-py3-none-any.whl.metadata (5.6 kB)
#20 17.58 Collecting pyasn1>=0.1.3 (from rsa<5,>=3.1.4->google-auth->django-google-sso==8.0.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 17.58   Using cached pyasn1-0.6.1-py3-none-any.whl.metadata (8.4 kB)
#20 17.80 Collecting httplib2>=0.19.0 (from google-auth-httplib2->django-google-sso==8.0.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 17.80   Using cached httplib2-0.22.0-py3-none-any.whl.metadata (2.6 kB)
#20 18.03 Collecting pyparsing!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3,<4,>=2.4.2 (from httplib2>=0.19.0->google-auth-httplib2->django-google-sso==8.0.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 18.03   Using cached pyparsing-3.2.3-py3-none-any.whl.metadata (5.0 kB)
#20 18.27 Collecting requests-oauthlib>=0.7.0 (from google-auth-oauthlib->django-google-sso==8.0.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 18.28   Using cached requests_oauthlib-2.0.0-py2.py3-none-any.whl.metadata (11 kB)
#20 18.50 Collecting oauthlib>=3.0.0 (from requests-oauthlib>=0.7.0->google-auth-oauthlib->django-google-sso==8.0.0->benefits==2025.4.2.dev138+gb67f8b3f7.d20250602)
#20 18.50   Using cached oauthlib-3.2.2-py3-none-any.whl.metadata (7.5 kB)
#20 18.50 Using cached azure_identity-1.21.0-py3-none-any.whl (189 kB)
#20 18.50 Using cached azure_keyvault_secrets-4.9.0-py3-none-any.whl (87 kB)
#20 18.50 Using cached calitp_littlepay-2025.4.1-py3-none-any.whl (28 kB)
#20 18.51 Using cached Django-5.1.7-py3-none-any.whl (8.3 MB)
#20 18.51 Using cached django_admin_sortable2-2.2.6-py3-none-any.whl (90 kB)
#20 18.51 Using cached django_csp-3.8-py3-none-any.whl (17 kB)
#20 18.51 Using cached django_google_sso-8.0.0-py3-none-any.whl (23 kB)
#20 18.51 Using cached django_multiselectfield-0.1.13-py3-none-any.whl (14 kB)
#20 18.51 Using cached eligibility_api-2025.4.1-py3-none-any.whl (13 kB)
#20 18.71 Downloading pandas-2.2.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (12.7 MB)
#20 21.58    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 12.7/12.7 MB 5.1 MB/s eta 0:00:00
#20 21.58 Using cached pillow-11.2.1-cp312-cp312-manylinux_2_28_x86_64.whl (4.6 MB)
#20 21.59 Using cached requests-2.32.3-py3-none-any.whl (64 kB)
#20 21.59 Using cached sentry_sdk-2.25.1-py2.py3-none-any.whl (339 kB)
#20 21.59 Using cached six-1.17.0-py2.py3-none-any.whl (11 kB)
#20 21.59 Using cached asgiref-3.8.1-py3-none-any.whl (23 kB)
#20 21.59 Using cached charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (148 kB)
#20 21.59 Using cached idna-3.10-py3-none-any.whl (70 kB)
#20 21.59 Using cached urllib3-2.4.0-py3-none-any.whl (128 kB)
#20 21.59 Using cached authlib-1.6.0-py2.py3-none-any.whl (239 kB)
#20 21.59 Using cached azure_core-1.34.0-py3-none-any.whl (207 kB)
#20 21.60 Using cached certifi-2025.4.26-py3-none-any.whl (159 kB)
#20 21.60 Using cached cryptography-45.0.3-cp311-abi3-manylinux_2_34_x86_64.whl (4.5 MB)
#20 21.60 Using cached cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (479 kB)
#20 21.60 Using cached isodate-0.7.2-py3-none-any.whl (22 kB)
#20 21.60 Using cached jwcrypto-1.5.6-py3-none-any.whl (92 kB)
#20 21.60 Using cached msal-1.32.3-py3-none-any.whl (115 kB)
#20 21.60 Using cached PyJWT-2.10.1-py3-none-any.whl (22 kB)
#20 21.60 Using cached msal_extensions-1.3.1-py3-none-any.whl (20 kB)
#20 21.85 Downloading numpy-2.2.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (16.5 MB)
#20 24.90    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 16.5/16.5 MB 5.3 MB/s eta 0:00:00
#20 24.90 Using cached python_dateutil-2.9.0.post0-py2.py3-none-any.whl (229 kB)
#20 25.12 Downloading pytz-2025.2-py2.py3-none-any.whl (509 kB)
#20 25.19 Using cached PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (767 kB)
#20 25.19 Using cached sqlparse-0.5.3-py3-none-any.whl (44 kB)
#20 25.19 Using cached typing_extensions-4.13.2-py3-none-any.whl (45 kB)
#20 25.44 Downloading tzdata-2025.2-py2.py3-none-any.whl (347 kB)
#20 25.45 Using cached google_auth-2.40.2-py2.py3-none-any.whl (216 kB)
#20 25.45 Using cached cachetools-5.5.2-py3-none-any.whl (10 kB)
#20 25.45 Using cached rsa-4.9.1-py3-none-any.whl (34 kB)
#20 25.46 Using cached pyasn1-0.6.1-py3-none-any.whl (83 kB)
#20 25.46 Using cached pyasn1_modules-0.4.2-py3-none-any.whl (181 kB)
#20 25.46 Using cached google_auth_httplib2-0.2.0-py2.py3-none-any.whl (9.3 kB)
#20 25.46 Using cached httplib2-0.22.0-py3-none-any.whl (96 kB)
#20 25.46 Using cached pyparsing-3.2.3-py3-none-any.whl (111 kB)
#20 25.47 Using cached google_auth_oauthlib-1.2.2-py3-none-any.whl (19 kB)
#20 25.47 Using cached requests_oauthlib-2.0.0-py2.py3-none-any.whl (24 kB)
#20 25.47 Using cached oauthlib-3.2.2-py3-none-any.whl (151 kB)
#20 25.47 Using cached loguru-0.7.3-py3-none-any.whl (61 kB)
#20 25.47 Using cached pycparser-2.22-py3-none-any.whl (117 kB)
#20 25.62 Installing collected packages: pytz, urllib3, tzdata, typing-extensions, sqlparse, six, PyYAML, pyparsing, PyJWT, pycparser, pyasn1, pillow, oauthlib, numpy, loguru, isodate, idna, charset-normalizer, certifi, cachetools, asgiref, sentry-sdk, rsa, requests, python-dateutil, pyasn1-modules, httplib2, Django, cffi, requests-oauthlib, pandas, google-auth, django-multiselectfield, django-csp, django-admin-sortable2, cryptography, azure-core, jwcrypto, google-auth-oauthlib, google-auth-httplib2, azure-keyvault-secrets, Authlib, msal, eligibility-api, django-google-sso, django-cdt-identity, calitp-littlepay, msal-extensions, azure-identity, benefits
#20 32.27 
#20 32.27 Successfully installed Authlib-1.6.0 Django-5.1.7 PyJWT-2.10.1 PyYAML-6.0.2 asgiref-3.8.1 azure-core-1.34.0 azure-identity-1.21.0 azure-keyvault-secrets-4.9.0 benefits-2025.4.2.dev138+gb67f8b3f7.d20250602 cachetools-5.5.2 calitp-littlepay-2025.4.1 certifi-2025.4.26 cffi-1.17.1 charset-normalizer-3.4.2 cryptography-45.0.3 django-admin-sortable2-2.2.6 django-cdt-identity-2025.4.1 django-csp-3.8 django-google-sso-8.0.0 django-multiselectfield-0.1.13 eligibility-api-2025.4.1 google-auth-2.40.2 google-auth-httplib2-0.2.0 google-auth-oauthlib-1.2.2 httplib2-0.22.0 idna-3.10 isodate-0.7.2 jwcrypto-1.5.6 loguru-0.7.3 msal-1.32.3 msal-extensions-1.3.1 numpy-2.2.6 oauthlib-3.2.2 pandas-2.2.3 pillow-11.2.1 pyasn1-0.6.1 pyasn1-modules-0.4.2 pycparser-2.22 pyparsing-3.2.3 python-dateutil-2.9.0.post0 pytz-2025.2 requests-2.32.3 requests-oauthlib-2.0.0 rsa-4.9.1 sentry-sdk-2.25.1 six-1.17.0 sqlparse-0.5.3 typing-extensions-4.13.2 tzdata-2025.2 urllib3-2.4.0
#20 DONE 32.4s
```
</details>

Note the significant difference in time taken between `cold_build` (54.5s in the above logs) and `warm_build` (32.4s in the above logs)!! :tada: 

## Confirm you can still launch the appcontainer and it functions as normal

Back in the `benefits` repo directory:

```
$ docker compose run --rm -P client
+ bin/init.sh
+ python manage.py migrate
[02/Jun/2025 05:51:19] DEBUG benefits.core.analytics:133 Initialize Client for https://api2.amplitude.com/2/httpapi
[02/Jun/2025 05:51:19] DEBUG benefits.core.urls:43 Register path converter: TransitAgencyPathConverter
[02/Jun/2025 05:51:19] DEBUG benefits.urls:65 Register admin urls
Operations to perform:
  Apply all migrations: admin, auth, cdt_identity, contenttypes, core, django_google_sso, enrollment_littlepay, enrollment_switchio, sessions
Running migrations:
  # migrations...
+ python manage.py compilemessages
[02/Jun/2025 05:51:21] DEBUG benefits.core.analytics:133 Initialize Client for https://api2.amplitude.com/2/httpapi
File “/calitp/app/benefits/locale/es/LC_MESSAGES/django.po” is already compiled and up to date.
File “/calitp/app/benefits/locale/en/LC_MESSAGES/django.po” is already compiled and up to date.
+ python manage.py collectstatic --no-input
[02/Jun/2025 05:51:22] DEBUG benefits.core.analytics:133 Initialize Client for https://api2.amplitude.com/2/httpapi

167 static files copied to '/calitp/app/static', 167 post-processed.
+ nginx
+ python -m gunicorn -c /calitp/run/gunicorn.conf.py benefits.wsgi
```

### Confirm the `devcontainer` builds also take advantage of the cache

Building the devcontainer is now significantly faster, since all the primary dependencies from the appcontainer should be cached already, and only new `[dev,test]` dependencies are downloaded (only the first time).

Further, the `devcontainer` installs additional `apt` packages (Azure CLI, `webp`) -- these will also be cached and speed up builds the second time around, assuming no changes to the `apt install` list.

## Notes

### Buildkit caches are shared between projects

This was surprising! And pretty awesome given our similar setup across Benefits and CDRC. 

https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/pull/204 introduced the same caching strategy for CDRC, and the Buildkit cache will be warmed for all shared libraries at the same version! (_Note, this is for **local** builds only, CI/CD does not currently share caches as the pipelines run in different GitHub orgs_).

### Testing with `docker-python-web`

It possible to test the full build without waiting for https://github.com/cal-itp/docker-python-web/pull/56 to be merged.

Checkout that PR's branch locally, and build the image as normal

```console
docker compose build app
```

Then modify the base image `FROM` keywords (make sure to update _both_) in this branch's Dockerfile to use the locally built `docker-python-web`:

```diff
- FROM ghcr.io/cal-itp/docker-python-web:main AS build_wheel
+ FROM docker-python-web:app AS build_wheel
```

Then build this branch's image as normal:

```console
docker compose build client
```

This is also how I tested/ensured that `eligibility-server` is unaffected by this change in `docker-python-web`.