### PR TITLE
Feat: Switchio locale

### DIFF
--- a/benefits/enrollment_switchio/templates/enrollment_switchio/index.html
+++ b/benefits/enrollment_switchio/templates/enrollment_switchio/index.html
@@ -12,6 +12,7 @@
       StRpClient.tokenizeWithRedirect({
         tokenizationParams: { uri: gtwUrl },
         state: 'tokenize',
+        locale: '{{ locale }}',
       });
     };
 

--- a/benefits/enrollment_switchio/views.py
+++ b/benefits/enrollment_switchio/views.py
@@ -25,6 +25,7 @@ class IndexView(AgencySessionRequiredMixin, EligibleSessionRequiredMixin, Templa
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
+        request = self.request
         flow = session.flow(self.request)
 
         context.update(
@@ -33,9 +34,16 @@ class IndexView(AgencySessionRequiredMixin, EligibleSessionRequiredMixin, Templa
                 "cta_button": "tokenize_card",
                 "enrollment_method": models.EnrollmentMethods.DIGITAL,
                 "transit_processor": {"name": "Switchio", "website": "https://switchio.com/transport/"},
+                "locale": self._get_locale(request.LANGUAGE_CODE),
             }
         )
         return context
+
+    def _get_locale(self, django_language_code):
+        """Given a Django language code, return the corresponding locale to use with Switchio's tokenization gateway."""
+        # mapping from Django's I18N LANGUAGE_CODE to Switchio's locales
+        locale = {"en": "en", "es": "es"}.get(django_language_code, "en")
+        return locale
 
     def get(self, request: HttpRequest, *args, **kwargs):
         session = Session(request)

--- a/tests/pytest/enrollment_switchio/test_views.py
+++ b/tests/pytest/enrollment_switchio/test_views.py
@@ -52,10 +52,18 @@ class TestIndexView:
         assert "next_step" in context
         assert "partner_post_link" in context
         assert "alert_include" in context
+        assert "locale" in context
         assert "transit_processor" in context.keys()
         transit_processor_context = context["transit_processor"]
         assert "name" in transit_processor_context
         assert "website" in transit_processor_context
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize("LANGUAGE_CODE, expected_locale", [("en", "en"), ("es", "es"), ("unsupported", "en")])
+    def test_get_locale(self, view, LANGUAGE_CODE, expected_locale):
+        locale = view._get_locale(LANGUAGE_CODE)
+
+        assert locale == expected_locale
 
     @pytest.mark.django_db
     @pytest.mark.usefixtures("mocked_session_flow")


### PR DESCRIPTION
Part of #2905 

Maintain the user's selected language when they are redirected to Switchio.