### PR TITLE
Feat: error-handling for GatewayUrlView

### DIFF
--- a/benefits/enrollment/analytics.py
+++ b/benefits/enrollment/analytics.py
@@ -24,11 +24,11 @@ class ReturnedEnrollmentEvent(core.Event):
             self.update_event_properties(enrollment_group=enrollment_group)
 
 
-class FailedAccessTokenRequestEvent(core.Event):
-    """Analytics event representing a failure to acquire an access token for card tokenization."""
+class FailedPretokenizationRequestEvent(core.Event):
+    """Analytics event representing a failure to do the pre-tokenization step for card tokenization."""
 
     def __init__(self, request, status_code=None, enrollment_method=models.EnrollmentMethods.DIGITAL):
-        super().__init__(request, "failed access token request", enrollment_method)
+        super().__init__(request, "failed pre-tokenization request", enrollment_method)
         if status_code is not None:
             self.update_event_properties(status_code=status_code)
 
@@ -56,6 +56,6 @@ def returned_success(request, enrollment_group, enrollment_method: str = models.
     )
 
 
-def failed_access_token_request(request, status_code=None, enrollment_method: str = models.EnrollmentMethods.DIGITAL):
-    """Send the "failed access token request" analytics event with the response status code."""
-    core.send_event(FailedAccessTokenRequestEvent(request, status_code=status_code, enrollment_method=enrollment_method))
+def failed_pretokenization_request(request, status_code=None, enrollment_method: str = models.EnrollmentMethods.DIGITAL):
+    """Send the "failed pre-tokenization request" analytics event with the response status code."""
+    core.send_event(FailedPretokenizationRequestEvent(request, status_code=status_code, enrollment_method=enrollment_method))

--- a/benefits/enrollment_littlepay/views.py
+++ b/benefits/enrollment_littlepay/views.py
@@ -32,7 +32,7 @@ class TokenView(EligibleSessionRequiredMixin, View):
             elif response.status is Status.SYSTEM_ERROR or response.status is Status.EXCEPTION:
                 logger.debug("Error occurred while requesting access token", exc_info=response.exception)
                 sentry_sdk.capture_exception(response.exception)
-                analytics.failed_access_token_request(request, response.status_code)
+                analytics.failed_pretokenization_request(request, response.status_code)
 
                 if response.status is Status.SYSTEM_ERROR:
                     redirect = reverse(routes.ENROLLMENT_SYSTEM_ERROR)

--- a/benefits/enrollment_switchio/enrollment.py
+++ b/benefits/enrollment_switchio/enrollment.py
@@ -1,34 +1,63 @@
+from dataclasses import dataclass
 from django.conf import settings
 from django.http import HttpRequest
 from django.urls import reverse
+from requests import HTTPError
 
+from benefits.enrollment.enrollment import Status
 from benefits.routes import routes
 from benefits.core import session
 from benefits.enrollment_switchio.api import Client, EshopResponseMode, Registration, RegistrationMode
 
 
-def request_registration(request) -> Registration:
+@dataclass
+class RegistrationResponse:
+    status: Status
+    registration: Registration
+    exception: Exception = None
+    status_code: int = None
+
+
+def request_registration(request) -> RegistrationResponse:
     agency = session.agency(request)
     switchio_config = agency.switchio_config
 
-    client = Client(
-        api_url=switchio_config.api_base_url,
-        api_key=switchio_config.api_key,
-        api_secret=switchio_config.api_secret,
-        private_key=switchio_config.private_key_data,
-        client_certificate=switchio_config.client_certificate_data,
-        ca_certificate=switchio_config.ca_certificate_data,
-    )
+    try:
+        client = Client(
+            api_url=switchio_config.api_base_url,
+            api_key=switchio_config.api_key,
+            api_secret=switchio_config.api_secret,
+            private_key=switchio_config.private_key_data,
+            client_certificate=switchio_config.client_certificate_data,
+            ca_certificate=switchio_config.ca_certificate_data,
+        )
 
-    route = reverse(routes.ENROLLMENT_SWITCHIO_INDEX)
-    redirect_url = _generate_redirect_uri(request, route)
+        route = reverse(routes.ENROLLMENT_SWITCHIO_INDEX)
+        redirect_url = _generate_redirect_uri(request, route)
 
