### PR TITLE
Fix: error when uploading agency logo in the Container App

### DIFF
--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -300,6 +300,10 @@ MEDIA_ROOT = os.path.join(STORAGE_DIR, "uploads/")
 
 MEDIA_URL = "/media/"
 
+# Prevent Django from attempting to use os.chmod() when saving agency logos since it causes permission errors
+# on the Container App's Azure File Share
+FILE_UPLOAD_PERMISSIONS = None
+
 # Logging configuration
 LOG_LEVEL = os.environ.get("DJANGO_LOG_LEVEL", "DEBUG" if DEBUG else "WARNING")
 LOGGING = {


### PR DESCRIPTION
Closes #3861.

This PR adds the [FILE_UPLOAD_PERMISSIONS](https://docs.djangoproject.com/en/6.0/ref/settings/#file-upload-permissions) Django setting and sets it to `None` so that Django uses operating-system dependent behavior.

The error occurs when Django saves the logo using its [`_save` method which has a call to `os.chmod()`](https://github.com/django/django/blob/6c8eee41f778da87bdd17e27381d3705ed2d068b/django/core/files/storage/filesystem.py#L156). According to an LLM, this only becomes an issue in the Azure File Share used in the Container App (and not in the App Service which uses the `WEBSITES_ENABLE_APP_SERVICE_STORAGE` feature) due to how these volume mounts are implemented in Azure. The App Service mount knows how to handle `os.chmod()` calls because it uses a proprietary CIFS/SMB mount, while the Container App uses a standard Azure File CSI (Container Storage Interface) which does not allow Django to change permissions. This explains the need for setting `FILE_UPLOAD_PERMISSIONS = None` to avoid calling `os.chmod()` when saving the logo.

## Reviewing

- [x] Ensure uploading an agency logo still works locally by reproducing #3861.
- [x] When this PR is merged to `main`, reproduce https://github.com/cal-itp/benefits/issues/3861 in the `dev` environment's App Container by:
  - [x] Updating a transit agency's logo
  - [x] Creating a throwaway transit agency with a logo
  - [x] For completeness, ensuring that you can delete the agency logo that was created for the throwaway agency after the agency has been deleted


