### PR TITLE
Fix: remove hardcoded text from Admin control portal link

### DIFF
--- a/benefits/templates/admin/agency-dashboard-index.html
+++ b/benefits/templates/admin/agency-dashboard-index.html
@@ -26,7 +26,7 @@
             <p class="mb-4">Manage fare-calculation, view rider transactions, and process refunds.</p>
             <div class="row">
               <div class="col-lg-6">
-                <a href="{{ transit_processor_portal_url }}" target="_blank" rel="noopener noreferrer" class="btn btn-lg btn-outline-primary">Launch Littlepay Control Portal</a>
+                <a href="{{ transit_processor_portal_url }}" target="_blank" rel="noopener noreferrer" class="btn btn-lg btn-outline-primary">Launch Control Portal</a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Closes #3774

Replaces #3979 with a much simpler, straighforward text replacement :+1: 