### PR TITLE
chore: run 'terraform apply' via github action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,10 @@ defaults:
   run:
     shell: bash
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   id-token: write
   contents: write
@@ -86,9 +90,6 @@ jobs:
         check-dynamic-version,
       ]
     if: (!cancelled())
-    concurrency:
-      group: ${{ needs.setup.outputs.env_name }}
-      cancel-in-progress: true
     environment: ${{ needs.setup.outputs.env_name }}
     steps:
       - name: Checkout

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,40 +15,81 @@ defaults:
   run:
     shell: bash
 
-concurrency:
-  # this ternary operator like expression gives us the name of the deployment environment (see https://docs.github.com/en/actions/learn-github-actions/expressions#example)
-  group: ${{ github.ref_type != 'tag' && github.ref_name || contains(github.ref, '-rc') && 'test' || 'prod' }}
-  cancel-in-progress: true
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
 
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      env_name: ${{ steps.set-env.outputs.env_name }}
+      is_tag: ${{ steps.set-env.outputs.is_tag }}
+      is_release: ${{ steps.set-env.outputs.is_release }}
+    steps:
+      - id: set-env
+        run: |
+          # 1. Determine if its a tag
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            IS_TAG="true"
+          else
+            IS_TAG="false"
+          fi
+          echo "is_tag=$IS_TAG" >> $GITHUB_OUTPUT
+
+          # 1. Determine environment name
+          if [[ $IS_TAG == "false" ]]; then
+            ENV="dev"
+          elif [[ "${{ github.ref }}" == *"-rc"* ]]; then
+            ENV="test"
+          else
+            ENV="prod"
+          fi
+          echo "env_name=$ENV" >> $GITHUB_OUTPUT
+
+          # 2. Determine if it's a final release tag
+          if [[ "$IS_TAG" == "true" && "${{ github.ref }}" != *"-rc"* ]]; then
+            echo "is_release=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_release=false" >> $GITHUB_OUTPUT
+          fi
+
   tests-ui:
+    needs: [setup]
     uses: ./.github/workflows/tests-ui.yml
-    if: github.ref_type == 'tag'
+    if: ${{ needs.setup.outputs.is_tag == 'true' }}
 
   tests-pytest:
+    needs: [setup]
     uses: ./.github/workflows/tests-pytest.yml
-    if: github.ref_type == 'tag'
+    if: ${{ needs.setup.outputs.is_tag == 'true' }}
 
   check-migrations-and-messages:
+    needs: [setup]
     uses: ./.github/workflows/check-migrations-and-messages.yml
-    if: github.ref_type == 'tag'
+    if: ${{ needs.setup.outputs.is_tag == 'true'}}
 
   check-dynamic-version:
+    needs: [setup]
     uses: ./.github/workflows/check-dynamic-version.yml
-    if: github.ref_type == 'tag'
+    if: ${{ needs.setup.outputs.is_tag == 'true' }}
 
   deploy:
     runs-on: ubuntu-latest
     needs:
       [
+        setup,
         tests-ui,
         tests-pytest,
         check-migrations-and-messages,
         check-dynamic-version,
       ]
     if: (!cancelled())
-    environment: ${{ github.ref_type != 'tag' && github.ref_name || contains(github.ref, '-rc') && 'test' || 'prod' }}
-
+    concurrency:
+      group: ${{ needs.setup.outputs.env_name }}
+      cancel-in-progress: true
+    environment: ${{ needs.setup.outputs.env_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -103,6 +144,7 @@ jobs:
           push: true
           tags: ghcr.io/${{ github.repository }}:${{ github.sha }}
 
+      # deploy application service
       - name: Deploy to Azure Web App
         uses: azure/webapps-deploy@v2
         with:
@@ -110,67 +152,39 @@ jobs:
           images: ghcr.io/${{ github.repository }}:${{ github.sha }}
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
 
-      - name: Trigger Azure Pipeline
-        id: trigger_pipeline
-        run: |
-          TOKEN_RESPONSE=$(curl -sS -X POST \
-            -H "Content-Type: application/x-www-form-urlencoded" \
-            -d "client_id=${{ secrets.AZURE_ADO_CLIENT_ID }}" \
-            -d "client_secret=${{ secrets.AZURE_ADO_CLIENT_SECRET }}" \
-            -d "grant_type=client_credentials" \
-            -d "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
-            "https://login.microsoftonline.com/${{ secrets.AZURE_ADO_TENANT_ID }}/oauth2/v2.0/token")
+      # begin setup to deploy container app
+      - name: Log in to azure using federated identity credentials
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
+        with:
+          client-id: ${{ secrets.AZURE_SP_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_SP_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SP_SUBSCRIPTION_ID }}
 
-          export AZURE_DEVOPS_EXT_PAT=$(echo "$TOKEN_RESPONSE" | jq -r '.access_token // empty')
+      - name: Setup terraform
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
+        with:
+          terraform_version: 1.14.5
 
-          if [ -z "$AZURE_DEVOPS_EXT_PAT" ]; then
-            echo "Failed to get Azure DevOps token"
-            exit 1
-          fi
+      - name: Initialize terraform and select workspace
+        working-directory: terraform
+        run: ./init.sh "${{ needs.setup.outputs.env_name }}"
 
-          RUN_ID=$(az pipelines run \
-            --id "${{ secrets.AZURE_ADO_PIPELINE_ID }}" \
-            --org "${{ secrets.AZURE_ADO_ORG_URL }}" \
-            --project "${{ secrets.AZURE_ADO_PROJECT }}" \
-            --branch "${{ github.ref }}" \
-            --commit-id ${{ github.sha }} \
-            --query "id" -o tsv)
+      - name: Terraform plan
+        working-directory: terraform
+        env:
+          TF_VAR_ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SP_SUBSCRIPTION_ID }}
+          TF_VAR_CONTAINER_TAG: ${{ github.sha }}
+          TF_VAR_DEVSECOPS_OBJECT_ID: ${{ secrets.TF_VAR_DEVSECOPS_OBJECT_ID }}
+          TF_VAR_ENGINEERING_GROUP_OBJECT_ID: ${{ secrets.TF_VAR_ENGINEERING_GROUP_OBJECT_ID }}
+        run: terraform plan -out=tfplan -lock-timeout=5m
 
