### PR TITLE
Fix: avoid unnecessary `JSONDecodeError`

### DIFF
--- a/benefits/enrollment_switchio/enrollment.py
+++ b/benefits/enrollment_switchio/enrollment.py
@@ -225,7 +225,7 @@ def enroll(request, switchio_config: SwitchioConfig, flow: EnrollmentFlow, token
             exception = e
         else:
             status = Status.EXCEPTION
-            exception = Exception(f"{e}: {e.response.json()}")
+            exception = Exception(f"{e}: {e.response.text}")
     except Exception as e:
         status = Status.EXCEPTION
         exception = e

--- a/tests/pytest/enrollment_switchio/test_enrollment.py
+++ b/tests/pytest/enrollment_switchio/test_enrollment.py
@@ -344,7 +344,7 @@ def test_enroll_exception_http_error_400(
 
     assert status is Status.EXCEPTION
     assert isinstance(exception, Exception)
-    assert exception.args[0] == f"{http_error}: {http_error.response.json()}"
+    assert exception.args[0] == f"{http_error}: {http_error.response.text}"
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Fixes #3468 

We've seen `JSONDecodeError`s occur at https://github.com/cal-itp/benefits/blob/281b201d14e1492d07cd504ff3eb65683a1d29a1/benefits/enrollment_switchio/enrollment.py#L228

but it's not necessarily true that the response will contain JSON. Rather than indicating an actual issue, this is just obscuring the actual HTTP error that was returned from the Switchio API.

We're not parsing the JSON or anything, so it should be just as good, if not better, to read the response contents as text instead.