### PR TITLE
fix: update non-existent template and centralize more JS

### DIFF
--- a/.github/workflows/agency-onboarding.yml
+++ b/.github/workflows/agency-onboarding.yml
@@ -39,6 +39,8 @@ permissions:
 jobs:
   scaffold-issues:
     runs-on: ubuntu-latest
+    env:
+      helpers_script: "${{ github.workspace }}/.github/workflows/agency-onboarding/helpers.js"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -48,48 +50,8 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const fs = await import('fs')
-            const path = await import('path')
-            const { linkSubIssue } = await import('${{ github.workspace }}/.github/workflows/agency-onboarding/helpers.js')
-
-            const templatePath = '.github/workflows/agency-onboarding/parent.md';
-            const {
-              long_name,
-              short_name,
-              transit_processor,
-              website,
-              launch_date,
-              initiative_issue
-            } = context.payload.inputs;
-
-            // read body from template, fill in placeholders
-            const body = fs.readFileSync(templatePath, 'utf8')
-              .replace(/{{LONG_NAME}}/g, long_name)
-              .replace(/{{SHORT_NAME}}/g, short_name)
-              .replace(/{{TRANSIT_PROCESSOR}}/g, transit_processor)
-              .replace(/{{WEBSITE}}/g, website ?? "N/A")
-              .replace(/{{LAUNCH_DATE}}/g, launch_date ?? "TBD");
-
-            const epicIssue = await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: `Agency onboarding: ${long_name}`,
-              labels: ['epic', 'agency-onboarding'],
-              body: body
-            });
-
-            if (initiative_issue) {
-              const initiativeIssue = await github.rest.issues.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: initiative_issue
-              });
-              await linkSubIssue({
-                github, core,
-                parentNodeId: initiativeIssue.data.node_id,
-                childNodeId: epicIssue.data.node_id
-              });
-            }
+            const { createEpicIssue } = await import(process.env.helpers_script);
+            const epicIssue = await createEpicIssue({ context, core, github });
 
             core.setOutput('node_id', epicIssue.data.node_id);
             core.setOutput('issue_number', epicIssue.data.number);
@@ -99,7 +61,7 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const { createSubIssue } = await import('${{ github.workspace }}/.github/workflows/agency-onboarding/helpers.js')
+            const { createSubIssue } = await import(process.env.helpers_script);
 
             await createSubIssue({
               github, context, core,
@@ -113,7 +75,7 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const { updateAdoptionTable } = await import('${{ github.workspace }}/.github/workflows/agency-onboarding/helpers.js')
+            const { updateAdoptionTable } = await import(process.env.helpers_script);
 
             draftPr = await updateAdoptionTable({
               github, context,
@@ -127,7 +89,7 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const { createSubIssue } = await import('${{ github.workspace }}/.github/workflows/agency-onboarding/helpers.js')
+            const { createSubIssue } = await import(process.env.helpers_script);
 
             const { transit_processor } = context.payload.inputs;
 
@@ -143,7 +105,7 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const { createSubIssue } = await import('${{ github.workspace }}/.github/workflows/agency-onboarding/helpers.js')
+            const { createSubIssue } = await import(process.env.helpers_script);
 
             await createSubIssue({
               github, context, core,
@@ -158,7 +120,7 @@ jobs:
         if: inputs.transit_processor == 'Littlepay'
         with:
           script: |
-            const { createSubIssue } = await import('${{ github.workspace }}/.github/workflows/agency-onboarding/helpers.js')
+            const { createSubIssue } = await import(process.env.helpers_script);
 
             await createSubIssue({
               github, context, core,
@@ -172,7 +134,7 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const { createSubIssue } = await import('${{ github.workspace }}/.github/workflows/agency-onboarding/helpers.js')
+            const { createSubIssue } = await import(process.env.helpers_script);
 
             await createSubIssue({
               github, context, core,
@@ -186,7 +148,7 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const { createSubIssue } = await import('${{ github.workspace }}/.github/workflows/agency-onboarding/helpers.js')
+            const { createSubIssue } = await import(process.env.helpers_script);
 
             await createSubIssue({
               github, context, core,
@@ -200,7 +162,7 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const { createSubIssue } = await import('${{ github.workspace }}/.github/workflows/agency-onboarding/helpers.js')
+            const { createSubIssue } = await import(process.env.helpers_script);
 
             await createSubIssue({
               github, context, core,
@@ -214,7 +176,7 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const { createSubIssue } = await import('${{ github.workspace }}/.github/workflows/agency-onboarding/helpers.js')
+            const { createSubIssue } = await import(process.env.helpers_script);
 
             await createSubIssue({
               github, context, core,
@@ -228,11 +190,11 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const { createSubIssue } = await import('${{ github.workspace }}/.github/workflows/agency-onboarding/helpers.js')
+            const { createSubIssue } = await import(process.env.helpers_script);
 
             await createSubIssue({
               github, context, core,
               parentNodeId: "${{ steps.parent.outputs.node_id }}",
-              templateName: 'metabase-enrollments.md',
+              templateName: 'metabase-metrics.md',
               title: `Metabase metrics display activity for this transit provider`
             });


### PR DESCRIPTION
closes #3532

playing around with prettier a couple days ago gave me the idea to pull even more JS out of the agency-onboarding.yml file to take advantage of formatting/linting.

doing this helped uncover a few small issues that i'll describe inline and encouraged me to consolidate the logic for creating an issue to DRY things up a bit.

Test initiative: https://github.com/thekaveman/test-issue-scaffold/issues/139
epic: https://github.com/thekaveman/test-issue-scaffold/issues/142

relevant branch: https://github.com/thekaveman/test-issue-scaffold/compare/chore/cleanup?expand=1