### PR TITLE
Fix: special characters in email for password reset

### DIFF
--- a/benefits/core/admin/views.py
+++ b/benefits/core/admin/views.py
@@ -1,3 +1,5 @@
+from urllib.parse import quote
+
 from django.contrib.auth.views import PasswordResetView, PasswordResetDoneView, PasswordResetConfirmView
 from django.contrib import messages
 from django.urls import reverse_lazy
@@ -12,7 +14,11 @@ class BenefitsPasswordResetView(RecaptchaEnabledMixin, PasswordResetView):
     form_class = BenefitsPasswordResetForm
 
     def form_valid(self, form):
-        self.success_url = f"{reverse_lazy("password_reset_done")}?email={form.cleaned_data["email"]}"
+        email = form.cleaned_data["email"]
+        # encode special characters in email address so it's safe for use in a URL
+        url_encoded_email = quote(email)
+
+        self.success_url = f"{reverse_lazy("password_reset_done")}?email={url_encoded_email}"
         return super().form_valid(form)
 
 

--- a/tests/pytest/core/admin/test_views.py
+++ b/tests/pytest/core/admin/test_views.py
@@ -19,12 +19,12 @@ class TestBenefitsPasswordResetView:
         return v
 
     def test_form_valid(self, view):
-        email = "mail@example.com"
+        email = "mail+alias@example.com"
         form = view.form_class(data={"email": email})
         assert form.is_valid()
 
         view.form_valid(form)
-        assert view.success_url == f"{reverse("password_reset_done")}?email={email}"
+        assert view.success_url == f"{reverse("password_reset_done")}?email=mail%2Balias%40example.com"
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Followup to #3318

This PR implements a small fix to encode the email address (using [quote](https://docs.python.org/3/library/urllib.parse.html#url-quoting) from the standard library) in the password reset link to handle special characters correctly since they need to be URL-encoded. Before, `+` characters were not displaying, but now they do appear in the password reset template:

<img width="495" height="392" alt="image" src="https://github.com/user-attachments/assets/7acb90eb-1134-4e6c-bb14-5b054a2dd164" />


## Reviewing

Start a debugger in your local environment and set up a test user. Use special characters in the test user's email address (for example `name+alias@gmail.com` as used by Gmail's "plus" aliases). Request a password reset for the test user and confirm that the email address displays all the characters.
