### PR TITLE
Fix: override request method for OAuth verified logic

### DIFF
--- a/benefits/oauth/hooks.py
+++ b/benefits/oauth/hooks.py
@@ -53,6 +53,10 @@ class OAuthHooks(DefaultHooks):
         flow = session.flow(request)
         eligibility_analytics.started_eligibility(request, flow)
 
+        # changing the method to POST since this now represents a verification success
+        # and we want to run the associated logic e.g. sending analytics events
+        # GET requests to the VerifiedView simply redirect to enrollment index
+        request.method = "POST"
         return VerifiedView().setup_and_dispatch(request)
 
     @classmethod

--- a/tests/pytest/oauth/test_hooks.py
+++ b/tests/pytest/oauth/test_hooks.py
@@ -69,15 +69,17 @@ def test_post_logout(app_request, mocked_oauth_analytics_module, origin):
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_session_agency", "mocked_session_flow_uses_claims_verification", "mocked_session_logged_in")
-def test_claims_verified_eligible(
-    mocker, app_request, mocked_oauth_analytics_module, mocked_session_update, mocked_eligibility_analytics_module
-):
+def test_claims_verified_eligible(mocker, app_request, mocked_oauth_analytics_module, mocked_session_update):
+    assert app_request.method == "GET"
+
     mock_cls = mocker.patch.object(benefits.oauth.hooks, "VerifiedView")
     mock_view = mock_cls.return_value
 
     result = OAuthHooks.claims_verified_eligible(app_request, ClaimsVerificationRequest(), ClaimsResult())
 
     mock_cls.assert_called_once()
+    # the method should have been changed to POST
+    assert app_request.method == "POST"
     mock_view.setup_and_dispatch.assert_called_once_with(app_request)
     assert result == mock_view.setup_and_dispatch.return_value
 


### PR DESCRIPTION
Follow up to #3009.

The `VerifiedView` only runs e.g. session and analytics logic for POST requests. 

GET requests represent having a previously verified session (where we don't need to e.g. send another analytics event).

But the request coming back from the OAuth flow is a GET, so this PR temporarily overrides its method to POST in the hook that calls `VerifiedView`.