### PR TITLE
Fix: correctly parse hyphen in agency paths

### DIFF
--- a/benefits/core/urls.py
+++ b/benefits/core/urls.py
@@ -26,7 +26,7 @@ class TransitAgencyPathConverter:
     """Path converter to parse valid TransitAgency objects from URL paths."""
 
     # used to test the url fragment, determines if this PathConverter is used
-    regex = "[a-zA-Z]{3,}"
+    regex = "[a-zA-Z-]{3,}"
 
     def to_python(self, value):
         """Determine if the matched fragment corresponds to an active Agency."""

--- a/tests/pytest/core/test_urls.py
+++ b/tests/pytest/core/test_urls.py
@@ -1,0 +1,47 @@
+"""
+h/t to this blog post for the inspiration for these tests
+https://adamj.eu/tech/2025/08/01/django-custom-url-converter-string/
+"""
+
+import pytest
+from django.urls import path, reverse
+
+# Import forces registration
+from benefits.core.urls import TransitAgencyPathConverter  # noqa: F401
+
+urlpatterns = [
+    path(
+        "<agency:agency>",
+        lambda *args, **kwargs: None,  # dummy view
+        name="sample",
+    )
+]
+sample_path = urlpatterns[0]
+
+
+@pytest.mark.django_db
+class TestTransitAgencyPathConverter:
+    def test_active_agency(self, model_TransitAgency):
+        result = sample_path.resolve(model_TransitAgency.slug)
+        assert result.kwargs["agency"] == model_TransitAgency
+
+        result = reverse("sample", urlconf=__name__, kwargs={"agency": model_TransitAgency})
+        assert result == f"/{model_TransitAgency.slug}"
+
+    def test_active_agency__hyphen_slug(self, model_TransitAgency):
+        model_TransitAgency.slug = "c-s-t"
+        model_TransitAgency.save()
+
+        result = sample_path.resolve(model_TransitAgency.slug)
+        assert result.kwargs["agency"] == model_TransitAgency
+
+        result = reverse("sample", urlconf=__name__, kwargs={"agency": model_TransitAgency})
+        assert result == f"/{model_TransitAgency.slug}"
+
+    def test_inactive_agency(self, model_TransitAgency_inactive):
+        result = sample_path.resolve(model_TransitAgency_inactive.slug)
+        assert result is None
+
+    def test_unknown_agency(self):
+        result = sample_path.resolve("unknown")
+        assert result is None


### PR DESCRIPTION
Closes #3863 

---

[`TransitAgency.slug` is a `SlugField`](https://github.com/cal-itp/benefits/blob/9789d4b9f614320088daaf8bc37c3be4cd28fa44/benefits/core/models/transit.py#L69) and so allows configuring an agency with hyphens in its slug, e.g. 
`simi-valley-transit`.

However the URL path parsing in [`TransitAgencyPathConverter`](https://github.com/cal-itp/benefits/blob/9789d4b9f614320088daaf8bc37c3be4cd28fa44/benefits/core/urls.py#L29) failed to account for hyphens, leading to an error for agencies so configured, e.g.

```log
Reverse for 'agency_index' with arguments '('simi-valley-transit',)' not found. 
1 pattern(s) tried: ['(?P<agency>[a-zA-Z]{3,})\\Z']
```

This PR fixes the regex in `TransitAgencyPathConverter` to correctly allow hyphens, and adds test coverage for this class as well.

## Review

- Edit any active `TransitAgency` instance to have a `slug` with hyphens, e.g. `c-s-t`
- Navigate to the agency index URL e.g. `/c-s-t`
- See the expected agency-specific entry page