### PR TITLE
docs: marked VCTC LIVE in the agency adoption table

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,7 @@ The following California transit providers have adopted Cal-ITP Benefits. The be
 | **Santa Barbara Metropolitan Transit District** | 10/2023             | ✅           | ✅                    | ―             | ✅          | ―          |
 | **Sacramento Regional Transit District**        | 10/2024             | ✅           | ✅                    | ✅            | ―           | ―          |
 | **Nevada County Connects**                      | 03/2025             | ✅           | ✅                    | ✅            | ―           | ―          |
-| **Ventura County Transportation Commission**    | 10/2025 (target)    | ✅           | ✅                    | ―             | ―           | ―          |
+| **Ventura County Transportation Commission**    | 10/2025             | ✅           | ✅                    | ―             | ―           | ―          |
 | **El Dorado Transit Authority**                 | 10/2025 (target)    | ✅           | ✅                    | ―             | ―           | ―          |
 | **Redding Area Bus Authority**                  | 11/2025 (target)    | ✅           | ✅                    | ―             | ―           | ―          |
 | **San Luis Obispo Regional Transit**            | 02/2026 (target)    | ✅           | ✅                    | ―             | ―           | ―          |


### PR DESCRIPTION
- removed "target" next to "initial launch date" for VCTC