### PR TITLE
docs: updates target launch date for several agencies

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -90,8 +90,8 @@ The following California transit providers have adopted Cal-ITP Benefits. The be
 | **El Dorado Transit Authority**                     | 01/2026             | ✅           | ✅                   | ―             | ―                    | ―           |
 | **Redding Area Bus Authority**                      | 02/2026             | ✅           | ✅                   | ✅            | ✅                   | ―           |
 | **City of San Luis Obispo**                         | 04/2026             | ✅           | ✅                   | ―             | ―                    | ―           |
-| **Gold Coast Transit Distict**                      | 06/2026 (target)    | \*           | \*                   | \*            | \*                   | \*          |
-| **Santa Cruz Metropolitan Transit District**        | 06/2026 (target)    | \*           | \*                   | \*            | \*                   | \*          |
+| **Santa Cruz Metropolitan Transit District**        | 07/2026 (target)    | \*           | \*                   | \*            | \*                   | \*          |
+| **Gold Coast Transit Distict**                      | 07/2026 (target)    | \*           | \*                   | \*            | \*                   | \*          |
 | **City of Camarillo**                               | 07/2026 (target)    | \*           | \*                   | \*            | \*                   | \*          |
 | **City of Simi Valley**                             | 07/2026 (target)    | \*           | \*                   | \*            | \*                   | \*          |
 | **City of Thousand Oaks**                           | 07/2026 (target)    | \*           | \*                   | \*            | \*                   | \*          |

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,11 +93,11 @@ The following California transit providers have adopted Cal-ITP Benefits. The be
 | **Gold Coast Transit Distict**                      | 06/2026 (target)    | \*           | \*                   | \*            | \*                   | \*          |
 | **Santa Cruz Metropolitan Transit District**        | 06/2026 (target)    | \*           | \*                   | \*            | \*                   | \*          |
 | **City of Camarillo**                               | 07/2026 (target)    | \*           | \*                   | \*            | \*                   | \*          |
-| **City of Roseville**                               | 07/2026 (target)    | \*           | \*                   | \*            | \*                   | \*          |
 | **City of Simi Valley**                             | 07/2026 (target)    | \*           | \*                   | \*            | \*                   | \*          |
 | **City of Thousand Oaks**                           | 07/2026 (target)    | \*           | \*                   | \*            | \*                   | \*          |
 | **Valley Express**                                  | 07/2026 (target)    | \*           | \*                   | \*            | \*                   | \*          |
 | **City of Wasco**                                   | 08/2026 (target)    | \*           | \*                   | \*            | \*                   | \*          |
+| **City of Roseville**                               | 10/2026 (target)    | \*           | \*                   | \*            | \*                   | \*          |
 | **Santa Barbara County Association of Governments** | Planned             | \*           | \*                   | \*            | \*                   | \*          |
 
 ## Supported enrollment pathways


### PR DESCRIPTION
Roseville's launch is now expected in Q4 2026. See this comment for details: https://github.com/cal-itp/benefits/issues/2825#issuecomment-4746509819. Additionally, SCMTD and the Ventura county agencies will likely not launch until July.