### PR TITLE
chore(docs): update djlint url

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
       - id: prettier
         types_or: [javascript, css]
 
-  - repo: https://github.com/Riverside-Healthcare/djLint
+  - repo: https://github.com/djlint/djLint
     rev: v1.36.4
     hooks:
       - id: djlint-reformat-django


### PR DESCRIPTION
while i was poking through the dependencies i noticed that djLint now lives in its own dedicated github org. the original maintainer appears to be [offloading his projects](https://github.com/christopherpickering/christopherpickering), but djLint itself certainly hasn't been abandoned. 😅 

i'll miss seeing the word 'Riverside' in the build log going forward, but the .000000001 second speed boost we'll get by sidestepping the redirect is certainly enough to justify it. 😆 

ps. i used this PR to verify my git [name and email](https://github.com/cal-itp/benefits/pull/3159/commits/f9ce1bfb2a6bed19fa74f46a7ac1554bb96d3433.patch) are configured correctly.

```
From f9ce1bfb2a6bed19fa74f46a7ac1554bb96d3433 Mon Sep 17 00:00:00 2001
From: jgravois <jgravois@compiler.la>
Date: Tue, 16 Sep 2025 22:36:31 +0000
Subject: [PATCH] chore(deps): update djLint url
```
