### PR TITLE
Fix: replace 'qa' with 'test' for the sample LittlepayConfig

### DIFF
--- a/benefits/core/migrations/local_fixtures.json
+++ b/benefits/core/migrations/local_fixtures.json
@@ -107,7 +107,7 @@
     "model": "core.transitprocessorconfig",
     "pk": 1,
     "fields": {
-      "environment": "qa",
+      "environment": "test",
       "transit_agency": 1,
       "portal_url": "https://www.transit-processor-portal.com"
     }


### PR DESCRIPTION
Small fix to something we missed when we reviewed #3452

The `environment` on the sample `LittlepayConfig` needed to be updated from `qa` to `test`.

Using an invalid value for `environment` causes this error when running through the app:
<img width="1920" height="1032" alt="Screenshot from 2026-02-11 10-44-56" src="https://github.com/user-attachments/assets/a3742f70-d98a-468a-9f58-2b0100dd6ae1" />
