### PR TITLE
Fix: allow language cookie to travel with user

### DIFF
--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -211,7 +211,10 @@ AUTH_PASSWORD_VALIDATORS = [
 LANGUAGE_CODE = "en"
 
 LANGUAGE_COOKIE_HTTPONLY = True
-LANGUAGE_COOKIE_SAMESITE = "Strict"
+# `Lax` allows the cookie to travel with the user and be sent back to Benefits
+# during redirection e.g. through IdG/Login.gov or a Transit Processor portal
+# ensuring the app is displayed in the same language
+LANGUAGE_COOKIE_SAMESITE = "Lax"
 LANGUAGE_COOKIE_SECURE = True
 
 LANGUAGES = [("en", "English"), ("es", "Español")]


### PR DESCRIPTION
Similar to the session cookie, we need to have the language cookie's `SameSite` flag set to `Lax` so that the cookie stays with the user during redirects e.g. for IdG/Login.gov and Switchio.

Otherwise, the user gets the app's default language (`en`) upon redirection back, even if they originally left the app with a different language selection (e.g. `es`).

Fixes #3081 

See more: https://docs.djangoproject.com/en/5.2/ref/settings/#language-cookie-samesite

## Reviewing

1. Checkout this branch, start the app with `F5`
2. Click the `Español` button to change to `es`
3. Use the browser dev tools to confirm a cookie was set with name `django_language`, value `es`, and `SameSite = Lax`
4. Select a flow that takes you through Login.gov, e.g. Older Adult
5. Complete identity proofing with Login.gov
6. Confirm that the app is still displayed in `es` when you are redirected back
7. (The same behavior should be seen for Switchio enrollment through their gateway redirect)