-    return client.request_registration(
-        eshopRedirectUrl=redirect_url,
-        mode=RegistrationMode.REGISTER,
-        eshopResponseMode=EshopResponseMode.FORM_POST,
-        timeout=settings.REQUESTS_TIMEOUT,
-    )
+        registration = client.request_registration(
+            eshopRedirectUrl=redirect_url,
+            mode=RegistrationMode.REGISTER,
+            eshopResponseMode=EshopResponseMode.FORM_POST,
+            timeout=settings.REQUESTS_TIMEOUT,
+        )
+
+        return RegistrationResponse(status=Status.SUCCESS, registration=registration)
+    except Exception as e:
+        exception = e
+
+        if isinstance(e, HTTPError):
+            status_code = e.response.status_code
+
+            if status_code >= 500:
+                status = Status.SYSTEM_ERROR
+            else:
+                status = Status.EXCEPTION
+        else:
+            status_code = None
+            status = Status.EXCEPTION
+
+    return RegistrationResponse(status=status, registration=None, exception=exception, status_code=status_code)
 
 
 # copied from https://github.com/Office-of-Digital-Services/django-cdt-identity/blob/main/cdt_identity/views.py#L42-L50

--- a/benefits/enrollment_switchio/enrollment.py
+++ b/benefits/enrollment_switchio/enrollment.py
@@ -1,0 +1,43 @@
+from django.conf import settings
+from django.http import HttpRequest
+from django.urls import reverse
+
+from benefits.routes import routes
+from benefits.core import session
+from benefits.enrollment_switchio.api import Client, EshopResponseMode, Registration, RegistrationMode
+
+
+def request_registration(request) -> Registration:
+    agency = session.agency(request)
+    switchio_config = agency.switchio_config
+
+    client = Client(
+        api_url=switchio_config.api_base_url,
+        api_key=switchio_config.api_key,
+        api_secret=switchio_config.api_secret,
+        private_key=switchio_config.private_key_data,
+        client_certificate=switchio_config.client_certificate_data,
+        ca_certificate=switchio_config.ca_certificate_data,
+    )
+
+    route = reverse(routes.ENROLLMENT_SWITCHIO_INDEX)
+    redirect_url = _generate_redirect_uri(request, route)
+
+    return client.request_registration(
+        eshopRedirectUrl=redirect_url,
+        mode=RegistrationMode.REGISTER,
+        eshopResponseMode=EshopResponseMode.FORM_POST,
+        timeout=settings.REQUESTS_TIMEOUT,
+    )
+
+
+# copied from https://github.com/Office-of-Digital-Services/django-cdt-identity/blob/main/cdt_identity/views.py#L42-L50
+def _generate_redirect_uri(request: HttpRequest, redirect_path: str):
+    redirect_uri = str(request.build_absolute_uri(redirect_path)).lower()
+
+    # this is a temporary hack to ensure redirect URIs are HTTPS when the app is deployed
+    # see https://github.com/cal-itp/benefits/issues/442 for more context
+    if not redirect_uri.startswith("http://localhost"):
+        redirect_uri = redirect_uri.replace("http://", "https://")
+
+    return redirect_uri

--- a/benefits/enrollment_switchio/enrollment.py
+++ b/benefits/enrollment_switchio/enrollment.py
@@ -6,7 +6,6 @@ from requests import HTTPError
 
 from benefits.enrollment.enrollment import Status
 from benefits.routes import routes
-from benefits.core import session
 from benefits.enrollment_switchio.api import Client, EshopResponseMode, Registration, RegistrationMode
 
 
@@ -18,10 +17,7 @@ class RegistrationResponse:
     status_code: int = None
 
 
