### PR TITLE
fix: include logo-strip in both landing page variants

### DIFF
--- a/benefits/core/templates/core/index-base.html
+++ b/benefits/core/templates/core/index-base.html
@@ -32,7 +32,6 @@
         </div>
       </div>
     </div>
-    {% block logo-strip %}
-    {% endblock logo-strip %}
+    {% include "core/includes/logo-strip.html" %}
   </div>
 {% endblock main-content %}

--- a/benefits/core/templates/core/index.html
+++ b/benefits/core/templates/core/index.html
@@ -14,7 +14,3 @@
   {% include "core/includes/modal-trigger.html" with modal="modal--agency-selector" classes="btn btn-lg btn-primary" text=text period=False %}
   {% include "core/includes/modal--agency-selector.html" with id="modal--agency-selector" size="modal-lg" body="pt-0 pb-4 pb-lg-5 mb-lg-1 px-lg-5 mx-lg-1" %}
 {% endblock call-to-action %}
-
-{% block logo-strip %}
-  {% include "core/includes/logo-strip.html" %}
-{% endblock logo-strip %}


### PR DESCRIPTION
resolves #3248

## Screenshots
<img width="600" height="369" alt="Screenshot 2025-10-23 at 10 56 28 AM" src="https://github.com/user-attachments/assets/8622e304-671b-4ed6-b3cb-4ff06640a613" />
<img width="600" height="368" alt="Screenshot 2025-10-23 at 10 56 38 AM" src="https://github.com/user-attachments/assets/dbfd1190-158e-4afc-a2ab-b28f0827a8c2" />
