### PR TITLE
Chore: enable in-person for inactive agencies

### DIFF
--- a/benefits/admin.py
+++ b/benefits/admin.py
@@ -68,7 +68,9 @@ class BenefitsAdminSite(AdminSite):
                         "transit_processor_portal_url": transit_processor_portal_url,
                         "title": f"{agency.long_name} | {self.index_title} | {self.site_title}",
                         "start_url": (
-                            routes.IN_PERSON_ADDITIONAL_AGENCIES if agency.group_agencies() else routes.IN_PERSON_ELIGIBILITY
+                            routes.IN_PERSON_ADDITIONAL_AGENCIES
+                            if agency.group_agencies(only_active=False)
+                            else routes.IN_PERSON_ELIGIBILITY
                         ),
                     }
                 )

--- a/benefits/core/mixins.py
+++ b/benefits/core/mixins.py
@@ -16,15 +16,16 @@ class AgencySessionRequiredMixin:
 
     Gets the active `TransitAgency` out of session and sets an attribute on `self`.
 
-    If the session is not configured with an agency, return a user error.
+    Allows inactive agencies ONLY if the user is an authenticated staff member, otherwise returns a user error.
     """
 
     def dispatch(self, request, *args, **kwargs):
-        if session.active_agency(request):
-            self.agency = session.agency(request)
+        agency = session.agency(request)
+        if agency and (agency.active or getattr(request.user, "is_staff", False)):
+            self.agency = agency
             return super().dispatch(request, *args, **kwargs)
         else:
-            logger.warning("Session not configured with an active agency")
+            logger.warning("Session missing an agency, or user lacks permission to access an inactive agency")
             return user_error(request)
 
 

--- a/benefits/core/models/transit.py
+++ b/benefits/core/models/transit.py
@@ -215,14 +215,16 @@ class TransitAgency(models.Model):
 
         return list(agencies_in_group.exclude(pk=self.pk).order_by("short_name"))
 
-    def group_agency_short_names(self):
+    def group_agency_short_names(self, only_active=True):
         """A list of agency short names for this agency and any agencies it shares a group with.
+        If only_active is True, only active short names are returned. If only_active is False,
+        all short names are returned.
 
         The list begins with the current agency and the rest follow in alphabetical order.
         If an agency is not associated with any other agencies via TransitAgencyGroup,
         this returns an empty list.
         """
-        agencies = [self] + self.group_agencies()
+        agencies = [self] + self.group_agencies(only_active=only_active)
 
         if len(agencies) > 1:
             return [agency.short_name for agency in agencies]

--- a/benefits/core/models/transit.py
+++ b/benefits/core/models/transit.py
@@ -206,14 +206,16 @@ class TransitAgency(models.Model):
         this returns an empty list.
         """
 
-        agencies_in_group = TransitAgency.objects.filter(
-            transitagencygroup__in=list(self.transitagencygroup_set.all())
-        ).distinct()
+        agencies_in_group = (
+            TransitAgency.objects.filter(transitagencygroup__in=list(self.transitagencygroup_set.all()))
+            .distinct()
+            .exclude(pk=self.pk)
+        )
 
         if only_active:
             agencies_in_group = agencies_in_group.exclude(active=False)
 
-        return list(agencies_in_group.exclude(pk=self.pk).order_by("short_name"))
+        return list(agencies_in_group.order_by("short_name"))
 
     def group_agency_short_names(self, only_active=True):
         """A list of agency short names for this agency and any agencies it shares a group with.

--- a/benefits/core/models/transit.py
+++ b/benefits/core/models/transit.py
@@ -198,7 +198,7 @@ class TransitAgency(models.Model):
         return f"{self.short_name} Customer Service"
 
     def group_agencies(self):
-        """The set of all agencies in all groups associated with this agency, excluding itself.
+        """The set of all active agencies in all groups associated with this agency, excluding itself.
 
         If an agency is not associated with any other agencies via TransitAgencyGroup,
         this returns an empty list.

--- a/benefits/core/models/transit.py
+++ b/benefits/core/models/transit.py
@@ -197,19 +197,23 @@ class TransitAgency(models.Model):
         """Returns the standardized name for this Agency's customer service group."""
         return f"{self.short_name} Customer Service"
 
