### PR TITLE
Password reset: implement email templates

### DIFF
--- a/benefits/templates/registration/password_reset_email.html
+++ b/benefits/templates/registration/password_reset_email.html
@@ -1,0 +1,63 @@
+<link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;700&display=swap" rel="stylesheet">
+<style>
+  body {
+    color: #535456;
+    font-family: 'Noto Sans', sans-serif;
+    font-size: 14px;
+  }
+
+  h1 {
+    color: #212121;
+    font-size: 24px;
+  }
+
+  a {
+    color: unset;
+  }
+
+  .message-body {
+    max-width: 576px;
+  }
+
+  .link-wrapper {
+    padding: 16px 0px;
+  }
+
+  .link-button {
+    background: #025B86;
+    border-radius: 16px;
+    color: #fff;
+    font-weight: 700;
+    padding: 8px 16px;
+    text-decoration: none;
+  }
+
+  .divider {
+    border: 2px solid #ECEFF1;
+  }
+</style>
+
+{% autoescape off %}
+  <h1>Your reset password link</h1>
+  <div class="message-body">
+    <p>
+      Click the button below to reset the password for your Cal-ITP Benefits Administrator account. This link will expire in 15 minutes and can only be used once.
+    </p>
+    <div class="link-wrapper">
+      <a class="link-button" href="{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}">
+        Reset your password
+      </a>
+    </div>
+    <p>
+      If the button above doesn't work, paste this link into your web browser:
+      <a href="{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}">
+        {{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
+      </a>
+    </p>
+    <p>If you did not make this request, you can safely ignore this email.</p>
+  </div>
+  <div class="divider"></div>
+  <p>
+    Sent by <a href="https://calitp.org">California Integrated Travel Project</a> California Department of Transportation 1120 N Street Sacramento, CA 95814
+  </p>
+{% endautoescape %}

--- a/benefits/templates/registration/password_reset_subject.txt
+++ b/benefits/templates/registration/password_reset_subject.txt
@@ -1,0 +1,1 @@
+Reset your password for Cal-ITP Benefits Administrator


### PR DESCRIPTION
resolves #3273

### design
https://www.figma.com/design/Y7fffLWV4cvZMgLM0fLvtP/Cal-ITP-Benefits-Admin?node-id=2515-5606&m=dev
(note that in the comment thread [here](https://www.figma.com/design/Y7fffLWV4cvZMgLM0fLvtP?node-id=2515-5606&m=dev#1513595711) Product/Design landed in favor of using the term 'Administrator' instead of 'Admin', to match the existing login UI)

### dev
this work attempts to keep the email styles as primitive and portable as possible (ie: no flexbox, bootstrap, etc.)

in anticipation of the actual email pipeline being stood up in #3293, i just riffed in Codepen: https://codepen.io/jgravois/pen/PwNoNOW?editors=1100

### testing
i cherry-picked this commit on top of @Scotchester's work in #3285 and confirmed that the same email is written to the console on submit with no additional code changes. 😎 