### PR TITLE
fix: patch admin google sso login bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "django-azure-communication-email==1.5.0",
     "django-cdt-identity @ git+https://github.com/Office-of-Digital-Services/django-cdt-identity.git@c635773a75e7f184a9382748afcef6d5a705b2d6",
     "django-csp==4.0",
-    "django-google-sso==8.0.0",
+    "django-google-sso==9.0.3",
     "django-multiselectfield==1.0.1",
     "eligibility-api==2025.4.1",
     "pillow==12.1.0",


### PR DESCRIPTION
closes #3541

turns out `django-google-sso` patched https://github.com/megalus/django-google-sso/issues/57 and published a new release yesterday.

https://github.com/megalus/django-google-sso/commit/a7fb81697c207164df75da98ad3c1df06293ecbe

i followed the steps in #1855 to test the 9.x release locally. initially i couldn't reproduce the error we're seeing on dev because my local transitive google deps were stale.

i reproed the error via:
```
pip install --force-reinstall -v "django-google-sso==8.0.0"
```
```
# before
django-google-sso                8.0.0
google-auth                      2.48.0
google-auth-httplib2             0.3.0
google-auth-oauthlib             1.2.4

# after
django-google-sso                8.0.0
google-auth                      2.49.0
google-auth-httplib2             0.3.0
google-auth-oauthlib             1.3.0
```

i installed django-google-sso@9.0.3 and verified the fix by running this: 
(after updating the pyproject.toml file)
```
pip install --force-reinstall django-google-sso
```