### PR TITLE
Feat: support additional card types for Littlepay in-person enrollment

### DIFF
--- a/benefits/enrollment_littlepay/enrollment.py
+++ b/benefits/enrollment_littlepay/enrollment.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from datetime import timedelta
+import json
 
+from django.conf import settings
 from django.utils import timezone
 from littlepay.api.client import Client
 from requests.exceptions import HTTPError
@@ -16,6 +18,15 @@ class CardTokenizationAccessResponse:
     expires_at: int
     exception: Exception = None
     status_code: int = None
+
+
+def get_card_types_for_js() -> str:
+    """Get a list of card types to use for enrollment, converted to a JSON string for use in JavaScript."""
+    card_types = ["visa", "mastercard"]
+    if settings.LITTLEPAY_ADDITIONAL_CARDTYPES:
+        card_types.extend(["discover", "amex"])
+
+    return json.dumps(card_types)
 
 
 def request_card_tokenization_access(request) -> CardTokenizationAccessResponse:

--- a/benefits/enrollment_littlepay/views.py
+++ b/benefits/enrollment_littlepay/views.py
@@ -1,7 +1,5 @@
-import json
 import logging
 
-from django.conf import settings
 from django.http import JsonResponse
 from django.urls import reverse
 from django.views.generic import FormView, View
@@ -13,7 +11,7 @@ from benefits.core.mixins import EligibleSessionRequiredMixin
 
 from benefits.enrollment import analytics, forms
 from benefits.enrollment.enrollment import Status, handle_enrollment_results
-from benefits.enrollment_littlepay.enrollment import enroll, request_card_tokenization_access
+from benefits.enrollment_littlepay.enrollment import enroll, get_card_types_for_js, request_card_tokenization_access
 from benefits.enrollment_littlepay.session import Session
 
 logger = logging.getLogger(__name__)
@@ -66,10 +64,6 @@ class IndexView(EligibleSessionRequiredMixin, FormView):
             action_url=routes.ENROLLMENT_LITTLEPAY_INDEX, auto_id=True, label_suffix=""
         )
 
-        card_types = ["visa", "mastercard"]
-        if settings.LITTLEPAY_ADDITIONAL_CARDTYPES:
-            card_types.extend(["discover", "amex"])
-
         context = {
             "forms": [tokenize_retry_form, tokenize_server_error_form, tokenize_system_error_form, tokenize_success_form],
             "cta_button": "tokenize_card",
@@ -80,8 +74,7 @@ class IndexView(EligibleSessionRequiredMixin, FormView):
             "form_success": tokenize_success_form.id,
             "form_system_error": tokenize_system_error_form.id,
             "overlay_language": self._get_overlay_language(request.LANGUAGE_CODE),
-            # convert the python list to a JSON string for use in JavaScript
-            "card_types": json.dumps(card_types),
+            "card_types": get_card_types_for_js(),
         }
 
         enrollment_index_context_dict = flow.enrollment_index_context

--- a/benefits/in_person/templates/in_person/enrollment/index.html
+++ b/benefits/in_person/templates/in_person/enrollment/index.html
@@ -59,6 +59,10 @@
                     $(this).addClass("disabled").attr("aria-disabled", "true").text("{{ loading_text }}");
                 });
 
