### PR TITLE
Docs: how to use pgAdmin

### DIFF
--- a/docs/guides/postgresql.md
+++ b/docs/guides/postgresql.md
@@ -68,15 +68,16 @@ Generally we expect that the steps to be:
 
 ## Use pgAdmin
 
-You can use pgAdmin to manage the PostgreSQL server via a GUI. Setting up pgAdmin is slightly different depending on the environment where it is being hosted.
+pgAdmin provides a GUI to manage the PostgreSQL server. pgAdmin is setup slightly differently depending on the hosted environment.
 
 ### Local development environment
 
 If this is your first time using pgAdmin or if you have recently cleared your associated Docker volume (`pgadmin_data`), you will need to register the PostgreSQL server:
 
-1. Select _Add New Server_ from the dashboard or navigate to _Object > Register > Server_.
-2. Under the _General_ tab, provide any descriptive _Name_ for the server.
-3. Under the _Connection_ tab, configure the following properties based on your environment variables:
+1. Navigate to http://localhost:8081 (replace 8081 with your `PGADMIN_PORT` value if it was changed).
+2. Select _Add New Server_ from the dashboard or navigate to _Object > Register > Server_.
+3. Under the _General_ tab, provide any descriptive _Name_ for the server.
+4. Under the _Connection_ tab, configure the following properties based on your environment variables:
    - _Host name/address_: Value of `POSTGRES_HOSTNAME` (usually `postgres`)
    - _Port_: Value of `POSTGRES_PORT` (usually `5432`)
    - _Maintenance database_: Value of `POSTGRES_DB` (usually `postgres`)
@@ -88,11 +89,11 @@ Note that because `PGADMIN_CONFIG_SERVER_MODE=false`, pgAdmin runs in desktop mo
 
 ### Cloud environments
 
-To use pgAdmin in any of the Cloud environments:
+To use pgAdmin in any of the cloud environments:
 
 1. Select the _pgAdmin Container App_ resource in Azure Portal.
 2. Go to _Networking > Ingress > IP Restrictions_ and add your local public IP as an allowed _Source_.
