### PR TITLE
Fix: Benefits version number

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 **/__pycache__/
 node_modules/
+.pytest_cache/
 static/
 .coverage
 *.db

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ __pycache__/
 .DS_Store
 .sent_emails/
 .venv
+
+# including this just to be explicit. Pytest itself already ensures its cache directory is ignored by Git.
+.pytest_cache/


### PR DESCRIPTION
Closes #3311

## Background 

Notice in `pyproject.toml` that our version is [dynamic](https://github.com/cal-itp/benefits/blob/main/pyproject.toml#L3). Python packaging build tools can set the version - see https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#static-vs-dynamic-metadata.

We use [`setuptools-scm`](https://setuptools-scm.readthedocs.io/en/latest/) during our [Python-package build process](https://github.com/cal-itp/benefits/blob/4f9c3ac134e57157d0a3d1c5b3757e470270ad87/pyproject.toml#L55) so that it will calculate our version number for us by looking at the Git repo's metadata. The [default versioning scheme](https://setuptools-scm.readthedocs.io/en/latest/usage/#default-versioning-scheme), which we use, uses the name of the latest annotated tag, whose name follows a [version tag format](https://setuptools-scm.readthedocs.io/en/latest/usage/#version-tag-formats), as the version number if there are no pending changes.

## The problem

Starting with `2025.08.1`, the calculated version number is not what we expect; it is formatted with `{next_version}.dev{distance}+{scm letter}{revision hash}.dYYYYMMDD` rather than `{tag}`. This tells us that during the build process, something is causing the build tool to see that there are changes to the repo's files.

In the diff of `2025.07.1` to `2025.08.1`, we see that some directories were added to `.dockerignore` - https://github.com/cal-itp/benefits/compare/2025.07.1...2025.08.1#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5.

These directories are tracked by Git, so that explains why the build process running from within the Docker build context is seeing changes.

## The fix

Remove those directories from `.dockerignore` so that all git-tracked files will be seen during the build.

## Testing

I followed the steps listed in #2389 to first reproduce the issue and then confirm that with the fix, we get the correct version number.

To see that the fix works,
- (Outside of the devcontainer) Check out this branch - `git checkout fix/version-number`
- Create an annotated tag - `git tag -a 2025.11.2`, use whatever test message you want for the tag annotation
- Run `docker compose build --no-cache client; docker compose up -d client; docker compose exec -ti client /bin/bash`
- Run `python manage.py shell`
- Run `import benefits; print(benefits.VERSION);`
  - You should see `2025.11.2` :white_check_mark: 
- Now, clean-up :broom: :
  - Run `exit()`
  - Run `exit`
  - Run `git tag -d 2025.11.2`

## Screenshots

| Version | Output |
| --- | --- |
| `2025.07.1` :white_check_mark: | <img width="407" height="44" alt="Screenshot from 2025-11-17 18-37-25" src="https://github.com/user-attachments/assets/3418b490-5f1e-412e-8257-d46098dac60d" /> |
|`2025.08.1` :x: | <img width="407" height="44" alt="Screenshot from 2025-11-17 18-37-40" src="https://github.com/user-attachments/assets/2dfa63b8-57aa-4dd7-8069-4c8cde22e661" /> |
| `2025.11.1` :x:  | <img width="407" height="44" alt="Screenshot from 2025-11-17 18-38-15" src="https://github.com/user-attachments/assets/68b53ad2-26f4-4f84-a716-12a2230c16f3" /> |
| `2025.11.2` (my tag for testing) :white_check_mark: | <img width="407" height="44" alt="Screenshot from 2025-11-17 18-38-29" src="https://github.com/user-attachments/assets/0f309aeb-968b-445f-83c9-6914dd7e3349" /> |
