### PR TITLE
Feat: base Enrollment view for in-person

### DIFF
--- a/benefits/core/models/transit.py
+++ b/benefits/core/models/transit.py
@@ -197,6 +197,21 @@ class TransitAgency(models.Model):
             return None
 
     @property
+    def in_person_enrollment_index_route(self):
+        """This Agency's in-person enrollment index route, based on its configured transit processor."""
+        if self.littlepay_config:
+            return routes.IN_PERSON_ENROLLMENT_LITTLEPAY_INDEX
+        elif self.switchio_config:
+            return routes.IN_PERSON_ENROLLMENT_SWITCHIO_INDEX
+        else:
+            raise ValueError(
+                (
+                    "TransitAgency must have either a LittlepayConfig or SwitchioConfig "
+                    "in order to show in-person enrollment index."
+                )
+            )
+
+    @property
     def enrollment_index_route(self):
         """This Agency's enrollment index route, based on its configured transit processor."""
         if self.littlepay_config:

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -28,11 +28,8 @@ class IndexView(AgencySessionRequiredMixin, EligibleSessionRequiredMixin, Redire
 
     route_origin = routes.ENROLLMENT_INDEX
 
-    def get_target_route_name(self):
-        return self.agency.enrollment_index_route
-
     def get_redirect_url(self, *args, **kwargs):
-        route_name = self.get_target_route_name()
+        route_name = self.agency.enrollment_index_route
         return reverse(route_name)
 
     def get(self, request, *args, **kwargs):

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -26,8 +26,12 @@ logger = logging.getLogger(__name__)
 class IndexView(AgencySessionRequiredMixin, EligibleSessionRequiredMixin, RedirectView):
     """CBV for the enrollment landing page."""
 
+    def get_target_route_name(self):
+        return self.agency.enrollment_index_route
+
     def get_redirect_url(self, *args, **kwargs):
-        return reverse(self.agency.enrollment_index_route)
+        route_name = self.get_target_route_name()
+        return reverse(route_name)
 
     def get(self, request, *args, **kwargs):
         session.update(request, origin=reverse(routes.ENROLLMENT_INDEX))

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -26,6 +26,8 @@ logger = logging.getLogger(__name__)
 class IndexView(AgencySessionRequiredMixin, EligibleSessionRequiredMixin, RedirectView):
     """CBV for the enrollment landing page."""
 
+    route_origin = routes.ENROLLMENT_INDEX
+
     def get_target_route_name(self):
         return self.agency.enrollment_index_route
 
@@ -34,7 +36,7 @@ class IndexView(AgencySessionRequiredMixin, EligibleSessionRequiredMixin, Redire
         return reverse(route_name)
 
     def get(self, request, *args, **kwargs):
-        session.update(request, origin=reverse(routes.ENROLLMENT_INDEX))
+        session.update(request, origin=reverse(self.route_origin))
         return super().get(request, *args, **kwargs)
 
 

--- a/benefits/in_person/urls.py
+++ b/benefits/in_person/urls.py
@@ -11,7 +11,17 @@ urlpatterns = [
         "eligibility/", admin.site.admin_view(views.EligibilityView.as_view()), name=routes.name(routes.IN_PERSON_ELIGIBILITY)
     ),
     path("token/", admin.site.admin_view(views.token), name=routes.name(routes.IN_PERSON_ENROLLMENT_TOKEN)),
-    path("enrollment/", admin.site.admin_view(views.enrollment), name=routes.name(routes.IN_PERSON_ENROLLMENT)),
+    path("enrollment/", admin.site.admin_view(views.EnrollmentView.as_view()), name=routes.name(routes.IN_PERSON_ENROLLMENT)),
+    path(
+        "enrollment/littlepay",
+        admin.site.admin_view(views.enrollment),
+        name=routes.name(routes.IN_PERSON_ENROLLMENT_LITTLEPAY_INDEX),
+    ),
+    path(
+        "enrollment/switchio",
+        admin.site.admin_view(views.enrollment),
+        name=routes.name(routes.IN_PERSON_ENROLLMENT_SWITCHIO_INDEX),
+    ),
     path(
         "enrollment/error/reenrollment",
         admin.site.admin_view(views.reenrollment_error),

--- a/benefits/in_person/views.py
+++ b/benefits/in_person/views.py
@@ -10,6 +10,7 @@ import sentry_sdk
 
 
 from benefits.core.models.transit import TransitAgency
+from benefits.enrollment.views import IndexView
 from benefits.routes import routes
 from benefits.core import models, session
 from benefits.eligibility import analytics as eligibility_analytics
@@ -98,6 +99,14 @@ def token(request):
     data = {"token": session.access_token}
 
     return JsonResponse(data)
+
+
+class EnrollmentView(IndexView):
+
+    route_origin = routes.IN_PERSON_ENROLLMENT
+
+    def get_target_route_name(self):
+        return self.agency.in_person_enrollment_index_route
 
 
 def enrollment(request):

--- a/benefits/in_person/views.py
+++ b/benefits/in_person/views.py
@@ -105,8 +105,9 @@ class EnrollmentView(IndexView):
 
     route_origin = routes.IN_PERSON_ENROLLMENT
 
-    def get_target_route_name(self):
-        return self.agency.in_person_enrollment_index_route
+    def get_redirect_url(self, *args, **kwargs):
+        route_name = self.agency.in_person_enrollment_index_route
+        return reverse(route_name)
 
 
 def enrollment(request):

--- a/benefits/routes.py
+++ b/benefits/routes.py
@@ -140,6 +140,16 @@ class Routes:
         return "in_person:enrollment"
 
     @property
+    def IN_PERSON_ENROLLMENT_LITTLEPAY_INDEX(self):
+        """In-person (e.g. agency assisted) enrollment using Littlepay"""
+        return "in_person:enrollment_littlepay_index"
+
+    @property
+    def IN_PERSON_ENROLLMENT_SWITCHIO_INDEX(self):
+        """In-person (e.g. agency assisted) enrollment using Switchio"""
+        return "in_person:enrollment_switchio_index"
+
+    @property
     def IN_PERSON_ENROLLMENT_TOKEN(self):
         """Acquire a TransitProcessor API token for in-person enrollment."""
         return "in_person:token"

--- a/tests/pytest/core/models/test_transit.py
+++ b/tests/pytest/core/models/test_transit.py
@@ -204,3 +204,31 @@ def test_TransitAgency_enrollment_index_route_no_config(model_TransitAgency):
         match="TransitAgency must have either a LittlepayConfig or SwitchioConfig in order to show enrollment index.",
     ):
         model_TransitAgency.enrollment_index_route
+
+
+@pytest.mark.django_db
+def test_TransitAgency_in_person_enrollment_index_route_littlepay(model_TransitAgency, model_LittlepayConfig):
+    model_LittlepayConfig.transit_agency = model_TransitAgency
+    model_TransitAgency.save()
+
+    assert model_TransitAgency.in_person_enrollment_index_route == routes.IN_PERSON_ENROLLMENT_LITTLEPAY_INDEX
+
+
+@pytest.mark.django_db
+def test_TransitAgency_in_person_enrollment_index_route_switchio(model_TransitAgency, model_SwitchioConfig):
+    model_SwitchioConfig.transit_agency = model_TransitAgency
+    model_TransitAgency.save()
+
+    assert model_TransitAgency.in_person_enrollment_index_route == routes.IN_PERSON_ENROLLMENT_SWITCHIO_INDEX
+
+
+@pytest.mark.django_db
+def test_TransitAgency_in_person_enrollment_index_route_no_config(model_TransitAgency):
+    with pytest.raises(
+        ValueError,
+        match=(
+            "TransitAgency must have either a LittlepayConfig or SwitchioConfig "
+            "in order to show in-person enrollment index."
+        ),
+    ):
+        model_TransitAgency.in_person_enrollment_index_route

--- a/tests/pytest/enrollment/test_views.py
+++ b/tests/pytest/enrollment/test_views.py
@@ -38,6 +38,9 @@ class TestIndexView:
         v.agency = model_LittlepayConfig.transit_agency
         return v
 
+    def test_get_target_route_name(self, view):
+        assert view.get_target_route_name() == view.agency.enrollment_index_route
+
     def test_get_redirect_url(self, view):
 
         assert view.get_redirect_url() == reverse(view.agency.enrollment_index_route)

--- a/tests/pytest/enrollment/test_views.py
+++ b/tests/pytest/enrollment/test_views.py
@@ -38,9 +38,6 @@ class TestIndexView:
         v.agency = model_LittlepayConfig.transit_agency
         return v
 
-    def test_get_target_route_name(self, view):
-        assert view.get_target_route_name() == view.agency.enrollment_index_route
-
     def test_get_redirect_url(self, view):
 
         assert view.get_redirect_url() == reverse(view.agency.enrollment_index_route)

--- a/tests/pytest/in_person/test_views.py
+++ b/tests/pytest/in_person/test_views.py
@@ -285,8 +285,8 @@ class TestEnrollmentView:
         v.agency = mocked_session_agency_littlepay(app_request)
         return v
 
-    def test_get_target_route_name_for_littlepay(self, view):
-        assert view.get_target_route_name() == routes.IN_PERSON_ENROLLMENT_LITTLEPAY_INDEX
+    def test_get_redirect_url_for_littlepay(self, view):
+        assert view.get_redirect_url() == reverse(view.agency.in_person_enrollment_index_route)
 
 
 @pytest.mark.django_db

--- a/tests/pytest/in_person/test_views.py
+++ b/tests/pytest/in_person/test_views.py
@@ -49,6 +49,13 @@ def mocked_transit_agency_class(mocker):
     return mocker.patch.object(benefits.in_person.views, "TransitAgency")
 
 
+@pytest.fixture
+def mocked_session_agency_littlepay(mocker, model_TransitAgency, model_LittlepayConfig):
+    model_LittlepayConfig.transit_agency = model_TransitAgency
+    model_TransitAgency.save()
+    return mocker.patch("benefits.core.session.agency", autospec=True, return_value=model_TransitAgency)
+
+
 @pytest.mark.django_db
 @pytest.mark.parametrize("viewname", [routes.IN_PERSON_ELIGIBILITY, routes.IN_PERSON_ENROLLMENT])
 def test_view_not_logged_in(client, viewname):
@@ -270,9 +277,22 @@ def test_token_connection_error(mocker, admin_client, mocked_enrollment_analytic
 
 
 @pytest.mark.django_db
+class TestEnrollmentView:
+    @pytest.fixture
+    def view(self, app_request, mocked_session_agency_littlepay):
+        v = benefits.in_person.views.EnrollmentView()
+        v.setup(app_request)
+        v.agency = mocked_session_agency_littlepay(app_request)
+        return v
+
+    def test_get_target_route_name_for_littlepay(self, view):
+        assert view.get_target_route_name() == routes.IN_PERSON_ENROLLMENT_LITTLEPAY_INDEX
+
+
+@pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_session_agency", "mocked_session_flow", "model_LittlepayConfig")
 def test_enrollment_logged_in_get(admin_client):
-    path = reverse(routes.IN_PERSON_ENROLLMENT)
+    path = reverse(routes.IN_PERSON_ENROLLMENT_LITTLEPAY_INDEX)
 
     response = admin_client.get(path)
     assert response.status_code == 200
@@ -291,7 +311,7 @@ def test_enrollment_logged_in_get(admin_client):
 @pytest.mark.django_db
 @pytest.mark.usefixtures("mocked_session_agency", "mocked_session_flow", "mocked_session_eligible")
 def test_enrollment_post_invalid_form(admin_client, invalid_form_data):
-    path = reverse(routes.IN_PERSON_ENROLLMENT)
+    path = reverse(routes.IN_PERSON_ENROLLMENT_LITTLEPAY_INDEX)
 
     with pytest.raises(Exception, match=r"form"):
         admin_client.post(path, invalid_form_data)
@@ -316,7 +336,7 @@ def test_enrollment_post_valid_form_success(
     # e.g. the TransitAgency staff person assisting this in-person enrollment
     admin_client.force_login(model_User)
 
-    path = reverse(routes.IN_PERSON_ENROLLMENT)
+    path = reverse(routes.IN_PERSON_ENROLLMENT_LITTLEPAY_INDEX)
     response = admin_client.post(path, card_tokenize_form_data)
 
     spy.assert_called_once_with(
@@ -339,7 +359,7 @@ def test_enrollment_post_valid_form_system_error(
 ):
     mocker.patch("benefits.in_person.views.enroll", return_value=(Status.SYSTEM_ERROR, None))
 
-    path = reverse(routes.IN_PERSON_ENROLLMENT)
+    path = reverse(routes.IN_PERSON_ENROLLMENT_LITTLEPAY_INDEX)
     response = admin_client.post(path, card_tokenize_form_data)
 
     assert response.status_code == 302
@@ -355,7 +375,7 @@ def test_enrollment_post_valid_form_exception(
 ):
     mocker.patch("benefits.in_person.views.enroll", return_value=(Status.EXCEPTION, None))
 
-    path = reverse(routes.IN_PERSON_ENROLLMENT)
+    path = reverse(routes.IN_PERSON_ENROLLMENT_LITTLEPAY_INDEX)
     response = admin_client.post(path, card_tokenize_form_data)
 
     assert response.status_code == 302
@@ -371,7 +391,7 @@ def test_enrollment_post_valid_form_reenrollment_error(
 ):
     mocker.patch("benefits.in_person.views.enroll", return_value=(Status.REENROLLMENT_ERROR, None))
 
-    path = reverse(routes.IN_PERSON_ENROLLMENT)
+    path = reverse(routes.IN_PERSON_ENROLLMENT_LITTLEPAY_INDEX)
     response = admin_client.post(path, card_tokenize_form_data)
 
     assert response.status_code == 302


### PR DESCRIPTION
Closes #3075

This PR defines a base Enrollment view for in-person. The new base view inherits from `IndexView` on the Digital side and redirects to the appropriate in-person enrollment view based on the transit agency.

## Notes

- The in_person `urls.py` file has placeholders for `enrollment/littlepay` and `"enrollment/switchio` but both are associated with the current `enrollment` (Littlepay) view so that the app continues to work during this in-person refactor.
- ~The refactor in be4445ae1512eabadbe8970a7cb76e563a8df996 tried to make the least amount of changes to `TransitAgency` yet still introduce a way for it to support in-person too. We could replace this with a more significant refactor (such as changing `enrollment_index_route` from a property to a function and passing in the enrollment URLs, like the proposed `get_route_by_processor`, where the view is responsible for passing in the URLs). This wouldn't require too many changes since `enrollment_index_route` is only called in one place in the code, most changes would be related to updating tests.~

## Reviewing

1. Start the app with `F5`
2. In the browser, enter the URL `/admin`
3. Log in with `cst-user`
4. Run through an enrollment and verify that you reach the `in_person/enrollment/littlepay` page after selecting an eligibility type

Also ensure that the Digital side still works.

