### PR TITLE
fix: ensure setuptools_scm can run git commands when building dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -30,6 +30,8 @@ USER $USER
 # copy only minimal files needed for dev dependency installs
 COPY .git .git
 COPY pyproject.toml pyproject.toml
+# ensure setuptools_scm can run git commands
+RUN git config --global --add safe.directory /calitp/app
 
 # this RUN command uses pipcache
 # setting uid,gid here is critical, as otherwise the Buildkit cache is mounted as root

--- a/.devcontainer/postAttach.sh
+++ b/.devcontainer/postAttach.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 set -eu
 
-# initialize pre-commit
-
-git config --global --add safe.directory /calitp/app
-
 # initialize hook environments
 pre-commit install --install-hooks --overwrite
 


### PR DESCRIPTION
resolves #3628

i tested this fix locally and confirmed that the container can once again be built and pre-commit still functions as expected.

automerge is enabled.