-def request_registration(request) -> RegistrationResponse:
-    agency = session.agency(request)
-    switchio_config = agency.switchio_config
-
+def request_registration(request, switchio_config) -> RegistrationResponse:
     try:
         client = Client(
             api_url=switchio_config.api_base_url,

--- a/benefits/enrollment_switchio/views.py
+++ b/benefits/enrollment_switchio/views.py
@@ -1,13 +1,10 @@
-from django.conf import settings
 from django.http import HttpRequest, JsonResponse
-from django.urls import reverse
 from django.views.generic import TemplateView, View
 
 from benefits.core import models, session
 from benefits.core.mixins import EligibleSessionRequiredMixin, AgencySessionRequiredMixin
-from benefits.enrollment_switchio.api import Client, EshopResponseMode, RegistrationMode
+from benefits.enrollment_switchio.enrollment import request_registration
 from benefits.enrollment_switchio.session import Session
-from benefits.routes import routes
 
 
 class IndexView(EligibleSessionRequiredMixin, TemplateView):
@@ -35,39 +32,9 @@ class GatewayUrlView(AgencySessionRequiredMixin, EligibleSessionRequiredMixin, V
     """View for the tokenization gateway registration"""
 
     def get(self, request: HttpRequest, *args, **kwargs):
-        switchio_config = self.agency.switchio_config
+        registration = request_registration(request)
 
-        client = Client(
-            api_url=switchio_config.api_base_url,
-            api_key=switchio_config.api_key,
-            api_secret=switchio_config.api_secret,
-            private_key=switchio_config.private_key_data,
-            client_certificate=switchio_config.client_certificate_data,
-            ca_certificate=switchio_config.ca_certificate_data,
-        )
-
-        route = reverse(routes.ENROLLMENT_SWITCHIO_INDEX)
-        redirect_url = _generate_redirect_uri(request, route)
-
-        registration = client.request_registration(
-            eshopRedirectUrl=redirect_url,
-            mode=RegistrationMode.REGISTER,
-            eshopResponseMode=EshopResponseMode.FORM_POST,
-            timeout=settings.REQUESTS_TIMEOUT,
-        )
         Session(request=request, registration_id=registration.regId)
 
         data = {"gateway_url": registration.gtwUrl}
         return JsonResponse(data)
-
-
-# copied from https://github.com/Office-of-Digital-Services/django-cdt-identity/blob/main/cdt_identity/views.py#L42-L50
-def _generate_redirect_uri(request: HttpRequest, redirect_path: str):
-    redirect_uri = str(request.build_absolute_uri(redirect_path)).lower()
-
-    # this is a temporary hack to ensure redirect URIs are HTTPS when the app is deployed
-    # see https://github.com/cal-itp/benefits/issues/442 for more context
-    if not redirect_uri.startswith("http://localhost"):
-        redirect_uri = redirect_uri.replace("http://", "https://")
-
-    return redirect_uri

--- a/benefits/enrollment_switchio/views.py
+++ b/benefits/enrollment_switchio/views.py
@@ -40,7 +40,7 @@ class GatewayUrlView(AgencySessionRequiredMixin, EligibleSessionRequiredMixin, V
     """View for the tokenization gateway registration"""
 
     def get(self, request: HttpRequest, *args, **kwargs):
-        response = request_registration(request)
+        response = request_registration(request, self.agency.switchio_config)
 
         if response.status is Status.SUCCESS:
             registration = response.registration

--- a/benefits/enrollment_switchio/views.py
+++ b/benefits/enrollment_switchio/views.py
@@ -52,7 +52,7 @@ class GatewayUrlView(AgencySessionRequiredMixin, EligibleSessionRequiredMixin, V
         else:
             logger.debug("Error occurred while requesting access token", exc_info=response.exception)
             sentry_sdk.capture_exception(response.exception)
-            analytics.failed_access_token_request(request, response.status_code)
+            analytics.failed_pretokenization_request(request, response.status_code)
 
             if response.status is Status.SYSTEM_ERROR:
                 redirect = reverse(routes.ENROLLMENT_SYSTEM_ERROR)

--- a/benefits/enrollment_switchio/views.py
+++ b/benefits/enrollment_switchio/views.py
@@ -50,7 +50,7 @@ class GatewayUrlView(AgencySessionRequiredMixin, EligibleSessionRequiredMixin, V
             data = {"gateway_url": registration.gtwUrl}
             return JsonResponse(data)
         else:
-            logger.debug("Error occurred while requesting access token", exc_info=response.exception)
+            logger.debug("Error occurred while requesting a tokenization gateway registration", exc_info=response.exception)
             sentry_sdk.capture_exception(response.exception)
             analytics.failed_pretokenization_request(request, response.status_code)
 

--- a/benefits/enrollment_switchio/views.py
+++ b/benefits/enrollment_switchio/views.py
@@ -49,7 +49,7 @@ class GatewayUrlView(AgencySessionRequiredMixin, EligibleSessionRequiredMixin, V
 
             data = {"gateway_url": registration.gtwUrl}
             return JsonResponse(data)
-        elif response.status is Status.SYSTEM_ERROR or response.status is Status.EXCEPTION:
+        else:
             logger.debug("Error occurred while requesting access token", exc_info=response.exception)
             sentry_sdk.capture_exception(response.exception)
             analytics.failed_access_token_request(request, response.status_code)
@@ -61,5 +61,3 @@ class GatewayUrlView(AgencySessionRequiredMixin, EligibleSessionRequiredMixin, V
 
             data = {"redirect": redirect}
             return JsonResponse(data)
-        else:
-            raise ValueError(f"Unexpected Status: {response.status}")

--- a/benefits/in_person/views.py
+++ b/benefits/in_person/views.py
@@ -65,7 +65,7 @@ def token(request):
         elif response.status is Status.SYSTEM_ERROR or response.status is Status.EXCEPTION:
             logger.debug("Error occurred while requesting access token", exc_info=response.exception)
             sentry_sdk.capture_exception(response.exception)
-            enrollment_analytics.failed_access_token_request(
+            enrollment_analytics.failed_pretokenization_request(
                 request, response.status_code, enrollment_method=models.EnrollmentMethods.IN_PERSON
             )
 

--- a/tests/pytest/enrollment/test_analytics.py
+++ b/tests/pytest/enrollment/test_analytics.py
@@ -1,12 +1,12 @@
 import pytest
 
 from cdt_identity.claims import ClaimsResult
-from benefits.enrollment.analytics import FailedAccessTokenRequestEvent, ReturnedEnrollmentEvent
+from benefits.enrollment.analytics import FailedPretokenizationRequestEvent, ReturnedEnrollmentEvent
 
 
 @pytest.mark.django_db
 def test_FailedAccessTokenRequestEvent_sets_status_code(app_request):
-    event = FailedAccessTokenRequestEvent(app_request, 500)
+    event = FailedPretokenizationRequestEvent(app_request, 500)
 
     assert event.event_properties["status_code"] == 500
 

--- a/tests/pytest/enrollment_littlepay/test_views.py
+++ b/tests/pytest/enrollment_littlepay/test_views.py
@@ -103,8 +103,8 @@ def test_token_system_error(mocker, client, mocked_analytics_module, mocked_sent
     assert "token" not in data
     assert "redirect" in data
     assert data["redirect"] == reverse(routes.ENROLLMENT_SYSTEM_ERROR)
-    mocked_analytics_module.failed_access_token_request.assert_called_once()
-    assert 500 in mocked_analytics_module.failed_access_token_request.call_args.args
+    mocked_analytics_module.failed_pretokenization_request.assert_called_once()
+    assert 500 in mocked_analytics_module.failed_pretokenization_request.call_args.args
     mocked_sentry_sdk_module.capture_exception.assert_called_once()
 
 
@@ -133,8 +133,8 @@ def test_token_http_error_400(mocker, client, mocked_analytics_module, mocked_se
     assert "token" not in data
     assert "redirect" in data
     assert data["redirect"] == reverse(routes.SERVER_ERROR)
-    mocked_analytics_module.failed_access_token_request.assert_called_once()
-    assert 400 in mocked_analytics_module.failed_access_token_request.call_args.args
+    mocked_analytics_module.failed_pretokenization_request.assert_called_once()
+    assert 400 in mocked_analytics_module.failed_pretokenization_request.call_args.args
     mocked_sentry_sdk_module.capture_exception.assert_called_once()
 
 
@@ -160,7 +160,7 @@ def test_token_misconfigured_client_id(mocker, client, mocked_analytics_module, 
     assert "token" not in data
     assert "redirect" in data
     assert data["redirect"] == reverse(routes.SERVER_ERROR)
-    mocked_analytics_module.failed_access_token_request.assert_called_once()
+    mocked_analytics_module.failed_pretokenization_request.assert_called_once()
     mocked_sentry_sdk_module.capture_exception.assert_called_once()
 
 
@@ -186,7 +186,7 @@ def test_token_connection_error(mocker, client, mocked_analytics_module, mocked_
     assert "token" not in data
     assert "redirect" in data
     assert data["redirect"] == reverse(routes.SERVER_ERROR)
-    mocked_analytics_module.failed_access_token_request.assert_called_once()
+    mocked_analytics_module.failed_pretokenization_request.assert_called_once()
     mocked_sentry_sdk_module.capture_exception.assert_called_once()
 
 

--- a/tests/pytest/enrollment_switchio/test_enrollment.py
+++ b/tests/pytest/enrollment_switchio/test_enrollment.py
@@ -1,0 +1,79 @@
+import pytest
+from requests import HTTPError
+from benefits.enrollment.enrollment import Status
+from benefits.enrollment_switchio.api import Registration
+from benefits.enrollment_switchio.enrollment import request_registration
+
+
+@pytest.fixture
+def mocked_registration():
+    return Registration(regId="1111", gtwUrl="https://example.com/?regId=1111")
+
+
+@pytest.fixture
+def mocked_api_base_url(mocker):
+    return mocker.patch(
+        "benefits.enrollment_switchio.models.get_secret_by_name", return_value="https://example.com/backend-api"
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("mocked_api_base_url")
+def test_request_registration_success(mocker, app_request, model_SwitchioConfig, mocked_registration):
+    mocker.patch("benefits.enrollment_switchio.enrollment.Client.request_registration", return_value=mocked_registration)
+
+    registration_response = request_registration(app_request, model_SwitchioConfig)
+
+    assert registration_response.status == Status.SUCCESS
+    assert registration_response.registration == mocked_registration
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("mocked_api_base_url")
+@pytest.mark.parametrize("status_code", [500, 501, 502, 503, 504])
+def test_request_registration_system_error(mocker, status_code, app_request, model_SwitchioConfig):
+    mock_error = {"message": "Mock error message"}
+    mock_error_response = mocker.Mock(status_code=status_code, **mock_error)
+    mock_error_response.json.return_value = mock_error
+    http_error = HTTPError(response=mock_error_response)
+
+    mocker.patch("benefits.enrollment_switchio.enrollment.Client.request_registration", side_effect=http_error)
+
+    registration_response = request_registration(app_request, model_SwitchioConfig)
+
+    assert registration_response.status == Status.SYSTEM_ERROR
+    assert registration_response.exception == http_error
+    assert registration_response.registration is None
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("mocked_api_base_url")
+def test_request_registration_http_error_400(mocker, app_request, model_SwitchioConfig):
+    mock_error = {"message": "Mock error message"}
+    mock_error_response = mocker.Mock(status_code=400, **mock_error)
+    mock_error_response.json.return_value = mock_error
+    http_error = HTTPError(response=mock_error_response)
+
+    mocker.patch("benefits.enrollment_switchio.enrollment.Client.request_registration", side_effect=http_error)
+
+    registration_response = request_registration(app_request, model_SwitchioConfig)
+
+    assert registration_response.status == Status.EXCEPTION
+    assert registration_response.exception == http_error
+    assert isinstance(registration_response.exception, HTTPError)
+    assert registration_response.registration is None
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("mocked_api_base_url")
+def test_request_registration_non_http_error(mocker, app_request, model_SwitchioConfig):
+
+    mocker.patch(
+        "benefits.enrollment_switchio.enrollment.Client.request_registration", side_effect=Exception("some other exception")
+    )
+
+    registration_response = request_registration(app_request, model_SwitchioConfig)
+
+    assert registration_response.status == Status.EXCEPTION
+    assert isinstance(registration_response.exception, Exception)
+    assert registration_response.registration is None

--- a/tests/pytest/enrollment_switchio/test_views.py
+++ b/tests/pytest/enrollment_switchio/test_views.py
@@ -47,15 +47,16 @@ class TestIndexView:
 
 class TestGatewayUrlView:
     @pytest.fixture
-    def view(self, app_request):
+    def view(self, app_request, mocked_session_agency):
         """Fixture to create an instance of GatewayUrlView."""
         v = GatewayUrlView()
         v.setup(app_request)
+        v.agency = mocked_session_agency(app_request)
 
         return v
 
     @pytest.mark.django_db
-    @pytest.mark.usefixtures("mocked_api_base_url", "mocked_session_agency", "mocked_session_eligible")
+    @pytest.mark.usefixtures("mocked_api_base_url")
     def test_get_gateway_url(self, view, app_request, mocker, model_TransitAgency, model_SwitchioConfig):
         model_TransitAgency.switchio_config = model_SwitchioConfig
         gateway_url = "https://example.com/cst/?regId=1234"
@@ -67,8 +68,7 @@ class TestGatewayUrlView:
         )
         session_spy = mocker.spy(benefits.enrollment_switchio.views, "Session")
 
-        # need to call `dispatch` here so that variables that the mixins assign (e.g. self.agency) are available to the view
-        response = view.dispatch(app_request)
+        response = view.get(app_request)
 
         assert response.status_code == 200
         assert json.loads(response.content) == {"gateway_url": gateway_url}

--- a/tests/pytest/enrollment_switchio/test_views.py
+++ b/tests/pytest/enrollment_switchio/test_views.py
@@ -55,7 +55,7 @@ class TestGatewayUrlView:
         model_TransitAgency.switchio_config = model_SwitchioConfig
         gateway_url = "https://example.com/cst/?regId=1234"
         mocker.patch(
-            "benefits.enrollment_switchio.views.Client.request_registration",
+            "benefits.enrollment_switchio.views.request_registration",
             return_value=Registration(regId="1234", gtwUrl=gateway_url),
         )
         session_spy = mocker.spy(benefits.enrollment_switchio.views, "Session")

--- a/tests/pytest/enrollment_switchio/test_views.py
+++ b/tests/pytest/enrollment_switchio/test_views.py
@@ -1,7 +1,12 @@
 import json
+from django.urls import reverse
 import pytest
+from requests import HTTPError
 
+from benefits.routes import routes
+from benefits.enrollment.enrollment import Status
 from benefits.enrollment_switchio.api import Registration
+from benefits.enrollment_switchio.enrollment import RegistrationResponse
 import benefits.enrollment_switchio.views
 from benefits.enrollment_switchio.views import GatewayUrlView, IndexView
 
@@ -56,7 +61,9 @@ class TestGatewayUrlView:
         gateway_url = "https://example.com/cst/?regId=1234"
         mocker.patch(
             "benefits.enrollment_switchio.views.request_registration",
-            return_value=Registration(regId="1234", gtwUrl=gateway_url),
+            return_value=RegistrationResponse(
+                status=Status.SUCCESS, registration=Registration(regId="1234", gtwUrl=gateway_url)
+            ),
         )
         session_spy = mocker.spy(benefits.enrollment_switchio.views, "Session")
 
@@ -66,3 +73,35 @@ class TestGatewayUrlView:
         assert response.status_code == 200
         assert json.loads(response.content) == {"gateway_url": gateway_url}
         session_spy.assert_called_once_with(request=app_request, registration_id="1234")
+
+    @pytest.mark.django_db
+    @pytest.mark.usefixtures("mocked_api_base_url")
+    def test_get_gateway_url_system_error(self, view, app_request, mocker, model_TransitAgency, model_SwitchioConfig):
+        model_TransitAgency.switchio_config = model_SwitchioConfig
+        mocker.patch(
+            "benefits.enrollment_switchio.views.request_registration",
+            return_value=RegistrationResponse(
+                status=Status.SYSTEM_ERROR, exception=HTTPError("mock 500 error"), registration=None
+            ),
+        )
+
+        response = view.get(app_request)
+
+        assert response.status_code == 200
+        assert json.loads(response.content) == {"redirect": reverse(routes.ENROLLMENT_SYSTEM_ERROR)}
+
+    @pytest.mark.django_db
+    @pytest.mark.usefixtures("mocked_api_base_url")
+    def test_get_gateway_url_http_error_400(self, view, app_request, mocker, model_TransitAgency, model_SwitchioConfig):
+        model_TransitAgency.switchio_config = model_SwitchioConfig
+        mocker.patch(
+            "benefits.enrollment_switchio.views.request_registration",
+            return_value=RegistrationResponse(
+                status=Status.EXCEPTION, exception=HTTPError("mock 400 error"), registration=None
+            ),
+        )
+
+        response = view.get(app_request)
+
+        assert response.status_code == 200
+        assert json.loads(response.content) == {"redirect": reverse(routes.SERVER_ERROR)}

--- a/tests/pytest/in_person/test_views.py
+++ b/tests/pytest/in_person/test_views.py
@@ -196,8 +196,8 @@ def test_token_system_error(mocker, admin_client, mocked_enrollment_analytics_mo
     assert "token" not in data
     assert "redirect" in data
     assert data["redirect"] == reverse(routes.IN_PERSON_ENROLLMENT_SYSTEM_ERROR)
-    mocked_enrollment_analytics_module.failed_access_token_request.assert_called_once()
-    assert 500 in mocked_enrollment_analytics_module.failed_access_token_request.call_args.args
+    mocked_enrollment_analytics_module.failed_pretokenization_request.assert_called_once()
+    assert 500 in mocked_enrollment_analytics_module.failed_pretokenization_request.call_args.args
     mocked_sentry_sdk_module.capture_exception.assert_called_once()
 
 
@@ -226,8 +226,8 @@ def test_token_http_error_400(mocker, admin_client, mocked_enrollment_analytics_
     assert "token" not in data
     assert "redirect" in data
     assert data["redirect"] == reverse(routes.IN_PERSON_SERVER_ERROR)
-    mocked_enrollment_analytics_module.failed_access_token_request.assert_called_once()
-    assert 400 in mocked_enrollment_analytics_module.failed_access_token_request.call_args.args
+    mocked_enrollment_analytics_module.failed_pretokenization_request.assert_called_once()
+    assert 400 in mocked_enrollment_analytics_module.failed_pretokenization_request.call_args.args
     mocked_sentry_sdk_module.capture_exception.assert_called_once()
 
 
@@ -253,7 +253,7 @@ def test_token_misconfigured_client_id(mocker, admin_client, mocked_enrollment_a
     assert "token" not in data
     assert "redirect" in data
     assert data["redirect"] == reverse(routes.IN_PERSON_SERVER_ERROR)
-    mocked_enrollment_analytics_module.failed_access_token_request.assert_called_once()
+    mocked_enrollment_analytics_module.failed_pretokenization_request.assert_called_once()
     mocked_sentry_sdk_module.capture_exception_assert_called_once()
 
 
@@ -279,7 +279,7 @@ def test_token_connection_error(mocker, admin_client, mocked_enrollment_analytic
     assert "token" not in data
     assert "redirect" in data
     assert data["redirect"] == reverse(routes.IN_PERSON_SERVER_ERROR)
-    mocked_enrollment_analytics_module.failed_access_token_request.assert_called_once()
+    mocked_enrollment_analytics_module.failed_pretokenization_request.assert_called_once()
     mocked_sentry_sdk_module.capture_exception_assert_called_once()
 
 


### PR DESCRIPTION
Part of #2904 

Builds off #2952 

This PR adds error-handling for the Switchio `/gateway_url` view, similar to what we added for Littlepay in https://github.com/cal-itp/benefits/issues/2032. That is:
- 500 errors from Switchio should take the user to the "system error" page
- 400 errors from Switchio should take the user to the "server error" page (because it's most likely a problem on our end)
- non-HTTP errors occurring from calling Switchio should take the user to the "server error" page

Code changes that were done:
- extracts usage of `benefits.enrollment_switchio.api` to an intermediary module - `benefits.enrollment_switchio.enrollment` - which is responsible for providing additional data about the response like exceptions, status_codes, etc.
- refactors `GatewayUrlView` to use this abstraction rather than directly consuming the `api` module
- adds error-handling to `GatewayUrlView` using the additional data from the `enrollment` module's response