### PR TITLE
Docs - Fix: Update mobile sidebar color to match theme

### DIFF
--- a/docs/styles/theme.css
+++ b/docs/styles/theme.css
@@ -1,6 +1,7 @@
 [data-md-color-scheme="default"] {
   --md-primary-fg-color: #045b86;
   --md-accent-fg-color: #044869;
+  --md-primary-fg-color--dark: #045b86;
   --md-footer-fg-color: hsla(0, 0%, 100%, 1);
   --md-footer-fg-color--light: hsla(0, 0%, 100%, 1);
   --md-footer-fg-color--lighter: hsla(0, 0%, 100%, 1);


### PR DESCRIPTION
closes #2899 

## Before vs. after
<img width="900" height="898" alt="image" src="https://github.com/user-attachments/assets/da76db29-5b70-493a-9438-b7802ba4c8d3" />

## How to test
- Run the docs locally
- Test the docs in mobile mode
- Click on the nav
- Click the back arrow

## After this PR is merged
- All the Benefits family of repos' docs themes will be updated