### PR TITLE
Fix: admin portal link text

### DIFF
--- a/benefits/admin.py
+++ b/benefits/admin.py
@@ -59,13 +59,20 @@ class BenefitsAdminSite(AdminSite):
 
                 if agency.transit_processor_config is not None:
                     transit_processor_portal_url = agency.transit_processor_config.portal_url
+                    transit_processor_portal_text = "Control Portal"
+                    if agency.littlepay_config:
+                        transit_processor_portal_text = "Littlepay " + transit_processor_portal_text
+                    elif agency.switchio_config:
+                        transit_processor_portal_text = "Switchio " + transit_processor_portal_text
                 else:
                     transit_processor_portal_url = ""
+                    transit_processor_portal_text = ""
 
                 context.update(
                     {
                         "has_permission_for_in_person": has_permission_for_in_person,
                         "transit_processor_portal_url": transit_processor_portal_url,
+                        "transit_processor_portal_text": transit_processor_portal_text,
                         "title": f"{agency.long_name} | {self.index_title} | {self.site_title}",
                         "start_url": (
                             routes.IN_PERSON_ADDITIONAL_AGENCIES

--- a/benefits/templates/admin/agency-dashboard-index.html
+++ b/benefits/templates/admin/agency-dashboard-index.html
@@ -26,7 +26,7 @@
             <p class="mb-4">Manage fare-calculation, view rider transactions, and process refunds.</p>
             <div class="row">
               <div class="col-lg-6">
-                <a href="{{ transit_processor_portal_url }}" target="_blank" rel="noopener noreferrer" class="btn btn-lg btn-outline-primary">Launch Littlepay Control Portal</a>
+                <a href="{{ transit_processor_portal_url }}" target="_blank" rel="noopener noreferrer" class="btn btn-lg btn-outline-primary">Launch {{ transit_processor_portal_text }}</a>
               </div>
             </div>
           </div>

--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -212,6 +212,7 @@ def model_LittlepayConfig(model_TransitAgency):
         client_id="client_id",
         client_secret_name="client_secret_name",
         audience="audience",
+        portal_url="https://www.transit-processor.com/littlepay",
     )
     model_TransitAgency.transit_processor_config = littlepay_config
     model_TransitAgency.save()
@@ -225,6 +226,7 @@ def model_SwitchioConfig(model_TransitAgency):
         environment=Environment.DEV,
         tokenization_api_key="api_key",
         tokenization_api_secret_name="apisecret",
+        portal_url="https://www.transit-processor.com/switchio",
     )
 
     model_TransitAgency.transit_processor_config = switchio_config

--- a/tests/pytest/test_admin.py
+++ b/tests/pytest/test_admin.py
@@ -40,7 +40,23 @@ def model_SuperUser(model_User):
 
 
 @pytest.mark.django_db
-def test_admin_override_agency_user_customer_service(model_AgencyCustomerServiceUser, model_TransitAgency, client):
+@pytest.mark.parametrize(
+    "processor_fixture_name,expected_text",
+    [("model_LittlepayConfig", "Littlepay Control Portal"), ("model_SwitchioConfig", "Switchio Control Portal")],
+)
+def test_admin_agency_customer_service_user(
+    request,
+    model_AgencyCustomerServiceUser,
+    model_TransitAgency,
+    client,
+    processor_fixture_name,
+    expected_text,
+):
+    # request here is the built-in pytest fixture FixtureRequest
+    # https://docs.pytest.org/en/latest/reference/reference.html#request
+    # use .getfixturevalue(processor_fixture_name) to "Dynamically run a named fixture function." (see above reference page)
+    processor_fixture = request.getfixturevalue(processor_fixture_name)
+
     url = reverse(routes.ADMIN_INDEX)
     client.force_login(model_AgencyCustomerServiceUser)
 
@@ -54,6 +70,8 @@ def test_admin_override_agency_user_customer_service(model_AgencyCustomerService
     assert response.status_code == 200
     assert response.template_name == "admin/agency-dashboard-index.html"
     assert response.context_data["has_permission_for_in_person"] is True
+    assert response.context_data["transit_processor_portal_url"] == processor_fixture.portal_url
+    assert response.context_data["transit_processor_portal_text"] == expected_text
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Closes #3774 

---

Fairly straightforward fix to figure out which `TransitProcessorConfig` subclass is in use based on the logged in user's agency. From there, just hard-code the correct portal link text in context and use it on the template.

More interesting in this PR are the test changes: I feel like we've run across this a few times where we wanted to `pytest.mark.parameterize` with a list of _fixtures_, i.e. inject different fixtures for different instances of the test (vs. copying a test over and over for each fixture). Well it turns out there is a mostly non-hacky way to do it: 

`pytest` has a built-in fixture called [`request`](https://docs.pytest.org/en/latest/reference/reference.html#request) with a helper function [`getfixturevalue(argname)`](https://docs.pytest.org/en/latest/reference/reference.html#pytest.FixtureRequest.getfixturevalue):

> Dynamically run a named fixture function.
>
> Declaring fixtures via function argument is recommended where possible. But if you can only decide whether to use another fixture at test setup time, you may use this function to retrieve it inside a fixture or test function body.

So rather than have multiple instances of the same test that pass a different fixture for `model_LittlepayConfig` and `model_SwitchioConfig`, this PR parameterizes the existing test via the above to keep things DRY :+1:

---

I went with naming the processor vs. something more generic (as indicated in the original ticket) because it isn't clear to me if something like `"Launch Transit Processor Control Portal"` would be recognizable to an agency staffer. E.g. is the phrase `"Transit Processor"` widely understood? This avoids that question, and related questions like _Well what text should we use instead?_ and just keeps things simple.

## Review

- Sign in to the admin as an agency user with a Littlepay agency, see the expected portal link text
- Sign in to the admin as an agency user with a Switchio agency, see the expected portal link text