### PR TITLE
Feat: Support in-person for Switchio

### DIFF
--- a/benefits/enrollment/enrollment.py
+++ b/benefits/enrollment/enrollment.py
@@ -23,7 +23,16 @@ class Status(Enum):
     REENROLLMENT_ERROR = 4
 
 
-def handle_enrollment_results(request, status: Status, exception: Exception):
+def handle_enrollment_results(
+    request,
+    status: Status,
+    verified_by: str,
+    exception: Exception = None,
+    enrollment_method: str = models.EnrollmentMethods.DIGITAL,
+    route_reenrollment_error=routes.ENROLLMENT_REENROLLMENT_ERROR,
+    route_success=routes.ENROLLMENT_SUCCESS,
+    route_system_error=routes.ENROLLMENT_SYSTEM_ERROR,
+):
     match (status):
         case Status.SUCCESS:
             agency = session.agency(request)
@@ -38,24 +47,26 @@ def handle_enrollment_results(request, status: Status, exception: Exception):
             event = models.EnrollmentEvent.objects.create(
                 transit_agency=agency,
                 enrollment_flow=flow,
-                enrollment_method=models.EnrollmentMethods.DIGITAL,
-                verified_by=flow.eligibility_verifier,
+                enrollment_method=enrollment_method,
+                verified_by=verified_by,
                 expiration_datetime=expiry,
                 extra_claims=str_extra_claims,
             )
             event.save()
-            analytics.returned_success(request, flow.group_id, extra_claims=oauth_extra_claims)
-            return redirect(routes.ENROLLMENT_SUCCESS)
+            analytics.returned_success(
+                request, enrollment_group=flow.group_id, enrollment_method=enrollment_method, extra_claims=oauth_extra_claims
+            )
+            return redirect(route_success)
 
         case Status.SYSTEM_ERROR:
-            analytics.returned_error(request, str(exception))
+            analytics.returned_error(request, str(exception), enrollment_method=enrollment_method)
             sentry_sdk.capture_exception(exception)
-            return redirect(routes.ENROLLMENT_SYSTEM_ERROR)
+            return redirect(route_system_error)
 
         case Status.EXCEPTION:
-            analytics.returned_error(request, str(exception))
+            analytics.returned_error(request, str(exception), enrollment_method=enrollment_method)
             raise exception
 
         case Status.REENROLLMENT_ERROR:
-            analytics.returned_error(request, "Re-enrollment error.")
-            return redirect(routes.ENROLLMENT_REENROLLMENT_ERROR)
+            analytics.returned_error(request, "Re-enrollment error.", enrollment_method=enrollment_method)
+            return redirect(route_reenrollment_error)

--- a/benefits/enrollment_switchio/enrollment.py
+++ b/benefits/enrollment_switchio/enrollment.py
@@ -46,7 +46,9 @@ class Token:
     par: str = None
 
 
-def request_registration(request, switchio_config: SwitchioConfig) -> RegistrationResponse:
+def request_registration(
+    request, switchio_config: SwitchioConfig, redirect_route: str = routes.ENROLLMENT_SWITCHIO_INDEX
+) -> RegistrationResponse:
     try:
         client = TokenizationClient(
             api_url=switchio_config.tokenization_api_base_url,
@@ -57,7 +59,7 @@ def request_registration(request, switchio_config: SwitchioConfig) -> Registrati
             ca_certificate=switchio_config.ca_certificate_data,
         )
 
