### PR TITLE
fix: add explicit packages permission to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,7 @@ concurrency:
 permissions:
   contents: write
   id-token: write
+  packages: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
this PR is a follow up to #3917 that resolves the error from https://github.com/cal-itp/benefits/actions/runs/30400995011/job/90415514014#step:9:3082

i didn't fully understand the implications when i opened #3913, but the explicit `permissions` block that was added disabled some of the defaults that are enabled for actions throughout the repository.

<img width="980" height="175" alt="Screenshot 2026-07-28 at 2 39 43 PM" src="https://github.com/user-attachments/assets/a8edcef1-66b8-4020-a246-e1b1b67593a2" />

working e2e run (triggered by temporarily looking for changes on the `fix/package-permissions` branch)
https://github.com/cal-itp/benefits/actions/runs/30401396208