### PR TITLE
docs: updates to agency adoption table

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -95,7 +95,7 @@ The following California transit providers have adopted Cal-ITP Benefits. The be
 | **Sacramento Regional Transit District**        | 10/2024             | ✅           | ✅                   | ✅            | ―           | ―          |
 | **Nevada County Connects**                      | 03/2025             | ✅           | ✅                   | ✅            | ―           | ―          |
 | **Ventura County Transportation Commission**    | 10/2025             | ✅           | ✅                   | ―             | ―           | ―          |
-| **San Luis Obispo Regional Transit**            | 12/2025             | ✅           | ✅                   | \*            | \*          | \*         |
+| **San Luis Obispo Regional Transit**            | 12/2025             | ✅           | ✅                   | ―             | ―           | ―          |
 | **El Dorado Transit Authority**                 | 01/2026 (target)    | \*           | \*                   | \*            | \*          | \*         |
 | **Redding Area Bus Authority**                  | 01/2026 (target)    | \*           | \*                   | \*            | \*          | \*         |
 | **City of San Luis Obispo**                     | 02/2026 (target)    | \*           | \*                   | \*            | \*          | \*         |


### PR DESCRIPTION
Today we activated SLORTA in `prod` so they can begin rider pre-enrollment.