### PR TITLE
chore: advertise a looser reset password link expiration

### DIFF
--- a/benefits/templates/registration/password_reset_email.html
+++ b/benefits/templates/registration/password_reset_email.html
@@ -1,63 +1,71 @@
-<link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;700&display=swap" rel="stylesheet">
-<style>
-  body {
-    color: #535456;
-    font-family: 'Noto Sans', sans-serif;
-    font-size: 14px;
-  }
-
-  h1 {
-    color: #212121;
-    font-size: 24px;
-  }
-
-  a {
-    color: unset;
-  }
-
-  .message-body {
-    max-width: 576px;
-  }
-
-  .link-wrapper {
-    padding: 16px 0px;
-  }
-
-  .link-button {
-    background: #025B86;
-    border-radius: 16px;
-    color: #fff;
-    font-weight: 700;
-    padding: 8px 16px;
-    text-decoration: none;
-  }
-
-  .divider {
-    border: 2px solid #ECEFF1;
-  }
-</style>
-
 {% autoescape off %}
-  <h1>Your reset password link</h1>
-  <div class="message-body">
-    <p>
-      Click the button below to reset the password for your Cal-ITP Benefits Administrator account. This link will expire in 24 hours and can only be used once.
-    </p>
-    <div class="link-wrapper">
-      <a class="link-button" href="{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}">
-        Reset your password
-      </a>
-    </div>
-    <p>
-      If the button above doesn't work, paste this link into your web browser:
-      <a href="{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}">
-        {{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
-      </a>
-    </p>
-    <p>If you did not make this request, you can safely ignore this email.</p>
-  </div>
-  <hr class="divider" />
-  <p>
-    Sent by <a href="https://calitp.org">California Integrated Travel Project</a> California Department of Transportation 1120 N Street Sacramento, CA 95814
-  </p>
+  <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+  <html lang="en-US">
+    <head>
+      <meta name="description" content="Cal-ITP Administrator - password reset" />
+      <title>Reset password</title>
+      <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;700&display=swap" rel="stylesheet">
+      <style type="text/css">
+        body {
+          color: #535456;
+          font-family: 'Noto Sans', sans-serif;
+          font-size: 14px;
+        }
+
+        h1 {
+          color: #212121;
+          font-size: 24px;
+        }
+
+        a {
+          color: unset;
+        }
+
+        .message-body {
+          max-width: 576px;
+        }
+
+        .link-wrapper {
+          padding: 16px 0px;
+        }
+
+        .link-button {
+          background: #025B86;
+          border-radius: 16px;
+          color: #fff;
+          font-weight: 700;
+          padding: 8px 16px;
+          text-decoration: none;
+        }
+
+        .divider {
+          border: 2px solid #ECEFF1;
+        }
+      </style>
+    </head>
+    <body>
+      <h1>Your reset password link</h1>
+      <div class="message-body">
+        <p>
+          Click the button below to reset the password for your Cal-ITP Benefits Administrator account. This link will expire in 24 hours and can only be used once.
+        </p>
+        <div class="link-wrapper">
+          <a class="link-button" href="{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}">
+            Reset your password
+          </a>
+        </div>
+        <p>
+          If the button above doesn't work, paste this link into your web browser:
+          <a href="{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}">
+            {{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
+          </a>
+        </p>
+        <p>If you did not make this request, you can safely ignore this email.</p>
+      </div>
+      <hr class="divider" />
+      <p>
+        Sent by <a href="https://calitp.org">California Integrated Travel Project</a> California Department of Transportation 1120 N Street Sacramento, CA 95814
+      </p>
+    </body>
+  </html>
 {% endautoescape %}


### PR DESCRIPTION
## TL;DR

* advertise a 24 hour expiration for password reset links instead of 15 minutes. (relevant [Figma discussion](https://www.figma.com/design/Y7fffLWV4cvZMgLM0fLvtP?node-id=2515-5606&m=dev#1520258848))
* use a `<hr/>` instead of a plain old `<div/>` where appropriate
* add wrapping tags to ensure compatibility with legacy email clients

## deets

after i merged #3286 i got to thinking that i probably should have wrapped the template in the wrapper tags we all know and love. 

```html
<html>
  <body> 
    { message }
  </body>
</html>
```

i checked a few raw emails and found some that omit them, but the conventional wisdom is definitely still that there's a benefit to ☝️ (for example: [mailchimp templates](https://github.com/mailchimp/email-blueprints/blob/4d4daa85a8107baf128b88dd3baaf16137befb8e/templates/simple-letterhead-centerlogo.html) include them)

the resulting HTML is a bit uglier, but i'm more confident that it will render correctly if a transit agency is using an outdated email client. i suspect the odds of that are higher than 0%.

while i was rearranging the closet, i swapped in a more semantic [`<hr/>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/hr) tag too.

new: https://codepen.io/jgravois/pen/PwNoNOW?editors=1100
old: https://codepen.io/jgravois/pen/PwNoNOW?editors=1100

regardless, sorry for the noisy diff.