### PR TITLE
Fix: `RegistrationStatus` field names

### DIFF
--- a/tests/pytest/enrollment_switchio/test_api.py
+++ b/tests/pytest/enrollment_switchio/test_api.py
@@ -93,6 +93,9 @@ def test_client_get_registration_status(mocker, client):
         mode="register",
         tokens=[],
         eshopResponseMode="form_post",
+        identType="BPK",
+        maskCln="412501****1234",
+        cardExp="1119",
     )
     mock_response.json.return_value = mock_json
     mocker.patch("benefits.enrollment_switchio.api.requests.get", return_value=mock_response)


### PR DESCRIPTION
Needed for #2904 

Incorrect field names introduced in #2946.

 This PR simply fixes some incorrectly-named fields on `RegistrationStatus`. We want the fields to match the casing / names that will be used in the JSON response from Switchio's API so that we can instantiate the dataclass with keyword arguments: https://github.com/cal-itp/benefits/blob/429c8fac9686cdbc2cffd6c7d69073a0ef68b1b8/benefits/enrollment_switchio/api.py#L126