### PR TITLE
fix: grant pull request permissions in deploy workflow (for pytest)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,8 +20,9 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  id-token: write
   contents: write
+  id-token: write
+  pull-requests: write
 
 jobs:
   setup:


### PR DESCRIPTION
the error from https://github.com/cal-itp/benefits/actions/runs/30398989107 indicates that our deploy workflow is missing an explicit permission requested by our pytest workflow.

> The workflow is not valid. .github/workflows/deploy.yml (Line: 66, Col: 3): Error calling workflow 'cal-itp/benefits/.github/workflows/tests-pytest.yml@06fb8a8c53ffd195b1b583d3d890df1d43999dc7'. The nested job 'pytest' is requesting 'pull-requests: write', but is only allowed 'pull-requests: none'.

https://github.com/cal-itp/benefits/blob/06fb8a8c53ffd195b1b583d3d890df1d43999dc7/.github/workflows/tests-pytest.yml#L11

in the context of a deploy, there's no pull request to upload a coverage report to, but it feels harmless enough to add the requested scope.

the only other solution i can think of would be to isolate a pytest workflow variant that only runs on 'push'/'workflow_call', but that feels like it would be more confusing than helpful to me.

related: https://github.com/cal-itp/benefits/pull/3913#discussion_r3660532246