### PR TITLE
chore: for all issues created with an 'agency-onboarding' label, set a 'Todo' project status immediately

### DIFF
--- a/.github/workflows/add-to-project-dependabot.yml
+++ b/.github/workflows/add-to-project-dependabot.yml
@@ -10,7 +10,7 @@ jobs:
     # see https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#responding-to-events
     if: github.actor == 'dependabot[bot]' || github.actor == 'pre-commit-ci[bot]'
     steps:
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@1
         with:
           project-url: ${{ secrets.USB_PROJECT_URL }}
           github-token: ${{ secrets.USB_PROJECT_TOKEN }}

--- a/.github/workflows/add-to-project-issues.yml
+++ b/.github/workflows/add-to-project-issues.yml
@@ -8,7 +8,7 @@ jobs:
   add-to-project-issues:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@1
         with:
           project-url: ${{ secrets.USB_PROJECT_URL }}
           github-token: ${{ secrets.USB_PROJECT_TOKEN }}


### PR DESCRIPTION
resolves #3543

initially i thought we were going to need a fancier approach for creating the initial issue, but the snippet @thekaveman shared helped me realize that the easier option is to just wire up a follow-up action that looks for new (and moved) issues that are labeled as <kbd>agency-onboarding</kbd> and assign the appropriate project status after the fact.

