### PR TITLE
Fix: default focus ring styles

### DIFF
--- a/benefits/static/css/admin/styles.css
+++ b/benefits/static/css/admin/styles.css
@@ -55,7 +55,7 @@ input[type="text"]:focus,
 input[type="password"]:focus,
 a.sso-login-btn:focus,
 .login input[type="submit"]:focus {
-  outline: 3px solid var(--focus-color) !important;
+  outline: var(--focus-style-dark) !important;
   outline-offset: 2px !important;
   box-shadow: none !important; /* override CA State Web Template */
   text-decoration: none;
@@ -183,7 +183,7 @@ iframe.card-collection {
 
 .login a:focus:not(.btn):not(.sso-login-btn),
 .login a:focus-visible:not(.btn):not(.sso-login-btn) {
-  outline: var(--focus-style) !important;
+  outline: var(--focus-style-dark) !important;
   outline-offset: var(--focus-outline-offset) !important;
 }
 

--- a/benefits/static/css/styles.css
+++ b/benefits/static/css/styles.css
@@ -103,7 +103,7 @@ a:hover:not(.btn) {
 
 a:focus:not(.btn):not(.card):not(.footer-link):not(#skip-to-content),
 a:focus-visible:not(.btn):not(.card):not(.footer-link):not(#skip-to-content) {
-  outline: var(--focus-style) !important;
+  outline: var(--focus-style-dark) !important;
   outline-offset: var(--focus-outline-offset) !important;
 }
 
@@ -277,7 +277,7 @@ main {
 }
 
 #skip-to-content:focus span {
-  outline: var(--focus-style) !important;
+  outline: var(--focus-style-dark) !important;
   outline-offset: var(--focus-outline-offset) !important;
   font-weight: var(--bold-font-weight);
   border-radius: var(--focus-border-radius);
@@ -321,7 +321,7 @@ footer .footer-links li a.footer-link:hover {
 
 footer .footer-links li a.footer-link:focus,
 footer .footer-links li a.footer-link:focus-visible {
-  outline: 3px solid var(--secondary-bg-color) !important;
+  outline: var(--focus-style-light) !important;
   outline-offset: 2px !important;
 }
 
@@ -372,10 +372,15 @@ footer .footer-links li a.footer-link:visited {
 .btn.btn-lg:focus,
 .btn.btn-lg:focus-visible,
 .btn-outline-dark:focus,
-.btn-outline-dark:focus-visible,
+.btn-outline-dark:focus-visible {
+  outline: var(--focus-style-dark);
+  outline-offset: var(--focus-outline-offset);
+  box-shadow: none;
+}
+
 .btn-outline-light:focus,
 .btn-ouline-light:focus-visible {
-  outline: 3px solid var(--focus-color);
+  outline: var(--focus-style-light);
   outline-offset: var(--focus-outline-offset);
   box-shadow: none;
 }
@@ -564,7 +569,7 @@ footer .footer-links li a.footer-link:visited {
 
 .form-field-container .form-control:focus,
 .form-field-container .form-control:focus-visible {
-  outline: 3px solid var(--focus-color) !important;
+  outline: var(--focus-style-dark) !important;
   outline-offset: 2px !important;
   box-shadow: none !important;
 }
@@ -589,7 +594,7 @@ footer .footer-links li a.footer-link:visited {
 
 #form-agency-selection .form-select:focus,
 #form-agency-selection .form-select:focus-visible {
-  outline: var(--focus-style);
+  outline: var(--focus-style-light);
   outline-offset: var(--focus-outline-offset);
 }
 
@@ -597,6 +602,13 @@ footer .footer-links li a.footer-link:visited {
   font-size: var(--font-size-20px);
   line-height: var(--bs-body-line-height);
   letter-spacing: calc(var(--font-size-20px) * var(--letter-spacing-2));
+}
+
+#form-agency-selection .btn.btn-lg.btn-primary:focus,
+#form-agency-selection .btn.btn-lg.btn-primary:focus-visible {
+  outline: var(--focus-style-light);
+  outline-offset: var(--focus-outline-offset);
+  box-shadow: none;
 }
 
 @media (min-width: 992px) {
@@ -634,7 +646,7 @@ footer .footer-links li a.footer-link:visited {
 
 .radio-input:focus,
 .radio-input:focus-visible {
-  outline: 2px solid var(--focus-color) !important;
+  outline: 2px solid var(--focus-color-dark) !important;
   outline-offset: 1px !important;
 }
 
@@ -672,7 +684,7 @@ footer .footer-links li a.footer-link:visited {
 .modal-header .btn-close:focus,
 .modal-header .btn-close:focus-visible {
   filter: none;
-  outline: 2px solid var(--focus-color) !important;
+  outline: 2px solid var(--focus-color-dark) !important;
   outline-offset: 1px !important;
   box-shadow: none !important; /* override CA State Web Template */
 }

--- a/benefits/static/css/variables.css
+++ b/benefits/static/css/variables.css
@@ -25,7 +25,8 @@
   --hover-color: #044869;
   --error-color: #ea1010;
   --selected-color: #562b97;
-  --focus-color: #756fff;
+  --focus-color-light: #febd28;
+  --focus-color-dark: #756fff;
   --secondary-bg-color: #fafafa;
   --error-color-rgb: 234, 16, 16;
   --bs-danger: var(--error-color);
@@ -42,7 +43,8 @@
   --font-size-12px: calc(12rem / 16);
   --border-width: calc(2rem / 16);
   --border-radius: calc(3rem / 16);
-  --focus-style: 3px solid var(--focus-color);
+  --focus-style-light: 3px solid var(--focus-color-light);
+  --focus-style-dark: 3px solid var(--focus-color-dark);
   --focus-border-radius: calc(2rem / 16);
   --focus-outline-offset: calc(3rem / 16); /* 3px */
   --grid-spacer: calc(1rem / 2); /* 8px */


### PR DESCRIPTION
Closes #3387

In this PR a new focus ring style that now meets the 3:1 contrast ratio on white backgrounds is implemented. The focus outline offset is also increased to `3px` for more spacing between the element and focus indicator.

Updating the `--focus-style` and `--focus-outline-offset` css variables caught almost all the elements that needed updating, but a [change to the `outline-offset` for buttons was required to implement the new `3px` offset](https://github.com/cal-itp/benefits/pull/3389/files#diff-744df555aee38173a0b0868baa7befa720e6a28f80747523e74e724c126cd381R379).

These are some sample elements with the new style:

<p align="center">
<img width="332" height="264" alt="image" src="https://github.com/user-attachments/assets/f3347ab6-ea9d-4a42-a12e-49809de6a69b" />
</p>

<p align="center">
<img width="324" height="343" alt="image" src="https://github.com/user-attachments/assets/e38c2b8d-96ab-46c3-9429-78fc6ef91f20" />
</p>


<p align="center">
<img width="485" height="129" alt="image" src="https://github.com/user-attachments/assets/83af04f5-bf1d-4664-a32c-5c6b0412cb9a" />
</p>