### PR TITLE
chore: add agency-onboarding issues to Customer Success project

### DIFF
--- a/.github/workflows/add-to-project-issues.yml
+++ b/.github/workflows/add-to-project-issues.yml
@@ -29,5 +29,5 @@ jobs:
 
       - uses: actions/add-to-project@1
         with:
-          project-url: ${{ secrets.CS_PROJECT_URL }}
+          project-url: ${{ vars.CS_PROJECT_URL }}
           github-token: ${{ secrets.CS_PROJECT_TOKEN }}


### PR DESCRIPTION
closes #3544 

assumes the existence of one new organization-wide `CS_PROJECT_URL` variable and `CS_PROJECT_TOKEN` secret.