### PR TITLE
Feat: add subheading on Littlepay enrollment page

### DIFF
--- a/benefits/in_person/templates/in_person/enrollment/index_littlepay.html
+++ b/benefits/in_person/templates/in_person/enrollment/index_littlepay.html
@@ -13,6 +13,7 @@
   </div>
   <div class="p-3">
     <div class="invisible">
+      <h3 class="h5 mb-3">Card details</h3>
       <p>Provide the rider's contactless debit or credit card details.</p>
       <iframe class="card-collection" name="card-collection-iframe"></iframe>
     </div>


### PR DESCRIPTION
Closes #3609 

<img width="1680" height="1005" alt="image" src="https://github.com/user-attachments/assets/28152d2b-dfe8-4985-b2c7-0191a02a24ad" />