-3. Open pgAdmin by going to the Container App's _Application Url_.
+3. Open pgAdmin by launching the Container App's _Application Url_.
 4. On the pgAdmin landing page, use the value of the environment variable `PGADMIN_DEFAULT_EMAIL` for _Email Address / Username_ and the value of the `pgadmin-admin-password` secret for _Password_.
 
 You can then start using pgAdmin to manage the database since the _Azure Database for PostgreSQL flexible server_ is already registered via Terraform, mostly through the configuration of the appropriate [pgAdmin environment variables](../reference/environment-variables.md#pgadmin).

--- a/docs/guides/postgresql.md
+++ b/docs/guides/postgresql.md
@@ -66,4 +66,35 @@ Generally we expect that the steps to be:
 1. Trigger the upgrade in Azure
 1. Update `azurerm_postgresql_flexible_server` in [terraform][] and `terraform apply` to avoid reversion
 
+## Use pgAdmin
+
+You can use pgAdmin to manage the PostgreSQL server via a GUI. Setting up pgAdmin is slightly different depending on the environment where it is being hosted.
+
+### Local development environment
+
+If this is your first time using pgAdmin or if you have recently cleared your associated Docker volume (`pgadmin_data`), you will need to register the PostgreSQL server:
+
+1. Select _Add New Server_ from the dashboard or navigate to _Object > Register > Server_.
+2. Under the _General_ tab, provide any descriptive _Name_ for the server.
+3. Under the _Connection_ tab, configure the following properties based on your environment variables:
+   - _Host name/address_: Value of `POSTGRES_HOSTNAME` (usually `postgres`)
+   - _Port_: Value of `POSTGRES_PORT` (usually `5432`)
+   - _Maintenance database_: Value of `POSTGRES_DB` (usually `postgres`)
+   - _Username_: Value of `POSTGRES_USER` (usually `postgres`)
+   - _Password_: Value of `POSTGRES_PASSWORD` (usually `postgres`)
+   - _Save password?_: Yes
+
+Note that because `PGADMIN_CONFIG_SERVER_MODE=false`, pgAdmin runs in desktop mode which uses an automatic default login. After setting it up, you can start using pgAdmin to manage the database, e.g. going to _Servers > Name > Databases > django > Schemas > public > Tables_ to view the application's tables.
+
+### Cloud environments
+
+To use pgAdmin in any of the Cloud environments:
+
+1. Select the _pgAdmin Container App_ resource in Azure Portal.
+2. Go to _Networking > Ingress > IP Restrictions_ and add your local public IP as an allowed _Source_.
+3. Open pgAdmin by going to the Container App's _Application Url_.
+4. On the pgAdmin landing page, use the value of the environment variable `PGADMIN_DEFAULT_EMAIL` for _Email Address / Username_ and the value of the `pgadmin-admin-password` secret for _Password_.
+
+You can then start using pgAdmin to manage the database since the _Azure Database for PostgreSQL flexible server_ is already registered via Terraform, mostly through the configuration of the appropriate [pgAdmin environment variables](../reference/environment-variables.md#pgadmin).
+
 [terraform]: https://github.com/cal-itp/benefits/blob/3a930abe827601a8b541a0d464648f6d8979eb3a/terraform/database.tf#L11-L36

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -345,6 +345,52 @@ Comma-separated list of URIs. Configures the [`script-src`][mdn-csp-script-src] 
 
 Comma-separated list of URIs. Configures the [`style-src`][mdn-csp-style-src] Content Security Policy directive.
 
+## pgAdmin
+
+!!! tldr "Container Deployment configuration"
+
+    The pgAdmin image [exposes some environment variables directly for its configuration](https://www.pgadmin.org/docs/pgadmin4/latest/container_deployment.html#environment-variables). For other configuration settings, the `PGADMIN_CONFIG_` environment variable prefix can be used to override any of the configuration options in pgAdmin’s [`config.py`](https://www.pgadmin.org/docs/pgadmin4/latest/config_py.html#config-py) file.
+
+### `PGADMIN_DEFAULT_EMAIL`
+
+The email address used when setting up the initial administrator account to login to pgAdmin.
+
+### `PGADMIN_DEFAULT_PASSWORD`
+
+The password used when setting up the initial administrator account to login to pgAdmin.
+
+### `PGADMIN_CONFIG_SERVER_MODE`
+
+The server mode determines whether pgAdmin is running on a web `Server Mode` requiring user authentication (`true`), such as in Azure; or in `Desktop Mode`, such as for local development, which uses an automatic default login (`false`).
+
+### `PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED`
+
+Applicable to `Desktop Mode` only, the master password used to encrypt/decrypt saved server passwords. Set to `false` for local development.
+
+!!! info "Cloud configuration"
+
+    The environment variables below only need to be set for Cloud deployments.
+
+### `PGADMIN_CONFIG_CONFIG_DATABASE_URI`
+
+Configuration settings are stored by default in a SQLite database. SQLite does not work well over a network, such as an Azure File Share, thus requiring them to be stored in a Postgres database. In order to use the Postgres server's database, set this variable to the connection string to the Postgres server that stores the configuration settings.
+
+### `PGADMIN_LISTEN_PORT`
+
+On the pgAdmin Container App using the `dpage/pgadmin4:latest` image, it is not possible to run pgAdmin without specifying a value greater than `1024` for this variable. Since the container runs as `UID/GID 5050`, set this to `5050` by convention.
+
+### `PGSSLROOTCERT`
+
+When pgAdmin starts up and sets its configuration settings, `sqlalchemy` runs and uses this variable. Since the `dpage/pgadmin4:latest` image has system-provided certifications, set to `system` to avoid manually adding certifications to the image.
+
+### `PGADMIN_SETUP_EMAIL`
+
+[Required when running in `Server Mode`](https://github.com/pgadmin-org/pgadmin4/blob/master/web/pgadmin/setup/user_info.py#L34) (`PGADMIN_CONFIG_SERVER_MODE=true`) to configure authentication. Should be set to the same value as `PGADMIN_DEFAULT_EMAIL`.
+
+### `PGADMIN_SETUP_PASSWORD`
+
+[Required when running in `Server Mode`](https://github.com/pgadmin-org/pgadmin4/blob/master/web/pgadmin/setup/user_info.py#L34) (`PGADMIN_CONFIG_SERVER_MODE=true`) to configure authentication. Should be set to the same value as `PGADMIN_DEFAULT_PASSWORD`.
+
 ## PostgreSQL
 
 !!! tldr "`postgres` Docker image docs"

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -373,19 +373,19 @@ Applicable to `Desktop Mode` only, the master password used to encrypt/decrypt s
 
 ### `PGHOST`
 
-Maps to [POSTGRES_HOSTNAME](http://localhost:32862/benefits/reference/environment-variables/#postgres_hostname)
+Maps to [POSTGRES_HOSTNAME](#postgres_hostname)
 
 ### `PGPASSWORD`
 
-Maps to [POSTGRES_PASSWORD](http://localhost:32862/benefits/reference/environment-variables/#postgres_password)
+Maps to [POSTGRES_PASSWORD](#postgres_password)
 
 ### `PGUSER`
 
-Maps to [POSTGRES_USER](http://localhost:32862/benefits/reference/environment-variables/#postgres_user)
+Maps to [POSTGRES_USER](#postgres_user)
 
 ### `PGSSLMODE`
 
-Maps to [POSTGRES_SSLMODE](http://localhost:32862/benefits/reference/environment-variables/#postgres_sslmode)
+Maps to [POSTGRES_SSLMODE](#postgres_sslmode)
 
 !!! info "Cloud configuration"
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -367,6 +367,26 @@ The server mode determines whether pgAdmin is running on a web `Server Mode` req
 
 Applicable to `Desktop Mode` only, the master password used to encrypt/decrypt saved server passwords. Set to `false` for local development.
 
+!!! info "`psql` default connection parameters"
+
+    For convenience, the environment variables below are set for the `psql` command to run in the pgAdmin container.
+
+### `PGHOST`
+
+Maps to [POSTGRES_HOSTNAME](http://localhost:32862/benefits/reference/environment-variables/#postgres_hostname)
+
+### `PGPASSWORD`
+
+Maps to [POSTGRES_PASSWORD](http://localhost:32862/benefits/reference/environment-variables/#postgres_password)
+
+### `PGUSER`
+
+Maps to [POSTGRES_USER](http://localhost:32862/benefits/reference/environment-variables/#postgres_user)
+
+### `PGSSLMODE`
+
+Maps to [POSTGRES_SSLMODE](http://localhost:32862/benefits/reference/environment-variables/#postgres_sslmode)
+
 !!! info "Cloud configuration"
 
     The environment variables below only need to be set for Cloud deployments.


### PR DESCRIPTION
Closes #3873

Adds documentation on how to use pgAdmin in local development and Cloud environments. Also documents the environment variables that are used to configure pgAdmin for both types of environments.