### PR TITLE
chore: auto-assign PRs to their creator

### DIFF
--- a/.github/workflows/auto-assigner.yml
+++ b/.github/workflows/auto-assigner.yml
@@ -1,0 +1,14 @@
+name: Auto-assign author to pull request
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-assign author to PR
+        uses: hkusu/review-assign-action@v1
+        with:
+          assignees: ${{ github.actor }} # assign pull request author


### PR DESCRIPTION
resolves #3224. Copilot wrote this github action, so maybe i should assign it to `Claude Sonnet 3.5`. 😂 

https://github.com/cal-itp/benefits/actions/runs/18984075105/job/54223595429?pr=3262