### PR TITLE
docs: fix a few broken links to migrations and fixtures page

### DIFF
--- a/docs/explanation/development/django-models.md
+++ b/docs/explanation/development/django-models.md
@@ -14,7 +14,7 @@ Runtime configuration changes can be persisted via [Django's Admin interface](ht
 
 When models are updated, **migrations** will need to be added and **fixtures** will need to be updated.
 
-[Read our guide to migrations and fixtures](../guides/migrations-and-fixtures)
+[Read our guide to migrations and fixtures](../../../guides/migrations-and-fixtures)
 
 [core-models]: https://github.com/cal-itp/benefits/tree/main/benefits/core/models/
 [littlepay-models]: https://github.com/cal-itp/benefits/blob/main/benefits/enrollment_littlepay/models.py

--- a/docs/tutorials/load-sample-data.md
+++ b/docs/tutorials/load-sample-data.md
@@ -62,7 +62,7 @@ database rebuild.
 
 When models are updated, our fixtures will need to be updated.
 
-[Read our guide to migrations and fixtures](../guides/migrations-and-fixtures)
+[Read our guide to migrations and fixtures](../../guides/migrations-and-fixtures)
 
 [core-models]: https://github.com/cal-itp/benefits/tree/main/benefits/core/models/
 [django-fixtures]: https://docs.djangoproject.com/en/5.2/topics/db/fixtures/


### PR DESCRIPTION
just something small i noticed when i tested #3546 locally.

one thing that surprised me was that the ids in the `django_migrations` table didn't reset when i faked the migrations after blowing away all the previous rows.

<img width="610" height="331" alt="Screenshot 2026-03-05 at 8 25 11 AM" src="https://github.com/user-attachments/assets/c2460cfd-1ef8-456c-8882-d20f3e1fb238" />

i assume its harmless. i was just temporarily at a loss thinking that somehow @Scotchester's PR was able to preserve the original migration history without the files 😆 