### PR TITLE
Fix: Switchio in-person UX

### DIFF
--- a/benefits/enrollment_switchio/templates/enrollment_switchio/script.html
+++ b/benefits/enrollment_switchio/templates/enrollment_switchio/script.html
@@ -47,6 +47,7 @@
         return; // exit early so the rest of this function doesn't execute
       }
 
+      {% block gateway-url-handler %}
       document.querySelector(".loading").remove();
 
       // remove invisible and add back visible, so we aren't left with
@@ -69,5 +70,6 @@
         // open the tokenization gateway
         tokenizeWithRedirect(data.gateway_url)
       });
+      {% endblock gateway-url-handler %}
     }));
 </script>

--- a/benefits/in_person/templates/in_person/enrollment/index_switchio.html
+++ b/benefits/in_person/templates/in_person/enrollment/index_switchio.html
@@ -27,7 +27,7 @@
     </div>
   </div>
 
-  {% include "enrollment_switchio/script.html" with gateway_url_route=routes.IN_PERSON_ENROLLMENT_SWITCHIO_GATEWAY_URL %}
+  {% include "in_person/enrollment/switchio_script.html" with gateway_url_route=routes.IN_PERSON_ENROLLMENT_SWITCHIO_GATEWAY_URL %}
 
   {% for f in forms %}
     {% include "core/includes/form.html" with form=f %}

--- a/benefits/in_person/templates/in_person/enrollment/index_switchio.html
+++ b/benefits/in_person/templates/in_person/enrollment/index_switchio.html
@@ -9,21 +9,8 @@
     <div class="loading">
       <p>
         <span class="spinner-border align-middle text-primary" role="status"></span>
-        <span id="loading-message" class="fw-bold p-2">Please wait...</span>
+        <span id="loading-message" class="fw-bold p-2">{{ loading_message }}</span>
       </p>
-    </div>
-    <div class="row d-flex justify-content-start p-3">
-      <div class="col-12">
-        <div class="invisible">
-          <button id="{{ cta_button }}" href="#{{ cta_button }}" class="btn btn-lg btn-primary" role="button">Enroll</button>
-        </div>
-      </div>
-    </div>
-    <div class="row d-flex justify-content-start p-3 pt-8">
-      <div class="col-12">
-        {% url routes.ADMIN_INDEX as url_cancel %}
-        <a href="{{ url_cancel }}" class="btn btn-lg btn-outline-primary d-block">Cancel</a>
-      </div>
     </div>
   </div>
 

--- a/benefits/in_person/templates/in_person/enrollment/switchio_script.html
+++ b/benefits/in_person/templates/in_person/enrollment/switchio_script.html
@@ -1,0 +1,8 @@
+{% extends "enrollment_switchio/script.html" %}
+
+{% block gateway-url-handler %}
+  amplitude.getInstance().logEvent(startedEvent, { enrollment_method: "{{ enrollment_method }}" });
+
+  // open the tokenization gateway
+  tokenizeWithRedirect(data.gateway_url)
+{% endblock gateway-url-handler %}

--- a/benefits/in_person/views.py
+++ b/benefits/in_person/views.py
@@ -199,3 +199,13 @@ class SwitchioEnrollmentIndexView(SwitchioIndexView):
 
     def _get_verified_by(self):
         return f"{self.request.user.first_name} {self.request.user.last_name}"
+
+    def get_context_data(self, **kwargs):
+        """Add in-person specific context data."""
+        context = super().get_context_data(**kwargs)
+        context.update(
+            {
+                "title": f"{self.agency.long_name} | In-person enrollment | {admin_site.site_title}",
+            }
+        )
+        return context

--- a/benefits/in_person/views.py
+++ b/benefits/in_person/views.py
@@ -216,3 +216,11 @@ class SwitchioEnrollmentIndexView(SwitchioIndexView):
             }
         )
         return context
+
+    def get(self, request, *args, **kwargs):
+        if request.GET.get("error") == "canceled":
+            # the user clicked the "Back" button on the Switchio tokenization gateway
+            # send them back to the Admin index, similar to the Littlepay cancel button
+            return redirect(routes.ADMIN_INDEX)
+
+        return super().get(request, *args, **kwargs)

--- a/benefits/in_person/views.py
+++ b/benefits/in_person/views.py
@@ -203,8 +203,15 @@ class SwitchioEnrollmentIndexView(SwitchioIndexView):
     def get_context_data(self, **kwargs):
         """Add in-person specific context data."""
         context = super().get_context_data(**kwargs)
