### PR TITLE
Feat: load testing setup and scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
 ]
 test = [
     "coverage",
+    "locust",
     "pytest",
     "pytest-django",
     "pytest-mock",

--- a/tests/locust/.gitignore
+++ b/tests/locust/.gitignore
@@ -1,0 +1,3 @@
+# Results from locust runs
+*.csv
+*.html

--- a/tests/locust/loadtest.sh
+++ b/tests/locust/loadtest.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+locust  --config locust.conf --html load_test_report.html

--- a/tests/locust/locust.conf
+++ b/tests/locust/locust.conf
@@ -1,0 +1,9 @@
+locustfile = locustfile.py
+headless = true
+host = http://localhost:8000
+users = 5
+run-time = 10m
+csv = load-test-benefits
+
+# target users/min rate
+target-rate = 2.32

--- a/tests/locust/locustfile.py
+++ b/tests/locust/locustfile.py
@@ -1,0 +1,80 @@
+import random
+
+from locust import HttpUser, constant_pacing, events, task
+
+# Experiment design
+# -----------------
+#
+# User distribution
+# https://docs.locust.io/en/stable/writing-a-locustfile.html#weight-and-fixed-count-attributes
+# Use weight to uniformly distribute users across all agencies
+# SingleAgencyUser gets 75% of the total users (3/4, weight=3)
+#  mst, sbmtd, and sacrt split the 75%, each gets 25% of the total site traffic
+# RegionalAgencyUser gets 25% of the total users (1/4, weight=1)
+#  vctc gets 25% of the total site traffic
+#
+# Load distribution
+# https://docs.locust.io/en/stable/writing-a-locustfile.html#wait-time-attribute
+# Pick a target_rate (users/min)
+# Pick number_of_concurrent_users (users)
+# Calculate the pacing_time (seconds)
+# pacing_time = 60 * number_of_concurrent_users / target_rate
+
+
+class SingleAgencyUser(HttpUser):
+    # Weight of 3 so each agency gets 25% of the total site traffic
+    weight = 3
+
+    @task
+    def complete_entire_flow(self):
+        agencies = ["mst", "sbmtd", "sacrt"]
+        start_agency = random.choice(agencies)
+
+        response = self.client.get(f"/{start_agency}")
+
+        # (Sequential form steps will go here)
+        print(response)
+
+
+class RegionalAgencyUser(HttpUser):
+    # Weight of 1 so the regional agency gets 25% of the total site traffic
+    weight = 1
+
+    @task
+    def complete_entire_flow(self):
+        start_agency = "vctc"
+
+        # STEP 1: Start the journey
+        response = self.client.get(f"/{start_agency}")
+
+        # (Sequential form steps will go here)
+        print(response)
+
+
+@events.init_command_line_parser.add_listener
+def _(parser):
+    # https://docs.locust.io/en/stable/extending-locust.html#custom-arguments
+    # Add a custom argument for the target rate
+    parser.add_argument("--target-rate", type=float, default=1, help="Target users per minute for dynamic pacing")
+
+
+@events.init.add_listener
+def on_locust_init(environment, **kwargs):
+    # https://docs.locust.io/en/stable/writing-a-locustfile.html#init
+    num_users = environment.parsed_options.num_users
+    target_rate = environment.parsed_options.target_rate
+    calculated_spawn_rate = target_rate / 60
+    environment.parsed_options.spawn_rate = calculated_spawn_rate
+
+    # Calculate the "pacing time" needed to have r users per minute (target rate) running
+    pacing_seconds = 60 * num_users / target_rate
+
+    # Print to the console when the test starts
+    print("---")
+    print(f"Targeting {target_rate} users/min with {num_users} users.")
+    print(f"Dynamic Pacing set to {pacing_seconds:.1f} seconds.")
+    print("---")
+
+    # Inject the calculated wait time into the User classes
+    SingleAgencyUser.wait_time = constant_pacing(pacing_seconds)
+    RegionalAgencyUser.wait_time = constant_pacing(pacing_seconds)

--- a/tests/locust/locustfile.py
+++ b/tests/locust/locustfile.py
@@ -86,7 +86,12 @@ class BenefitsUser(HttpUser):
 
             # Get started with Login.gov
             with self.client.get("/oauth/login", allow_redirects=True, catch_response=True) as login_response:
-                print(f"login: {page_title(login_response)}")
+                title = page_title(login_response)
+                print(f"login: {title}")
+                if "Sign in" not in title and "Login.gov" not in title:
+                    login_response.failure(f"Expected Login.gov, but landed on: {title}")
+                    return
+
             soup = BeautifulSoup(login_response.text, "html.parser")
             form = soup.find("form")
             if not form or not form.get("action"):
@@ -182,7 +187,7 @@ class BenefitsUser(HttpUser):
             action_url = success_form.get("action")
             action_url = urljoin(current_response.url, action_url)
             # POST the hidden form to complete the enrollment
-            enrollment_response = self.client.post(
+            with self.client.post(
                 action_url,
                 data={
                     "csrfmiddlewaretoken": csrf_token(
@@ -194,7 +199,11 @@ class BenefitsUser(HttpUser):
                     "card_token": CARD_TOKEN,
                 },
                 allow_redirects=True,
-            )
+                catch_response=True,
+            ) as enrollment_response:
+                if enrollment_response.status_code != 200:
+                    enrollment_response.failure(f"Littlepay failed: {enrollment_response.status_code}")
+                    return
 
             # Success
             print(f"Enrollment submission returned: {enrollment_response.status_code}")
@@ -250,7 +259,11 @@ class BenefitsUser(HttpUser):
 
             # Get started with Login.gov
             with self.client.get("/oauth/login", allow_redirects=True, catch_response=True) as login_response:
-                print(f"login: {page_title(login_response)}")
+                title = page_title(login_response)
+                print(f"login: {title}")
+                if "Sign in" not in title and "Login.gov" not in title:
+                    login_response.failure(f"Expected Login.gov, but landed on: {title}")
+                    return
             soup = BeautifulSoup(login_response.text, "html.parser")
             form = soup.find("form")
             if not form or not form.get("action"):

--- a/tests/locust/locustfile.py
+++ b/tests/locust/locustfile.py
@@ -17,8 +17,8 @@ CARD_TOKEN = os.environ["LOCUST_CARD_TOKEN"]
 # User distribution
 # https://docs.locust.io/en/stable/writing-a-locustfile.html#weight-and-fixed-count-attributes
 # Use weight to create eligible vs ineligible users
-# EligibleUser gets 93% of the total users (93/100, weight=93)
-# IneligibleUser gets 7% of the total users (7/100, weight=7)
+# eligible users get 93% of the total users (93/100, weight=93)
+# ineligible users get 7% of the total users (7/100, weight=7)
 # Based on Amplitude data (last 90 days)
 #
 # Load distribution
@@ -40,11 +40,10 @@ def page_title(response) -> str:
     return title_tag.text.strip() if title_tag else "No Title Found"
 
 
-class EligibleUser(HttpUser):
-    weight = 93
+class BenefitsUser(HttpUser):
 
-    @task
-    def complete_entire_flow(self):
+    @task(93)
+    def eligible_flow(self):
         try:
             agencies = ["mst", "sbmtd", "sacrt"]
             start_agency = random.choice(agencies)
@@ -207,12 +206,8 @@ class EligibleUser(HttpUser):
             # Reset cookies on client for the next time this user spawns
             self.client.cookies.clear()
 
-
-class IneligibleUser(HttpUser):
-    weight = 7
-
-    @task
-    def complete_entire_flow(self):
+    @task(7)
+    def ineligible_flow(self):
         try:
             agencies = ["mst", "sbmtd", "sacrt"]
             start_agency = random.choice(agencies)
@@ -370,6 +365,5 @@ def on_locust_init(environment, **kwargs):
     print(f"Dynamic Pacing set to {pacing_seconds:.1f} seconds.")
     print("---")
 
-    # Inject the calculated wait time into the User classes
-    EligibleUser.wait_time = constant_pacing(pacing_seconds)
-    IneligibleUser.wait_time = constant_pacing(pacing_seconds)
+    # Inject the calculated wait time into the User class
+    BenefitsUser.wait_time = constant_pacing(pacing_seconds)

--- a/tests/locust/locustfile.py
+++ b/tests/locust/locustfile.py
@@ -213,13 +213,137 @@ class IneligibleUser(HttpUser):
 
     @task
     def complete_entire_flow(self):
-        start_agency = "vctc"
+        try:
+            agencies = ["mst", "sbmtd", "sacrt"]
+            start_agency = random.choice(agencies)
 
-        # STEP 1: Start the journey
-        response = self.client.get(f"/{start_agency}")
+            # /
+            with self.client.get("/", catch_response=True) as index:
+                print(f"index: {page_title(index)}")
 
-        # (Sequential form steps will go here)
-        print(response)
+            # Select agency
+            with self.client.post(
+                "/",
+                data={
+                    "csrfmiddlewaretoken": csrf_token(
+                        index, element="input", name_attribute_value="csrfmiddlewaretoken", csrf_value_attribute_name="value"
+                    ),
+                    "select_transit_agency": start_agency,
+                },
+                catch_response=True,
+            ) as eligibility:
+                if eligibility.status_code != 200:
+                    eligibility.failure(f"Failed to select agency. Status code: {eligibility.status_code}")
+                    return
+                print(f"eligibility: {page_title(eligibility)}")
+
+            # Select enrollment flow
+            with self.client.post(
+                "/eligibility/",
+                data={
+                    "csrfmiddlewaretoken": csrf_token(
+                        eligibility,
+                        element="input",
+                        name_attribute_value="csrfmiddlewaretoken",
+                        csrf_value_attribute_name="value",
+                    ),
+                    "flow": "2",
+                },
+                catch_response=True,
+            ) as start:
+                print(f"start: {page_title(start)}")
+
+            # Get started with Login.gov
+            with self.client.get("/oauth/login", allow_redirects=True, catch_response=True) as login_response:
+                print(f"login: {page_title(login_response)}")
+            soup = BeautifulSoup(login_response.text, "html.parser")
+            form = soup.find("form")
+            if not form or not form.get("action"):
+                print("Could not find login form action")
+                return
+            login_post_url = urljoin(login_response.url, form["action"])
+            print(f"posturl: {login_post_url}")
+
+            # Login.gov sign in
+            login_gov = self.client.post(
+                login_post_url,
+                data={
+                    "authenticity_token": csrf_token(
+                        login_response, element="meta", name_attribute_value="csrf-token", csrf_value_attribute_name="content"
+                    ),
+                    "user[email]": USER_EMAIL,
+                    "user[password]": USER_PASSWORD,
+                },
+            )
+            print(f"login: {page_title(login_gov)}")
+
+            # Multi-factor authentication
+            current_totp_code = pyotp.TOTP(TOTP_SECRET).now()
+            mfa_response = self.client.post(
+                login_gov.url,
+                data={
+                    "authenticity_token": csrf_token(
+                        login_gov, element="meta", name_attribute_value="csrf-token", csrf_value_attribute_name="content"
+                    ),
+                    "code": current_totp_code,
+                },
+                allow_redirects=True,
+            )
+            print(f"mfa: {page_title(mfa_response)}")
+
+            # login.gov <> IdG <> Benefits
+            # LLM assisted code
+            # Handle any JavaScript "auto-submit" forms which implement the redirect behavior
+            # This is required since locust does not run JavaScript or drive a real browser
+            current_response = mfa_response
+            while True:
+                soup = BeautifulSoup(current_response.text, "html.parser")
+                title_tag = soup.find("title")
+                title_text = title_tag.text if title_tag else ""
+
+                form = soup.find("form")
+
+                # 1. Is there an auto-submit form? (Used by Login.gov and IdG)
+                if form and (
+                    "Redirect" in title_text
+                    or "Submit" in title_text
+                    or "Working" in title_text
+                    or "/external/callback" in current_response.url
+                ):
+                    action_url = form.get("action")
+                    action_url = urljoin(current_response.url, action_url) if action_url else current_response.url
+
+                    # Extract all hidden security tokens (code, state, etc.)
+                    payload = {
+                        inp.get("name"): inp.get("value") for inp in form.find_all("input", type="hidden") if inp.get("name")
+                    }
+                    print(f"Auto-submitting form to: {action_url}")
+
+                    current_response = self.client.post(action_url, data=payload, allow_redirects=True)
+                    print(f"Landed on: {current_response.status_code} | {current_response.url}")
+
+                # 2. Is there a fallback 'Click Here' link?
+                elif "Redirect" in title_text and soup.find("a"):
+                    action_url = urljoin(current_response.url, soup.find("a").get("href"))
+
+                    print(f"Following fallback link to: {action_url}")
+                    current_response = self.client.get(action_url, allow_redirects=True)
+                    print(f"Landed on: {current_response.status_code} | {current_response.url}")
+
+                else:
+                    # We have reached a normal page (or are completely stuck)
+                    if "Redirect" in title_text:
+                        # If we are stuck on a redirect page, print the HTML so you can see exactly why
+                        print("Stuck! Found 'Redirecting' page but no form, meta, or link. HTML Dump:")
+                        print(current_response.text)
+                    break
+            print(f"ineligible: {page_title(current_response)}")
+        finally:
+            # Log out of Login.gov (via Benefits)
+            # to avoid having to conditionally skip the MFA page the next time the user runs and is still logged in
+            self.client.get("/oauth/logout", catch_response=True)
+            # Reset cookies on client for the next time this user spawns
+            self.client.cookies.clear()
 
 
 @events.init_command_line_parser.add_listener

--- a/tests/locust/locustfile.py
+++ b/tests/locust/locustfile.py
@@ -16,11 +16,10 @@ CARD_TOKEN = os.environ["LOCUST_CARD_TOKEN"]
 #
 # User distribution
 # https://docs.locust.io/en/stable/writing-a-locustfile.html#weight-and-fixed-count-attributes
-# Use weight to uniformly distribute users across all agencies
-# SingleAgencyUser gets 75% of the total users (3/4, weight=3)
-#  mst, sbmtd, and sacrt split the 75%, each gets 25% of the total site traffic
-# RegionalAgencyUser gets 25% of the total users (1/4, weight=1)
-#  vctc gets 25% of the total site traffic
+# Use weight to create eligible vs ineligible users
+# EligibleUser gets 93% of the total users (93/100, weight=93)
+# IneligibleUser gets 7% of the total users (7/100, weight=7)
+# Based on Amplitude data (last 90 days)
 #
 # Load distribution
 # https://docs.locust.io/en/stable/writing-a-locustfile.html#wait-time-attribute
@@ -41,9 +40,8 @@ def page_title(response) -> str:
     return title_tag.text.strip() if title_tag else "No Title Found"
 
 
-class SingleAgencyUser(HttpUser):
-    # Weight of 3 so each agency gets 25% of the total site traffic
-    weight = 3
+class EligibleUser(HttpUser):
+    weight = 93
 
     @task
     def complete_entire_flow(self):
@@ -210,9 +208,8 @@ class SingleAgencyUser(HttpUser):
             self.client.cookies.clear()
 
 
-class RegionalAgencyUser(HttpUser):
-    # Weight of 1 so the regional agency gets 25% of the total site traffic
-    weight = 1
+class IneligibleUser(HttpUser):
+    weight = 7
 
     @task
     def complete_entire_flow(self):
@@ -250,5 +247,5 @@ def on_locust_init(environment, **kwargs):
     print("---")
 
     # Inject the calculated wait time into the User classes
-    SingleAgencyUser.wait_time = constant_pacing(pacing_seconds)
-    RegionalAgencyUser.wait_time = constant_pacing(pacing_seconds)
+    EligibleUser.wait_time = constant_pacing(pacing_seconds)
+    IneligibleUser.wait_time = constant_pacing(pacing_seconds)

--- a/tests/locust/locustfile.py
+++ b/tests/locust/locustfile.py
@@ -9,7 +9,11 @@ from locust import HttpUser, constant_pacing, events, task
 USER_EMAIL = os.environ["LOCUST_LOGIN_GOV_OLDER_ADULT_USER_EMAIL"]
 USER_PASSWORD = os.environ["LOCUST_LOGIN_GOV_OLDER_ADULT_USER_PASSWORD"]
 TOTP_SECRET = os.environ["LOCUST_LOGIN_GOV_OLDER_ADULT_AUTHENTICATOR_SECRET"]
-CARD_TOKEN = os.environ["LOCUST_CARD_TOKEN"]
+CARD_TOKENS = {
+    "mst": os.environ["LOCUST_CARD_TOKEN_MST"],
+    "sbmtd": os.environ["LOCUST_CARD_TOKEN_SBMTD"],
+    "nevco": os.environ["LOCUST_CARD_TOKEN_NEVCO"],
+}
 
 # Experiment design
 # -----------------
@@ -45,7 +49,7 @@ class BenefitsUser(HttpUser):
     @task(93)
     def eligible_flow(self):
         try:
-            agencies = ["mst", "sbmtd", "sacrt"]
+            agencies = ["mst", "sbmtd", "nevco"]
             start_agency = random.choice(agencies)
 
             # /
@@ -196,13 +200,13 @@ class BenefitsUser(HttpUser):
                         name_attribute_value="csrfmiddlewaretoken",
                         csrf_value_attribute_name="value",
                     ),
-                    "card_token": CARD_TOKEN,
+                    "card_token": CARD_TOKENS[start_agency],
                 },
                 allow_redirects=True,
                 catch_response=True,
             ) as enrollment_response:
                 if enrollment_response.status_code != 200:
