### PR TITLE
Refactor: convert in-person success to class-based view

### DIFF
--- a/benefits/in_person/urls.py
+++ b/benefits/in_person/urls.py
@@ -36,7 +36,11 @@ urlpatterns = [
         admin.site.admin_view(views.RetryView.as_view()),
         name=routes.name(routes.IN_PERSON_ENROLLMENT_RETRY),
     ),
-    path("enrollment/success", admin.site.admin_view(views.success), name=routes.name(routes.IN_PERSON_ENROLLMENT_SUCCESS)),
+    path(
+        "enrollment/success",
+        admin.site.admin_view(views.SuccessView.as_view()),
+        name=routes.name(routes.IN_PERSON_ENROLLMENT_SUCCESS),
+    ),
     path(
         "enrollment/switchio",
         admin.site.admin_view(views.SwitchioEnrollmentIndexView.as_view()),

--- a/benefits/in_person/views.py
+++ b/benefits/in_person/views.py
@@ -1,8 +1,6 @@
 import logging
 
-from django.contrib.admin import site as admin_site
 from django.shortcuts import redirect
-from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.views.generic import FormView, TemplateView
 
@@ -15,6 +13,7 @@ from benefits.enrollment.views import (
     ReenrollmentErrorView as DigitalReenrollmentErrorView,
     RetryView as DigitalRetryView,
     SystemErrorView as DigitalSystemErrorView,
+    SuccessView as DigitalSuccessView,
 )
 from benefits.enrollment_littlepay.session import Session as LittlepaySession
 from benefits.enrollment_littlepay.views import TokenView, IndexView as LittlepayIndexView
@@ -139,15 +138,10 @@ class ServerErrorView(mixins.CommonContextMixin, AgencySessionRequiredMixin, Tem
         return super().get(request, *args, **kwargs)
 
 
-def success(request):
+class SuccessView(mixins.CommonContextMixin, AgencySessionRequiredMixin, DigitalSuccessView):
     """View handler for the final success page."""
-    agency = session.agency(request)
-    context = {
-        **admin_site.each_context(request),
-        "title": f"{agency.long_name} | In-person enrollment | {admin_site.site_title}",
-    }
 
-    return TemplateResponse(request, "in_person/enrollment/success.html", context)
+    template_name = "in_person/enrollment/success.html"
 
 
 class SwitchioGatewayUrlView(GatewayUrlView):

--- a/tests/pytest/in_person/test_views.py
+++ b/tests/pytest/in_person/test_views.py
@@ -211,14 +211,15 @@ class TestServerErrorView:
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("mocked_session_flow", "mocked_session_agency")
-def test_success(admin_client):
-    path = reverse(routes.IN_PERSON_ENROLLMENT_SUCCESS)
+class TestSuccessView:
+    @pytest.fixture
+    def view(self, app_request):
+        v = views.SuccessView()
+        v.setup(app_request)
+        return v
 
-    response = admin_client.get(path)
-
-    assert response.status_code == 200
-    assert response.template_name == "in_person/enrollment/success.html"
+    def test_view(self, view):
+        assert view.template_name == "in_person/enrollment/success.html"
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Closes #3113 

## Reviewing

1. Checkout the branch and start the app locally
2. Login to the admin as `cst-user`
3. Start a new In-Person Enrollment, pick any pathway, continue to card registration.
4. Complete card registration with test card details
5. See the expected success screen

<img width="1588" height="773" alt="image" src="https://github.com/user-attachments/assets/18dd39da-30aa-4298-8001-3d06caee5de8" />

## Note

~Currently stacked on top of #3370 to ease mergeability.~