### PR TITLE
fix: improve contrast of homepage select indicator

### DIFF
--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -587,6 +587,12 @@ footer .footer-links li a.footer-link:visited {
   padding: calc(var(--grid-spacer) * 1.5);
 }
 
+#form-agency-selection .form-select:focus,
+#form-agency-selection .form-select:focus-visible {
+  outline: var(--focus-style);
+  outline-offset: var(--focus-outline-offset);
+}
+
 #form-agency-selection label {
   font-size: var(--font-size-20px);
   line-height: var(--bs-body-line-height);


### PR DESCRIPTION
resolves #3264 

<img width="506" height="179" alt="Screenshot 2025-11-04 at 11 34 56 AM" src="https://github.com/user-attachments/assets/ce758686-7c09-4e94-bd31-115ab1b47ec1" />

assigning @cmajel as an (optional) reviewer in addition to the usual suspects.