### PR TITLE
chore: run 'terraform plan' via github action

### DIFF
--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -43,4 +43,4 @@ jobs:
           TF_VAR_CONTAINER_TAG: ${{ github.sha }}
           TF_VAR_DEVSECOPS_OBJECT_ID: ${{ secrets.TF_VAR_DEVSECOPS_OBJECT_ID }}
           TF_VAR_ENGINEERING_GROUP_OBJECT_ID: ${{ secrets.TF_VAR_ENGINEERING_GROUP_OBJECT_ID }}
-        run: terraform plan -lock=false
+        run: terraform plan

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -43,4 +43,4 @@ jobs:
           TF_VAR_CONTAINER_TAG: ${{ github.sha }}
           TF_VAR_DEVSECOPS_OBJECT_ID: ${{ secrets.TF_VAR_DEVSECOPS_OBJECT_ID }}
           TF_VAR_ENGINEERING_GROUP_OBJECT_ID: ${{ secrets.TF_VAR_ENGINEERING_GROUP_OBJECT_ID }}
-        run: terraform plan
+        run: terraform plan -lock-timeout=5m

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -1,0 +1,46 @@
+name: Terraform plan
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "terraform/**"
+      - ".github/workflows/terraform-plan.yml"
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  terraform-plan:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: terraform
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Log in to azure using federated identity credentials
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
+        with:
+          client-id: ${{ secrets.AZURE_SP_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_SP_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SP_SUBSCRIPTION_ID }}
+
+      - name: Setup terraform
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
+        with:
+          terraform_version: 1.14.5
+
+      - name: Initialize terraform and select workspace
+        run: ./init.sh "dev"
+
+      - name: Terraform Plan
+        env:
+          TF_VAR_ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SP_SUBSCRIPTION_ID }}
+          TF_VAR_CONTAINER_TAG: ${{ github.sha }}
+          TF_VAR_DEVSECOPS_OBJECT_ID: ${{ secrets.TF_VAR_DEVSECOPS_OBJECT_ID }}
+          TF_VAR_ENGINEERING_GROUP_OBJECT_ID: ${{ secrets.TF_VAR_ENGINEERING_GROUP_OBJECT_ID }}
+        run: terraform plan -lock=false

--- a/terraform/azure-pipelines.yml
+++ b/terraform/azure-pipelines.yml
@@ -1,6 +1,6 @@
 trigger: none
-# it will be triggered "manually" from a GitHub Actions workflow
-# but will still automatically run on pull requests
+pr: none
+# all previous triggers are now disabled but "manual" runs from a GitHub Actions workflow are still supported
 # https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/trigger?view=azure-pipelines#trigger-none
 
 stages:

--- a/terraform/azure-pipelines.yml
+++ b/terraform/azure-pipelines.yml
@@ -1,7 +1,7 @@
 trigger: none
 pr: none
-# all previous triggers are now disabled but "manual" runs from a GitHub Actions workflow are still supported
-# https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/trigger?view=azure-pipelines#trigger-none
+# automatic pull request validation triggers are also now disabled but "manual" runs from a GitHub Actions workflow are still supported
+# https://learn.microsoft.com/en-us/azure/devops/pipelines/build/triggers?view=azure-devops&tabs=yaml#pr-triggers
 
 stages:
   - stage: terraform

--- a/terraform/key_vault.tf
+++ b/terraform/key_vault.tf
@@ -78,6 +78,8 @@ resource "azurerm_key_vault_access_policy" "engineering" {
   depends_on = [azurerm_key_vault.main]
 }
 
+# this access policy below can be removed when the ADO pipeline has been deprecated
+
 # Standalone Access Policy for DevSecOps
 resource "azurerm_key_vault_access_policy" "devsecops" {
   key_vault_id = azurerm_key_vault.main.id


### PR DESCRIPTION
adds a new pull_request driven github action to run `terraform plan` anytime the contents of the `terraform/` directory have changed and disables the pull request triggered ADO pipeline run that did the same thing formerly.

part of #3897

as part of this effort, DevSecOps created a new service principal and federated credentials on our behalf and we worked together to grant the runner needed privileges.