### PR TITLE
Fix: enrollment retry implements dispatch() instead of get()

### DIFF
--- a/tests/pytest/enrollment/test_views.py
+++ b/tests/pytest/enrollment/test_views.py
@@ -110,13 +110,21 @@ class TestRetryView:
         v.flow = model_LittlepayGroup.enrollment_flow
         return v
 
-    def test_get(self, app_request, view, mocked_analytics_module, model_LittlepayGroup):
-        response = view.get(app_request)
+    def test_dispatch__get(self, app_request, view, mocked_analytics_module, model_LittlepayGroup):
+        response = view.dispatch(app_request)
+
+        assert response.status_code == 200
+        assert response.template_name == "200-user-error.html"
+        mocked_analytics_module.returned_retry.assert_not_called()
+
+    def test_dispatch__post(self, app_request_post, view, mocked_analytics_module, model_LittlepayGroup):
+        view.setup(app_request_post)
+        response = view.dispatch(app_request_post)
 
         assert response.status_code == 200
         assert response.template_name == ["enrollment/retry.html"]
         mocked_analytics_module.returned_retry.assert_called_once_with(
-            app_request, enrollment_group=model_LittlepayGroup.group_id, transit_processor="littlepay"
+            app_request_post, enrollment_group=model_LittlepayGroup.group_id, transit_processor="littlepay"
         )
 
 


### PR DESCRIPTION
For Littlepay, the Javascript in [`enrollment_littlepay/index.html`](https://github.com/cal-itp/benefits/blob/main/benefits/enrollment_littlepay/templates/enrollment_littlepay/index.html#L71) sends a form POST to this view. To simplify, we check the method and process POSTs rather than implementing as a `FormView`, which requires instantiating the [`enrollment.forms.CardTokenizeFailForm`](https://github.com/cal-itp/benefits/blob/main/benefits/enrollment/forms.py#L22), needing additional parameters such as a form `id` and `action_url`, that are already specified in the [`enrollment_littlepay/views.IndexView`](https://github.com/cal-itp/benefits/blob/main/benefits/enrollment_littlepay/views.py#L54).

For other request methods (non-POST), we don't want/need to serve the retry template since users should only arrive via the form POST, returning `super().dispatch()` results in a 200 User Error response.

Switchio doesn't use this view at all.

As a follow-up, we could look at moving the `RetryView` into `enrollment_littlepay` and implementing as a proper `FormView`.