### PR TITLE
chore: gh actions service principal keyvault access policies

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -159,8 +159,8 @@ jobs:
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
           client-id: ${{ secrets.AZURE_SP_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_SP_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SP_SUBSCRIPTION_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Setup terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
@@ -177,6 +177,8 @@ jobs:
           TF_VAR_CONTAINER_TAG: ${{ github.sha }}
           TF_VAR_DEVSECOPS_OBJECT_ID: ${{ secrets.TF_VAR_DEVSECOPS_OBJECT_ID }}
           TF_VAR_ENGINEERING_GROUP_OBJECT_ID: ${{ secrets.TF_VAR_ENGINEERING_GROUP_OBJECT_ID }}
+          TF_VAR_sp_apply_object_id: ${{ secrets.AZURE_SP_OBJECT_ID }}
+          TF_VAR_sp_plan_object_id: ${{ secrets.AZURE_SP_PLAN_OBJECT_ID }}
         run: terraform plan -out=tfplan -lock-timeout=5m
 
       - name: Terraform apply

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -34,9 +34,9 @@ jobs:
       - name: Log in to azure using federated identity credentials
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
-          client-id: ${{ secrets.AZURE_SP_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_SP_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SP_SUBSCRIPTION_ID }}
+          client-id: ${{ secrets.AZURE_SP_PLAN_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Setup terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
@@ -51,6 +51,8 @@ jobs:
           TF_VAR_CONTAINER_TAG: ${{ steps.get_main_sha.outputs.sha }}
           TF_VAR_DEVSECOPS_OBJECT_ID: ${{ secrets.TF_VAR_DEVSECOPS_OBJECT_ID }}
           TF_VAR_ENGINEERING_GROUP_OBJECT_ID: ${{ secrets.TF_VAR_ENGINEERING_GROUP_OBJECT_ID }}
+          TF_VAR_sp_apply_object_id: ${{ secrets.AZURE_SP_DEV_CLIENT_ID }}
+          TF_VAR_sp_plan_object_id: ${{ secrets.AZURE_SP_PLAN_OBJECT_ID }}
         run: terraform plan -out=tfplan -lock-timeout=5m
 
       # tf-summarize generates a course-grained summary w/ no sensitive infra details

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -51,7 +51,7 @@ jobs:
           TF_VAR_CONTAINER_TAG: ${{ steps.get_main_sha.outputs.sha }}
           TF_VAR_DEVSECOPS_OBJECT_ID: ${{ secrets.TF_VAR_DEVSECOPS_OBJECT_ID }}
           TF_VAR_ENGINEERING_GROUP_OBJECT_ID: ${{ secrets.TF_VAR_ENGINEERING_GROUP_OBJECT_ID }}
-          TF_VAR_sp_apply_object_id: ${{ secrets.AZURE_SP_DEV_CLIENT_ID }}
+          TF_VAR_sp_apply_object_id: ${{ secrets.AZURE_SP_DEV_OBJECT_ID }}
           TF_VAR_sp_plan_object_id: ${{ secrets.AZURE_SP_PLAN_OBJECT_ID }}
         run: terraform plan -out=tfplan -lock-timeout=5m
 

--- a/docs/explanation/infrastructure.md
+++ b/docs/explanation/infrastructure.md
@@ -161,6 +161,7 @@ Use the following shorthand for conveying the Resource Type as part of the Resou
    ```
 
 1. Create a local `terraform.tfvars` file (ignored by git) using the `terraform.tfvars.sample` file.
+1. Create local `env/[env].tfvars` files (ignored by git) using `env/dev.tfvars.sample` for any environments you plan on interacting with.
 
 ### Development process
 
@@ -170,7 +171,7 @@ When configuration changes to infrastructure resources are needed, they should b
 1. Preview the changes, as necessary.
 
    ```sh
-   terraform plan
+   ./plan.sh # runs terraform plan with necessary variables hydrated
    ```
 
 1. [Submit the changes via pull request.](development/commits-branches-merging.md)

--- a/terraform/apply.sh
+++ b/terraform/apply.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+if [[ $(terraform workspace show) != "dev" ]]; then
+  echo "Running terraform apply against environments other than dev is not supported"
+  exit 1
+fi
+
+echo "Running terraform apply using an interactively supplied SHA..."
+
+terraform apply \
+  -var-file="./env/$(terraform workspace show).tfvars"

--- a/terraform/env/dev.tfvars.sample
+++ b/terraform/env/dev.tfvars.sample
@@ -1,0 +1,2 @@
+# create test.tfvars and/or prod.tfvars to terraform plan in those envs
+sp_apply_object_id = "object-id"

--- a/terraform/key_vault.tf
+++ b/terraform/key_vault.tf
@@ -93,6 +93,30 @@ resource "azurerm_key_vault_access_policy" "devsecops" {
   depends_on = [azurerm_key_vault.main]
 }
 
+# Standalone Access Policies for GH Actions Service Principals
+
+resource "azurerm_key_vault_access_policy" "devsecops_apply" {
+  key_vault_id = azurerm_key_vault.main.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = var.sp_apply_object_id
+
+  secret_permissions = local.all_secret_permissions
+
+  # This ensures the Key Vault itself is created before trying to attach a policy.
+  depends_on = [azurerm_key_vault.main]
+}
+
+resource "azurerm_key_vault_access_policy" "devsecops_plan" {
+  key_vault_id = azurerm_key_vault.main.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = var.sp_plan_object_id
+
+  secret_permissions = ["Get", "List"]
+
+  # This ensures the Key Vault itself is created before trying to attach a policy.
+  depends_on = [azurerm_key_vault.main]
+}
+
 # https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references?tabs=azure-cli#granting-your-app-access-to-key-vault
 # Standalone Access Policy for App Service Managed Identity
 resource "azurerm_key_vault_access_policy" "webapp" {

--- a/terraform/plan.sh
+++ b/terraform/plan.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+echo "Running terraform plan using the HEAD of main..."
+
+TF_VAR_CONTAINER_TAG=$(git rev-parse origin/main) \
+terraform plan \
+  -var-file="./env/$(terraform workspace show).tfvars"

--- a/terraform/terraform.tfvars.sample
+++ b/terraform/terraform.tfvars.sample
@@ -1,3 +1,4 @@
 # these values can be found in the 'Azure env variables' note in LastPass
 DEVSECOPS_OBJECT_ID         = "object-id"
 ENGINEERING_GROUP_OBJECT_ID = "object-id"
+sp_plan_object_id           = "object-id"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,6 +1,6 @@
-# these are all uppercase because Azure DevOps transformed pipeline variables to uppercase environment variables
+# many of these are uppercase because Azure DevOps transformed pipeline variables to uppercase environment variables
 # https://gaunacode.com/terraform-input-variables-using-azure-devops
-# now that we run terraform commands via GitHub actions, lowercase variables may be fine
+# lowercase variables *are* supported when running terraform commands via GH Actions
 
 variable "DEVSECOPS_OBJECT_ID" {
   description = "Object ID for the DevSecOps principal, which includes the Production service connection"
@@ -29,4 +29,14 @@ variable "CONTAINER_REPOSITORY" {
 variable "CONTAINER_TAG" {
   type        = string
   description = "The specific tag of the image to deploy (e.g., a commit SHA)."
+}
+
+variable "sp_apply_object_id" {
+  description = "Object ID for the GH Actions service principal created by DevSecOps"
+  type        = string
+}
+
+variable "sp_plan_object_id" {
+  description = "Object ID for the plan-only GH Actions service principal created by DevSecOps"
+  type        = string
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -34,9 +34,11 @@ variable "CONTAINER_TAG" {
 variable "sp_apply_object_id" {
   description = "Object ID for the GH Actions service principal created by DevSecOps"
   type        = string
+  sensitive   = true
 }
 
 variable "sp_plan_object_id" {
   description = "Object ID for the plan-only GH Actions service principal created by DevSecOps"
   type        = string
+  sensitive   = true
 }


### PR DESCRIPTION
resolves #3897

## Explanation

this PR introduces two new terraform variables:

### `sp_plan_object_id`

the ObjectId of the Service Principal that runs `terraform plan` from GH Actions and needs an access policy that allows it to READ/LIST KeyVault secrets in each of our resource groups.

this one will be added to our existing `terraform.tfvars` file.
```tfvars
# terraform.tfvars 
sp_plan_object_id = "990dc63..." # see LastPass 'Azure env vars' note for full id
```

### `sp_apply_object_id`

the ObjectId of the Service Principal that has permission to run `terraform apply` from GH Actions in _one resource group only_. this one needs exhaustive secret permissions.

this environment-specific  variable can either be supplied interactively or persisted in a new _environment-specific_ .tfvars file

```tfvars
# env/dev.tfvars 
sp_apply_object_id = "bb48b01..."
```

```bash
# use the new helper/wrapper script
./plan.sh

# or load the new environment-specific tfvars file explicitly yourself
terraform plan -var-file="./env/$(terraform workspace show).tfvars"
```

## Misc

While i was digging in the closet I couldn't resist the urge to prove out whether lowercase variables are supported in GH Actions. they are indeed. the casing i'm proposing in this PR is more idiomatic, but if y'all prefer to shout, i'm not fussed.

I also updated a few existing GitHub secret names in the interest of clarity.

## How to test

right now running [`terraform plan`](https://github.com/cal-itp/benefits/actions/runs/30960906036/job/92164403074#step:7:107) locally against `dev` will propose that two brand new access policies be added to our KeyVault.

immediately prior to merging the PR, i will re-import the existing access policies to ensure they are updated in place instead.

~it would have been nice to leave them imported and allow folks to verify the plan themselves locally, but doing that would result in the existing azure access policies being destroyed as soon as any other PR was merged to `main`.~ 

@lalver1 and i verified the correct behavior during a pairing session corresponding with a code-freeze.

## The plan itself

Since the access policies already exist, you'd expect the (post-import) [`terraform plan`](https://github.com/cal-itp/benefits/actions/runs/30856853328/job/91829763242#step:7:135) for this PR to show 'no changes'. it doesn't because: 

* i took the liberty of downgrading the secret permission set for `sp_plan_object_id` back to GET,LIST. (we confirmed this is sufficient and then DevSecOps granted additional permissions when we were testing the apply runner)
* i'm proposing here that we remove _all_ KeyVault key permissions from the existing access policies. @lalver1 and i are under the impression that we aren't using keys in Benefits.

## `TODO:`
- [x] `terraform import` existing access policies in `dev`
- [x] ensure that the only discrepancy in the plan is downgraded permissions for the tf planner 
- [x] `terraform state rm azurerm_key_vault_access_policy.[name]`
- [x] re-run `terraform import` in `dev`
- [x] re-run `terraform import` in `test` and `prod`

after this PR is merged, i will 🗑️ the redundant/outdated GitHub actions secrets below.

* <kbd>AZURE_SP_SUBSCRIPTION_ID</kbd> ✅
* <kbd>AZURE_SP_TENANT_ID</kbd> ✅
* <kbd>AZURE_SP_CLIENT_ID</kbd> ✅