### PR TITLE
chore: pin docker-python-web and track using Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,7 +28,9 @@ updates:
     labels:
       - "dependencies"
   - package-ecosystem: "docker"
-    directory: "/tests/playwright" # Playwright Docker image
+    directories:
+      - "/appcontainer" # appcontainer Docker image
+      - "/tests/playwright" # Playwright Docker image
     schedule:
       interval: "daily"
     commit-message:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,9 @@
 version: 2
 updates:
   - package-ecosystem: "pip"
-    directory: "/" # pyproject.toml
+    directories:
+      - "/" # pyproject.toml
+      - "/tests/playwright" # Playwright pytest plugin
     schedule:
       interval: "daily"
     commit-message:
@@ -27,15 +29,6 @@ updates:
       - "dependencies"
   - package-ecosystem: "docker"
     directory: "/tests/playwright" # Playwright Docker image
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-    labels:
-      - "dependencies"
-  - package-ecosystem: "pip"
-    directory: "/tests/playwright" # Playwright pytest plugin
     schedule:
       interval: "daily"
     commit-message:

--- a/appcontainer/Dockerfile
+++ b/appcontainer/Dockerfile
@@ -9,7 +9,7 @@ ARG PYTHONDONTWRITEBYTECODE=1 \
 #
 # stage 1: builds the benefits package from source
 #          using the git metadata for version info
-FROM ghcr.io/cal-itp/docker-python-web:main AS build_wheel
+FROM ghcr.io/cal-itp/docker-python-web:1.0.0 AS build_wheel
 
 # renew top-level args in this stage
 ARG PYTHONDONTWRITEBYTECODE \
@@ -55,7 +55,7 @@ RUN --mount=type=cache,id=pipcache,target=${PIP_CACHE_DIR},uid=${USER_UID},gid=$
 #
 # stage 2: installs the benefits package in a fresh base container
 #          using the pre-built package, and copying only needed source
-FROM ghcr.io/cal-itp/docker-python-web:main AS appcontainer
+FROM ghcr.io/cal-itp/docker-python-web:1.0.0 AS appcontainer
 
 # renew top-level args in this stage
 ARG PYTHONDONTWRITEBYTECODE \


### PR DESCRIPTION
resolves #3577. while i was in here i did a little unrelated cleanup of our dependabot.yml` config file. 😇 

* start using [`directories`](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/manage-your-dependency-security/controlling-dependencies-updated#defining-multiple-locations-for-manifest-files) (instead of maintaining two unique pip configurations)
* ~use a YAML anchor (to centralize/reuse common input arguments)~

i _think_ this is all that we'll need to ensure Dependabot opens a PR to update to docker-python-web@1.0.x when a new version is tagged.

after the PR is merged, i'll create a 1.0.1 tag to test and to make sure that we don't get bitten by https://github.com/dependabot/dependabot-core/issues/13383 given our multi-arch image.

## Steps to test

```bash
# outside the devcontainer
docker compose build --no-cache client
```

afterwards the DevContainer should build and the app should boot up as normal. i tested an e2e self-service medicare flow just to make sure.