### PR TITLE
Docs on littlepay-additional-cardtypes variable

### DIFF
--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -204,6 +204,17 @@ Comma-separated list of hosts which are trusted origins for unsafe requests (e.g
 
 Comma-separated list of User-Agent strings which, when present as an HTTP header, should only receive healthcheck responses. Used by our `HealthcheckUserAgents` middleware.
 
+## Littlepay
+
+### `LITTLEPAY_ADDITIONAL_CARDTYPES`
+
+A temporary feature flag setting, allowing for certain copy to be shown or hidden depending on the status of the American Express and Discover card feature.
+
+Boolean:
+
+- `True`: The American Express and Discover card feature is on, and copy about those cardtypes are displayed throughout the app
+- `False`: The feature is off, and copy about cardtypes on the app show only Visa and Mastercard
+
 ## `requests` configuration
 
 !!! tldr "`requests` docs"


### PR DESCRIPTION
Closes #2956 

During the deployment process, @angela-tran and I noticed that I did not write docs on this env var, or how to configure it. And we reflected that it's good to have some sort of place to do this, at least so the person deploying remembers to configure it. So we created this ticket to remedy this. Even though this is a fairly simple variable, that we will only need for a short temporary period, I thought it would be good to be thorough and document it. 

Note: These docs should be also removed when the environment variable and the feature flagged copy is removed.