### PR TITLE
feat: Support both HTML and plain text password reset emails

### DIFF
--- a/benefits/core/admin/views.py
+++ b/benefits/core/admin/views.py
@@ -10,6 +10,8 @@ class BenefitsPasswordResetView(RecaptchaEnabledMixin, PasswordResetView):
     """Subclass of stock PasswordResetView to enable reCAPTCHA and pass email to done view"""
 
     form_class = BenefitsPasswordResetForm
+    email_template_name = "registration/password_reset_email.txt"
+    html_email_template_name = "registration/password_reset_email.html"
 
     def form_valid(self, form):
         self.success_url = f"{reverse_lazy("password_reset_done")}?email={form.cleaned_data["email"]}"

--- a/benefits/templates/registration/password_reset_email.txt
+++ b/benefits/templates/registration/password_reset_email.txt
@@ -1,0 +1,17 @@
+{% autoescape off %}
+Your reset password link
+------------------------
+
+
+Click the link below to reset the password for your Cal-ITP Benefits Administrator account. This link will expire in 24 hours and can only be used once.
+
+{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
+
+If the link can't be clicked, you can copy and paste it into your web browser.
+
+If you did not make this request, you can safely ignore this email.
+
+
+---
+Sent by California Integrated Travel Project (https://www.calitp.org) California Department of Transportation 1120 N Street Sacramento, CA 95814
+{% endautoescape %}


### PR DESCRIPTION
- Adds a plain text version of the email template.
- Sets the parent `PasswordResetView` class's `email_template_name` and `html_email_template_name` attributes so that we can send both types of emails.

Not sure how to completely test this until we get it on dev and can send actual emails, but  confirmed that the file-based email backend now saves a multipart email with both text and HTML formats included. I opened it with macOS mail and the HTML view looked great, but I could not figure out how to get it to show me the plain text view.