+
+        if self.request.GET.get("state") == "tokenize":
+            message = "Registering this contactless card for reduced fares..."
+        else:
+            message = "Connecting with payment processor..."
+
         context.update(
             {
+                "loading_message": message,
                 "title": f"{self.agency.long_name} | In-person enrollment | {admin_site.site_title}",
             }
         )

--- a/tests/pytest/in_person/test_views.py
+++ b/tests/pytest/in_person/test_views.py
@@ -246,13 +246,14 @@ class TestSwitchioGatewayUrlView:
 @pytest.mark.django_db
 class TestSwitchioEnrollmentIndexView:
     @pytest.fixture
-    def view(self, app_request, model_SwitchioConfig):
+    def view(self, app_request, model_SwitchioConfig, model_EnrollmentFlow):
         v = views.SwitchioEnrollmentIndexView()
         v.setup(app_request)
         v.agency = model_SwitchioConfig.transit_agency
+        v.flow = model_EnrollmentFlow
         return v
 
-    def test_view(self, view: views.SwitchioGatewayUrlView):
+    def test_view(self, view: views.SwitchioEnrollmentIndexView):
         assert view.enrollment_method == models.EnrollmentMethods.IN_PERSON
         assert view.form_class == forms.CardTokenizeSuccessForm
         assert view.route_enrollment_success == routes.IN_PERSON_ENROLLMENT_SUCCESS
@@ -267,3 +268,8 @@ class TestSwitchioEnrollmentIndexView:
         app_request.user = mocker.Mock(first_name="First", last_name="Last")
 
         assert view._get_verified_by() == "First Last"
+
+    def test_get_context_data(self, view):
+        context = view.get_context_data()
+
+        assert "title" in context

--- a/tests/pytest/in_person/test_views.py
+++ b/tests/pytest/in_person/test_views.py
@@ -264,12 +264,24 @@ class TestSwitchioEnrollmentIndexView:
         assert view.route_tokenize_success == routes.IN_PERSON_ENROLLMENT_SWITCHIO_INDEX
         assert view.template_name == "in_person/enrollment/index_switchio.html"
 
-    def test_get_verified_by(self, mocker, app_request, view):
+    def test_get_verified_by(self, mocker, app_request, view: views.SwitchioEnrollmentIndexView):
         app_request.user = mocker.Mock(first_name="First", last_name="Last")
 
         assert view._get_verified_by() == "First Last"
 
-    def test_get_context_data(self, view):
+    def test_get_context_data(self, view: views.SwitchioEnrollmentIndexView):
         context = view.get_context_data()
 
         assert "title" in context
+
+    def test_get_context_data__pre_tokenize(self, view: views.SwitchioEnrollmentIndexView):
+        context = view.get_context_data()
+
+        assert context["loading_message"] == "Connecting with payment processor..."
+
+    def test_get_context_data__post_tokenize(self, view: views.SwitchioEnrollmentIndexView, app_request):
+        app_request.GET = {"state": "tokenize"}
+
+        context = view.get_context_data()
+
+        assert context["loading_message"] == "Registering this contactless card for reduced fares..."

--- a/tests/pytest/in_person/test_views.py
+++ b/tests/pytest/in_person/test_views.py
@@ -285,3 +285,11 @@ class TestSwitchioEnrollmentIndexView:
         context = view.get_context_data()
 
         assert context["loading_message"] == "Registering this contactless card for reduced fares..."
+
+    def test_get__cancel_tokenize(self, view: views.SwitchioEnrollmentIndexView, app_request):
+        app_request.GET = {"error": "canceled"}
+
+        response = view.get(app_request)
+
+        assert response.status_code == 302
+        assert response.url == reverse(routes.ADMIN_INDEX)


### PR DESCRIPTION
Closes #3089 

- Pre-tokenization loading message matches that in Figma
- Immediate redirect into Switchio gateway
- Post-tokenization loading message matches that in Figma
- Fixed handling of the Switchio gateway "Back" button, similar to Littlepay "Cancel" button
- _This does not yet update the loading icon from the spinner to the bar -- this will be a little more complex_

## Reviewing

1. Checkout this branch, make sure you are setup for Switchio enrollment with CST
2. `F5` to launch the app
3. Login to the `/admin` as `cst-user`
5. Start a new enrollment, choose any flow
6. Note the initial loading message `Connecting with payment processor...`
7. Note the auto-redirection into tokenization gateway
8. Enter sample card details and submit
9. Upon redirection back to In-person, note the second loading message: `Registering this contactless card for reduced fares...`
10. Try again and this time click the `Back` button in the Switchio gateway -- expect to be redirected back to the Admin index