### PR TITLE
Refactor: convert In-person Enrollment reenrollment error to CBV

### DIFF
--- a/benefits/in_person/urls.py
+++ b/benefits/in_person/urls.py
@@ -18,7 +18,7 @@ urlpatterns = [
     ),
     path(
         "enrollment/error/reenrollment",
-        admin.site.admin_view(views.reenrollment_error),
+        admin.site.admin_view(views.ReenrollmentErrorView.as_view()),
         name=routes.name(routes.IN_PERSON_ENROLLMENT_REENROLLMENT_ERROR),
     ),
     path(

--- a/tests/pytest/in_person/test_views.py
+++ b/tests/pytest/in_person/test_views.py
@@ -161,14 +161,21 @@ class TestLittlepayEnrollmentView:
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("mocked_session_flow", "mocked_session_agency")
-def test_reenrollment_error(admin_client):
-    path = reverse(routes.IN_PERSON_ENROLLMENT_REENROLLMENT_ERROR)
+class TestReenrollmentErrorView:
+    @pytest.fixture
+    def view(self, app_request, model_LittlepayConfig, model_EnrollmentFlow, model_User):
+        app_request.user = model_User
+        v = views.ReenrollmentErrorView()
+        v.setup(app_request)
+        v.agency = model_LittlepayConfig.transit_agency
+        v.flow = model_EnrollmentFlow
+        return v
 
-    response = admin_client.get(path)
+    def test_get_context_data(self, view):
+        context = view.get_context_data()
 
-    assert response.status_code == 200
-    assert response.template_name == "in_person/enrollment/reenrollment_error.html"
+        assert "title" in context
+        assert context["flow_label"] == view.flow.label
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Closes #3109

This PR refactors `benefits/in_person/views.reenrollment_error` to a class-based view. The in-person re-enrollment error page at `http://localhost/in_person/enrollment/error/reenrollment` still looks like:
<img width="2946" height="1274" alt="image" src="https://github.com/user-attachments/assets/04958151-3963-4a9b-864c-dc06b9b96e0f" />

## Reviewing

Reviewing this page requires a little setup but we can follow the method laid out in https://github.com/cal-itp/benefits/pull/3146#issue-3407906001

- Starting with the `dev` Littlepay fixtures in LastPass, log in to the Django admin and configure the Older Adult flow (or Medicare) to `Supports expiration`. Set `Expiration days` to 10 and `Expiration reenrollment days` to 5. This is necessary so that we can reuse the flows that are already set up in the fixtures for testing this refactor. Otherwise, the context for `in_person/enrollment/reenrollment_error.html` will be incomplete.
- Add the snippet below immediately under the `try` keyword on https://github.com/cal-itp/benefits/blob/main/benefits/enrollment_littlepay/enrollment.py#L78 to force the enrollment logic to return a re-enrollment error 

  ```python
  expiration_days = 10
  enrollment_expiry = _calculate_expiry(expiration_days)
  session.update(request, enrollment_expiry=enrollment_expiry)
  return Status.REENROLLMENT_ERROR, None, funding_source
  ```

  You could do something similar on `benefits/enrollment_switchio/enrollment.enroll` using the Switchio `dev` fixtures but testing Littlepay seems sufficient.
- Go through a complete in-person enrollment flow using the flow for which you enabled `Supports expiration` and using any test credit card to see the re-enrollment error at the end