### PR TITLE
Chore: clean up EDCTA key for enrollment success context

### DIFF
--- a/benefits/enrollment/context/flow.py
+++ b/benefits/enrollment/context/flow.py
@@ -93,7 +93,7 @@ enrollment_success = {
     SystemName.AGENCY_CARD.value: AgencyCardEnrollmentSuccess(
         transit_benefit=_("a CST Agency Card transit benefit"), transportation_type=_("a CST bus")
     ),
-    AgencySlug.EDCTA: DefaultEnrollmentSuccess(transportation_type=_("an EDCTA bus")),
+    AgencySlug.EDCTA.value: DefaultEnrollmentSuccess(transportation_type=_("an EDCTA bus")),
     AgencySlug.MST.value: DefaultEnrollmentSuccess(transportation_type=_("an MST bus")),
     SystemName.COURTESY_CARD.value: AgencyCardEnrollmentSuccess(
         transit_benefit=_("an MST Courtesy Card transit benefit"), transportation_type="an MST bus"

--- a/tests/pytest/enrollment/context/test_flow.py
+++ b/tests/pytest/enrollment/context/test_flow.py
@@ -1,0 +1,9 @@
+import pytest
+
+from benefits.core.context import AgencySlug
+from benefits.enrollment import context
+
+
+@pytest.mark.parametrize("slug", AgencySlug)
+def test_enrollent_success(slug):
+    assert context.enrollment_success[slug.value]


### PR DESCRIPTION
Follow-up to #3141 

See full discussion in https://github.com/cal-itp/benefits/pull/3141#discussion_r2388340075

We previously assumed that if you want to do the dict lookup using [an agency's slug](https://github.com/cal-itp/benefits/blob/main/benefits/core/models/enrollment.py#L218) (which is just a string), the keys of the dict need to be strings as well. We learned though that having the key be the `Choice` enum constant also works somehow. However, to keep things consistent, this PR adds the missing `.value` for EDCTA.