### PR TITLE
Add in-person additional providers view for agencies in a group

### DIFF
--- a/benefits/admin.py
+++ b/benefits/admin.py
@@ -68,7 +68,7 @@ class BenefitsAdminSite(AdminSite):
                         "transit_processor_portal_url": transit_processor_portal_url,
                         "title": f"{agency.long_name} | {self.index_title} | {self.site_title}",
                         "start_url": (
-                            routes.IN_PERSON_ADDITIONAL_PROVIDERS if agency.group_agencies() else routes.IN_PERSON_ELIGIBILITY
+                            routes.IN_PERSON_ADDITIONAL_AGENCIES if agency.group_agencies() else routes.IN_PERSON_ELIGIBILITY
                         ),
                     }
                 )

--- a/benefits/admin.py
+++ b/benefits/admin.py
@@ -9,6 +9,7 @@ from benefits.core import session
 from benefits.core.middleware import RecaptchaEnabled
 from benefits.core.mixins import ValidateRecaptchaMixin
 from benefits.core.models import TransitAgency
+from benefits.routes import routes
 
 
 class BenefitsAdminLoginForm(ValidateRecaptchaMixin, AdminAuthenticationForm):
@@ -66,6 +67,9 @@ class BenefitsAdminSite(AdminSite):
                         "has_permission_for_in_person": has_permission_for_in_person,
                         "transit_processor_portal_url": transit_processor_portal_url,
                         "title": f"{agency.long_name} | {self.index_title} | {self.site_title}",
+                        "start_url": (
+                            routes.IN_PERSON_ADDITIONAL_PROVIDERS if agency.group_agencies() else routes.IN_PERSON_ELIGIBILITY
+                        ),
                     }
                 )
 

--- a/benefits/in_person/templates/in_person/additional-agencies.html
+++ b/benefits/in_person/templates/in_person/additional-agencies.html
@@ -5,7 +5,7 @@
     <h3 class="h5 mb-3">Additional providers</h3>
     <p>Let the rider know they’ll get reduced fares when they tap to pay at {{ agencies|length }} transit providers.</p>
     <ul>
-      {% for agency in agencies %}<li class="fs-6">{{ agency }}</li>{% endfor %}
+      {% for agency in agencies %}<li>{{ agency }}</li>{% endfor %}
     </ul>
   </div>
 

--- a/benefits/in_person/templates/in_person/additional-agencies.html
+++ b/benefits/in_person/templates/in_person/additional-agencies.html
@@ -11,7 +11,7 @@
 
   <div class="row d-flex justify-content-start p-3 pt-8">
     <div class="col-6">
-      {% url cancel_url as url_cancel %}
+      {% url routes.ADMIN_INDEX as url_cancel %}
       <a href="{{ url_cancel }}" class="btn btn-lg btn-outline-primary d-block">Cancel</a>
     </div>
     <div class="col-6">

--- a/benefits/in_person/templates/in_person/additional-providers.html
+++ b/benefits/in_person/templates/in_person/additional-providers.html
@@ -1,0 +1,24 @@
+{% extends "admin/flow-base.html" %}
+
+{% block flow-content %}
+  <div class="p-3">
+    <h3 class="h5 mb-3">Additional providers</h3>
+    <p>Let the rider know they’ll get reduced fares when they tap to pay at {{ agencies|length }} transit providers.</p>
+    <ul>
+      {% for agency in agencies %}<li class="fs-6">{{ agency }}</li>{% endfor %}
+    </ul>
+  </div>
+
+  <div class="row d-flex justify-content-start p-3 pt-8">
+    <div class="col-6">
+      {% url cancel_url as url_cancel %}
+      <a href="{{ url_cancel }}" class="btn btn-lg btn-outline-primary d-block">Cancel</a>
+    </div>
+    <div class="col-6">
+      {% url routes.IN_PERSON_ELIGIBILITY as url_eligibility %}
+      <a href="{{ url_eligibility }}" class="btn btn-lg btn-primary d-flex justify-content-center align-items-center text-white">
+        <span class="btn-text">Continue</span>
+      </a>
+    </div>
+  </div>
+{% endblock flow-content %}

