### PR TITLE
Refactor: convert agency card to class-based view

### DIFF
--- a/benefits/core/urls.py
+++ b/benefits/core/urls.py
@@ -51,7 +51,7 @@ urlpatterns = [
     path("logged_out", views.logged_out, name=routes.name(routes.LOGGED_OUT)),
     path("error", views.server_error, name=routes.name(routes.SERVER_ERROR)),
     path("<agency:agency>", views.AgencyIndexView.as_view(), name=routes.name(routes.AGENCY_INDEX)),
-    path("<agency:agency>/agency-card", views.agency_card, name=routes.name(routes.AGENCY_CARD)),
+    path("<agency:agency>/agency-card", views.AgencyCardView.as_view(), name=routes.name(routes.AGENCY_CARD)),
     path(
         "<agency:agency>/eligibility",
         views.AgencyEligibilityIndexView.as_view(),


### PR DESCRIPTION
View forwards the request to the agency's Agency Card (e.g. Eligibility API) flow, or returns a user error.

Closes #2999 

## Reviewing

1. Checkout the branch and start the app locally
2. In the browser, enter the URL path `/cst/agency-card`
3. See the Eligibility Confirm (agency card form) page for CST; confirm in the `DEBUG` bar that CST is stored as the agency in session and the Agency Card flow is stored as the flow in session.
4. Login to the Admin, navigate to Enrollment Flows, find CST's Agency Card flow, and unlink CST (deselect any transit agency), then save the flow.
5. In the browser, enter the URL path `/cst/agency-card`
6. See the "You may have reached this page on accident." error page.

## Note

Currently stacked on top of #3377 (which itself is stacked on #3373), we could easily put this commit in the underlying PR and close all 3 issues with one merge.

