### PR TITLE
fix: set storage_account_id with appropriate value

### DIFF
--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -66,7 +66,7 @@ resource "azurerm_backup_policy_file_share" "policy" {
 
 resource "azurerm_storage_share" "data" {
   name                 = "benefits-data"
-  storage_account_id = azurerm_storage_account.main.name
+  storage_account_id   = azurerm_storage_account.main.id
   quota                = 5
   enabled_protocol     = "SMB"
   acl {


### PR DESCRIPTION
unexpected fast-follow to https://github.com/cal-itp/benefits/pull/3250

---

alright, i've got my mind wrapped around what went wrong [here](https://calenterprise.visualstudio.com/CDT.OET.CAL-ITP/_build/results?buildId=110774&view=logs&j=5af648c4-4294-55a7-6072-dd70820d3dba&t=39708da4-e251-5130-285a-f2fe36c9a5aa) and i'm confident that the change proposed in this PR will result in correct behavior applying changes on test and prod.

i say this because local attempts to `terraform plan` the test environment report the correct `id` for the change.

```tf
# azurerm_storage_share.data will be updated in-place
~ resource "azurerm_storage_share" "data" {
      id                   = "https://sacdtcalitpt001.file.core.windows.net/benefits-data"
      name                 = "benefits-data"
    + storage_account_id   = "/subscriptions/9bd.../resourceGroups/...
    - storage_account_name = "sacdtcalitpt001" -> null
```

the issue that remains is that attempting to `terraform plan` in the dev environment fails with the same error that was reported by the last apply, presumably because it succeeded in altering _some_ resources, leaving the environment in a liminal/unstable state.

https://community.gruntwork.io/t/cleanup-of-terraform-apply-partial-fails/420

~i must confess i'm fairly clueless as to the best way to untangle the mess on dev. i'd suspect the nuclear option would be to back up its db, blow away the storage account entirely and have terraform recreate it from scratch, but i have no idea what other repercussions there might be to doing something that drastic.~

~i'll keep looking into more surgical options, but if anyone else has any ideas i'd love to discuss them.~

edit: i think i found the scalpel (w/ a little help from Gemini).

instead of touching the storage account or samba fileshare in azure, i backed up the django db and ran the command below:

```
mise exec terraform@1.13.4 -- terraform state rm azurerm_storage_share.data
```

and rehydrated terraform state by asking it to take a fresh look at the resource that still exists in azure:

```
mise exec terraform@1.13.4 -- terraform import azurerm_storage_share.data /subscriptions/9bdb8e29...
```

afterward, i could `plan` and `apply` locally again. 😎 