-                    enrollment_response.failure(f"Littlepay failed: {enrollment_response.status_code}")
+                    enrollment_response.failure(f"Littlepay failed for {start_agency}: {enrollment_response.status_code}")
                     return
 
             # Success
@@ -218,7 +222,7 @@ class BenefitsUser(HttpUser):
     @task(7)
     def ineligible_flow(self):
         try:
-            agencies = ["mst", "sbmtd", "sacrt"]
+            agencies = ["mst", "sbmtd", "nevco"]
             start_agency = random.choice(agencies)
 
             # /

--- a/tests/locust/locustfile.py
+++ b/tests/locust/locustfile.py
@@ -1,6 +1,15 @@
+import os
 import random
+from urllib.parse import urljoin
 
+import pyotp
+from bs4 import BeautifulSoup
 from locust import HttpUser, constant_pacing, events, task
+
+USER_EMAIL = os.environ["LOCUST_LOGIN_GOV_OLDER_ADULT_USER_EMAIL"]
+USER_PASSWORD = os.environ["LOCUST_LOGIN_GOV_OLDER_ADULT_USER_PASSWORD"]
+TOTP_SECRET = os.environ["LOCUST_LOGIN_GOV_OLDER_ADULT_AUTHENTICATOR_SECRET"]
+CARD_TOKEN = os.environ["LOCUST_CARD_TOKEN"]
 
 # Experiment design
 # -----------------
