### PR TITLE
feat(analytics): Add transit_processor to enrollment events

### DIFF
--- a/benefits/core/models/transit.py
+++ b/benefits/core/models/transit.py
@@ -203,6 +203,15 @@ class TransitAgency(models.Model):
             return None
 
     @property
+    def transit_processor(self):
+        if self.littlepay_config:
+            return "littlepay"
+        elif self.switchio_config:
+            return "switchio"
+        else:
+            return None
+
+    @property
     def in_person_enrollment_index_route(self):
         """This Agency's in-person enrollment index route, based on its configured transit processor."""
         if self.littlepay_config:

--- a/benefits/enrollment/enrollment.py
+++ b/benefits/enrollment/enrollment.py
@@ -58,6 +58,7 @@ def handle_enrollment_results(
     card_scheme: str = None,
 ):
     flow = session.flow(request)
+    agency = session.agency(request)
     match (status):
         case Status.SUCCESS:
             agency = session.agency(request)
@@ -80,6 +81,7 @@ def handle_enrollment_results(
             analytics.returned_success(
                 request,
                 enrollment_group=flow.group_id,
+                transit_processor=agency.transit_processor,
                 enrollment_method=enrollment_method,
                 extra_claims=oauth_extra_claims,
                 card_scheme=card_scheme,
@@ -92,6 +94,7 @@ def handle_enrollment_results(
                 request,
                 str(exception),
                 enrollment_group=flow.group_id,
+                transit_processor=agency.transit_processor,
                 enrollment_method=enrollment_method,
             )
             sentry_sdk.capture_exception(exception)
@@ -102,6 +105,7 @@ def handle_enrollment_results(
                 request,
                 str(exception),
                 enrollment_group=flow.group_id,
+                transit_processor=agency.transit_processor,
                 enrollment_method=enrollment_method,
             )
             raise exception
@@ -111,6 +115,7 @@ def handle_enrollment_results(
                 request,
                 "Re-enrollment error.",
                 enrollment_group=flow.group_id,
+                transit_processor=agency.transit_processor,
                 enrollment_method=enrollment_method,
             )
             return redirect(route_reenrollment_error)

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -86,7 +86,8 @@ class ReenrollmentErrorView(FlowSessionRequiredMixin, EligibleSessionRequiredMix
 def retry(request):
     """View handler for a recoverable failure condition."""
     flow = session.flow(request)
-    analytics.returned_retry(request, enrollment_group=flow.group_id)
+    agency = session.agency(request)
+    analytics.returned_retry(request, enrollment_group=flow.group_id, transit_processor=agency.transit_processor)
     return TemplateResponse(request, TEMPLATE_RETRY)
 
 

--- a/benefits/enrollment_littlepay/views.py
+++ b/benefits/enrollment_littlepay/views.py
@@ -37,7 +37,7 @@ class TokenView(EligibleSessionRequiredMixin, View):
             elif response.status is Status.SYSTEM_ERROR or response.status is Status.EXCEPTION:
                 logger.debug("Error occurred while requesting access token", exc_info=response.exception)
                 sentry_sdk.capture_exception(response.exception)
-                analytics.failed_pretokenization_request(request, response.status_code, self.enrollment_method)
+                analytics.failed_pretokenization_request(request, "littlepay", response.status_code, self.enrollment_method)
 
                 if response.status is Status.SYSTEM_ERROR:
                     redirect = reverse(self.route_system_error)

--- a/benefits/enrollment_switchio/views.py
+++ b/benefits/enrollment_switchio/views.py
@@ -145,7 +145,7 @@ class GatewayUrlView(AgencySessionRequiredMixin, EligibleSessionRequiredMixin, V
             else:
                 logger.debug(f"Error occurred while attempting to get registration status for {session.registration_id}")
                 sentry_sdk.capture_exception(response.exception)
-                analytics.failed_pretokenization_request(request, response.status_code, self.enrollment_method)
+                analytics.failed_pretokenization_request(request, "switchio", response.status_code, self.enrollment_method)
 
                 if response.status is Status.SYSTEM_ERROR:
                     redirect = reverse(self.route_system_error)
@@ -167,7 +167,7 @@ class GatewayUrlView(AgencySessionRequiredMixin, EligibleSessionRequiredMixin, V
         else:
             logger.debug("Error occurred while requesting a tokenization gateway registration", exc_info=response.exception)
             sentry_sdk.capture_exception(response.exception)
-            analytics.failed_pretokenization_request(request, response.status_code, self.enrollment_method)
+            analytics.failed_pretokenization_request(request, "switchio", response.status_code, self.enrollment_method)
 
             if response.status is Status.SYSTEM_ERROR:
                 redirect = reverse(self.route_system_error)

--- a/tests/pytest/core/models/test_transit.py
+++ b/tests/pytest/core/models/test_transit.py
@@ -183,6 +183,27 @@ def test_TransitAgency_clean(model_TransitAgency_inactive):
 
 
 @pytest.mark.django_db
+def test_TransitAgency_transit_processor_littlepay(model_TransitAgency, model_LittlepayConfig):
+    model_LittlepayConfig.transit_agency = model_TransitAgency
+    model_TransitAgency.save()
+
+    assert model_TransitAgency.transit_processor == "littlepay"
+
+
+@pytest.mark.django_db
+def test_TransitAgency_transit_processor_switchio(model_TransitAgency, model_SwitchioConfig):
+    model_SwitchioConfig.transit_agency = model_TransitAgency
+    model_TransitAgency.save()
+
+    assert model_TransitAgency.transit_processor == "switchio"
+
+
+@pytest.mark.django_db
+def test_TransitAgency_transit_processor_no_config(model_TransitAgency):
+    assert model_TransitAgency.transit_processor is None
+
+
+@pytest.mark.django_db
 def test_TransitAgency_enrollment_index_route_littlepay(model_TransitAgency, model_LittlepayConfig):
     model_LittlepayConfig.transit_agency = model_TransitAgency
     model_TransitAgency.save()

--- a/tests/pytest/enrollment/test_analytics.py
+++ b/tests/pytest/enrollment/test_analytics.py
@@ -6,9 +6,10 @@ from benefits.enrollment.analytics import FailedPretokenizationRequestEvent, Ret
 
 
 @pytest.mark.django_db
-def test_FailedAccessTokenRequestEvent_sets_status_code(app_request):
-    event = FailedPretokenizationRequestEvent(app_request, 500)
+def test_FailedPretokenizationRequestEvent_sets_properties(app_request):
+    event = FailedPretokenizationRequestEvent(app_request, "processor", 500)
 
+    assert event.event_properties["transit_processor"] == "processor"
     assert event.event_properties["status_code"] == 500
 
 
@@ -21,19 +22,25 @@ def test_ReturnedEnrollmentEvent_without_error(app_request, mocker):
     mock_verified = {"eligibility_claim": "medicare", "extra_claim": "disabled"}
     mocker.patch("benefits.core.session.OAuthSession.claims_result", return_value=ClaimsResult(verified=mock_verified))
 
-    event = ReturnedEnrollmentEvent(app_request, status="success", enrollment_group="TEST GROUP")
+    event = ReturnedEnrollmentEvent(
+        app_request, status="success", enrollment_group="TEST GROUP", transit_processor="processor"
+    )
     assert "error_code" not in event.event_properties
     assert "enrollment_flows" in event.event_properties
 
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("model_LittlepayGroup")
-def test_returned_success_sends_event_with_optional_data(app_request, mocker, model_EnrollmentFlow_with_scope_and_claim):
-    keys = ["enrollment_group", "extra_claims", "card_scheme", "card_category"]
+def test_returned_success_sends_event_with_optional_data(
+    app_request, mocker, model_EnrollmentFlow_with_scope_and_claim, model_LittlepayConfig
+):
+    keys = ["enrollment_group", "transit_processor", "extra_claims", "card_scheme", "card_category"]
     spy_send_event = mocker.spy(benefits.core.analytics, "send_event")
+    agency = model_LittlepayConfig.transit_agency
     returned_success(
         app_request,
         enrollment_group=model_EnrollmentFlow_with_scope_and_claim.group_id,
+        transit_processor=agency.transit_processor,
         extra_claims="claim",
         card_scheme="scheme",
         card_category="catgegory",


### PR DESCRIPTION
Closes #3210

This PR adds a `transit_processor` property to enrollment events. It's accessed by way of a new property on the `TransitAgency` model.