### PR TITLE
chore(deps): bump django from 5.1.7 to 5.2.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "azure-keyvault-secrets==4.10.0",
     "azure-identity==1.24.0",
     "calitp-littlepay==2025.4.1",
-    "Django==5.1.7",
+    "Django==5.2.7",
     "django-admin-sortable2==2.2.8",
     "django-cdt-identity @ git+https://github.com/Office-of-Digital-Services/django-cdt-identity.git@c635773a75e7f184a9382748afcef6d5a705b2d6",
     "django-csp==3.8",


### PR DESCRIPTION
Resolves some GitHub security alerts / CVEs (that didn't necessarily affect us anyway, but this feels better).

See also https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/pull/420