### PR TITLE
Fix: de-duplicate the `display_order` values on sample EnrollmentFlows

### DIFF
--- a/benefits/core/migrations/local_fixtures.json
+++ b/benefits/core/migrations/local_fixtures.json
@@ -252,7 +252,7 @@
     "fields": {
       "system_name": "veteran",
       "label": "U.S. Veteran",
-      "display_order": 3,
+      "display_order": 4,
       "oauth_config": "00e5cbdb-242a-4df5-a147-45d0c1e4dceb",
       "claims_request": "8fa9e649-4de6-4bd6-8eec-f5f47802ceab",
       "supported_enrollment_methods": ["digital"],
@@ -268,7 +268,7 @@
       "system_name": "agency_card",
       "label": "Agency Cardholder",
       "api_request": 1,
-      "display_order": 4,
+      "display_order": 5,
       "supported_enrollment_methods": ["digital"],
       "transit_agency": 1
     }
@@ -282,7 +282,7 @@
       "supports_expiration": "True",
       "expiration_days": 5,
       "expiration_reenrollment_days": 3,
-      "display_order": 2,
+      "display_order": 3,
       "oauth_config": "00e5cbdb-242a-4df5-a147-45d0c1e4dceb",
       "claims_request": "c6332e8c-7081-48e9-ae3c-07360879a8ae",
       "supported_enrollment_methods": ["digital"],


### PR DESCRIPTION
The need for this fix was discovered while testing #3348. You can read https://github.com/cal-itp/benefits/pull/3348#issuecomment-3614268062 for more details and context, but the gist is that we need the `display_order`s to be unique, sequential values in order for `django-admin-sortable2` to work correctly. (I think loading fixtures doesn't run any constraint validation, so that'd be how this invalid config went undetected.)

The two flows that had the same `display_order` value were Older Adult and Calfresh Cardholder:

https://github.com/cal-itp/benefits/blob/d7ce8e8ba8159956a868ba231afb0688d29c46f5/benefits/core/migrations/local_fixtures.json#L235-L240

https://github.com/cal-itp/benefits/blob/d7ce8e8ba8159956a868ba231afb0688d29c46f5/benefits/core/migrations/local_fixtures.json#L277-L285

Fixtures to fix:
- [x] `local_fixtures.json`
- [ ] ~~Fixtures in LastPass~~ -- I looked over these, and they were fine as-is. Nice!