### PR TITLE
Refactor: trigger Container Apps deploy from GH Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -110,6 +110,64 @@ jobs:
           images: ghcr.io/${{ github.repository }}:${{ github.sha }}
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
 
+      - name: Trigger Azure Pipeline
+        id: trigger_pipeline
+        run: |
+          TOKEN_RESPONSE=$(curl -sS -X POST \
+            -H "Content-Type: application/x-www-form-urlencoded" \
+            -d "client_id=${{ secrets.AZURE_CLIENT_ID }}" \
+            -d "client_secret=${{ secrets.AZURE_CLIENT_SECRET }}" \
+            -d "grant_type=client_credentials" \
+            -d "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+            "https://login.microsoftonline.com/${{ secrets.AZURE_TENANT_ID }}/oauth2/v2.0/token")
+
+          export AZURE_DEVOPS_EXT_PAT=$(echo "$TOKEN_RESPONSE" | jq -r '.access_token // empty')
+
+          if [ -z "$AZURE_DEVOPS_EXT_PAT" ]; then
+            echo "Failed to get Azure DevOps token"
+            exit 1
+          fi
+
+          RUN_ID=$(az pipelines run \
+            --id "${{ secrets.ADO_PIPELINE_ID }}" \
+            --org "${{ secrets.ADO_ORG_URL }}" \
+            --project "${{ secrets.ADO_PROJECT }}" \
+            --branch "${{ github.ref }}" \
+            --commit-id ${{ github.sha }} \
+            --query "id" -o tsv)
+
+          echo "Waiting for Azure DevOps Pipeline run to complete..."
+          while true; do
+            PIPELINE_STATUS=$(az pipelines runs show \
+              --id $RUN_ID \
+              --org "${{ secrets.ADO_ORG_URL }}" \
+              --project "${{ secrets.ADO_PROJECT }}" \
+              --query "status" -o tsv)
+
+            echo "Current pipeline status: $PIPELINE_STATUS"
+
+            if [[ "$PIPELINE_STATUS" == "completed" ]]; then
+              PIPELINE_RESULT=$(az pipelines runs show \
+                --id $RUN_ID \
+                --org "${{ secrets.ADO_ORG_URL }}" \
+                --project "${{ secrets.ADO_PROJECT }}" \
+                --query "result" -o tsv)
+
+              echo "Pipeline completed with result: $PIPELINE_RESULT"
+              if [[ "$PIPELINE_RESULT" == "succeeded" ]]; then
+                exit 0
+              else
+                echo "Azure DevOps Pipeline failed with result: $PIPELINE_RESULT"
+                exit 1
+              fi
+            elif [[ "$PIPELINE_STATUS" == "cancelling" || "$PIPELINE_STATUS" == "notStarted" || "$PIPELINE_STATUS" == "inProgress" ]]; then
+              sleep 10
+            else
+              echo "Azure DevOps Pipeline finished with unexpected status: $PIPELINE_STATUS"
+              exit 1
+            fi
+          done
+
   release:
     needs: deploy
     if: ${{ github.ref_type == 'tag' && !contains(github.ref, '-rc') }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -110,6 +110,64 @@ jobs:
           images: ghcr.io/${{ github.repository }}:${{ github.sha }}
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
 
+      - name: Trigger Azure Pipeline
+        id: trigger_pipeline
+        run: |
+          TOKEN_RESPONSE=$(curl -sS -X POST \
+            -H "Content-Type: application/x-www-form-urlencoded" \
+            -d "client_id=${{ secrets.AZURE_ADO_CLIENT_ID }}" \
+            -d "client_secret=${{ secrets.AZURE_ADO_CLIENT_SECRET }}" \
+            -d "grant_type=client_credentials" \
+            -d "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+            "https://login.microsoftonline.com/${{ secrets.AZURE_ADO_TENANT_ID }}/oauth2/v2.0/token")
+
+          export AZURE_DEVOPS_EXT_PAT=$(echo "$TOKEN_RESPONSE" | jq -r '.access_token // empty')
+
+          if [ -z "$AZURE_DEVOPS_EXT_PAT" ]; then
+            echo "Failed to get Azure DevOps token"
+            exit 1
+          fi
+
+          RUN_ID=$(az pipelines run \
+            --id "${{ secrets.AZURE_ADO_PIPELINE_ID }}" \
+            --org "${{ secrets.AZURE_ADO_ORG_URL }}" \
+            --project "${{ secrets.AZURE_ADO_PROJECT }}" \
+            --branch "${{ github.ref }}" \
+            --commit-id ${{ github.sha }} \
+            --query "id" -o tsv)
+
+          echo "Waiting for Azure DevOps Pipeline run to complete..."
+          while true; do
+            PIPELINE_STATUS=$(az pipelines runs show \
+              --id $RUN_ID \
+              --org "${{ secrets.AZURE_ADO_ORG_URL }}" \
+              --project "${{ secrets.AZURE_ADO_PROJECT }}" \
+              --query "status" -o tsv)
+
+            echo "Current pipeline status: $PIPELINE_STATUS"
+
+            if [[ "$PIPELINE_STATUS" == "completed" ]]; then
+              PIPELINE_RESULT=$(az pipelines runs show \
+                --id $RUN_ID \
+                --org "${{ secrets.AZURE_ADO_ORG_URL }}" \
+                --project "${{ secrets.AZURE_ADO_PROJECT }}" \
+                --query "result" -o tsv)
+
+              echo "Pipeline completed with result: $PIPELINE_RESULT"
+              if [[ "$PIPELINE_RESULT" == "succeeded" ]]; then
+                exit 0
+              else
+                echo "Azure DevOps Pipeline failed with result: $PIPELINE_RESULT"
+                exit 1
+              fi
+            elif [[ "$PIPELINE_STATUS" == "cancelling" || "$PIPELINE_STATUS" == "notStarted" || "$PIPELINE_STATUS" == "inProgress" ]]; then
+              sleep 10
+            else
+              echo "Azure DevOps Pipeline finished with unexpected status: $PIPELINE_STATUS"
+              exit 1
+            fi
+          done
+
   release:
     needs: deploy
     if: ${{ github.ref_type == 'tag' && !contains(github.ref, '-rc') }}

--- a/terraform/azure-pipelines.yml
+++ b/terraform/azure-pipelines.yml
@@ -1,15 +1,8 @@
-trigger:
-  # automatically runs on pull requests
-  # https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#pr-triggers
-  branches:
-    include:
-      - main
-      - refs/tags/20??.??.?*-rc?*
-      - refs/tags/20??.??.?*
-  # only run for changes to Terraform files
-  paths:
-    include:
-      - terraform/*
+trigger: none
+# it will be triggered "manually" from a GitHub Actions workflow
+# but will still automatically run on pull requests
+# https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/trigger?view=azure-pipelines#trigger-none
+
 stages:
   - stage: terraform
     pool:

--- a/terraform/azure-pipelines.yml
+++ b/terraform/azure-pipelines.yml
@@ -1,11 +1,8 @@
-trigger:
-  # automatically runs on pull requests
-  # https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#pr-triggers
-  branches:
-    include:
-      - main
-      - refs/tags/20??.??.?*-rc?*
-      - refs/tags/20??.??.?*
+trigger: none
+# it will be triggered "manually" from a GitHub Actions workflow
+# but will still automatically run on pull requests
+# https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/trigger?view=azure-pipelines#trigger-none
+
 stages:
   - stage: terraform
     pool:


### PR DESCRIPTION
Part of #3637, #3638, #3639

This PR refactors our CI/CD to "manually" trigger the DevOps Pipeline (which deploys the Container Apps) from the GH Actions `Deploy` workflow. We are still keeping the `Deploy to Azure Web App` step in the `Deploy` workflow to ensure that this PR is entirely an additive change so that we can continue deploying the App Service until we are completely cut over to Container Apps.

~We won't merge this PR until we make the manual changes to Front Door and confirm that the full cutover is complete.~ We decided to push forward with this change instead of waiting so that we are in a better state to continue the Postgres Stabilization and Optimization work.