### PR TITLE
Fix: remove anonymous blob access to storage account

### DIFF
--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -1,9 +1,10 @@
 resource "azurerm_storage_account" "main" {
-  name                     = "sacdtcalitp${lower(local.env_letter)}001"
-  location                 = data.azurerm_resource_group.main.location
-  resource_group_name      = data.azurerm_resource_group.main.name
-  account_tier             = "Standard"
-  account_replication_type = "RAGRS"
+  name                            = "sacdtcalitp${lower(local.env_letter)}001"
+  location                        = data.azurerm_resource_group.main.location
+  resource_group_name             = data.azurerm_resource_group.main.name
+  account_tier                    = "Standard"
+  account_replication_type        = "RAGRS"
+  allow_nested_items_to_be_public = false
 
   blob_properties {
     last_access_time_enabled = true


### PR DESCRIPTION
Closes #3059 

Adds `allow_nested_items_to_be_public = false` to storage account definition.