### PR TITLE
refactor: deprecate ARM_SUBSCRIPTION_ID terraform variable and plan against the head of main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -174,7 +174,6 @@ jobs:
       - name: Terraform plan
         working-directory: terraform
         env:
-          TF_VAR_ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SP_SUBSCRIPTION_ID }}
           TF_VAR_CONTAINER_TAG: ${{ github.sha }}
           TF_VAR_DEVSECOPS_OBJECT_ID: ${{ secrets.TF_VAR_DEVSECOPS_OBJECT_ID }}
           TF_VAR_ENGINEERING_GROUP_OBJECT_ID: ${{ secrets.TF_VAR_ENGINEERING_GROUP_OBJECT_ID }}

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -47,7 +47,6 @@ jobs:
 
       - name: Terraform Plan
         env:
-          TF_VAR_ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SP_SUBSCRIPTION_ID }}
           TF_VAR_CONTAINER_TAG: ${{ steps.get_main_sha.outputs.sha }}
           TF_VAR_DEVSECOPS_OBJECT_ID: ${{ secrets.TF_VAR_DEVSECOPS_OBJECT_ID }}
           TF_VAR_ENGINEERING_GROUP_OBJECT_ID: ${{ secrets.TF_VAR_ENGINEERING_GROUP_OBJECT_ID }}

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -22,6 +22,14 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
+      # when we run terraform plan, we assume that the container image tag will remain on the currently deployed SHA
+      - name: Get head SHA of main
+        id: get_main_sha
+        run: |
+          git fetch origin main --depth=1
+          MAIN_SHA=$(git rev-parse origin/main)
+          echo "sha=${MAIN_SHA}" >> $GITHUB_OUTPUT
+
       - name: Log in to azure using federated identity credentials
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
@@ -40,7 +48,7 @@ jobs:
       - name: Terraform Plan
         env:
           TF_VAR_ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SP_SUBSCRIPTION_ID }}
-          TF_VAR_CONTAINER_TAG: ${{ github.sha }}
+          TF_VAR_CONTAINER_TAG: ${{ steps.get_main_sha.outputs.sha }}
           TF_VAR_DEVSECOPS_OBJECT_ID: ${{ secrets.TF_VAR_DEVSECOPS_OBJECT_ID }}
           TF_VAR_ENGINEERING_GROUP_OBJECT_ID: ${{ secrets.TF_VAR_ENGINEERING_GROUP_OBJECT_ID }}
         run: terraform plan -lock-timeout=5m

--- a/terraform/init.sh
+++ b/terraform/init.sh
@@ -10,20 +10,21 @@ if [ $# -ne 1 ]; then
   exit 1
 fi
 
-printf "Intializing Terraform...\n\n"
-# automatically inject the subscription ID
-PROD_ID=$(az account list --query "[?name == 'CDT/ODI Production'] | [0].id" --output tsv)
-terraform init -backend-config="subscription_id=$PROD_ID"
+SUBSCRIPTION_NAME="CDT/ODI Production"
+SUBSCRIPTION_ID=$(az account list --query "[?name == '$SUBSCRIPTION_NAME'] | [0].id" --output tsv)
 
-printf "\n\nSelecting the Terraform workspace...\n"
-SUBSCRIPTION="CDT/ODI Production"
+# ensure that the correct subscription is active before running terraform commands
+echo "Setting the subscription for the Azure CLI..."
+az account set --subscription="$SUBSCRIPTION_NAME"
+
+printf "Intializing Terraform...\n\n"
+terraform init -backend-config="subscription_id=$SUBSCRIPTION_ID"
+
+printf "Selecting the Terraform workspace...\n"
 if [ "$ENV" = "prod" ]; then
   terraform workspace select default
 else
   terraform workspace select "$ENV"
 fi
-
-echo "Setting the subscription for the Azure CLI..."
-az account set --subscription="$SUBSCRIPTION"
 
 echo "Done!"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -16,8 +16,8 @@ terraform {
   }
 }
 
+// subscription_id is inferred from the active Azure CLI session
 provider "azurerm" {
-  subscription_id = var.ARM_SUBSCRIPTION_ID
   features {}
 }
 

--- a/terraform/terraform.tfvars.sample
+++ b/terraform/terraform.tfvars.sample
@@ -1,4 +1,3 @@
 # these values can be found in the 'Azure env variables' note in LastPass
-ARM_SUBSCRIPTION_ID         = "object-id"
 DEVSECOPS_OBJECT_ID         = "object-id"
 ENGINEERING_GROUP_OBJECT_ID = "object-id"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -2,10 +2,6 @@
 # https://gaunacode.com/terraform-input-variables-using-azure-devops
 # now that we run terraform commands via GitHub actions, lowercase variables may be fine
 
-variable "ARM_SUBSCRIPTION_ID" {
-  description = "Production Subscription ID"
-  type        = string
-}
 variable "DEVSECOPS_OBJECT_ID" {
   description = "Object ID for the DevSecOps principal, which includes the Production service connection"
   type        = string


### PR DESCRIPTION
closes #3932
closes #3933

https://github.com/cal-itp/benefits/actions/runs/30661620562/job/91258945124#step:7:70

> No changes. Your infrastructure matches the configuration.

> Terraform has compared your real infrastructure against your configuration
and found no differences, so no changes are needed.
Releasing state lock. This may take a few moments...