### PR TITLE
Chore: removed outdated metabase config step and issue template

### DIFF
--- a/.github/workflows/agency-onboarding.yml
+++ b/.github/workflows/agency-onboarding.yml
@@ -157,20 +157,6 @@ jobs:
               title: `Transit provider is configured for In-Person Enrollments in Benefits Administrator`
             });
 
-      - name: Metabase configuration issue
-        id: metabase-config
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const { createSubIssue } = await import(process.env.helpers_script);
-
-            await createSubIssue({
-              github, context, core,
-              parentNodeId: "${{ steps.parent.outputs.node_id }}",
-              templateName: 'metabase-config.md',
-              title: `Add product names to transaction charts in Metabase`
-            });
-
       - name: Amplitude enrollment issue
         id: amplitude-enrollment
         uses: actions/github-script@v9

--- a/.github/workflows/agency-onboarding/metabase-config.md
+++ b/.github/workflows/agency-onboarding/metabase-config.md
@@ -1,6 +1,0 @@
-## Acceptance criteria
-
-Add {{SHORT_NAME}} product codes to Metabase queries that generate charts to track transactions, so this agency’s transaction activity is logged in our program metrics.
-
-- [ ] [Reduced-fare open-loop transactions per month by transit agency](https://dashboards.calitp.org/question/2343-reduced-fare-open-loop-transactions-per-month-by-transit-agency-updated)
-- [ ] [Benefits - agencies in production](https://dashboards.calitp.org/model/4430-benefits-agencies-in-production)


### PR DESCRIPTION
Essentially the exact same changes as 2644733fb410b004c4197d3d9051d8477ce95009 from https://github.com/cal-itp/benefits/pull/3818.

The context around this change is that since [June 11, 2026](https://github.com/cal-itp/benefits/issues/3697#issuecomment-4684523992) (~1 month ago), we have not needed this issue to be created anymore.

Closes #3816

There are no open tickets corresponding to this template, so no post-merge clean-up needed. :white_check_mark: 