### PR TITLE
CI: notify Sentry of new releases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -216,7 +216,7 @@ jobs:
           SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
         with:
           environment: ${{ needs.setup.outputs.env_name }}
-          release: ${{ github.ref_name }}
+          release: benefits@${{ github.ref_name }}
 
   release:
     needs: deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -216,7 +216,7 @@ jobs:
           SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
         with:
           environment: ${{ needs.setup.outputs.env_name }}
-          release: ${{ github.ref }}
+          release: ${{ github.ref_name }}
 
   release:
     needs: deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -197,6 +197,27 @@ jobs:
           skip-comment: true
           working-directory: terraform
 
+  sentry:
+    needs: [setup, deploy]
+    if: ${{ needs.setup.outputs.is_tag == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      # notify Sentry of new release
+      - name: Create Sentry release
+        uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528 # v3.7.0
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
+        with:
+          environment: ${{ needs.setup.outputs.env_name }}
+          release: ${{ github.ref }}
+
   release:
     needs: deploy
     if: ${{ needs.setup.outputs.is_release =='true' }}


### PR DESCRIPTION
Closes #3685 

---

~Per Sentry docs guidance, notify of the release _before_ it is deployed: https://docs.sentry.io/product/releases/~

~> We recommend notifying Sentry about a new release before deploying it. But if you don't, Sentry will automatically create a release entity in the system the first time it sees an event with that release identifier.~

Notify of the release as a separate job, in between the existing `deploy` (e.g. Docker and Terraform) and `release` (e.g. GitHub release) jobs.

Only notify for `test` and `prod`, using the tag as the release version, with a `benefits@` project prefix since releases are _global across a Sentry org._

The referenced environment secret and variables have been configured.