@@ -21,19 +30,184 @@ from locust import HttpUser, constant_pacing, events, task
 # pacing_time = 60 * number_of_concurrent_users / target_rate
 
 
+def csrf_token(response, element=None, name_attribute_value=None, csrf_value_attribute_name=None) -> str:
+    soup = BeautifulSoup(response.text, "html.parser")
+    return soup.find(element, {"name": name_attribute_value})[csrf_value_attribute_name]
+
+
+def page_title(response) -> str:
+    soup = BeautifulSoup(response.text, "html.parser")
+    title_tag = soup.find("title")
+    return title_tag.text.strip() if title_tag else "No Title Found"
+
+
 class SingleAgencyUser(HttpUser):
     # Weight of 3 so each agency gets 25% of the total site traffic
     weight = 3
 
     @task
     def complete_entire_flow(self):
-        agencies = ["mst", "sbmtd", "sacrt"]
-        start_agency = random.choice(agencies)
+        try:
+            agencies = ["mst", "sbmtd", "sacrt"]
+            start_agency = random.choice(agencies)
 
-        response = self.client.get(f"/{start_agency}")
+            # /
+            with self.client.get("/", catch_response=True) as index:
+                print(f"index: {page_title(index)}")
 
-        # (Sequential form steps will go here)
-        print(response)
+            # Select agency
+            with self.client.post(
+                "/",
+                data={
+                    "csrfmiddlewaretoken": csrf_token(
+                        index, element="input", name_attribute_value="csrfmiddlewaretoken", csrf_value_attribute_name="value"
+                    ),
+                    "select_transit_agency": start_agency,
+                },
+                catch_response=True,
+            ) as eligibility:
+                if eligibility.status_code != 200:
+                    eligibility.failure(f"Failed to select agency. Status code: {eligibility.status_code}")
+                    return
+                print(f"eligibility: {page_title(eligibility)}")
+
+            # Select enrollment flow
+            with self.client.post(
+                "/eligibility/",
+                data={
+                    "csrfmiddlewaretoken": csrf_token(
+                        eligibility,
+                        element="input",
+                        name_attribute_value="csrfmiddlewaretoken",
+                        csrf_value_attribute_name="value",
+                    ),
+                    "flow": "1",
+                },
+                catch_response=True,
+            ) as start:
+                print(f"start: {page_title(start)}")
+
+            # Get started with Login.gov
+            with self.client.get("/oauth/login", allow_redirects=True, catch_response=True) as login_response:
+                print(f"login: {page_title(login_response)}")
+            soup = BeautifulSoup(login_response.text, "html.parser")
+            form = soup.find("form")
+            if not form or not form.get("action"):
+                print("Could not find login form action")
+                return
+            login_post_url = urljoin(login_response.url, form["action"])
+            print(f"posturl: {login_post_url}")
+
+            # Login.gov sign in
+            login_gov = self.client.post(
+                login_post_url,
+                data={
+                    "authenticity_token": csrf_token(
+                        login_response, element="meta", name_attribute_value="csrf-token", csrf_value_attribute_name="content"
+                    ),
+                    "user[email]": USER_EMAIL,
+                    "user[password]": USER_PASSWORD,
+                },
+            )
+            print(f"login: {page_title(login_gov)}")
+
+            # Multi-factor authentication
+            current_totp_code = pyotp.TOTP(TOTP_SECRET).now()
+            mfa_response = self.client.post(
+                login_gov.url,
+                data={
+                    "authenticity_token": csrf_token(
+                        login_gov, element="meta", name_attribute_value="csrf-token", csrf_value_attribute_name="content"
+                    ),
+                    "code": current_totp_code,
+                },
+                allow_redirects=True,
+            )
+            print(f"mfa: {page_title(mfa_response)}")
+
+            # login.gov <> IdG <> Benefits
+            # LLM assisted code
+            # Handle any JavaScript "auto-submit" forms which implement the redirect behavior
+            # This is required since locust does not run JavaScript or drive a real browser
+            current_response = mfa_response
+            while True:
+                soup = BeautifulSoup(current_response.text, "html.parser")
+                title_tag = soup.find("title")
+                title_text = title_tag.text if title_tag else ""
+
+                form = soup.find("form")
+
+                # 1. Is there an auto-submit form? (Used by Login.gov and IdG)
+                if form and (
+                    "Redirect" in title_text
+                    or "Submit" in title_text
+                    or "Working" in title_text
+                    or "/external/callback" in current_response.url
+                ):
+                    action_url = form.get("action")
+                    action_url = urljoin(current_response.url, action_url) if action_url else current_response.url
+
+                    # Extract all hidden security tokens (code, state, etc.)
+                    payload = {
+                        inp.get("name"): inp.get("value") for inp in form.find_all("input", type="hidden") if inp.get("name")
+                    }
+                    print(f"Auto-submitting form to: {action_url}")
+
+                    current_response = self.client.post(action_url, data=payload, allow_redirects=True)
+                    print(f"Landed on: {current_response.status_code} | {current_response.url}")
+
+                # 2. Is there a fallback 'Click Here' link?
+                elif "Redirect" in title_text and soup.find("a"):
+                    action_url = urljoin(current_response.url, soup.find("a").get("href"))
+
+                    print(f"Following fallback link to: {action_url}")
+                    current_response = self.client.get(action_url, allow_redirects=True)
+                    print(f"Landed on: {current_response.status_code} | {current_response.url}")
+
+                else:
+                    # We have reached a normal page (or are completely stuck)
+                    if "Redirect" in title_text:
+                        # If we are stuck on a redirect page, print the HTML so you can see exactly why
+                        print("Stuck! Found 'Redirecting' page but no form, meta, or link. HTML Dump:")
+                        print(current_response.text)
+                    break
+            print(f"eligible: {page_title(current_response)}")
+
+            # Littlepay enrollment
+            # Simulate the background initialization request the browser makes
+            self.client.get("/littlepay/token", catch_response=True)
+            # Extract the success form
+            soup_enroll = BeautifulSoup(current_response.text, "html.parser")
+            success_form = soup_enroll.find("form", id="form-card-tokenize-success")
+            if not success_form:
+                print("Could not find the success form")
+                return
+            action_url = success_form.get("action")
+            action_url = urljoin(current_response.url, action_url)
+            # POST the hidden form to complete the enrollment
+            enrollment_response = self.client.post(
+                action_url,
+                data={
+                    "csrfmiddlewaretoken": csrf_token(
+                        current_response,
+                        element="input",
+                        name_attribute_value="csrfmiddlewaretoken",
+                        csrf_value_attribute_name="value",
+                    ),
+                    "card_token": CARD_TOKEN,
+                },
+                allow_redirects=True,
+            )
+
+            # Success
+            print(f"Enrollment submission returned: {enrollment_response.status_code}")
+            print(f"Final Success Title: {page_title(enrollment_response)}")
+        finally:
+            # Log out of Login.gov (via Benefits)
+            # to avoid having to conditionally skip the MFA page the next time the user runs and is still logged in
+            self.client.get("/oauth/logout", catch_response=True)
+            # Reset cookies on client for the next time this user spawns
+            self.client.cookies.clear()
 
 
 class RegionalAgencyUser(HttpUser):

