### PR TITLE
Refactor: class-based view for Eligibility Verified

### DIFF
--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -7,7 +7,7 @@ from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.decorators import decorator_from_middleware
-from django.views.generic import TemplateView
+from django.views.generic import RedirectView, TemplateView
 
 from benefits.routes import routes
 from benefits.core import recaptcha, session
@@ -119,16 +119,30 @@ def confirm(request):
             return verified(request)
 
 
-@decorator_from_middleware(AgencySessionRequired)
-def verified(request):
-    """View handler for the verified eligibility page."""
+class VerifiedView(AgencySessionRequiredMixin, FlowSessionRequiredMixin, RedirectView):
+    """CBV for verified eligibility.
 
-    flow = session.flow(request)
-    analytics.returned_success(request, flow)
+    Note we do not register a URL for this view, as it should only be used
+    after the user's eligibility is verified and not generally accessible.
 
-    session.update(request, eligible=True)
+    GET requests simply forward along as part of the RedirectView logic.
 
-    return redirect(routes.ENROLLMENT_INDEX)
+    POST requests represent a new verification success, triggering additional logic.
+
+    `setup_and_dispatch(request)` is a helper for external callers.
+    """
+
+    def get_redirect_url(self, *args, **kwargs):
+        return reverse(routes.ENROLLMENT_INDEX)
+
+    def post(self, request, *args, **kwargs):
+        session.update(request, eligible=True)
+        analytics.returned_success(request, self.flow)
+        return super().post(request, *args, **kwargs)
+
+    def setup_and_dispatch(self, request, *args, **kwargs):
+        self.setup(request)
+        return self.dispatch(request, *args, **kwargs)
 
 
 class UnverifiedView(AgencySessionRequiredMixin, FlowSessionRequiredMixin, TemplateView):

--- a/benefits/eligibility/views.py
+++ b/benefits/eligibility/views.py
@@ -75,9 +75,11 @@ def start(request):
 def confirm(request):
     """View handler for the eligibility verification form."""
 
+    verified_view = VerifiedView()
+
     # GET from an already verified user, no need to verify again
     if request.method == "GET" and session.eligible(request):
-        return verified(request)
+        return verified_view.setup_and_dispatch(request)
 
     agency = session.agency(request)
     flow = session.flow(request)
@@ -116,7 +118,7 @@ def confirm(request):
             return redirect(routes.ELIGIBILITY_UNVERIFIED)
         # type was verified
         else:
-            return verified(request)
+            return verified_view.setup_and_dispatch(request)
 
 
 class VerifiedView(AgencySessionRequiredMixin, FlowSessionRequiredMixin, RedirectView):

--- a/benefits/oauth/hooks.py
+++ b/benefits/oauth/hooks.py
@@ -6,7 +6,7 @@ import sentry_sdk
 from benefits.routes import routes
 from benefits.core import session
 from benefits.core.middleware import AgencySessionRequired, FlowSessionRequired
-from benefits.eligibility.views import verified, analytics as eligibility_analytics
+from benefits.eligibility.views import VerifiedView, analytics as eligibility_analytics
 from . import analytics
 
 
@@ -53,7 +53,7 @@ class OAuthHooks(DefaultHooks):
         flow = session.flow(request)
         eligibility_analytics.started_eligibility(request, flow)
 
-        return verified(request)
+        return VerifiedView().setup_and_dispatch(request)
 
     @classmethod
     @method_decorator(

--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -45,6 +45,25 @@ def app_request(rf):
 
 
 @pytest.fixture
+def app_request_post(rf):
+    """
+    Fixture creates and initializes a new Django POST request object similar to a real application request.
+    """
+    # create a request for the path, initialize
+    app_request = rf.post("/some/arbitrary/path")
+
+    # https://stackoverflow.com/a/55530933/358804
+    middleware = [SessionMiddleware(lambda x: x), LocaleMiddleware(lambda x: x)]
+    for m in middleware:
+        m.process_request(app_request)
+
+    app_request.session.save()
+    session.reset(app_request)
+
+    return app_request
+
+
+@pytest.fixture
 def model_User():
     return User.objects.create(is_active=True, is_staff=True, first_name="Test", last_name="User")
 

--- a/tests/pytest/oauth/test_hooks.py
+++ b/tests/pytest/oauth/test_hooks.py
@@ -70,16 +70,19 @@ def test_post_logout(app_request, mocked_oauth_analytics_module, origin):
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_session_agency", "mocked_session_flow_uses_claims_verification", "mocked_session_logged_in")
 def test_claims_verified_eligible(
-    app_request, mocked_oauth_analytics_module, mocked_session_update, mocked_eligibility_analytics_module
+    mocker, app_request, mocked_oauth_analytics_module, mocked_session_update, mocked_eligibility_analytics_module
 ):
+    mock_cls = mocker.patch.object(benefits.oauth.hooks, "VerifiedView")
+    mock_view = mock_cls.return_value
+
     result = OAuthHooks.claims_verified_eligible(app_request, ClaimsVerificationRequest(), ClaimsResult())
 
-    assert result.status_code == 302
-    assert result.url == reverse(routes.ENROLLMENT_INDEX)
+    mock_cls.assert_called_once()
+    mock_view.setup_and_dispatch.assert_called_once_with(app_request)
+    assert result == mock_view.setup_and_dispatch.return_value
+
     mocked_oauth_analytics_module.finished_sign_in.assert_called_once_with(app_request)
     mocked_session_update.assert_any_call(app_request, logged_in=True)
-    mocked_session_update.assert_any_call(app_request, eligible=True)
-    mocked_eligibility_analytics_module.returned_success.assert_called_once()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Closes #2871 

## Reviewing

- Run through an agency card and non-agency card flow
- Pass eligibility verification
- Confirm you still see the same `enrollment:index` view for each flow type