### PR TITLE
chore: add --livereload mkdocs flag instead of pinning click

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -31,7 +31,7 @@ services:
   docs:
     image: benefits_client:dev
     entrypoint: mkdocs
-    command: serve --dev-addr "0.0.0.0:8001"
+    command: serve --livereload --dev-addr "0.0.0.0:8001"
     ports:
       - "8001"
     volumes:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,10 +1,4 @@
 
-# Temporary local pin to work around bug in click>=8.2.2 that breaks watching.
-# See: https://github.com/squidfunk/mkdocs-material/issues/8478
-#      https://github.com/mkdocs/mkdocs/issues/4032
-#      https://github.com/pallets/click/issues/3084
-# Remove when a fixed version of Click has been released
-click==8.2.1
 mdx_truly_sane_lists
 mkdocs==1.6.1
 mkdocs-awesome-pages-plugin


### PR DESCRIPTION
closes #3591

after rebuilding the dev container locally i verified that live reload is indeed still working.

```bash
calitp@b63e319d8f5d  /calitp/app (fix/3591)
$ pip freeze
asgiref==3.11.1
...
click==8.3.1
```