### PR TITLE
fix: ensure deploy workflow aborts subsequent jobs when a prerequisite explicitly fails

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,6 +69,8 @@ jobs:
     needs: [setup]
     uses: ./.github/workflows/tests-pytest.yml
     if: ${{ needs.setup.outputs.is_tag == 'true' }}
+    with:
+      parent_event: ${{ github.event_name }}
 
   check-migrations-and-messages:
     needs: [setup]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,7 +92,8 @@ jobs:
         check-migrations-and-messages,
         check-dynamic-version,
       ]
-    if: (!cancelled())
+    # this convoluted syntax allows skipped and successful prerequisite runs and disallows failures
+    if: (always() && !cancelled() && !failure())
     environment: ${{ needs.setup.outputs.env_name }}
     steps:
       - name: Checkout

--- a/.github/workflows/tests-pytest.yml
+++ b/.github/workflows/tests-pytest.yml
@@ -1,6 +1,13 @@
 name: Pytest
 
-on: [push, pull_request, workflow_call]
+on:
+  push:
+  pull_request:
+  workflow_call:
+    inputs:
+      parent_event:
+        type: string
+        required: true
 
 jobs:
   pytest:
@@ -47,6 +54,7 @@ jobs:
           path: benefits/static/coverage
 
       - name: Coverage comment
+        if: ${{ inputs.parent_event != 'workflow_dispatch' }}
         uses: py-cov-action/python-coverage-comment-action@v3
         with:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
resolves #3967

* skip posting a comment with code coverage results in `tests-pytest` when the action was triggered by an upstream `workflow_dispatch`
* distinguish failed prerequisite jobs from both those that were skipped and those that succeeded

| prerequisite | deploy | gh action run | `sha` |
| -- | -- | -- | -- |
| `tests-pytest` ✅ (via `workflow_dispatch`) | ✅ | [runs/31220198968](https://github.com/cal-itp/benefits/actions/runs/31220198968) | fda26243ee19c182d824eea6e3d002f568ad0a24 |
| `tests-pytest` ✅ / `tests-ui` ⏭️ | ✅ | [runs/31220062984](https://github.com/cal-itp/benefits/actions/runs/31220062984) | fda26243ee19c182d824eea6e3d002f568ad0a24 | 
| `tests-pytest` ❌ / `tests-ui` ⏭️ | `skipped` | [/runs/31220336744](https://github.com/cal-itp/benefits/actions/runs/31220336744) | 3423f867e723d792298799b2c62987001ea0dc0d | 

~there are three throwaway commits on this branch that allowed me to trigger mock deploys and make this nifty chart. i'll `-f` push and eradicate them prior to merge.~