### PR TITLE
Fix: Switchio API datetime parsing

### DIFF
--- a/benefits/enrollment_switchio/api.py
+++ b/benefits/enrollment_switchio/api.py
@@ -37,6 +37,9 @@ class RegistrationStatus:
     maskCln: str = None
     cardExp: str = None
 
+    def __post_init__(self):
+        self.created = datetime.fromisoformat(self.created)
+
 
 class Client:
     def __init__(
@@ -178,7 +181,11 @@ class Group:
 @dataclass
 class GroupExpiry:
     group: str
-    expiresAt: datetime
+    expiresAt: datetime | None = None
+
+    def __post_init__(self):
+        if self.expiresAt:
+            self.expiresAt = datetime.fromisoformat(self.expiresAt)
 
 
 class EnrollmentClient(Client):

--- a/tests/pytest/enrollment_switchio/test_views.py
+++ b/tests/pytest/enrollment_switchio/test_views.py
@@ -92,7 +92,7 @@ class TestIndexView:
                 status=Status.SUCCESS,
                 registration_status=RegistrationStatus(
                     regState="tokenization_finished",
-                    created=datetime.now(),
+                    created=datetime.now().isoformat(),
                     mode="register",
                     eshopResponseMode="query",
                     tokens=[
@@ -130,7 +130,7 @@ class TestIndexView:
                 status=Status.SUCCESS,
                 registration_status=RegistrationStatus(
                     regState="verification_failed",
-                    created=datetime.now(),
+                    created=datetime.now().isoformat(),
                     mode="register",
                     eshopResponseMode="query",
                     tokens=[],
@@ -158,7 +158,7 @@ class TestIndexView:
                 status=Status.SUCCESS,
                 registration_status=RegistrationStatus(
                     regState="tokenization_failed",
-                    created=datetime.now(),
+                    created=datetime.now().isoformat(),
                     mode="register",
                     eshopResponseMode="query",
                     tokens=[],
@@ -367,7 +367,7 @@ class TestGatewayUrlView:
                 status=Status.SUCCESS,
                 registration_status=RegistrationStatus(
                     regState="created",
-                    created=datetime.now(),
+                    created=datetime.now().isoformat(),
                     mode="register",
                     eshopResponseMode="query",
                     tokens=[],
@@ -405,7 +405,7 @@ class TestGatewayUrlView:
                 status=Status.SUCCESS,
                 registration_status=RegistrationStatus(
                     regState=regState,
-                    created=datetime.now(),
+                    created=datetime.now().isoformat(),
                     mode="register",
                     eshopResponseMode="query",
                     tokens=[],


### PR DESCRIPTION
Part of #2993

Adds a `__post_init__` method to `RegistrationStatus` and `GroupExpiry` so that their datetime fields are parsed into Python datetime objects. We need `GroupExpiry.expiresAt` to be a datetime object to implement enrollment of expiring discounts.