### PR TITLE
Refactor: convert Enrollment retry to CBV

### DIFF
--- a/benefits/enrollment/urls.py
+++ b/benefits/enrollment/urls.py
@@ -13,7 +13,7 @@ urlpatterns = [
     # /enrollment
     path("", views.IndexView.as_view(), name=routes.name(routes.ENROLLMENT_INDEX)),
     path("error/reenrollment", views.ReenrollmentErrorView.as_view(), name=routes.name(routes.ENROLLMENT_REENROLLMENT_ERROR)),
-    path("retry", views.retry, name=routes.name(routes.ENROLLMENT_RETRY)),
+    path("retry", views.RetryView.as_view(), name=routes.name(routes.ENROLLMENT_RETRY)),
     path("success", views.SuccessView.as_view(), name=routes.name(routes.ENROLLMENT_SUCCESS)),
     path("error", views.system_error, name=routes.name(routes.ENROLLMENT_SYSTEM_ERROR)),
 ]

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -25,7 +25,6 @@ from benefits.core.mixins import (
 from benefits.core.middleware import EligibleSessionRequired
 from . import analytics
 
-TEMPLATE_RETRY = "enrollment/retry.html"
 TEMPLATE_SYSTEM_ERROR = "enrollment/system_error.html"
 
 
@@ -82,13 +81,16 @@ class ReenrollmentErrorView(FlowSessionRequiredMixin, EligibleSessionRequiredMix
         return super().get(request, *args, **kwargs)
 
 
-@decorator_from_middleware(EligibleSessionRequired)
-def retry(request):
+class RetryView(AgencySessionRequiredMixin, FlowSessionRequiredMixin, EligibleSessionRequiredMixin, TemplateView):
     """View handler for a recoverable failure condition."""
-    flow = session.flow(request)
-    agency = session.agency(request)
-    analytics.returned_retry(request, enrollment_group=flow.group_id, transit_processor=agency.transit_processor)
-    return TemplateResponse(request, TEMPLATE_RETRY)
+
+    template_name = "enrollment/retry.html"
+
+    def get(self, request, *args, **kwargs):
+        enrollment_group = self.flow.group_id
+        transit_processor = self.agency.transit_processor
+        analytics.returned_retry(request, enrollment_group=enrollment_group, transit_processor=transit_processor)
+        return super().get(request, *args, **kwargs)
 
 
 @decorator_from_middleware(EligibleSessionRequired)


### PR DESCRIPTION
Closes #3011 

This is a hard one to reproduce in a testing environment, since e.g. Littlepay accepts any combination of name/test card/future expiry/CVV in QA, and the error condition is meant to capture a card verification error on the transit processor side (e.g. the user fat-fingers their card number or CVV).

You can confirm the page still loads as expected though:

1. Configure localhost with any transit processor's QA env
2. Run through eligibility verification and pass
3. Once at the transit processor enrollment page, manually enter the URL `/enrollment/retry`
4. Confirm the page looks like we expect (`"The card information may not have been entered correctly"`), with contact details for the chosen transit agency
5. Confirm the `Try again` button takes you back to the transit processor enrollment page

<img width="1746" height="1202" alt="image" src="https://github.com/user-attachments/assets/e6aa4e04-ca05-436a-b7e9-690aafaecd72" />

