### PR TITLE
fix: use progress bar for in-person loading instead of a circle

### DIFF
--- a/benefits/in_person/templates/in_person/enrollment/index_littlepay.html
+++ b/benefits/in_person/templates/in_person/enrollment/index_littlepay.html
@@ -5,13 +5,13 @@
 {% endblock title %}
 
 {% block flow-content %}
-  <div class="p-3">
-    <div class="loading">
-      <p>
-        <span class="spinner-border align-middle text-primary" role="status"></span>
-        <span id="loading-message" class="fw-bold p-2">Please wait...</span>
-      </p>
+  <div class="loading">
+    <p id="loading-message" class="pt-3 px-3">Please wait...</p>
+    <div class="progress progress-indeterminate">
+      <div class="progress-bar" role="progressbar" aria-label="progress bar"></div>
     </div>
+  </div>
+  <div class="p-3">
     <div class="invisible">
       <p>Provide the rider's contactless debit or credit card details.</p>
       <iframe class="card-collection" name="card-collection-iframe"></iframe>

--- a/benefits/in_person/templates/in_person/enrollment/index_switchio.html
+++ b/benefits/in_person/templates/in_person/enrollment/index_switchio.html
@@ -5,12 +5,10 @@
 {% endblock title %}
 
 {% block flow-content %}
-  <div class="p-3">
-    <div class="loading">
-      <p>
-        <span class="spinner-border align-middle text-primary" role="status"></span>
-        <span id="loading-message" class="fw-bold p-2">{{ loading_message }}</span>
-      </p>
+  <div class="loading">
+    <p id="loading-message" class="pt-3 px-3">{{ loading_message }}</p>
+    <div class="progress progress-indeterminate">
+      <div class="progress-bar" role="progressbar" aria-label="progress bar"></div>
     </div>
   </div>
 

--- a/benefits/static/css/admin/styles.css
+++ b/benefits/static/css/admin/styles.css
@@ -267,3 +267,61 @@ a.sso-login-btn:hover {
 .login ul.messagelist li:not(:first-child) {
   margin-top: 8px 0 0 0;
 }
+
+/*
+  indeterminate progress bar
+  adapted from https://fastbootstrap.com/components/progress-bar/ (MIT licensed)
+*/
+.progress {
+  --bs-progress-height: 0.5rem;
+  --bs-progress-border-radius: 0;
+  --bs-progress-bar-bg: var(--primary-color);
+
+  position: relative;
+}
+
+.progress-indeterminate {
+  .progress-bar {
+    &:before,
+    &:after {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+      bottom: 0;
+      background-color: inherit;
+    }
+
+    &:before {
+      animation: animation-indeterminate 5s ease infinite;
+    }
+
+    &:after {
+      animation: animation-indeterminate-short 5s ease 0.5s infinite;
+    }
+  }
+}
+
+@keyframes animation-indeterminate {
+  0% {
+    left: -5%;
+    width: 5%;
+  }
+
+  100% {
+    left: 130%;
+    width: 100%;
+  }
+}
+
+@keyframes animation-indeterminate-short {
+  0% {
+    left: -80%;
+    width: 80%;
+  }
+
+  100% {
+    left: 110%;
+    width: 10%;
+  }
+}


### PR DESCRIPTION
> @indexing: I'd propose that Christine review this component to ensure it aligns with her overall vision for admin styling before we begin implementing it.
> @jgravois: my feelings wouldn't be hurt to shelf it entirely if she decides we should take a different tack or postpone altogether. 🤗 

Figma: https://www.figma.com/design/Y7fffLWV4cvZMgLM0fLvtP/Cal-ITP-Benefits-Admin?node-id=2784-3791&m=dev

resolves #2635

littlepay:
![littlepay](https://github.com/user-attachments/assets/712e4804-1aa2-4fc0-82ce-b1a177394fdf)

switchio:
![switchio](https://github.com/user-attachments/assets/115cb8a6-1ca5-4c51-ae88-40235e57b481)

## local testing trick
throwing an error on the blank line below immediately before attempting to tokenize the user's card makes it a lot easier to visually inspect the indeterminate loader.

```js
// keep loader on screen indefinitely
throw Error('whoops')
```
https://github.com/cal-itp/benefits/blob/64a34f87f8d76994ea30ec524282830ac114fcdd/benefits/in_person/templates/in_person/enrollment/index_littlepay.html#L38-L40