+                // parse the JSON string back into a JS array
+                // the escapejs filter handles e.g. quote conversion
+                let cardTypes = JSON.parse('{{ card_types|escapejs }}');
+
                 new Promise((resolve) => {
                     littlepay({
                         authorization: data.token,
@@ -66,7 +70,8 @@
                         envUrl: '{{ transit_processor.card_tokenize_env }}',
                         options: {
                             color: '#046b99',
-                            targetiframename: 'card-collection-iframe'
+                            targetiframename: 'card-collection-iframe',
+                            cardTypes: cardTypes
                         },
                         onTokenize: function (response) {
                             /* This function executes when the

--- a/benefits/in_person/views.py
+++ b/benefits/in_person/views.py
@@ -13,7 +13,7 @@ from benefits.core import models, session
 from benefits.eligibility import analytics as eligibility_analytics
 from benefits.enrollment import analytics as enrollment_analytics
 from benefits.enrollment.enrollment import Status
-from benefits.enrollment_littlepay.enrollment import request_card_tokenization_access, enroll
+from benefits.enrollment_littlepay.enrollment import get_card_types_for_js, request_card_tokenization_access, enroll
 from benefits.enrollment_littlepay.session import Session as LittlepaySession
 
 from benefits.in_person import forms
@@ -158,6 +158,7 @@ def enrollment(request):
             "form_success": tokenize_success_form.id,
             "form_system_error": tokenize_system_error_form.id,
             "title": f"{agency.long_name} | In-person enrollment | {admin_site.site_title}",
+            "card_types": get_card_types_for_js(),
         }
 
         match agency.littlepay_config.environment:

--- a/tests/pytest/enrollment_littlepay/test_enrollment.py
+++ b/tests/pytest/enrollment_littlepay/test_enrollment.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+import json
 
 import pytest
 from django.utils import timezone
@@ -8,6 +9,7 @@ from requests import HTTPError
 
 from benefits.enrollment.enrollment import Status
 from benefits.enrollment_littlepay.enrollment import (
+    get_card_types_for_js,
     request_card_tokenization_access,
     enroll,
     _get_group_funding_source,
@@ -63,6 +65,23 @@ def mocked_group_funding_source_with_expiry(mocked_funding_source):
 @pytest.fixture
 def card_token():
     return "card_token_1234"
+
+
+@pytest.mark.parametrize("additional_cardtypes", [True, False])
+def test_get_card_types_for_js(settings, additional_cardtypes):
+    settings.LITTLEPAY_ADDITIONAL_CARDTYPES = additional_cardtypes
+
+    card_types = get_card_types_for_js()
+    assert isinstance(card_types, str)
+
+    parsed_card_types = json.loads(card_types)
+    assert isinstance(parsed_card_types, list)
+
+    assert "visa" in card_types
+    assert "mastercard" in card_types
+    if additional_cardtypes:
+        assert "discover" in card_types
+        assert "amex" in card_types
 
 
 @pytest.mark.django_db

--- a/tests/pytest/enrollment_littlepay/test_views.py
+++ b/tests/pytest/enrollment_littlepay/test_views.py
@@ -201,10 +201,7 @@ class TestIndexView:
 
     @pytest.mark.django_db
     @pytest.mark.usefixtures("mocked_session_agency", "mocked_session_flow")
-    @pytest.mark.parametrize("additional_cardtypes", [True, False])
-    def test_get_context_data(self, view, settings, additional_cardtypes):
-        settings.LITTLEPAY_ADDITIONAL_CARDTYPES = additional_cardtypes
-
+    def test_get_context_data(self, view):
         context = view.get_context_data()
 
         assert "forms" in context
@@ -229,12 +226,7 @@ class TestIndexView:
         assert "card_tokenize_url" in transit_processor_context
         assert "card_tokenize_env" in transit_processor_context
 
-        card_types = context["card_types"]
-        assert "visa" in card_types
-        assert "mastercard" in card_types
-        if additional_cardtypes:
-            assert "discover" in card_types
-            assert "amex" in card_types
+        assert "card_types" in context
 
     @pytest.mark.parametrize(
         "LANGUAGE_CODE, expected_overlay_language", [("en", "en"), ("es", "es-419"), ("unsupported", "en")]

--- a/tests/pytest/in_person/test_views.py
+++ b/tests/pytest/in_person/test_views.py
@@ -296,6 +296,7 @@ def test_enrollment_logged_in_get(admin_client):
     assert "token_field" in response.context_data
     assert "form_retry" in response.context_data
     assert "form_success" in response.context_data
+    assert "card_types" in response.context_data
 
     # not supporting internationalization in in_person app yet
     assert "overlay_language" not in response.context_data


### PR DESCRIPTION
Closes #2963.

It turns out the In-person flow does not mention card types in the user-facing copy, so this was a simple change to the overlay window `options`.

## Reviewing

Similar to #2943, the easiest way to test is just set `LITTLEPAY_ADDITIONAL_CARDTYPES = True` in your local settings file (e.g. on the very last line in the file).

```python
# other settings...

# Temporary flag for Littlepay card types
LITTLEPAY_ADDITIONAL_CARDTYPES = os.environ.get("LITTLEPAY_ADDITIONAL_CARDTYPES", "False").lower() == "true"
LITTLEPAY_ADDITIONAL_CARDTYPES = True  # <-- quick and dirty override
```

Then launch the app, login to the Admin as `cst-user`, and go to the enrollment step. It should support the existing Visa/MC, and Discover/Amex as well:

| Existing card types | New card types |
| --------------------------- | -----------------------| 
| ![image](https://github.com/user-attachments/assets/33cb3a30-ecd8-4ec6-903f-b93f2ae7852b) | ![image](https://github.com/user-attachments/assets/f669fa64-4d83-4361-97ae-9d4446de11f6) |
| ![image](https://github.com/user-attachments/assets/7d189d6f-b8c1-4691-92da-85c04cc7a216) | ![image](https://github.com/user-attachments/assets/ed15b5a0-3523-4c72-b419-5dfbd36c57f5) |