### PR TITLE
Docs: update URL for project board

### DIFF
--- a/docs/enrollment-pathways/README.md
+++ b/docs/enrollment-pathways/README.md
@@ -77,5 +77,5 @@ timeline
 }%%
 ```
 
-[board]: https://github.com/orgs/compilerla/projects/6/views/7
+[board]: https://github.com/orgs/compilerla/projects/6/views/8
 [milestones]: https://github.com/cal-itp/benefits/milestones

--- a/docs/enrollment-pathways/README.md
+++ b/docs/enrollment-pathways/README.md
@@ -77,5 +77,5 @@ timeline
 }%%
 ```
 
-[board]: https://github.com/orgs/cal-itp/projects/8/views/1
+[board]: https://github.com/orgs/compilerla/projects/6/views/7
 [milestones]: https://github.com/cal-itp/benefits/milestones


### PR DESCRIPTION
Project board URL now points to the Compiler Unified Sprint Board rather than the now-closed Digital Services project.