### PR TITLE
Refactor: convert agency eligibility index to class-based view

### DIFF
--- a/benefits/core/urls.py
+++ b/benefits/core/urls.py
@@ -52,6 +52,10 @@ urlpatterns = [
     path("error", views.server_error, name=routes.name(routes.SERVER_ERROR)),
     path("<agency:agency>", views.AgencyIndexView.as_view(), name=routes.name(routes.AGENCY_INDEX)),
     path("<agency:agency>/agency-card", views.agency_card, name=routes.name(routes.AGENCY_CARD)),
-    path("<agency:agency>/eligibility", views.agency_eligibility_index, name=routes.name(routes.AGENCY_ELIGIBILITY_INDEX)),
+    path(
+        "<agency:agency>/eligibility",
+        views.AgencyEligibilityIndexView.as_view(),
+        name=routes.name(routes.AGENCY_ELIGIBILITY_INDEX),
+    ),
     path("<agency:agency>/publickey", views.agency_public_key, name=routes.name(routes.AGENCY_PUBLIC_KEY)),
 ]


### PR DESCRIPTION
Closes #2998

This view redirects to the `/eligibility` route with a session pre-configured with the agency parsed from the path via [`TransitAgencyPathConverter`](https://github.com/cal-itp/benefits/blob/main/benefits/core/urls.py#L16)

## Small implementation detail

We have to remove the `agency` key from kwargs incoming to the `get()` call before passing along to `super().get()`. This is because `super().get()` eventually calls `reverse(self.pattern_name, *args, **kwargs)`, where `pattern_name` is specified in this new CBV. The `reverse()` call would fail because this pattern doesn't expect any extra kwargs.

This is fine, as the CBV itself still has a reference to the original `self.kwargs`, if needed.

Alternatively, we could just call `super().get(request)` without passing along additional incoming args/kwargs, as we know they are unused. Happy to adjust the PR to go that direction if it seems cleaner.

## Reviewing

1. Checkout the branch and start the app locally
2. In the browser, enter the URL path `/cst/eligibility`
3. See the Eligibility Index page with CST's flows; confirm in the `DEBUG` bar that CST is stored as the agency in session

## Note

#3377 and #3378 are stacked on top of this one as separate PRs, but I could easily put the commits into this single PR and close all 3 issues with one merge.