### PR TITLE
Chore: local fixtures cleanup

### DIFF
--- a/benefits/core/migrations/local_fixtures.json
+++ b/benefits/core/migrations/local_fixtures.json
@@ -1,9 +1,36 @@
 [
   {
-    "model": "auth.Group",
+    "model": "auth.group",
+    "pk": 1,
+    "fields": {
+      "name": "Cal-ITP",
+      "permissions": []
+    }
+  },
+  {
+    "model": "auth.group",
     "pk": 2,
     "fields": {
-      "name": "CST Customer Service"
+      "name": "CST Customer Service",
+      "permissions": []
+    }
+  },
+  {
+    "model": "auth.user",
+    "pk": 1,
+    "fields": {
+      "password": "pbkdf2_sha256$1000000$H6BFlszeskSeWPovh1VLeO$Cl5tArANop26610+d3XJfuh5C2d9UZ/ZVD4cGiP1iXo=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "benefits-admin",
+      "first_name": "",
+      "last_name": "",
+      "email": "benefits-admin@calitp.org",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2026-03-03T16:45:12.147Z",
+      "groups": [],
+      "user_permissions": []
     }
   },
   {
@@ -48,7 +75,9 @@
     "fields": {
       "system_name": "veteran",
       "scopes": "veteran:confirm",
-      "eligibility_claim": "va38"
+      "eligibility_claim": "va38",
+      "extra_claims": "",
+      "scheme": ""
     }
   },
   {
@@ -57,7 +86,9 @@
     "fields": {
       "system_name": "senior",
       "scopes": "age:65plus",
-      "eligibility_claim": "age65p"
+      "eligibility_claim": "age65p",
+      "extra_claims": "",
+      "scheme": ""
     }
   },
   {
@@ -66,7 +97,9 @@
     "fields": {
       "system_name": "calfresh",
       "scopes": "income:calfresh",
-      "eligibility_claim": "calfresh"
+      "eligibility_claim": "calfresh",
+      "extra_claims": "",
+      "scheme": ""
     }
   },
   {
@@ -75,7 +108,9 @@
     "fields": {
       "system_name": "medicare",
       "scopes": "medicare:enrolled",
-      "eligibility_claim": "medicare"
+      "eligibility_claim": "medicare",
+      "extra_claims": "",
+      "scheme": ""
     }
   },
   {
@@ -103,6 +138,7 @@
     "pk": 1,
     "fields": {
       "label": "(CST) eligibility server public key",
+      "text_secret_name": "",
       "remote_url": "https://raw.githubusercontent.com/cal-itp/eligibility-server/main/keys/server.pub"
     }
   },
@@ -111,7 +147,8 @@
     "pk": 2,
     "fields": {
       "label": "Benefits client private key",
-      "text_secret_name": "client-private-key"
+      "text_secret_name": "client-private-key",
+      "remote_url": ""
     }
   },
   {
@@ -119,7 +156,8 @@
     "pk": 3,
     "fields": {
       "label": "Benefits client public key",
-      "text_secret_name": "client-public-key"
+      "text_secret_name": "client-public-key",
+      "remote_url": ""
     }
   },
   {
@@ -127,7 +165,8 @@
     "pk": 4,
     "fields": {
       "label": "Switchio client certificate",
-      "text_secret_name": "switchio-int-client-cert"
+      "text_secret_name": "switchio-int-client-cert",
+      "remote_url": ""
     }
   },
   {
@@ -135,7 +174,8 @@
     "pk": 5,
     "fields": {
       "label": "Switchio CA certificate",
-      "text_secret_name": "switchio-int-ca-cert"
+      "text_secret_name": "switchio-int-ca-cert",
+      "remote_url": ""
     }
   },
   {
@@ -143,7 +183,8 @@
     "pk": 6,
     "fields": {
       "label": "Switchio private key",
-      "text_secret_name": "switchio-int-private-key"
+      "text_secret_name": "switchio-int-private-key",
+      "remote_url": ""
     }
   },
   {
@@ -168,12 +209,16 @@
     "fields": {
       "system_name": "senior",
       "label": "Older Adult",
-      "display_order": 2,
+      "supported_enrollment_methods": "digital,in_person",
+      "sign_out_button_template": "core/includes/button--sign-out--login-gov.html",
+      "sign_out_link_template": "core/includes/link--sign-out--login-gov.html",
       "oauth_config": "00e5cbdb-242a-4df5-a147-45d0c1e4dceb",
       "claims_request": "a0b45237-b056-4d25-aebe-d4f2a5fe6bbc",
-      "supported_enrollment_methods": ["digital", "in_person"],
-      "sign_out_button_template": "core/includes/button--sign-out--login-gov.html",
-      "sign_out_link_template": "core/includes/link--sign-out--login-gov.html"
+      "api_request": null,
+      "supports_expiration": false,
+      "expiration_days": null,
+      "expiration_reenrollment_days": null,
+      "display_order": 2
     }
   },
   {
@@ -182,12 +227,16 @@
     "fields": {
       "system_name": "veteran",
       "label": "U.S. Veteran",
-      "display_order": 4,
+      "supported_enrollment_methods": "digital",
+      "sign_out_button_template": "core/includes/button--sign-out--login-gov.html",
+      "sign_out_link_template": "core/includes/link--sign-out--login-gov.html",
       "oauth_config": "00e5cbdb-242a-4df5-a147-45d0c1e4dceb",
       "claims_request": "8fa9e649-4de6-4bd6-8eec-f5f47802ceab",
-      "supported_enrollment_methods": ["digital"],
-      "sign_out_button_template": "core/includes/button--sign-out--login-gov.html",
-      "sign_out_link_template": "core/includes/link--sign-out--login-gov.html"
+      "api_request": null,
+      "supports_expiration": false,
+      "expiration_days": null,
+      "expiration_reenrollment_days": null,
+      "display_order": 4
     }
   },
   {
@@ -196,9 +245,16 @@
     "fields": {
       "system_name": "courtesy_card",
       "label": "Agency Cardholder",
+      "supported_enrollment_methods": "digital",
+      "sign_out_button_template": "",
+      "sign_out_link_template": "",
+      "oauth_config": null,
+      "claims_request": null,
       "api_request": 1,
-      "display_order": 5,
-      "supported_enrollment_methods": ["digital"]
+      "supports_expiration": false,
+      "expiration_days": null,
+      "expiration_reenrollment_days": null,
+      "display_order": 5
     }
   },
   {
@@ -207,15 +263,16 @@
     "fields": {
       "system_name": "calfresh",
       "label": "CalFresh Cardholder",
-      "supports_expiration": "True",
-      "expiration_days": 5,
-      "expiration_reenrollment_days": 3,
-      "display_order": 3,
+      "supported_enrollment_methods": "digital",
+      "sign_out_button_template": "core/includes/button--sign-out--login-gov.html",
+      "sign_out_link_template": "core/includes/link--sign-out--login-gov.html",
       "oauth_config": "00e5cbdb-242a-4df5-a147-45d0c1e4dceb",
       "claims_request": "c6332e8c-7081-48e9-ae3c-07360879a8ae",
-      "supported_enrollment_methods": ["digital"],
-      "sign_out_button_template": "core/includes/button--sign-out--login-gov.html",
-      "sign_out_link_template": "core/includes/link--sign-out--login-gov.html"
+      "api_request": null,
+      "supports_expiration": true,
+      "expiration_days": 5,
+      "expiration_reenrollment_days": 3,
+      "display_order": 3
     }
   },
   {
@@ -224,50 +281,56 @@
     "fields": {
       "system_name": "medicare",
       "label": "Medicare Cardholder",
-      "display_order": 1,
+      "supported_enrollment_methods": "digital,in_person",
+      "sign_out_button_template": "",
+      "sign_out_link_template": "",
       "oauth_config": "7687895d-c3d6-4063-a26e-518514fb01b2",
       "claims_request": "d27e630b-980c-40ae-9104-a36633bcf7ac",
-      "supported_enrollment_methods": ["digital", "in_person"]
+      "api_request": null,
+      "supports_expiration": false,
+      "expiration_days": null,
+      "expiration_reenrollment_days": null,
+      "display_order": 1
     }
   },
   {
     "model": "core.enrollmentgroup",
     "pk": 1,
     "fields": {
-      "enrollment_flow": 5,
-      "transit_agency": 1
+      "transit_agency": 1,
+      "enrollment_flow": 5
     }
   },
   {
     "model": "core.enrollmentgroup",
     "pk": 2,
     "fields": {
-      "enrollment_flow": 4,
-      "transit_agency": 1
+      "transit_agency": 1,
+      "enrollment_flow": 4
     }
   },
   {
     "model": "core.enrollmentgroup",
     "pk": 3,
     "fields": {
-      "enrollment_flow": 2,
-      "transit_agency": 1
+      "transit_agency": 1,
+      "enrollment_flow": 2
     }
   },
   {
     "model": "core.enrollmentgroup",
     "pk": 4,
     "fields": {
-      "enrollment_flow": 3,
-      "transit_agency": 1
+      "transit_agency": 1,
+      "enrollment_flow": 3
     }
   },
   {
     "model": "core.enrollmentgroup",
     "pk": 5,
     "fields": {
-      "enrollment_flow": 1,
-      "transit_agency": 1
+      "transit_agency": 1,
+      "enrollment_flow": 1
     }
   },
   {
@@ -278,8 +341,9 @@
       "enrollment_flow": 3,
       "enrollment_method": "digital",
       "verified_by": "http://server:8000/verify",
-      "enrollment_datetime": "2024-09-13T16:00:00.000Z",
-      "expiration_datetime": null
+      "enrollment_datetime": "2024-09-13T16:00:00Z",
+      "expiration_datetime": null,
+      "extra_claims": ""
     }
   },
   {
@@ -290,8 +354,9 @@
       "enrollment_flow": 2,
       "enrollment_method": "in_person",
       "verified_by": "Test User",
-      "enrollment_datetime": "2024-09-13T15:45:30.000Z",
-      "expiration_datetime": null
+      "enrollment_datetime": "2024-09-13T15:45:30Z",
+      "expiration_datetime": null,
+      "extra_claims": ""
     }
   },
   {
@@ -302,8 +367,9 @@
       "enrollment_flow": 1,
       "enrollment_method": "digital",
       "verified_by": "benefits-oauth-client-name",
-      "enrollment_datetime": "2024-09-12T18:25:25.000Z",
-      "expiration_datetime": null
+      "enrollment_datetime": "2024-09-12T18:25:25Z",
+      "expiration_datetime": null,
+      "extra_claims": ""
     }
   },
   {
@@ -314,8 +380,9 @@
       "enrollment_flow": 4,
       "enrollment_method": "digital",
       "verified_by": "benefits-oauth-client-name",
-      "enrollment_datetime": "2024-09-11T20:00:00.000Z",
-      "expiration_datetime": "2025-09-12T07:00:00.000Z"
+      "enrollment_datetime": "2024-09-11T20:00:00Z",
+      "expiration_datetime": "2025-09-12T07:00:00Z",
+      "extra_claims": ""
     }
   },
   {
@@ -346,10 +413,12 @@
       "long_name": "California State Transit (local)",
       "info_url": "https://www.agency-website.com",
       "phone": "1-800-555-5555",
-      "enrollment_flows": [1, 2, 3, 4, 5],
+      "supported_card_schemes": "visa,mastercard",
+      "sso_domain": "",
       "customer_service_group": 2,
       "logo": "agencies/cst.png",
-      "transit_processor_config": 1
+      "transit_processor_config": 1,
+      "enrollment_flows": [5, 1, 4, 2, 3]
     }
   },
   {
@@ -364,27 +433,37 @@
   {
     "model": "enrollment_littlepay.littlepaygroup",
     "pk": 1,
-    "fields": { "group_id": "d106dab3-bb24-42eb-8bbe-38dab3bfa4dc" }
+    "fields": {
+      "group_id": "d106dab3-bb24-42eb-8bbe-38dab3bfa4dc"
+    }
   },
   {
     "model": "enrollment_littlepay.littlepaygroup",
     "pk": 2,
-    "fields": { "group_id": "c0df1bf1-e5c5-4c25-a25d-86039c83ce52" }
+    "fields": {
+      "group_id": "c0df1bf1-e5c5-4c25-a25d-86039c83ce52"
+    }
   },
   {
     "model": "enrollment_littlepay.littlepaygroup",
     "pk": 3,
-    "fields": { "group_id": "4e37871d-3852-4171-a3a4-9d41f2b2276e" }
+    "fields": {
+      "group_id": "4e37871d-3852-4171-a3a4-9d41f2b2276e"
+    }
   },
   {
     "model": "enrollment_littlepay.littlepaygroup",
     "pk": 4,
-    "fields": { "group_id": "db631fbb-7949-485a-8068-066dd826acac" }
+    "fields": {
+      "group_id": "db631fbb-7949-485a-8068-066dd826acac"
+    }
   },
   {
     "model": "enrollment_littlepay.littlepaygroup",
     "pk": 5,
-    "fields": { "group_id": "30027174-bc59-40bb-935c-3bd9b1c26a63" }
+    "fields": {
+      "group_id": "30027174-bc59-40bb-935c-3bd9b1c26a63"
+    }
   },
   {
     "model": "enrollment_switchio.switchioconfig",


### PR DESCRIPTION
Last bit of follow-up for #3523 

This PR updates `local_fixtures.json` so that the ordering and included fields match what is exported by running the `./bin/dumpdata.sh` helper script. I used `HEAD` as the commit for both "pre" and "post" model changes.

This makes it so when making model changes, we can also use the helper script to update the local fixtures.