-    def group_agencies(self):
-        """The set of all active agencies in all groups associated with this agency, excluding itself.
+    def group_agencies(self, only_active=True):
+        """The set of agencies in all groups associated with this agency, excluding itself.
+        If only_active is True, only active agencies are returned. If only_active is False,
+        all agencies are returned.
 
         If an agency is not associated with any other agencies via TransitAgencyGroup,
         this returns an empty list.
         """
-        return list(
-            TransitAgency.objects.filter(transitagencygroup__in=list(self.transitagencygroup_set.all()))
-            .distinct()
-            .exclude(active=False)
-            .exclude(pk=self.pk)
-            .order_by("short_name")
-        )
+
+        agencies_in_group = TransitAgency.objects.filter(
+            transitagencygroup__in=list(self.transitagencygroup_set.all())
+        ).distinct()
+
+        if only_active:
+            agencies_in_group = agencies_in_group.exclude(active=False)
+
+        return list(agencies_in_group.exclude(pk=self.pk).order_by("short_name"))
 
     def group_agency_short_names(self):
         """A list of agency short names for this agency and any agencies it shares a group with.

--- a/benefits/core/views.py
+++ b/benefits/core/views.py
@@ -239,11 +239,12 @@ class AdditionalAgenciesView(AgencySessionRequiredMixin, TemplateView):
     """View handler for nearby/additional providers."""
 
     template_name = "core/additional-agencies.html"
