### PR TITLE
fix: Handle multiple forms when including reCAPTCHA on one of them

### DIFF
--- a/benefits/core/templates/core/includes/recaptcha.html
+++ b/benefits/core/templates/core/includes/recaptcha.html
@@ -4,9 +4,14 @@ Adapted from https://stackoverflow.com/a/63290578/453168
 {% endcomment %}
 
 {% comment %}
+Create a pseudorandom identifier from the current microseconds to ensure we attach the event to the right button.
+{% endcomment %}
+{% now "u" as unique_id %}
+
+{% comment %}
 hidden input field will later send g-recaptcha token back to server
 {% endcomment %}
-<input type="hidden" name="{{ request.recaptcha.data_field }}" value="">
+<input type="hidden" name="{{ request.recaptcha.data_field }}" data-recaptcha-id="{{ unique_id }}" value="">
 
 <div class="pt-8">{% include "core/includes/recaptcha-text.html" %}</div>
 
@@ -38,6 +43,8 @@ function recaptchaSubmit(event) {
   });
 };
 
-// bind the above handler to button click
-document.querySelector("[type=submit]").addEventListener("click", recaptchaSubmit);
+// bind the above handler to clicking the submit element of the form this is included within
+const hiddenInput = document.querySelector('[data-recaptcha-id="{{ unique_id }}"]');
+const parentForm = hiddenInput.form;
+parentForm.querySelector('[type="submit"]').addEventListener("click", recaptchaSubmit);
 </script>


### PR DESCRIPTION
Fixes #3325

Adds a unique identifier to the hidden reCAPTCHA field and uses that to ensure we attach the event listener to the correct form submit element.

### Testing instructions

1. To reproduce the issue, with your local repo still on `main`:
   1. Set up your local env to enable reCAPTCHA by adding the env vars found in the "Benefits reCAPTCHA config" note in LastPass to your `env` object in `launch.json`
   1. Go to your locally running application
   1. Select CST
   1. Try to choose an eligibility flow
   1. Observe error
1. To test the fix:
   1. Checkout this branch
   1. Follow reproduction steps again
   1. You should not encounter the error this time