### PR TITLE
Fix: remove outdated fields from ModelAdmin

### DIFF
--- a/benefits/core/admin/transit.py
+++ b/benefits/core/admin/transit.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.contrib import admin
 
 from benefits.core import models
+
 from .users import is_staff_member_or_superuser
 
 
@@ -16,8 +17,6 @@ class TransitAgencyAdmin(admin.ModelAdmin):
                     "eligibility_api_private_key",
                     "eligibility_api_public_key",
                     "sso_domain",
-                    "littlepay_config",
-                    "switchio_config",
                 ]
             )
 
@@ -30,7 +29,6 @@ class TransitAgencyAdmin(admin.ModelAdmin):
             fields.extend(
                 [
                     "eligibility_api_id",
-                    "transit_processor",
                 ]
             )
 

--- a/tests/pytest/core/admin/test_enrollment.py
+++ b/tests/pytest/core/admin/test_enrollment.py
@@ -102,6 +102,10 @@ class TestEnrollmentFlowAdmin:
         ],
     )
     def test_get_exclude(self, admin_user_request, flow_admin_model, user_type, expected):
+        if expected:
+            model_fields = [f.name for f in flow_admin_model.model._meta.get_fields()]
+            assert all(field in model_fields for field in expected)
+
         request = admin_user_request(user_type)
 
         excluded = flow_admin_model.get_exclude(request)
@@ -125,6 +129,10 @@ class TestEnrollmentFlowAdmin:
         ],
     )
     def test_get_readonly_fields(self, admin_user_request, flow_admin_model, user_type, expected):
+        if expected:
+            model_fields = [f.name for f in flow_admin_model.model._meta.get_fields()]
+            assert all(field in model_fields for field in expected)
+
         request = admin_user_request(user_type)
 
         readonly = flow_admin_model.get_readonly_fields(request)

--- a/tests/pytest/core/admin/test_transit.py
+++ b/tests/pytest/core/admin/test_transit.py
@@ -1,10 +1,9 @@
 import pytest
-
 from django.conf import settings
 from django.contrib import admin
 
-from benefits.core.admin.transit import TransitAgencyAdmin
 from benefits.core import models
+from benefits.core.admin.transit import TransitAgencyAdmin
 
 
 @pytest.fixture
@@ -24,14 +23,16 @@ class TestTransitAgencyAdmin:
                     "eligibility_api_private_key",
                     "eligibility_api_public_key",
                     "sso_domain",
-                    "littlepay_config",
-                    "switchio_config",
                 ],
             ),
-            ("super", None),
+            ("super", ()),
         ],
     )
     def test_get_exclude(self, admin_user_request, agency_admin_model, user_type, expected):
+        if expected:
+            model_fields = [f.name for f in agency_admin_model.model._meta.get_fields()]
+            assert all(field in model_fields for field in expected)
+
         request = admin_user_request(user_type)
 
         excluded = agency_admin_model.get_exclude(request)
@@ -46,12 +47,16 @@ class TestTransitAgencyAdmin:
         [
             (
                 "staff",
-                ["eligibility_api_id", "transit_processor"],
+                ["eligibility_api_id"],
             ),
             ("super", ()),
         ],
     )
     def test_get_readonly_fields(self, admin_user_request, agency_admin_model, user_type, expected):
+        if expected:
+            model_fields = [f.name for f in agency_admin_model.model._meta.get_fields()]
+            assert all(field in model_fields for field in expected)
+
         request = admin_user_request(user_type)
 
         readonly = agency_admin_model.get_readonly_fields(request)


### PR DESCRIPTION
Closes #3197

Make the relevant tests assert that expected fields actually exist on the model, to avoid this specific bug in the future.

## Reviewing

1. Checkout `main`, launch the app, login to the admin as `calitp-user`
2. Click into any `TransitAgency` instance
3. Confirm the error
4. Checkout this branch, launch the app, login to the admin as `calitp-user`
5. Click into any `TransitAgency` instance
6. Confirm the fix, the agency fields are visible and editable