-        route = reverse(routes.ENROLLMENT_SWITCHIO_INDEX)
+        route = reverse(redirect_route)
         redirect_url = _generate_redirect_uri(request, route)
 
         registration = client.request_registration(

--- a/benefits/enrollment_switchio/templates/enrollment_switchio/index.html
+++ b/benefits/enrollment_switchio/templates/enrollment_switchio/index.html
@@ -1,79 +1,8 @@
 {% extends "enrollment/index-base.html" %}
-{% load i18n %}
 
 {% block enrollment-form %}
 
-  {% translate "Please wait..." as loading_text %}
-
-  <script type="module" nonce="{{ request.csp_nonce }}">
-    import { StRpClient } from 'https://cdn.jsdelivr.net/npm/@switchio/st-rp-sdk@1.0.2/index.min.js';
-
-    function tokenizeWithRedirect(gtwUrl) {
-      StRpClient.tokenizeWithRedirect({
-        tokenizationParams: { uri: gtwUrl },
-        state: 'tokenize',
-        locale: '{{ locale }}',
-      });
-    };
-
-    const startedEvent = "started card tokenization";
-    const closedEvent = "finished card tokenization";
-
-    let returned_from_tokenization = window.location.href.search('state=tokenize') > -1;
-
-    if (returned_from_tokenization) {
-      StRpClient.handleTokenizeWithRedirectCallback().then((response) => {
-        if (response.type === 'success') {
-          amplitude.getInstance().logEvent(closedEvent, {status: "success", enrollment_method: "{{ enrollment_method }}"});
-
-          let form = document.querySelector("form#{{ form_success }}");
-          form.querySelector("#card_token").value = "{{ card_token }}";
-          form.submit();
-        } else if (response.error != "canceled") {
-          amplitude.getInstance().logEvent(closedEvent, {status: "error", error: response.error, enrollment_method: "{{ enrollment_method }}"});
-
-          let form = document.querySelector("form#{{ form_system_error }}");
-          form.submit();
-        } else {
-          amplitude.getInstance().logEvent(closedEvent, {status: "cancel", enrollment_method: "{{ enrollment_method }}"});
-        }
-      });
-    }
-
-    fetch("{% url routes.ENROLLMENT_SWITCHIO_GATEWAY_URL %}")
-        .then(response => response.json()
-        .then(data => {
-          if (data.redirect) {
-            // https://stackoverflow.com/a/42469170
-            // use 'assign' because 'replace' was giving strange Back button behavior
-            window.location.assign(data.redirect);
-            return; // exit early so the rest of this function doesn't execute
-          }
-
-          document.querySelector(".loading").remove();
-
-          // remove invisible and add back visible, so we aren't left with
-          // a div with an empty class attribute
-          // (this is purely for clarity when reviewing the HTML, no UX impact)
-          let invisibleElement = document.querySelector(".invisible");
-          invisibleElement.classList.remove("invisible");
-          invisibleElement.classList.add("visible");
-
-          let ctaButton = document.getElementById("{{ cta_button }}");
-          ctaButton.addEventListener("click", event => {
-            amplitude.getInstance().logEvent(startedEvent, {
-              enrollment_method: "{{ enrollment_method }}"
-            });
-
-            ctaButton.classList.add("disabled");
-            ctaButton.setAttribute("aria-disabled", "true");
-            ctaButton.textContent = "{{ loading_text }}";
-
-            // open the tokenization gateway
-            tokenizeWithRedirect(data.gateway_url)
-          });
-        }));
-  </script>
+  {% include "enrollment_switchio/script.html" with gateway_url_route=routes.ENROLLMENT_SWITCHIO_GATEWAY_URL %}
 
   {% for f in forms %}
     {% include "core/includes/form.html" with form=f %}

--- a/benefits/enrollment_switchio/templates/enrollment_switchio/script.html
+++ b/benefits/enrollment_switchio/templates/enrollment_switchio/script.html
@@ -1,0 +1,73 @@
+{% load i18n %}
+
+{% translate "Please wait..." as loading_text %}
+
+<script type="module" nonce="{{ request.csp_nonce }}">
+  import { StRpClient } from 'https://cdn.jsdelivr.net/npm/@switchio/st-rp-sdk@1.0.2/index.min.js';
+
+  function tokenizeWithRedirect(gtwUrl) {
+    StRpClient.tokenizeWithRedirect({
+      tokenizationParams: { uri: gtwUrl },
+      state: 'tokenize',
+      locale: '{{ locale }}',
+    });
+  };
+
+  const startedEvent = "started card tokenization";
+  const closedEvent = "finished card tokenization";
+
+  let returned_from_tokenization = window.location.href.search('state=tokenize') > -1;
+
+  if (returned_from_tokenization) {
+    StRpClient.handleTokenizeWithRedirectCallback().then((response) => {
+      if (response.type === 'success') {
+        amplitude.getInstance().logEvent(closedEvent, {status: "success", enrollment_method: "{{ enrollment_method }}"});
+
+        let form = document.querySelector("form#{{ form_success }}");
+        form.querySelector("#card_token").value = "{{ card_token }}";
+        form.submit();
+      } else if (response.error != "canceled") {
+        amplitude.getInstance().logEvent(closedEvent, {status: "error", error: response.error, enrollment_method: "{{ enrollment_method }}"});
+
+        let form = document.querySelector("form#{{ form_system_error }}");
+        form.submit();
+      } else {
+        amplitude.getInstance().logEvent(closedEvent, {status: "cancel", enrollment_method: "{{ enrollment_method }}"});
+      }
+    });
+  }
+
+  fetch("{% url gateway_url_route %}")
+    .then(response => response.json()
+    .then(data => {
+      if (data.redirect) {
+        // https://stackoverflow.com/a/42469170
+        // use 'assign' because 'replace' was giving strange Back button behavior
+        window.location.assign(data.redirect);
+        return; // exit early so the rest of this function doesn't execute
+      }
+
+      document.querySelector(".loading").remove();
+
+      // remove invisible and add back visible, so we aren't left with
+      // a div with an empty class attribute
+      // (this is purely for clarity when reviewing the HTML, no UX impact)
+      let invisibleElement = document.querySelector(".invisible");
+      invisibleElement.classList.remove("invisible");
+      invisibleElement.classList.add("visible");
+
+      let ctaButton = document.getElementById("{{ cta_button }}");
+      ctaButton.addEventListener("click", event => {
+        amplitude.getInstance().logEvent(startedEvent, {
+          enrollment_method: "{{ enrollment_method }}"
+        });
+
+        ctaButton.classList.add("disabled");
+        ctaButton.setAttribute("aria-disabled", "true");
+        ctaButton.textContent = "{{ loading_text }}";
+
+        // open the tokenization gateway
+        tokenizeWithRedirect(data.gateway_url)
+      });
+    }));
+</script>

--- a/benefits/enrollment_switchio/views.py
+++ b/benefits/enrollment_switchio/views.py
@@ -67,6 +67,9 @@ class IndexView(AgencySessionRequiredMixin, FlowSessionRequiredMixin, EligibleSe
         locale = {"en": "en", "es": "es"}.get(django_language_code, "en")
         return locale
 
+    def _get_verified_by(self):
+        return self.flow.eligibility_verifier
+
     def get(self, request: HttpRequest, *args, **kwargs):
         session = Session(request)
         switchio_config = self.agency.switchio_config
@@ -107,7 +110,7 @@ class IndexView(AgencySessionRequiredMixin, FlowSessionRequiredMixin, EligibleSe
         return handle_enrollment_results(
             request=self.request,
             status=status,
-            verified_by=flow.eligibility_verifier,
+            verified_by=self._get_verified_by(),
             exception=exception,
             enrollment_method=self.enrollment_method,
             route_reenrollment_error=self.route_reenrollment_error,

--- a/benefits/enrollment_switchio/views.py
+++ b/benefits/enrollment_switchio/views.py
@@ -25,8 +25,15 @@ logger = logging.getLogger(__name__)
 class IndexView(AgencySessionRequiredMixin, FlowSessionRequiredMixin, EligibleSessionRequiredMixin, FormView):
     """View for the enrollment landing page."""
 
-    template_name = "enrollment_switchio/index.html"
+    enrollment_method = models.EnrollmentMethods.DIGITAL
     form_class = forms.CardTokenizeSuccessForm
+    route_enrollment_success = routes.ENROLLMENT_SUCCESS
+    route_reenrollment_error = routes.ENROLLMENT_REENROLLMENT_ERROR
+    route_retry = routes.ENROLLMENT_RETRY
+    route_system_error = routes.ENROLLMENT_SYSTEM_ERROR
+    route_server_error = routes.SERVER_ERROR
+    route_tokenize_success = routes.ENROLLMENT_SWITCHIO_INDEX
+    template_name = "enrollment_switchio/index.html"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -35,10 +42,10 @@ class IndexView(AgencySessionRequiredMixin, FlowSessionRequiredMixin, EligibleSe
         flow = self.flow
 
         tokenize_system_error_form = forms.CardTokenizeFailForm(
-            routes.ENROLLMENT_SYSTEM_ERROR, "form-card-tokenize-fail-system-error"
+            self.route_system_error, "form-card-tokenize-fail-system-error"
         )
         tokenize_success_form = forms.CardTokenizeSuccessForm(
-            action_url=routes.ENROLLMENT_SWITCHIO_INDEX, auto_id=True, label_suffix=""
+            action_url=self.route_tokenize_success, auto_id=True, label_suffix=""
         )
         context.update(
             {
@@ -47,7 +54,7 @@ class IndexView(AgencySessionRequiredMixin, FlowSessionRequiredMixin, EligibleSe
                 "form_success": tokenize_success_form.id,
                 "form_system_error": tokenize_system_error_form.id,
                 "cta_button": "tokenize_card",
-                "enrollment_method": models.EnrollmentMethods.DIGITAL,
+                "enrollment_method": self.enrollment_method,
                 "transit_processor": {"name": "Switchio", "website": "https://switchio.com/transport/"},
                 "locale": self._get_locale(request.LANGUAGE_CODE),
             }
@@ -77,17 +84,17 @@ class IndexView(AgencySessionRequiredMixin, FlowSessionRequiredMixin, EligibleSe
                     context_data["card_token"] = get_latest_active_token_value(response.registration_status.tokens)
                     return self.render_to_response(context=context_data)
                 elif reg_state == "verification_failed":
-                    return redirect(routes.ENROLLMENT_RETRY)
+                    return redirect(self.route_retry)
                 elif reg_state == "tokenization_failed":
                     sentry_sdk.capture_exception(Exception("Tokenization failed"))
-                    return redirect(routes.ENROLLMENT_SYSTEM_ERROR)
+                    return redirect(self.route_system_error)
             else:
                 sentry_sdk.capture_exception(response.exception)
 
                 if response.status is Status.SYSTEM_ERROR:
-                    return redirect(routes.ENROLLMENT_SYSTEM_ERROR)
+                    return redirect(self.route_system_error)
                 elif response.status is Status.EXCEPTION:
-                    return redirect(routes.SERVER_ERROR)
+                    return redirect(self.route_server_error)
 
         return super().get(request=request, *args, **kwargs)
 
@@ -97,7 +104,16 @@ class IndexView(AgencySessionRequiredMixin, FlowSessionRequiredMixin, EligibleSe
         card_token = form.cleaned_data.get("card_token")
 
         status, exception = enroll(switchio_config=switchio_config, flow=flow, token=card_token)
-        return handle_enrollment_results(self.request, status, exception)
+        return handle_enrollment_results(
+            request=self.request,
+            status=status,
+            verified_by=flow.eligibility_verifier,
+            exception=exception,
+            enrollment_method=self.enrollment_method,
+            route_reenrollment_error=self.route_reenrollment_error,
+            route_success=self.route_enrollment_success,
+            route_system_error=self.route_system_error,
+        )
 
 
 class GatewayUrlView(AgencySessionRequiredMixin, EligibleSessionRequiredMixin, View):

--- a/benefits/enrollment_switchio/views.py
+++ b/benefits/enrollment_switchio/views.py
@@ -104,6 +104,7 @@ class GatewayUrlView(AgencySessionRequiredMixin, EligibleSessionRequiredMixin, V
     """View for the tokenization gateway registration"""
 
     enrollment_method = models.EnrollmentMethods.DIGITAL
+    route_redirect = routes.ENROLLMENT_SWITCHIO_INDEX
     route_system_error = routes.ENROLLMENT_SYSTEM_ERROR
     route_server_error = routes.SERVER_ERROR
 
@@ -136,7 +137,7 @@ class GatewayUrlView(AgencySessionRequiredMixin, EligibleSessionRequiredMixin, V
                 return JsonResponse(data)
 
     def _request_registration(self, request: HttpRequest, switchio_config: SwitchioConfig, session: Session) -> JsonResponse:
-        response = request_registration(request, switchio_config)
+        response = request_registration(request, switchio_config, self.route_redirect)
 
         if response.status is Status.SUCCESS:
             registration = response.registration

--- a/benefits/in_person/templates/in_person/enrollment/index_switchio.html
+++ b/benefits/in_person/templates/in_person/enrollment/index_switchio.html
@@ -1,0 +1,35 @@
+{% extends "admin/flow-base.html" %}
+
+{% block title %}
+  {{ title }}
+{% endblock title %}
+
+{% block flow-content %}
+  <div class="p-3">
+    <div class="loading">
+      <p>
+        <span class="spinner-border align-middle text-primary" role="status"></span>
+        <span id="loading-message" class="fw-bold p-2">Please wait...</span>
+      </p>
+    </div>
+    <div class="row d-flex justify-content-start p-3">
+      <div class="col-12">
+        <div class="invisible">
+          <button id="{{ cta_button }}" href="#{{ cta_button }}" class="btn btn-lg btn-primary" role="button">Enroll</button>
+        </div>
+      </div>
+    </div>
+    <div class="row d-flex justify-content-start p-3 pt-8">
+      <div class="col-12">
+        {% url routes.ADMIN_INDEX as url_cancel %}
+        <a href="{{ url_cancel }}" class="btn btn-lg btn-outline-primary d-block">Cancel</a>
+      </div>
+    </div>
+  </div>
+
+  {% include "enrollment_switchio/script.html" with gateway_url_route=routes.IN_PERSON_ENROLLMENT_SWITCHIO_GATEWAY_URL %}
+
+  {% for f in forms %}
+    {% include "core/includes/form.html" with form=f %}
+  {% endfor %}
+{% endblock flow-content %}

--- a/benefits/in_person/urls.py
+++ b/benefits/in_person/urls.py
@@ -10,33 +10,33 @@ urlpatterns = [
     path(
         "eligibility/", admin.site.admin_view(views.EligibilityView.as_view()), name=routes.name(routes.IN_PERSON_ELIGIBILITY)
     ),
-    path(
-        "enrollment/littlepay/token/",
-        admin.site.admin_view(views.LittlepayTokenView.as_view()),
-        name=routes.name(routes.IN_PERSON_ENROLLMENT_LITTLEPAY_TOKEN),
-    ),
     path("enrollment/", admin.site.admin_view(views.EnrollmentView.as_view()), name=routes.name(routes.IN_PERSON_ENROLLMENT)),
     path(
-        "enrollment/littlepay",
-        admin.site.admin_view(views.enrollment),
-        name=routes.name(routes.IN_PERSON_ENROLLMENT_LITTLEPAY_INDEX),
-    ),
-    path(
-        "enrollment/switchio",
-        admin.site.admin_view(views.enrollment),
-        name=routes.name(routes.IN_PERSON_ENROLLMENT_SWITCHIO_INDEX),
+        "enrollment/error",
+        admin.site.admin_view(views.system_error),
+        name=routes.name(routes.IN_PERSON_ENROLLMENT_SYSTEM_ERROR),
     ),
     path(
         "enrollment/error/reenrollment",
         admin.site.admin_view(views.reenrollment_error),
         name=routes.name(routes.IN_PERSON_ENROLLMENT_REENROLLMENT_ERROR),
     ),
+    path(
+        "enrollment/littlepay",
+        admin.site.admin_view(views.enrollment),
+        name=routes.name(routes.IN_PERSON_ENROLLMENT_LITTLEPAY_INDEX),
+    ),
+    path(
+        "enrollment/littlepay/token/",
+        admin.site.admin_view(views.LittlepayTokenView.as_view()),
+        name=routes.name(routes.IN_PERSON_ENROLLMENT_LITTLEPAY_TOKEN),
+    ),
     path("enrollment/retry", admin.site.admin_view(views.retry), name=routes.name(routes.IN_PERSON_ENROLLMENT_RETRY)),
     path("enrollment/success", admin.site.admin_view(views.success), name=routes.name(routes.IN_PERSON_ENROLLMENT_SUCCESS)),
     path(
-        "enrollment/error",
-        admin.site.admin_view(views.system_error),
-        name=routes.name(routes.IN_PERSON_ENROLLMENT_SYSTEM_ERROR),
+        "enrollment/switchio",
+        admin.site.admin_view(views.SwitchioEnrollmentIndexView.as_view()),
+        name=routes.name(routes.IN_PERSON_ENROLLMENT_SWITCHIO_INDEX),
     ),
     path(
         "enrollment/switchio/gateway_url",

--- a/benefits/in_person/urls.py
+++ b/benefits/in_person/urls.py
@@ -38,5 +38,10 @@ urlpatterns = [
         admin.site.admin_view(views.system_error),
         name=routes.name(routes.IN_PERSON_ENROLLMENT_SYSTEM_ERROR),
     ),
+    path(
+        "enrollment/switchio/gateway_url",
+        admin.site.admin_view(views.SwitchioGatewayUrlView.as_view()),
+        name=routes.name(routes.IN_PERSON_ENROLLMENT_SWITCHIO_GATEWAY_URL),
+    ),
     path("error/", admin.site.admin_view(views.server_error), name=routes.name(routes.IN_PERSON_SERVER_ERROR)),
 ]

--- a/benefits/in_person/views.py
+++ b/benefits/in_person/views.py
@@ -14,7 +14,9 @@ from benefits.enrollment import analytics as enrollment_analytics
 from benefits.enrollment.enrollment import Status
 from benefits.enrollment.views import IndexView
 from benefits.enrollment_littlepay.enrollment import get_card_types_for_js, enroll
+from benefits.enrollment_littlepay.session import Session as LittlepaySession
 from benefits.enrollment_littlepay.views import TokenView
+from benefits.enrollment_switchio.session import Session as SwitchioSession
 from benefits.enrollment_switchio.views import GatewayUrlView, IndexView as SwitchioIndexView
 from benefits.in_person import forms
 from benefits.routes import routes
@@ -30,6 +32,9 @@ class EligibilityView(FormView):
 
     def dispatch(self, request, *args, **kwargs):
         """Initialize session state before handling the request."""
+
+        LittlepaySession(request, reset=True)
+        SwitchioSession(request, reset=True)
 
         agency = session.agency(request)
         if not agency:

--- a/benefits/in_person/views.py
+++ b/benefits/in_person/views.py
@@ -1,25 +1,23 @@
 import logging
 
+import sentry_sdk
 from django.contrib.admin import site as admin_site
-from django.template.response import TemplateResponse
 from django.shortcuts import redirect
+from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.views.generic import FormView
-import sentry_sdk
-
 
 from benefits.core.models.transit import TransitAgency
-from benefits.enrollment.views import IndexView
-from benefits.routes import routes
 from benefits.core import models, session
 from benefits.eligibility import analytics as eligibility_analytics
 from benefits.enrollment import analytics as enrollment_analytics
 from benefits.enrollment.enrollment import Status
+from benefits.enrollment.views import IndexView
 from benefits.enrollment_littlepay.enrollment import get_card_types_for_js, enroll
 from benefits.enrollment_littlepay.views import TokenView
-from benefits.enrollment_switchio.views import GatewayUrlView
-
+from benefits.enrollment_switchio.views import GatewayUrlView, IndexView as SwitchioIndexView
 from benefits.in_person import forms
+from benefits.routes import routes
 
 logger = logging.getLogger(__name__)
 
@@ -251,3 +249,15 @@ class SwitchioGatewayUrlView(GatewayUrlView):
     enrollment_method = models.EnrollmentMethods.IN_PERSON
     route_server_error = routes.IN_PERSON_SERVER_ERROR
     route_system_error = routes.IN_PERSON_ENROLLMENT_SYSTEM_ERROR
+
+
+class SwitchioEnrollmentIndexView(SwitchioIndexView):
+    enrollment_method = models.EnrollmentMethods.IN_PERSON
+    form_class = forms.CardTokenizeSuccessForm
+    route_enrollment_success = routes.IN_PERSON_ENROLLMENT_SUCCESS
+    route_reenrollment_error = routes.IN_PERSON_ENROLLMENT_REENROLLMENT_ERROR
+    route_retry = routes.IN_PERSON_ENROLLMENT_RETRY
+    route_server_error = routes.IN_PERSON_SERVER_ERROR
+    route_system_error = routes.IN_PERSON_ENROLLMENT_SYSTEM_ERROR
+    route_tokenize_success = routes.IN_PERSON_ENROLLMENT_SWITCHIO_INDEX
+    template_name = ""

--- a/benefits/in_person/views.py
+++ b/benefits/in_person/views.py
@@ -17,6 +17,7 @@ from benefits.enrollment import analytics as enrollment_analytics
 from benefits.enrollment.enrollment import Status
 from benefits.enrollment_littlepay.enrollment import get_card_types_for_js, enroll
 from benefits.enrollment_littlepay.views import TokenView
+from benefits.enrollment_switchio.views import GatewayUrlView
 
 from benefits.in_person import forms
 
@@ -244,3 +245,9 @@ def success(request):
     }
 
     return TemplateResponse(request, "in_person/enrollment/success.html", context)
+
+
+class SwitchioGatewayUrlView(GatewayUrlView):
+    enrollment_method = models.EnrollmentMethods.IN_PERSON
+    route_server_error = routes.IN_PERSON_SERVER_ERROR
+    route_system_error = routes.IN_PERSON_ENROLLMENT_SYSTEM_ERROR

--- a/benefits/in_person/views.py
+++ b/benefits/in_person/views.py
@@ -260,4 +260,4 @@ class SwitchioEnrollmentIndexView(SwitchioIndexView):
     route_server_error = routes.IN_PERSON_SERVER_ERROR
     route_system_error = routes.IN_PERSON_ENROLLMENT_SYSTEM_ERROR
     route_tokenize_success = routes.IN_PERSON_ENROLLMENT_SWITCHIO_INDEX
-    template_name = ""
+    template_name = "in_person/enrollment/index_switchio.html"

--- a/benefits/in_person/views.py
+++ b/benefits/in_person/views.py
@@ -247,6 +247,7 @@ def success(request):
 
 class SwitchioGatewayUrlView(GatewayUrlView):
     enrollment_method = models.EnrollmentMethods.IN_PERSON
+    route_redirect = routes.IN_PERSON_ENROLLMENT_SWITCHIO_INDEX
     route_server_error = routes.IN_PERSON_SERVER_ERROR
     route_system_error = routes.IN_PERSON_ENROLLMENT_SYSTEM_ERROR
 

--- a/benefits/in_person/views.py
+++ b/benefits/in_person/views.py
@@ -261,3 +261,6 @@ class SwitchioEnrollmentIndexView(SwitchioIndexView):
     route_system_error = routes.IN_PERSON_ENROLLMENT_SYSTEM_ERROR
     route_tokenize_success = routes.IN_PERSON_ENROLLMENT_SWITCHIO_INDEX
     template_name = "in_person/enrollment/index_switchio.html"
+
+    def _get_verified_by(self):
+        return f"{self.request.user.first_name} {self.request.user.last_name}"

--- a/benefits/routes.py
+++ b/benefits/routes.py
@@ -155,6 +155,11 @@ class Routes:
         return "in_person:enrollment_littlepay_token"
 
     @property
+    def IN_PERSON_ENROLLMENT_SWITCHIO_GATEWAY_URL(self):
+        """Switchio Gateway for in-person (e.g. agency assisted) enrollment"""
+        return "in_person:enrollment_switchio_gateway"
+
+    @property
     def IN_PERSON_SERVER_ERROR(self):
         """Generic error handler for the in_person app."""
         return "in_person:error"

--- a/tests/pytest/enrollment_switchio/test_views.py
+++ b/tests/pytest/enrollment_switchio/test_views.py
@@ -66,6 +66,9 @@ class TestIndexView:
 
         assert locale == expected_locale
 
+    def test_get_verified_by(self, view):
+        assert view._get_verified_by() == view.flow.eligibility_verifier
+
     def test_get(self, view, app_request, mocker, model_TransitAgency, model_SwitchioConfig):
         model_SwitchioConfig.transit_agency = model_TransitAgency
         mocked_get_registration_status = mocker.patch(
@@ -235,7 +238,7 @@ class TestIndexView:
 
         mock_handler.assert_called_once()
         handler_kwargs = mock_handler.call_args.kwargs
-        assert handler_kwargs["verified_by"] == view.flow.eligibility_verifier
+        assert handler_kwargs["verified_by"] == view._get_verified_by()
         assert handler_kwargs["enrollment_method"] == models.EnrollmentMethods.DIGITAL
         assert handler_kwargs["route_reenrollment_error"] == routes.ENROLLMENT_REENROLLMENT_ERROR
         assert handler_kwargs["route_success"] == routes.ENROLLMENT_SUCCESS

--- a/tests/pytest/enrollment_switchio/test_views.py
+++ b/tests/pytest/enrollment_switchio/test_views.py
@@ -264,6 +264,7 @@ class TestGatewayUrlView:
 
     def test_view(self, view: GatewayUrlView):
         assert view.enrollment_method == models.EnrollmentMethods.DIGITAL
+        assert view.route_redirect == routes.ENROLLMENT_SWITCHIO_INDEX
         assert view.route_system_error == routes.ENROLLMENT_SYSTEM_ERROR
         assert view.route_server_error == routes.SERVER_ERROR
 

--- a/tests/pytest/enrollment_switchio/test_views.py
+++ b/tests/pytest/enrollment_switchio/test_views.py
@@ -31,6 +31,8 @@ def mocked_api_base_url(mocker):
     )
 
 
+@pytest.mark.django_db
+@pytest.mark.usefixtures("mocked_session_flow")
 class TestIndexView:
     @pytest.fixture
     def view(self, app_request, mocked_session_agency, mocked_session_flow):
@@ -42,8 +44,6 @@ class TestIndexView:
 
         return v
 
-    @pytest.mark.django_db
-    @pytest.mark.usefixtures("mocked_session_flow")
     def test_get_context_data(self, view):
 
         context = view.get_context_data()
@@ -60,15 +60,12 @@ class TestIndexView:
         assert "name" in transit_processor_context
         assert "website" in transit_processor_context
 
-    @pytest.mark.django_db
     @pytest.mark.parametrize("LANGUAGE_CODE, expected_locale", [("en", "en"), ("es", "es"), ("unsupported", "en")])
     def test_get_locale(self, view, LANGUAGE_CODE, expected_locale):
         locale = view._get_locale(LANGUAGE_CODE)
 
         assert locale == expected_locale
 
-    @pytest.mark.django_db
-    @pytest.mark.usefixtures("mocked_session_flow")
     def test_get(self, view, app_request, mocker, model_TransitAgency, model_SwitchioConfig):
         model_SwitchioConfig.transit_agency = model_TransitAgency
         mocked_get_registration_status = mocker.patch(
@@ -81,8 +78,6 @@ class TestIndexView:
         assert response.template_name == ["enrollment_switchio/index.html"]
         mocked_get_registration_status.assert_not_called()
 
-    @pytest.mark.django_db
-    @pytest.mark.usefixtures("mocked_session_flow")
     def test_get_with_session_registration_id_tokenization_finished(
         self, view, app_request, mocker, model_TransitAgency, model_SwitchioConfig
     ):
@@ -119,8 +114,6 @@ class TestIndexView:
         assert response.template_name == ["enrollment_switchio/index.html"]
         mocked_get_registration_status.assert_called_once()
 
-    @pytest.mark.django_db
-    @pytest.mark.usefixtures("mocked_session_flow")
     def test_get_with_session_registration_id_verification_failed(
         self, view, app_request, mocker, model_TransitAgency, model_SwitchioConfig
     ):
@@ -147,8 +140,6 @@ class TestIndexView:
         assert response.url == reverse(routes.ENROLLMENT_RETRY)
         mocked_get_registration_status.assert_called_once()
 
-    @pytest.mark.django_db
-    @pytest.mark.usefixtures("mocked_session_flow")
     def test_get_with_session_registration_id_tokenization_failed(
         self, view, app_request, mocker, model_TransitAgency, model_SwitchioConfig
     ):
@@ -175,8 +166,6 @@ class TestIndexView:
         assert response.url == reverse(routes.ENROLLMENT_SYSTEM_ERROR)
         mocked_get_registration_status.assert_called_once()
 
-    @pytest.mark.django_db
-    @pytest.mark.usefixtures("mocked_session_flow")
     def test_get_with_session_registration_id_system_error(
         self, view, app_request, mocker, model_TransitAgency, model_SwitchioConfig, mocked_sentry_sdk_module
     ):
@@ -206,8 +195,6 @@ class TestIndexView:
         mocked_get_registration_status.assert_called_once()
         mocked_sentry_sdk_module.capture_exception.assert_called_once()
 
-    @pytest.mark.django_db
-    @pytest.mark.usefixtures("mocked_session_flow")
     def test_get_with_session_registration_id_server_error(
         self, view, app_request, mocker, model_TransitAgency, model_SwitchioConfig, mocked_sentry_sdk_module
     ):
@@ -237,7 +224,6 @@ class TestIndexView:
         mocked_get_registration_status.assert_called_once()
         mocked_sentry_sdk_module.capture_exception.assert_called_once()
 
-    @pytest.mark.django_db
     def test_form_valid(self, mocker, view):
         mocker.patch("benefits.enrollment_switchio.views.enroll", return_value=(Status.SUCCESS, None))
 
@@ -247,7 +233,13 @@ class TestIndexView:
         assert form.is_valid()
         view.form_valid(form)
 
-        mock_handler.assert_called_once_with(view.request, Status.SUCCESS, None)
+        mock_handler.assert_called_once()
+        handler_kwargs = mock_handler.call_args.kwargs
+        assert handler_kwargs["verified_by"] == view.flow.eligibility_verifier
+        assert handler_kwargs["enrollment_method"] == models.EnrollmentMethods.DIGITAL
+        assert handler_kwargs["route_reenrollment_error"] == routes.ENROLLMENT_REENROLLMENT_ERROR
+        assert handler_kwargs["route_success"] == routes.ENROLLMENT_SUCCESS
+        assert handler_kwargs["route_system_error"] == routes.ENROLLMENT_SYSTEM_ERROR
 
 
 @pytest.mark.django_db

--- a/tests/pytest/in_person/test_views.py
+++ b/tests/pytest/in_person/test_views.py
@@ -319,6 +319,7 @@ class TestSwitchioGatewayUrlView:
 
     def test_view(self, view: views.SwitchioGatewayUrlView):
         assert view.enrollment_method == models.EnrollmentMethods.IN_PERSON
+        assert view.route_redirect == routes.IN_PERSON_ENROLLMENT_SWITCHIO_INDEX
         assert view.route_system_error == routes.IN_PERSON_ENROLLMENT_SYSTEM_ERROR
         assert view.route_server_error == routes.IN_PERSON_SERVER_ERROR
 

--- a/tests/pytest/in_person/test_views.py
+++ b/tests/pytest/in_person/test_views.py
@@ -342,3 +342,8 @@ class TestSwitchioEnrollmentIndexView:
         assert view.route_system_error == routes.IN_PERSON_ENROLLMENT_SYSTEM_ERROR
         assert view.route_tokenize_success == routes.IN_PERSON_ENROLLMENT_SWITCHIO_INDEX
         assert view.template_name == "in_person/enrollment/index_switchio.html"
+
+    def test_get_verified_by(self, mocker, app_request, view):
+        app_request.user = mocker.Mock(first_name="First", last_name="Last")
+
+        assert view._get_verified_by() == "First Last"

--- a/tests/pytest/in_person/test_views.py
+++ b/tests/pytest/in_person/test_views.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 
 from benefits.core import models
 from benefits.enrollment.enrollment import Status
+from benefits.in_person import forms
 import benefits.in_person.views as views
 from benefits.routes import routes
 
@@ -320,3 +321,24 @@ class TestSwitchioGatewayUrlView:
         assert view.enrollment_method == models.EnrollmentMethods.IN_PERSON
         assert view.route_system_error == routes.IN_PERSON_ENROLLMENT_SYSTEM_ERROR
         assert view.route_server_error == routes.IN_PERSON_SERVER_ERROR
+
+
+@pytest.mark.django_db
+class TestSwitchioEnrollmentIndexView:
+    @pytest.fixture
+    def view(self, app_request, model_SwitchioConfig):
+        v = views.SwitchioEnrollmentIndexView()
+        v.setup(app_request)
+        v.agency = model_SwitchioConfig.transit_agency
+        return v
+
+    def test_view(self, view: views.SwitchioGatewayUrlView):
+        assert view.enrollment_method == models.EnrollmentMethods.IN_PERSON
+        assert view.form_class == forms.CardTokenizeSuccessForm
+        assert view.route_enrollment_success == routes.IN_PERSON_ENROLLMENT_SUCCESS
+        assert view.route_reenrollment_error == routes.IN_PERSON_ENROLLMENT_REENROLLMENT_ERROR
+        assert view.route_retry == routes.IN_PERSON_ENROLLMENT_RETRY
+        assert view.route_server_error == routes.IN_PERSON_SERVER_ERROR
+        assert view.route_system_error == routes.IN_PERSON_ENROLLMENT_SYSTEM_ERROR
+        assert view.route_tokenize_success == routes.IN_PERSON_ENROLLMENT_SWITCHIO_INDEX
+        assert view.template_name == ""

--- a/tests/pytest/in_person/test_views.py
+++ b/tests/pytest/in_person/test_views.py
@@ -341,4 +341,4 @@ class TestSwitchioEnrollmentIndexView:
         assert view.route_server_error == routes.IN_PERSON_SERVER_ERROR
         assert view.route_system_error == routes.IN_PERSON_ENROLLMENT_SYSTEM_ERROR
         assert view.route_tokenize_success == routes.IN_PERSON_ENROLLMENT_SWITCHIO_INDEX
-        assert view.template_name == ""
+        assert view.template_name == "in_person/enrollment/index_switchio.html"

--- a/tests/pytest/in_person/test_views.py
+++ b/tests/pytest/in_person/test_views.py
@@ -81,6 +81,15 @@ class TestEligibilityView:
         context_data = view.get_context_data()
         assert "title" in context_data
 
+    def test_dispatch(self, view, mocker):
+        littlepay_session = mocker.patch.object(views, "LittlepaySession")
+        switchio_session = mocker.patch.object(views, "SwitchioSession")
+
+        view.dispatch(view.request)
+
+        littlepay_session.assert_called_once_with(view.request, reset=True)
+        switchio_session.assert_called_once_with(view.request, reset=True)
+
     def test_dispatch_no_agency_in_session(
         self, view, mocked_session_module, mocked_transit_agency_class, model_TransitAgency
     ):


### PR DESCRIPTION
Closes #3068 
Closes #3069 

## Reviewing

1. Ensure you are setup locally for Switchio INT/ACC environment
1. Start the app with `F5`
1. In the browser, enter the URL `/admin`
1. Log in with `cst-user`
1. Start a new in-person enrollment (choose any flow)
1. See a quick loading message, then click `Enroll`
1. Redirect into Switchio's tokenization flow, enter card details
1. Redirect back to Admin In-Person, see a quick loading message
1. See the success message with buttons to start a `New enrollment` or be `Done`
1. Confirm Switchio enrollment on Digital side works as normal