### PR TITLE
Fix: show in-person transit processor portal button

### DIFF
--- a/benefits/admin.py
+++ b/benefits/admin.py
@@ -57,8 +57,8 @@ class BenefitsAdminSite(AdminSite):
             if agency is not None:
                 has_permission_for_in_person = agency.customer_service_group in request.user.groups.all()
 
-                if hasattr(agency, "transitprocessorconfig"):
-                    transit_processor_portal_url = agency.transitprocessorconfig.portal_url
+                if agency.transit_processor_config is not None:
+                    transit_processor_portal_url = agency.transit_processor_config.portal_url
                 else:
                     transit_processor_portal_url = ""
 


### PR DESCRIPTION
At some point, the [attribute](https://github.com/cal-itp/benefits/blob/main/benefits/core/models/transit.py#L118) that refers to `TransitProcessorConfig` on `TransitAgency` changed from `transitprocessorconfig` to [`transit_processor_config`](https://github.com/cal-itp/benefits/blob/main/benefits/core/models/transit.py#L118). This PR updates the [attribute name in the in-person part of the code that sends the Transit Processor's URL to the template via its context](https://github.com/cal-itp/benefits/blob/main/benefits/admin.py#L60).

We also update the `if` condition to avoid running into a `AttributeError at /admin/ 'NoneType' object has no attribute 'portal_url'` for the case when we load the in-person dashboard for a transit agency that has been set up without a `TransitProcessorConfig` (this setup is only possible for an inactive agency, but it's still possible to reach this state when setting up an agency).

## Reviewing

Using the combined fixtures, log in to in-person using `ast-user` and confirm that you see the control portal button:

<img width="2940" height="1054" alt="image" src="https://github.com/user-attachments/assets/7d8f1d8c-15e8-492c-b934-4687cd5ac2a5" />
