### PR TITLE
chore: Replace logging in sentry module with basic print statements

### DIFF
--- a/benefits/sentry.py
+++ b/benefits/sentry.py
@@ -1,4 +1,4 @@
-import logging
+import datetime
 import os
 import shutil
 import subprocess
@@ -9,8 +9,6 @@ from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.scrubber import DEFAULT_DENYLIST, EventScrubber
 
 from benefits import VERSION
-
-logger = logging.getLogger(__name__)
 
 SENTRY_CSP_REPORT_URI = None
 
@@ -68,12 +66,21 @@ def get_traces_sample_rate():
     try:
         rate = float(os.environ.get("SENTRY_TRACES_SAMPLE_RATE", "0.0"))
         if rate < 0.0 or rate > 1.0:
-            logger.warning("SENTRY_TRACES_SAMPLE_RATE was not in the range [0.0, 1.0], defaulting to 0.0")
+            print(
+                f"[{datetime.datetime.now().strftime("%d/%b/%Y %H:%M:%S")}] "
+                "WARNING benefits.sentry SENTRY_TRACES_SAMPLE_RATE was not in the range [0.0, 1.0], defaulting to 0.0"
+            )
             rate = 0.0
         else:
-            logger.info(f"SENTRY_TRACES_SAMPLE_RATE set to: {rate}")
+            print(
+                f"[{datetime.datetime.now().strftime("%d/%b/%Y %H:%M:%S")}] "
+                f"INFO benefits.sentry SENTRY_TRACES_SAMPLE_RATE set to: {rate}"
+            )
     except ValueError:
-        logger.warning("SENTRY_TRACES_SAMPLE_RATE did not parse to float, defaulting to 0.0")
+        print(
+            f"[{datetime.datetime.now().strftime("%d/%b/%Y %H:%M:%S")}] "
+            "WARNING benefits.sentry SENTRY_TRACES_SAMPLE_RATE did not parse to float, defaulting to 0.0"
+        )
         rate = 0.0
 
     return rate
@@ -85,7 +92,11 @@ def configure():
 
     if sentry_dsn:
         release = get_release()
-        logger.info(f"Enabling Sentry for environment '{sentry_environment}', release '{release}'...")
+        print(
+            f"[{datetime.datetime.now().strftime("%d/%b/%Y %H:%M:%S")}] "
+            f"INFO benefits.sentry Enabling Sentry for environment '{sentry_environment}', "
+            f"release '{release}'..."
+        )
 
         # https://docs.sentry.io/platforms/python/configuration/
         sentry_sdk.init(
@@ -107,4 +118,7 @@ def configure():
         global SENTRY_CSP_REPORT_URI
         SENTRY_CSP_REPORT_URI = os.environ.get("SENTRY_REPORT_URI", "")
     else:
-        logger.info("SENTRY_DSN not set, so won't send events")
+        print(
+            f"[{datetime.datetime.now().strftime("%d/%b/%Y %H:%M:%S")}] "
+            "INFO benefits.sentry SENTRY_DSN not set, so won't send events"
+        )


### PR DESCRIPTION
Fixes #1379

---

I made them look mostly like the standard `logging` output format, but without digging into how to output the current line number dynamically. Seems good enough for this use case.

In this sample, the first line is a standard `logging` statement, and the second two lines are the custom `print`s implemented here:

```
[05/Feb/2026 15:37:51] INFO django.utils.autoreload:265 /calitp/app/benefits/sentry.py changed, reloading.
[05/Feb/2026 15:37:52] INFO benefits.sentry Enabling Sentry for environment 'local', release '6bff0df4ec0458ef4073bfb1b2d65e99bf8ed980'...
[05/Feb/2026 15:37:52] INFO benefits.sentry SENTRY_TRACES_SAMPLE_RATE set to: 0.1
```