### PR TITLE
Fix: guard against the flow's transit agency being null

### DIFF
--- a/benefits/core/models/enrollment.py
+++ b/benefits/core/models/enrollment.py
@@ -126,7 +126,8 @@ class EnrollmentFlow(models.Model):
         ordering = ["display_order"]
 
     def __str__(self):
-        return f"{self.label} ({self.transit_agency.slug})"
+        agency_slug = self.transit_agency.slug if self.transit_agency else "no agency"
+        return f"{self.label} ({agency_slug})"
 
     @property
     def group_id(self):

--- a/tests/pytest/core/models/test_enrollment.py
+++ b/tests/pytest/core/models/test_enrollment.py
@@ -14,6 +14,12 @@ def test_EnrollmentFlow_str(model_EnrollmentFlow):
 
 
 @pytest.mark.django_db
+def test_EnrollmentFlow_str_no_agency(model_EnrollmentFlow):
+    model_EnrollmentFlow.transit_agency = None
+    assert str(model_EnrollmentFlow) == f"{model_EnrollmentFlow.label} (no agency)"
+
+
+@pytest.mark.django_db
 def test_EnrollmentFlow_agency_card_name(model_EnrollmentFlow_with_eligibility_api):
     assert (
         model_EnrollmentFlow_with_eligibility_api.agency_card_name


### PR DESCRIPTION
Ran into this while testing #3146.

We added the agency slug to the flow's `__str__` so that when viewing the flow from a `LittlepayConfig` or `SwitchioConfig`, the label is usable. Seems like we just forgot to have this check for in case the flow doesn't have a transit agency.