### PR TITLE
docs: revisions to agencies still onboarding

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,22 +21,22 @@ The following California transit providers have adopted Cal-ITP Benefits. The be
 
 | Transit provider                                | Initial launch date | Older adults | Medicare cardholders | U.S. Veterans | Agency card | Low-income |
 | ----------------------------------------------- | ------------------- | ------------ | -------------------- | ------------- | ----------- | ---------- |
-| **Monterey-Salinas Transit**                    | 12/2021             | ✅           | ✅                    | ✅            | ✅          | ―          |
-| **Santa Barbara Metropolitan Transit District** | 10/2023             | ✅           | ✅                    | ―             | ✅          | ―          |
-| **Sacramento Regional Transit District**        | 10/2024             | ✅           | ✅                    | ✅            | ―           | ―          |
-| **Nevada County Connects**                      | 03/2025             | ✅           | ✅                    | ✅            | ―           | ―          |
-| **Ventura County Transportation Commission**    | 10/2025             | ✅           | ✅                    | ―             | ―           | ―          |
-| **El Dorado Transit Authority**                 | 10/2025 (target)    | ✅           | ✅                    | ―             | ―           | ―          |
-| **Redding Area Bus Authority**                  | 11/2025 (target)    | ✅           | ✅                    | ―             | ―           | ―          |
-| **San Luis Obispo Regional Transit**            | 02/2026 (target)    | ✅           | ✅                    | ―             | ―           | ―          |
-| **City of Roseville**                           | Planned             | ✅           | ✅                    | ―             | ―           | ―          |
-| **Santa Cruz Metropolitan Transit District**    | Planned             | ✅           | ✅                    | ―             | ―           | ―          |
+| **Monterey-Salinas Transit**                    | 12/2021             | ✅           | ✅                   | ✅            | ✅          | ―          |
+| **Santa Barbara Metropolitan Transit District** | 10/2023             | ✅           | ✅                   | ―             | ✅          | ―          |
+| **Sacramento Regional Transit District**        | 10/2024             | ✅           | ✅                   | ✅            | ―           | ―          |
+| **Nevada County Connects**                      | 03/2025             | ✅           | ✅                   | ✅            | ―           | ―          |
+| **Ventura County Transportation Commission**    | 10/2025             | ✅           | ✅                   | ―             | ―           | ―          |
+| **El Dorado Transit Authority**                 | 11/2025 (target)    | \*           | \*                   | \*            | \*          | \*         |
+| **Redding Area Bus Authority**                  | 11/2025 (target)    | \*           | \*                   | \*            | \*          | \*         |
+| **San Luis Obispo Regional Transit**            | 02/2026 (target)    | \*           | \*                   | \*            | \*          | \*         |
+| **City of Roseville**                           | Planned             | \*           | \*                   | \*            | \*          | \*         |
+| **Santa Cruz Metropolitan Transit District**    | Planned             | \*           | \*                   | \*            | \*          | \*         |
 
 ## Supported enrollment pathways
 
 The Cal-ITP Benefits app supports the following enrollment pathways that use the corresponding eligibility verification methods:
 
-| Enrollment pathway                                                             | Eligibility verification                                                            | Status | Launch                                                                |
+| Enrollment pathway                                                             | Eligibility verification                                                              | Status | Launch                                                                |
 | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- | ------ | --------------------------------------------------------------------- |
 | [**Older adults**](/benefits/enrollment-pathways/older-adults)                 | [Login.gov ID Proofed](https://developers.login.gov/attributes/)                      | Live   | [08/2022](https://github.com/cal-itp/benefits/releases/tag/2022.08.1) |
 | [**Agency cards**](/benefits/enrollment-pathways/agency-cards)                 | [Eligibility API](https://docs.calitp.org/eligibility-api/specification/)             | Live   | [11/2022](https://github.com/cal-itp/benefits/releases/tag/2022.11.1) |


### PR DESCRIPTION
- Removed the green checkmarks in enrollment pathway columns for all agencies that are not yet live in Cal-ITP Benefits.
- Added an asterisk in place of an en dash in enrollment pathway columns for all agencies that are not yet live in Cal-ITP Benefits  to clarify an en dash (–) denotes the agency doesn't offer that enrollment option.
- changed the target launch date for El Dorado to November