+    only_active_agencies = True
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         agency = self.agency
-        agencies = agency.group_agency_short_names()
+        agencies = agency.group_agency_short_names(only_active=self.only_active_agencies)
 
         context |= {
             "title": _("Nearby transit providers"),

--- a/benefits/enrollment/views.py
+++ b/benefits/enrollment/views.py
@@ -176,19 +176,20 @@ class SuccessView(PageViewMixin, FlowSessionRequiredMixin, EligibleSessionRequir
     """View handler for the final success page."""
 
     template_name = "enrollment/success.html"
+    only_active_agencies = True
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
         agency = self.agency
-        group_agencies = agency.group_agencies()
+        group_agencies = agency.group_agencies(only_active=self.only_active_agencies)
 
         if group_agencies:
             success_message = _(
                 "You were not charged anything today. When boarding public transit at the following providers, tap this card "
                 "and you will be charged a reduced fare:"
             )
-            agency_short_names = agency.group_agency_short_names()
+            agency_short_names = agency.group_agency_short_names(only_active=self.only_active_agencies)
         else:
             success_message = _(
                 "You were not charged anything today. When boarding public transit provided by {short_name}, tap this "

--- a/benefits/in_person/views.py
+++ b/benefits/in_person/views.py
@@ -30,6 +30,7 @@ class AdditionalAgenciesView(mixins.CommonContextMixin, SelfServiceAdditionalAge
     """View handler for showing the list of agencies the customer will be enrolled at (if more than one)."""
 
     template_name = "in_person/additional-agencies.html"
+    only_active_agencies = False
 
 
 class EligibilityView(mixins.CommonContextMixin, FormView):
@@ -148,6 +149,7 @@ class SuccessView(mixins.CommonContextMixin, AgencySessionRequiredMixin, SelfSer
     """View handler for the final success page."""
 
     template_name = "in_person/enrollment/success.html"
+    only_active_agencies = False
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/tests/pytest/core/models/test_transit.py
+++ b/tests/pytest/core/models/test_transit.py
@@ -244,6 +244,14 @@ class TestTransitAgency:
 
         assert model_TransitAgency_inactive not in model_TransitAgency_2.group_agencies()
 
+    def test_group_agencies__includes_inactives(
+        self, model_TransitAgency_2, model_TransitAgency_inactive, model_TransitAgencyGroup
+    ):
+        model_TransitAgencyGroup.transit_agencies.add(model_TransitAgency_2, model_TransitAgency_inactive)
+        model_TransitAgencyGroup.save()
+
+        assert model_TransitAgency_inactive in model_TransitAgency_2.group_agencies(only_active=False)
+
     @pytest.mark.usefixtures("model_TransitAgencyGroup")
     def test_group_agencies__excludes_self(self, model_TransitAgency):
         assert model_TransitAgency not in model_TransitAgency.group_agencies()

--- a/tests/pytest/core/models/test_transit.py
+++ b/tests/pytest/core/models/test_transit.py
@@ -264,6 +264,13 @@ class TestTransitAgency:
         assert len(model_TransitAgency.group_agencies()) == 1
 
     @pytest.mark.usefixtures("model_TransitAgencyGroup")
+    def test_group_agency_short_names_includes_inactives(self, model_TransitAgency_inactive, model_TransitAgency_2):
+        assert model_TransitAgency_2.group_agency_short_names(only_active=False) == [
+            model_TransitAgency_2.short_name,
+            model_TransitAgency_inactive.short_name,
+        ]
+
+    @pytest.mark.usefixtures("model_TransitAgencyGroup")
     def test_group_agency_short_names(self, model_TransitAgency, model_TransitAgency_2):
         assert model_TransitAgency_2.group_agency_short_names() == [
             model_TransitAgency_2.short_name,

--- a/tests/pytest/core/test_mixins.py
+++ b/tests/pytest/core/test_mixins.py
@@ -25,9 +25,9 @@ class TestAgencySessionRequiredMixin:
         v.setup(app_request)
         return v
 
-    def test_dispatch_without_active_agency(self, view, app_request, mocker):
+    def test_dispatch_without_agency(self, view, app_request, mocker):
         mock_session = mocker.patch("benefits.core.mixins.session")
-        mock_session.active_agency.return_value = False
+        mock_session.agency.return_value = None
 
         response = view.dispatch(app_request)
 
@@ -35,14 +35,25 @@ class TestAgencySessionRequiredMixin:
         assert response.status_code == 200
         assert response.template_name == TEMPLATE_USER_ERROR
 
-    def test_dispatch_with_active_agency(self, view, app_request, mocker):
+    @pytest.mark.django_db
+    def test_dispatch_with_active_agency(self, view, app_request, mocker, model_TransitAgency):
         mock_session = mocker.patch("benefits.core.mixins.session")
-        mock_session.active_agency.return_value = True
-        mock_session.agency.return_value = {"agency": "123"}
+        mock_session.agency.return_value = model_TransitAgency
 
         view.dispatch(app_request)
 
-        assert view.agency == {"agency": "123"}
+        assert view.agency == model_TransitAgency
+
+    @pytest.mark.django_db
+    def test_dispatch_with_inactive_agency_staff_user(self, view, app_request, mocker, model_TransitAgency):
+        mock_session = mocker.patch("benefits.core.mixins.session")
+        model_TransitAgency.active = False
+        mock_session.agency.return_value = model_TransitAgency
+        app_request.user = mocker.Mock(is_staff=True)
+
+        view.dispatch(app_request)
+
+        assert view.agency == model_TransitAgency
 
 
 class TestEligibleSessionRequiredMixin:


### PR DESCRIPTION
Closes #3802 

This PR enables the in-person flow for transit agencies that are marked as inactive. It does so by making the following minimal changes until we decide to implement a `status` field on the `TransitAgency` model:

- Refactoring `AgencySessionRequiredMixin` to allow in-person to work for inactive agencies ONLY if the user is an authenticated staff member, yet still fulfilling its original purpose of only allowing self-service for active transit agencies.
- Generalizing the `TransitAgency.group_agencies()` and `TransitAgency.group_agency_short_names()` methods to allow the caller to specify if all agencies or only active ones within a transit agency group should be returned. By using a default parameter value we keep the original behavior of the function unchanged.
- Keeping our original CBV pattern of using class attributes to set behavior for in-person or self-service views when the in-person view inherits from self-service.

## Reviewing

- Set your fixtures to use the combined fixtures in LastPass
- Verify the following cases:
  - [x] Aalifornia active, Balifornia active
    - [x] See the additional regional agencies view, can enroll a card, and see the regional agencies success view using in-person (using `ast-user`)
    - [x] Aalifornia and Balifornia in drop-down, see the additional agencies view, can enroll a card, see the regional agencies success view
  - [x] Aalifornia active, Balifornia inactive
    - [x] See the additional regional agencies view, can enroll a card, and see the regional agencies success view using in-person (using `ast-user`)
    - [x] Aalifornia in drop-down, no additional agencies view, can enroll a card, no regional agencies success view
  - [x] Aalifornia inactive, Balifornia active
    - [x] See the additional regional agencies view, can enroll a card, and see the regional agencies success view using in-person (using `ast-user`)
    - [x] Balifornia in drop-down, no additional agencies view, can enroll a card, no regional agencies success view
  - [x] Aalifornia inactive, Balifornia inactive
    - [x] See the additional regional agencies view, can enroll a card, and see the regional agencies success view using in-person (using `ast-user`)
    - [x] Only CST in drop-down so you can only proceed using CST