### PR TITLE
Refactor: class-based view for Eligibility Unverified

### DIFF
--- a/benefits/eligibility/urls.py
+++ b/benefits/eligibility/urls.py
@@ -14,5 +14,5 @@ urlpatterns = [
     path("", views.index, name=routes.name(routes.ELIGIBILITY_INDEX)),
     path("start", views.start, name=routes.name(routes.ELIGIBILITY_START)),
     path("confirm", views.confirm, name=routes.name(routes.ELIGIBILITY_CONFIRM)),
-    path("unverified", views.unverified, name=routes.name(routes.ELIGIBILITY_UNVERIFIED)),
+    path("unverified", views.UnverifiedView.as_view(), name=routes.name(routes.ELIGIBILITY_UNVERIFIED)),
 ]


### PR DESCRIPTION
Closes #2872 

## Reviewing

- Run through an agency card and non-agency card flow
- Fail eligibility verification
- Confirm you still see the same `eligibility:unverified` view for each flow type