### PR TITLE
Fix: update In-Person session with group

### DIFF
--- a/benefits/in_person/views.py
+++ b/benefits/in_person/views.py
@@ -56,7 +56,8 @@ class EligibilityView(mixins.CommonContextMixin, FormView):
 
         flow_id = form.cleaned_data.get("flow")
         flow = models.EnrollmentFlow.objects.get(id=flow_id)
-        session.update(self.request, flow=flow, eligible=True)
+        group = models.EnrollmentGroup.objects.get(transit_agency=self.agency, enrollment_flow=flow)
+        session.update(self.request, flow=flow, group=group, eligible=True)
         eligibility_analytics.selected_flow(self.request, flow, enrollment_method=models.EnrollmentMethods.IN_PERSON)
         eligibility_analytics.started_eligibility(self.request, flow, enrollment_method=models.EnrollmentMethods.IN_PERSON)
         eligibility_analytics.returned_success(self.request, flow, enrollment_method=models.EnrollmentMethods.IN_PERSON)

--- a/tests/pytest/in_person/test_views.py
+++ b/tests/pytest/in_person/test_views.py
@@ -100,9 +100,20 @@ class TestEligibilityView:
         mocked_session_module.update.assert_called_once()
         assert view.agency == model_TransitAgency
 
-    def test_form_valid(self, view, mocker, model_EnrollmentFlow, mocked_session_module, mocked_eligibility_analytics_module):
+    def test_form_valid(
+        self,
+        view,
+        mocker,
+        model_EnrollmentFlow,
+        model_LittlepayGroup,
+        mocked_session_module,
+        mocked_eligibility_analytics_module,
+    ):
         mock_enrollment_flow_model = mocker.patch.object(models.EnrollmentFlow.objects, "get")
         mock_enrollment_flow_model.return_value = model_EnrollmentFlow
+
+        mock_enrollment_group_model = mocker.patch.object(models.EnrollmentGroup.objects, "get")
+        mock_enrollment_group_model.return_value = model_LittlepayGroup
 
         mock_form = mocker.Mock()
         mock_form.cleaned_data = {"flow": model_EnrollmentFlow.id}
@@ -110,7 +121,10 @@ class TestEligibilityView:
         response = view.form_valid(mock_form)
 
         mock_enrollment_flow_model.assert_called_once_with(id=model_EnrollmentFlow.id)
-        mocked_session_module.update.assert_called_once_with(view.request, flow=model_EnrollmentFlow, eligible=True)
+        mock_enrollment_group_model.assert_called_once_with(transit_agency=view.agency, enrollment_flow=model_EnrollmentFlow)
+        mocked_session_module.update.assert_called_once_with(
+            view.request, flow=model_EnrollmentFlow, group=model_LittlepayGroup, eligible=True
+        )
         mocked_eligibility_analytics_module.selected_flow.assert_called_once_with(
             view.request, model_EnrollmentFlow, enrollment_method=models.EnrollmentMethods.IN_PERSON
         )


### PR DESCRIPTION
We forgot to update the In-Person session as part of #3509

This PR retrieves the group from the combination of agency and flow, and includes this with the initial `session.update()` call during the In-Person Eligibility phase.