-          echo "Waiting for Azure DevOps Pipeline run to complete..."
-          while true; do
-            PIPELINE_STATUS=$(az pipelines runs show \
-              --id $RUN_ID \
-              --org "${{ secrets.AZURE_ADO_ORG_URL }}" \
-              --project "${{ secrets.AZURE_ADO_PROJECT }}" \
-              --query "status" -o tsv)
-
-            echo "Current pipeline status: $PIPELINE_STATUS"
-
-            if [[ "$PIPELINE_STATUS" == "completed" ]]; then
-              PIPELINE_RESULT=$(az pipelines runs show \
-                --id $RUN_ID \
-                --org "${{ secrets.AZURE_ADO_ORG_URL }}" \
-                --project "${{ secrets.AZURE_ADO_PROJECT }}" \
-                --query "result" -o tsv)
-
-              echo "Pipeline completed with result: $PIPELINE_RESULT"
-              if [[ "$PIPELINE_RESULT" == "succeeded" ]]; then
-                exit 0
-              else
-                echo "Azure DevOps Pipeline failed with result: $PIPELINE_RESULT"
-                exit 1
-              fi
-            elif [[ "$PIPELINE_STATUS" == "cancelling" || "$PIPELINE_STATUS" == "notStarted" || "$PIPELINE_STATUS" == "inProgress" ]]; then
-              sleep 10
-            else
-              echo "Azure DevOps Pipeline finished with unexpected status: $PIPELINE_STATUS"
-              exit 1
-            fi
-          done
+      - name: Terraform apply
+        working-directory: terraform
+        run: terraform apply -lock-timeout=5m tfplan
 
   release:
     needs: deploy
-    if: ${{ github.ref_type == 'tag' && !contains(github.ref, '-rc') }}
+    if: ${{ needs.setup.outputs.is_release =='true' }}
     runs-on: ubuntu-latest
     permissions:
       # https://github.com/softprops/action-gh-release#permissions

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,6 @@ concurrency:
 permissions:
   id-token: write
   contents: write
-  pull-requests: write
 
 jobs:
   setup:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - id: set-env
         run: |
-          # 1. Determine if its a tag
+          # 1. Determine if it's a tag
           if [[ "${{ github.ref_type }}" == "tag" ]]; then
             IS_TAG="true"
           else
@@ -41,7 +41,7 @@ jobs:
           fi
           echo "is_tag=$IS_TAG" >> $GITHUB_OUTPUT
 
-          # 1. Determine environment name
+          # 2. Determine environment name
           if [[ $IS_TAG == "false" ]]; then
             ENV="dev"
           elif [[ "${{ github.ref }}" == *"-rc"* ]]; then
@@ -51,8 +51,8 @@ jobs:
           fi
           echo "env_name=$ENV" >> $GITHUB_OUTPUT
 
-          # 2. Determine if it's a final release tag
-          if [[ "$IS_TAG" == "true" && "${{ github.ref }}" != *"-rc"* ]]; then
+          # 3. Determine if it's a final release tag
+          if [[ $ENV == "prod" ]]; then
             echo "is_release=true" >> $GITHUB_OUTPUT
           else
             echo "is_release=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
part of #3897

https://github.com/cal-itp/benefits/actions/runs/30120264772 deployed 2b7a751 to the `dev` [container app](https://ca-cdt-pub-vip-calitp-d-web.wittyplant-56d5c43a.westus.azurecontainerapps.io/static/sha.txt).

i feel good enough about the changes here to merge and tag an RC after verifying that the deploy to `main` is successful, but we could easily create an RC tag on this branch too.

## artifacts

I didn't want to propose too many changes here, but i plan to investigate persisting the output of either terraform plan or apply as a [release artifact](https://docs.github.com/en/actions/concepts/workflows-and-actions/workflow-artifacts) in a subsequent PR.