--- a/benefits/in_person/urls.py
+++ b/benefits/in_person/urls.py
@@ -8,6 +8,11 @@ from . import views
 app_name = "in_person"
 urlpatterns = [
     path(
+        "additional-providers/",
+        admin.site.admin_view(views.AdditionalProvidersView.as_view()),
+        name=routes.name(routes.IN_PERSON_ADDITIONAL_PROVIDERS),
+    ),
+    path(
         "eligibility/", admin.site.admin_view(views.EligibilityView.as_view()), name=routes.name(routes.IN_PERSON_ELIGIBILITY)
     ),
     path("enrollment/", admin.site.admin_view(views.EnrollmentView.as_view()), name=routes.name(routes.IN_PERSON_ENROLLMENT)),

--- a/benefits/in_person/urls.py
+++ b/benefits/in_person/urls.py
@@ -9,8 +9,8 @@ app_name = "in_person"
 urlpatterns = [
     path(
         "additional-providers/",
-        admin.site.admin_view(views.AdditionalProvidersView.as_view()),
-        name=routes.name(routes.IN_PERSON_ADDITIONAL_PROVIDERS),
+        admin.site.admin_view(views.AdditionalAgenciesView.as_view()),
+        name=routes.name(routes.IN_PERSON_ADDITIONAL_AGENCIES),
     ),
     path(
         "eligibility/", admin.site.admin_view(views.EligibilityView.as_view()), name=routes.name(routes.IN_PERSON_ELIGIBILITY)

--- a/benefits/in_person/views.py
+++ b/benefits/in_person/views.py
@@ -44,9 +44,7 @@ class AdditionalProvidersView(mixins.CommonContextMixin, TemplateView):
         context = super().get_context_data(**kwargs)
 
         agency = self.agency
-        group_agencies = agency.group_agencies()
-        agencies = [agency] + group_agencies
-        context["agencies"] = [a.short_name for a in agencies]
+        context["agencies"] = agency.group_agency_short_names()
 
         context["cancel_url"] = routes.ADMIN_INDEX
 

--- a/benefits/in_person/views.py
+++ b/benefits/in_person/views.py
@@ -25,6 +25,34 @@ from benefits.routes import routes
 logger = logging.getLogger(__name__)
 
 
+class AdditionalProvidersView(mixins.CommonContextMixin, TemplateView):
+    """View handler for showing the list of agencies the customer will be enrolled at (if more than one)."""
+
+    template_name = "in_person/additional-providers.html"
+
+    def dispatch(self, request, *args, **kwargs):
+        """Initialize session state before handling the request."""
+
+        agency = session.agency(request)
+        if not agency:
+            agency = TransitAgency.for_user(request.user)
+            session.update(request, agency=agency)
+        self.agency = agency
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        agency = self.agency
+        group_agencies = agency.group_agencies()
+        agencies = [agency] + group_agencies
+        context["agencies"] = [a.short_name for a in agencies]
+
+        context["cancel_url"] = routes.ADMIN_INDEX
+
+        return context
+
+
 class EligibilityView(mixins.CommonContextMixin, FormView):
     """CBV for the in-person eligibility flow selection form."""
 

--- a/benefits/in_person/views.py
+++ b/benefits/in_person/views.py
@@ -7,6 +7,7 @@ from django.views.generic import FormView, TemplateView
 from benefits.core import models, session
 from benefits.core.mixins import AgencySessionRequiredMixin
 from benefits.core.models.transit import TransitAgency
+from benefits.core.views import AdditionalAgenciesView as DigitalAdditionalAgenciesView
 from benefits.eligibility import analytics as eligibility_analytics
 from benefits.enrollment.views import (
     IndexView as DigitalEnrollmentIndexView,
@@ -25,30 +26,10 @@ from benefits.routes import routes
 logger = logging.getLogger(__name__)
 
 
-class AdditionalProvidersView(mixins.CommonContextMixin, TemplateView):
+class AdditionalAgenciesView(mixins.CommonContextMixin, DigitalAdditionalAgenciesView):
     """View handler for showing the list of agencies the customer will be enrolled at (if more than one)."""
 
-    template_name = "in_person/additional-providers.html"
-
-    def dispatch(self, request, *args, **kwargs):
-        """Initialize session state before handling the request."""
-
-        agency = session.agency(request)
-        if not agency:
-            agency = TransitAgency.for_user(request.user)
-            session.update(request, agency=agency)
-        self.agency = agency
-        return super().dispatch(request, *args, **kwargs)
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-
-        agency = self.agency
-        context["agencies"] = agency.group_agency_short_names()
-
-        context["cancel_url"] = routes.ADMIN_INDEX
-
-        return context
+    template_name = "in_person/additional-agencies.html"
 
 
 class EligibilityView(mixins.CommonContextMixin, FormView):

--- a/benefits/routes.py
+++ b/benefits/routes.py
@@ -130,6 +130,11 @@ class Routes:
         return "admin:index"
 
     @property
+    def IN_PERSON_ADDITIONAL_PROVIDERS(self):
+        """In-person (e.g. agency assisted) additional providers prompt"""
+        return "in_person:additional_providers"
+
+    @property
     def IN_PERSON_ELIGIBILITY(self):
         """In-person (e.g. agency assisted) eligibility"""
         return "in_person:eligibility"

--- a/benefits/routes.py
+++ b/benefits/routes.py
@@ -130,9 +130,9 @@ class Routes:
         return "admin:index"
 
     @property
-    def IN_PERSON_ADDITIONAL_PROVIDERS(self):
-        """In-person (e.g. agency assisted) additional providers prompt"""
-        return "in_person:additional_providers"
+    def IN_PERSON_ADDITIONAL_AGENCIES(self):
+        """In-person (e.g. agency assisted) additional agencies prompt"""
+        return "in_person:additional_agencies"
 
     @property
     def IN_PERSON_ELIGIBILITY(self):

--- a/benefits/static/css/admin/theme.css
+++ b/benefits/static/css/admin/theme.css
@@ -137,3 +137,17 @@ div.breadcrumbs {
   height: 1rem;
   width: 1rem;
 }
+
+/* In-person enrollment flow, overriding Django Admin styles */
+
+.in-person li,
+.in-person dt,
+.in-person dd {
+  font-size: var(--bs-body-font-size);
+  line-height: 1.25;
+  margin-bottom: 0.5rem;
+}
+
+.in-person ul > li {
+  list-style-type: unset;
+}

--- a/benefits/templates/admin/agency-dashboard-index.html
+++ b/benefits/templates/admin/agency-dashboard-index.html
@@ -13,10 +13,10 @@
         <div class="bg-white border border-1 border-secondary p-3">
           <h2 class="pt-0 text-start fs-6 fw-bold">In-person enrollment</h2>
           <p class="mb-4">Verify transit benefit eligibility using agency criteria and complete a rider’s open-loop card enrollment.</p>
-          {% url routes.IN_PERSON_ELIGIBILITY as url_eligibility %}
+          {% url start_url as url_start %}
           <div class="row">
             <div class="col-lg-6">
-              <a href="{{ url_eligibility }}" class="btn btn-lg text-white btn-primary d-block">New enrollment</a>
+              <a href="{{ url_start }}" class="btn btn-lg text-white btn-primary d-block">New enrollment</a>
             </div>
           </div>
         </div>

--- a/benefits/templates/admin/flow-base.html
+++ b/benefits/templates/admin/flow-base.html
@@ -5,7 +5,7 @@
 {% endblock title %}
 
 {% block bodyclass %}
-  {{ block.super }} bg-secondary-subtle
+  {{ block.super }} bg-secondary-subtle in-person
 {% endblock bodyclass %}
 
 {% block content %}

--- a/tests/pytest/in_person/test_views.py
+++ b/tests/pytest/in_person/test_views.py
@@ -60,31 +60,20 @@ def test_view_not_logged_in(client, viewname):
 
 
 @pytest.mark.django_db
-class TestAdditionalProvidersView:
+class TestAdditionalAgenciesView:
     @pytest.fixture
     def view(self, model_User, app_request, mocked_session_agency):
         # manually attach a logged-in user to the request
         app_request.user = model_User
 
-        v = views.AdditionalProvidersView()
+        v = views.AdditionalAgenciesView()
         v.setup(app_request)
         v.agency = mocked_session_agency(app_request)
         return v
 
-    def test_dispatch_no_agency_in_session(
-        self, view, mocked_session_module, mocked_transit_agency_class, model_TransitAgency
-    ):
-        view.agency = None
-        mocked_session_module.agency.return_value = None
-        mocked_transit_agency_class.for_user.return_value = model_TransitAgency
-
-        view.dispatch(view.request)
-
-        mocked_session_module.update.assert_called_once()
-        assert view.agency == model_TransitAgency
-
     @pytest.mark.usefixtures("model_TransitAgencyGroup")
     def test_get_context_data(self, view, model_TransitAgency_2):
+        """Confirimg that it's inherited correctly from the self-service AdditionalAgenciesView."""
         context_data = view.get_context_data()
         assert model_TransitAgency_2.short_name in context_data["agencies"]
 

--- a/tests/pytest/in_person/test_views.py
+++ b/tests/pytest/in_person/test_views.py
@@ -60,6 +60,36 @@ def test_view_not_logged_in(client, viewname):
 
 
 @pytest.mark.django_db
+class TestAdditionalProvidersView:
+    @pytest.fixture
+    def view(self, model_User, app_request, mocked_session_agency):
+        # manually attach a logged-in user to the request
+        app_request.user = model_User
+
+        v = views.AdditionalProvidersView()
+        v.setup(app_request)
+        v.agency = mocked_session_agency(app_request)
+        return v
+
+    def test_dispatch_no_agency_in_session(
+        self, view, mocked_session_module, mocked_transit_agency_class, model_TransitAgency
+    ):
+        view.agency = None
+        mocked_session_module.agency.return_value = None
+        mocked_transit_agency_class.for_user.return_value = model_TransitAgency
+
+        view.dispatch(view.request)
+
+        mocked_session_module.update.assert_called_once()
+        assert view.agency == model_TransitAgency
+
+    @pytest.mark.usefixtures("model_TransitAgencyGroup")
+    def test_get_context_data(self, view, model_TransitAgency_2):
+        context_data = view.get_context_data()
+        assert model_TransitAgency_2.short_name in context_data["agencies"]
+
+
+@pytest.mark.django_db
 class TestEligibilityView:
     @pytest.fixture
     def view(self, model_User, app_request, mocked_session_agency):


### PR DESCRIPTION
Closes #3606 

---

Displayed at the beginning of the in-person enrollment process if the user's agency is in any groups with other agencies.

Includes an update to `TransitAgency.group_agencies()` that orders the returned list by `short_name`.

### TODO:

- [x] Unit test updates (blocked by #3611)
- [x] Extract generation of list of group agency short names into new helper function?

### Testing instructions

Using the combo fixtures:

1. Log into Admin with cst-user
2. Click "New enrollment"
3. Confirm that it goes to the flow selection screen, as before
4. Create an `ast-user`, then log out and back in with that
5. Click "New enrollment"
6. Confirm that you see the new additional providers screen