### PR TITLE
chore: use prettier@2.x in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,8 +53,10 @@ repos:
         args: ["-ll"]
         files: .py$
 
+  # esbenp.prettier-vscode defaults to using prettier@2.8.8. this mirror is the closest equivalent
+  # another option would be to 'npm install prettier' explicitly in the Dockerfile, as the VS Code plugin will use it
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+    rev: v2.7.1
     hooks:
       - id: prettier
         types_or: [javascript, css]

--- a/benefits/static/css/admin/styles.css
+++ b/benefits/static/css/admin/styles.css
@@ -195,13 +195,11 @@ iframe.card-collection {
   content: " ";
   background-color: currentColor;
 
-  mask-image:
-    url("/static/img/external-link.svg"),
+  mask-image: url("/static/img/external-link.svg"),
     linear-gradient(transparent, transparent);
   mask-position: center center;
   mask-size: contain;
-  -webkit-mask-image:
-    url("/static/img/external-link.svg"),
+  -webkit-mask-image: url("/static/img/external-link.svg"),
     linear-gradient(transparent, transparent);
   -webkit-mask-position: center center;
   -webkit-mask-size: contain;

--- a/benefits/static/css/admin/theme.css
+++ b/benefits/static/css/admin/theme.css
@@ -10,8 +10,7 @@ html[data-theme="light"],
   --bs-dark-rgb: 33, 33, 33; /* Background color for Header */
   --bs-heading-color: #212121; /* Header text color */
   --bs-secondary-bg-subtle: #f1f1f1; /* Background color for Admin, lighter than bs-secondary, used with bg-secondary-subtle */
-  --bs-secondary-rgb:
-    210, 210, 210; /* Border color for Admin, used with border-secondary */
+  --bs-secondary-rgb: 210, 210, 210; /* Border color for Admin, used with border-secondary */
   --bs-secondary: #c5c4c4;
   --breadcrumbs-link-fg: #066b99; /* Breadcrumbs on Django Admin */
   --breadcrumbs-bg: #ffffff;

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -4,9 +4,7 @@
   font-family: "Public Sans";
   font-weight: var(--bold-font-weight);
   font-style: normal;
-  /* prettier-ignore */
   src: local("PublicSans"), url("../fonts/PublicSans-Bold.woff") format("woff");
-  /* prettier-ignore */
 }
 
 html {
@@ -122,12 +120,10 @@ a[target="_blank"]::after {
   content: " ";
   background-color: currentColor;
 
-  mask-image:
-    url("/static/img/external-link.svg"),
+  mask-image: url("/static/img/external-link.svg"),
     linear-gradient(transparent, transparent);
   mask-position: center center;
-  -webkit-mask-image:
-    url("/static/img/external-link.svg"),
+  -webkit-mask-image: url("/static/img/external-link.svg"),
     linear-gradient(transparent, transparent);
   -webkit-mask-position: center center;
 

--- a/benefits/static/css/variables.css
+++ b/benefits/static/css/variables.css
@@ -11,8 +11,7 @@
   --medium-font-weight: 500;
   --bold-font-weight: 700;
   --bs-body-font-size: calc(18rem / 16);
-  --bs-font-sans-serif:
-    Roboto, system-ui, -apple-system, "Segoe UI", sans-serif,
+  --bs-font-sans-serif: Roboto, system-ui, -apple-system, "Segoe UI", sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --bs-body-font-family: var(--bs-font-sans-serif);
   --bs-body-line-height: 1.5; /* Displayed as 150% on Figma */


### PR DESCRIPTION
resolves #3227

the crux of the issue is that we don't want pre-commit to run prettier@4x if [`esbenp.prettier-vscode`](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) is running 2x

i'm planning on rebasing this PR prior to merge to get rid of the redundant commit, but i thought it would be helpful initially to have evidence that pre-commit is finally applying the same formatting changes to files that y'all are (hopefully) seeing in VS Code locally.

<img width="717" height="534" alt="Screenshot 2025-10-07 at 3 05 09 PM" src="https://github.com/user-attachments/assets/5a876cdc-6770-4df9-bcb9-aa40775a0d49" />
