### PR TITLE
Refactor: run Azure Pipeline on all repo changes

### DIFF
--- a/terraform/azure-pipelines.yml
+++ b/terraform/azure-pipelines.yml
@@ -6,10 +6,6 @@ trigger:
       - main
       - refs/tags/20??.??.?*-rc?*
       - refs/tags/20??.??.?*
-  # only run for changes to Terraform files
-  paths:
-    include:
-      - terraform/*
 stages:
   - stage: terraform
     pool:


### PR DESCRIPTION
Closes #3767 

This PR removes the file path filter on the Azure Pipeline so that it runs on all repository changes. This is to ensure that the side-by-side deployments of App Services and Container Apps have the same application code.