--- a/tests/locust/requirements.txt
+++ b/tests/locust/requirements.txt
@@ -1,0 +1,2 @@
+beautifulsoup4
+pyotp


### PR DESCRIPTION
Closes #3858

This PR sets up [locust](https://github.com/locustio/locust) to load test the Benefits Container App on `test`. While it is possible to [run the load testing in Azure using locust](https://learn.microsoft.com/en-us/azure/app-testing/load-testing/quickstart-create-run-load-test-with-locust?tabs=portal), this PR is focused on setting up the tool in the dev container or in the local host so that we can run tests from it and also quickly debug the tests by using our local Benefits setup.

# Experiment setup

## Target loads

| Timeframe | Today (users) | Normal Metro Load - 1x (users) | Extreme Metro Load - 10x (users) |
-- | -- | -- | -- |
2 months (60 days) | 538* | 100,000 | 1,000,000 |
Per day | 8.97 | 1,667 | 16,667 |
Per hour** | 0.75 | 139 | 1,389 |
Per minute | - | 2.32 | 23.15 |

\* Based on 80 enrolled users per month and scaling by 3.36 (1/0.298) to account for users which selected an enrollment flow but did not complete enrollment (based on last 3 months with _completed_flow_/_selected_flow_=226/759=0.298).
\** Assuming daily traffic distributed over a 12hr window

A typical e2e enrollment flow takes about 80s

| / | /eligibility | /eligibility/start | IdG | LP token | LP enter info | Enroll credit card | /success |
-- | -- | -- | -- | -- | -- | -- | -- |
5 | 10 | 20 | 28 | 35 | 55 | 75 | 80 |

We can use [constant_pacing](https://docs.locust.io/en/stable/api.html#locust.wait_time.constant_pacing) to ensure that each locust task runs at most once every _x_ seconds (where _x_ needs to be larger than 80s to ensure that the e2e flow completes). This way we can guarantee that the load (users/min) is achieved during the test.

The 2 inputs to the locust test are number of users, _n_, and the target load rate, _r_, in users/min. The wait time in seconds, _x_, can then be calculated as _x_= 60 * n / r. Since _n_ is the only parameter left to choose, it should be chosen so that _x_ is large enough to cover the time it takes for the e2e flow to complete as shown below

| Load          | _n_ | _x_ (s)|
|---------------|-----|--------|
| Normal        | 5   | 129    |
| Extreme       | 50  | 129    |

# Running a test from your local host

- Set up a Python virtual environment, activate it, and install `locust`, `beautifulsoup4`, and `pyotp`

  ```
  python3 -m venv .venv
  source .venv/bin/activate
  pip install locust beautifulsoup4 pyotp
  ```

- In `locust.conf` set `host`, `users`, `run-time`, and `target-rate`
- Using your Older Adult credentials, manually go through an Older Adult and Veteran Flow to ensure no “extra verification” pages from [login.gov](http://login.gov/) are presented to the locust users when load testing
- Set the USER_EMAIL, USER_PASSWORD, TOTP_SECRET environment variables associated with your Older Adult credentials
- Enroll in [test-benefits](https://test-benefits.calitp.org/) a LP card for each agency being tested and get `card_token` from the browser
- Set a `LOCUST_CARD_TOKEN_AGENCY` environment variable for each agency with `card_token` as its value (tokens are valid for about 1hr, enough for the load test)
- Sign out from login.gov using Benefits' logout link
- Run `loadtest.sh`
