### PR TITLE
Chore: bump Django from 5.2.7 to 5.2.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "azure-keyvault-secrets==4.10.0",
     "azure-identity==1.25.1",
     "calitp-littlepay==2025.4.1",
-    "Django==5.2.7",
+    "Django==5.2.11",
     "django-admin-sortable2==2.3.1",
     "django-azure-communication-email==1.5.0",
     "django-cdt-identity @ git+https://github.com/Office-of-Digital-Services/django-cdt-identity.git@c635773a75e7f184a9382748afcef6d5a705b2d6",


### PR DESCRIPTION
Addresses a number of [recently disclosed CVEs](https://github.com/cal-itp/benefits/security/dependabot?q=is%3Aopen+manifest%3Apyproject.toml+package%3ADjango) related to SQL injection

Tested a Login.gov and Medicare.gov flow locally with CST + Littlepay, plus In-Person and regular Django Admin tasks. 