### PR TITLE
Refactor: convert agency public key to class-based view

### DIFF
--- a/benefits/core/urls.py
+++ b/benefits/core/urls.py
@@ -57,5 +57,5 @@ urlpatterns = [
         views.AgencyEligibilityIndexView.as_view(),
         name=routes.name(routes.AGENCY_ELIGIBILITY_INDEX),
     ),
-    path("<agency:agency>/publickey", views.agency_public_key, name=routes.name(routes.AGENCY_PUBLIC_KEY)),
+    path("<agency:agency>/publickey", views.AgencyPublicKeyView.as_view(), name=routes.name(routes.AGENCY_PUBLIC_KEY)),
 ]

--- a/benefits/core/views.py
+++ b/benefits/core/views.py
@@ -7,7 +7,7 @@ from django.shortcuts import redirect
 from django.template import loader
 from django.template.response import TemplateResponse
 from django.utils.decorators import method_decorator
-from django.views.generic import RedirectView, TemplateView
+from django.views.generic import RedirectView, TemplateView, View
 from django.views.generic.edit import FormView
 
 from benefits.core.forms import ChooseAgencyForm
@@ -76,10 +76,13 @@ class AgencyEligibilityIndexView(RedirectView):
         return super().get(request, *args, **kwargs)
 
 
-@pageview_decorator
-def agency_public_key(request, agency: models.TransitAgency):
+class AgencyPublicKeyView(View):
     """View handler returns an agency's public key as plain text."""
-    return HttpResponse(agency.eligibility_api_public_key_data, content_type="text/plain")
+
+    @method_decorator(pageview_decorator)
+    def get(self, request, *args, **kwargs):
+        agency = kwargs.get("agency")
+        return HttpResponse(agency.eligibility_api_public_key_data, content_type="text/plain")
 
 
 @pageview_decorator

--- a/tests/pytest/core/test_views.py
+++ b/tests/pytest/core/test_views.py
@@ -92,13 +92,22 @@ class TestAgencyEligibilityIndexView:
 
 
 @pytest.mark.django_db
-def test_agency_public_key(client, model_TransitAgency):
-    url = reverse(routes.AGENCY_PUBLIC_KEY, args=[model_TransitAgency.slug])
-    response = client.get(url)
+class TestAgencyPublicKeyView:
 
-    assert response.status_code == 200
-    assert response.headers["Content-Type"] == "text/plain"
-    assert response.content.decode("utf-8") == model_TransitAgency.eligibility_api_public_key_data
+    @pytest.fixture
+    def view(self, app_request, model_TransitAgency):
+        v = views.AgencyPublicKeyView()
+        v.setup(app_request, agency=model_TransitAgency)
+        return v
+
+    def test_get(self, view, app_request):
+        agency = view.kwargs["agency"]
+        # recreate the condition of the live view, where the agency kwarg is passed to the get() call
+        response = view.get(app_request, agency=agency)
+
+        assert response.status_code == 200
+        assert response.headers["Content-Type"] == "text/plain"
+        assert response.content.decode("utf-8") == agency.eligibility_api_public_key_data
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
View returns the agency's public key for eligibility API as a utf-8 plaintext response

Closes #3372 


## Reviewing

1. Checkout the branch and start the app locally
2. In the browser, enter the URL path `/cst/publickey`
3. See a plaintext response with the public key contents:

```text
-----BEGIN PUBLIC KEY-----
MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1pt0ZoOuPEVPJJS+5r88
4zcjZLkZZ2GcPwr79XOLDbOi46onCa79kjRnhS0VUK96SwUPS0z9J5mDA5LSNL2R
oxFb5QGaevnJY828NupzTNdUd0sYJK3kRjKUggHWuB55hwJcH/Dx7I3DNH4NL68U
AlK+VjwJkfYPrhq/bl5z8ZiurvBa5C1mDxhFpcTZlCfxQoas7D1d+uPACF6mEMbQ
Nd3RaIaSREO50NvNywXIIt/OmCiRqI7JtOcn4eyh1I4j9WtlbMhRJLfwPMAgY5ep
TsWcURmhVofF2wVoFbib3JGCfA7tz/gmP5YoEKnf/cumKmF3e9LrZb8zwm7bTHUV
iwIDAQAB
-----END PUBLIC KEY-----
```

## Note

Currently stacked on top of #3373, we could easily put this commit in that PR and close both issues with one merge.