### PR TITLE
fix: make admin courtesy card confirmation agency agnostic

### DIFF
--- a/benefits/in_person/context/eligibility.py
+++ b/benefits/in_person/context/eligibility.py
@@ -20,7 +20,7 @@ eligibility_index = {
         "Medicare card."
     ),
     SystemName.COURTESY_CARD.value: EligibilityIndex(
-        policy_details="I confirmed this rider’s identity using a government-issued ID and verified they possess an MST "
+        policy_details="I confirmed this rider’s identity using a government-issued ID and verified they possess a "
         "Courtesy Card."
     ),
 }


### PR DESCRIPTION
just something small @Scotchester and i caught out testing the release today. 

<img width="531" height="588" alt="Screenshot 2025-11-05 at 10 55 06 AM" src="https://github.com/user-attachments/assets/8b451d5c-c646-40f3-bd07-286f5ec0b38a" />

i'm under the impression that even though we don't plan to offer additional digital courtesy card enrollments going forward, they will still be able to be configured in-person.