### PR TITLE
Fix: branch name formatting for adoption table

### DIFF
--- a/.github/workflows/agency-onboarding/helpers.js
+++ b/.github/workflows/agency-onboarding/helpers.js
@@ -180,7 +180,7 @@ export const updateAdoptionTable = async ({ github, context, parentIssue }) => {
   }
 
   // Create a new branch name
-  const branchName = `docs/update-adoption-table-${short_name.toLowerCase()}`;
+  const branchName = `docs/update-adoption-table-${short_name.toLowerCase().split(/\s+/).join("-")}`;
 
   // Get the main branch reference
   const mainRef = await github.rest.git.getRef({

--- a/.github/workflows/agency-onboarding/helpers.js
+++ b/.github/workflows/agency-onboarding/helpers.js
@@ -180,7 +180,7 @@ export const updateAdoptionTable = async ({ github, context, parentIssue }) => {
   }
 
   // Create a new branch name
-  const branchName = `docs/update-adoption-table-${short_name.toLowerCase().split(/\s+/).join("-")}`;
+  const branchName = `docs/update-adoption-table-${short_name.toLowerCase().replaceAll(/\s+/g, "-")}`;
 
   // Get the main branch reference
   const mainRef = await github.rest.git.getRef({


### PR DESCRIPTION
Replaces space characters with dash during branch name generation

See failed run here: https://github.com/cal-itp/benefits/actions/runs/25761548411/job/75663717809

Where the short name was `Thousand Oaks` and we saw a failure to create the branch:

> RequestError [HttpError]: refs/heads/docs/update-adoption-table-thousand oaks is not a valid ref name.