### PR TITLE
fix: clear select validation errors on change

### DIFF
--- a/benefits/core/templates/core/includes/form--select-agency.html
+++ b/benefits/core/templates/core/includes/form--select-agency.html
@@ -5,4 +5,13 @@
   <button class="btn btn-lg btn-primary mt-2" type="submit">{% translate "Next" %}</button>
   {% csrf_token %}
   {% include "core/includes/form-handlers.html" %}
+  <script nonce="{{ request.csp_nonce }}">
+    // clear stale errors immediately to ensure that they do not obscure the submit button
+    ready(function () {
+      const select = document.querySelector("#{{ form.id }} select");
+      select.addEventListener("change", function () {
+        select.setCustomValidity("");
+      });
+    });
+  </script>
 </form>


### PR DESCRIPTION
this tweak ensures that a stale validation error on the homepage never blocks the 'Next' button.

<img width="476" height="189" alt="Screenshot 2025-10-31 at 11 22 07 AM" src="https://github.com/user-attachments/assets/77c12385-b720-4e33-936d-df67ab57dae3" />

https://developer.mozilla.org/en-US/docs/Web/API/HTMLObjectElement/setCustomValidity

Part of #3125