### PR TITLE
Chore: update Django docs link

### DIFF
--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -384,7 +384,7 @@ except Exception:
 REQUESTS_TIMEOUT = (REQUESTS_CONNECT_TIMEOUT, REQUESTS_READ_TIMEOUT)
 
 # Email
-# https://docs.djangoproject.com/en/5.1/ref/settings/#email-backend
+# https://docs.djangoproject.com/en/5.2/ref/settings/#email-backend
 # https://github.com/retech-us/django-azure-communication-email
 AZURE_COMMUNICATION_CONNECTION_STRING = os.environ.get("AZURE_COMMUNICATION_CONNECTION_STRING")
 


### PR DESCRIPTION
Followup to #3293

Small update as pointed out in https://github.com/cal-itp/benefits/pull/3293#discussion_r2535085569, update the link to point to the 5.2 Django docs.