### PR TITLE
fix: ensure restart-app.sh helper script can also run on MacOS

### DIFF
--- a/docs/tutorials/secrets.md
+++ b/docs/tutorials/secrets.md
@@ -38,8 +38,13 @@ To make sure the Benefits application uses the latest secret values in Key Vault
 
 The steps are:
 
-1. After setting new secret values, go to the App Service configuration in Azure Portal, and change the value of the setting named `change_me_to_refresh_secrets`.
-1. Save your changes.
+1. After setting new secret values, cd into the `/terraform` directory
+2. run the command below, which updates a dummy environment variable called `change_me_to_refresh_secrets` in the relevant App Service configuration in Azure Portal.
+
+```bash
+cd terraform
+./restart-app.sh <environment_letter>
+```
 
 The effects of following those steps should be:
 

--- a/docs/tutorials/secrets.md
+++ b/docs/tutorials/secrets.md
@@ -34,19 +34,4 @@ To verify the value of a secret, you can use the helper script named `read.sh`.
 
 ## Refreshing secrets
 
-To make sure the Benefits application uses the latest secret values in Key Vault, you will need to make a change to the app service's configuration. If you don't do this step, the application will instead use cached values, which may not be what you expect. See the [Azure docs](https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references?tabs=azure-cli#rotation) for more details.
-
-The steps are:
-
-1. After setting new secret values, cd into the `/terraform` directory
-2. run the command below, which updates a dummy environment variable called `change_me_to_refresh_secrets` in the relevant App Service configuration in Azure Portal.
-
-```bash
-cd terraform
-./restart-app.sh <environment_letter>
-```
-
-The effects of following those steps should be:
-
-- A restart of the App Service is triggered.
-- The next time that our Azure infrastructure pipeline is run, the value of `change_me_to_refresh_secrets` is set back to the value defined in our Terraform file for the App Service resource.
+To make sure the Benefits application uses the latest secret values in Key Vault, you will need to navigate to App service > Settings > Environment variables and click 'Pull reference values'.

--- a/terraform/restart-app.sh
+++ b/terraform/restart-app.sh
@@ -10,6 +10,7 @@ fi
 ENV="$1"
 APP="AS-CDT-PUB-VIP-CALITP-$ENV-001"
 RG="RG-CDT-PUB-VIP-CALITP-$ENV-001"
-NOW=$(date --utc)
+# -u is a terse equivalent to --utc that is also recognized by MacOS
+NOW=$(date -u)
 
 az webapp config appsettings set --name "$APP" --resource-group "$RG" --settings change_me_to_refresh_secrets="$NOW"


### PR DESCRIPTION
## summary
this PR makes a small tweak to restart-app.sh to ensure it can be run successfully from both Linux and MacOS. i verified this by confirming that `date --utc` and `date -u` are analagous in a bash shell in the linux-based dev container.

it also updates the secrets tutorial to mention the current best practice for pulling fresh reference values. (see #1948 for more info)

## details

~while working on #3677 it wasn't immediately apparent to me how i could update the value of `change_me_to_refresh_secrets` manually to trigger an app restart. after making the tweak below, _then_ i was able to see the corresponding environment variable listed under "app service > settings > environment variables" in the Azure portal.~

~i assume this is 'by design', but if there's somewhere else i could have found the setting in the portal initially, i'd be curious to learn about it.~

