### PR TITLE
Chore: remove JS CodeQL config

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,51 +4,22 @@ name: CodeQL
 on:
   push:
     paths:
-      - "**.js"
       - "**.py"
   pull_request:
-    branches: [main, test, prod]
+    branches: [main]
     paths:
-      - "**.js"
       - "**.py"
   schedule:
     - cron: "24 9 * * 6"
 
 jobs:
-  setup:
-    name: Set up CodeQL analysis
-    runs-on: ubuntu-latest
-    # Required permissions
-    permissions:
-      pull-requests: read
-    outputs:
-      # changes is a JSON array with names of all filters matching any of the changed files
-      languages: ${{ steps.filter.outputs.changes }}
-    steps:
-      - uses: actions/checkout@v7
-      - uses: dorny/paths-filter@v4
-        id: filter
-        with:
-          filters: |
-            javascript: "**.js"
-            python: "**.py"
-
   codeql:
     name: CodeQL Analyze
     runs-on: ubuntu-latest
-    needs: setup
-    if: ${{ needs.setup.outputs.languages != '[]' }}
     permissions:
       actions: read
       contents: read
       security-events: write
-
-    strategy:
-      fail-fast: false
-      matrix:
-        # Parse JSON array containing names of all filters matching any of changed files
-        # e.g. ['javascript', 'python'] if both file types had changes
-        language: ${{ fromJSON(needs.setup.outputs.languages) }}
 
     steps:
       - name: Checkout repository
@@ -57,7 +28,7 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
-          languages: ${{ matrix.language }}
+          languages: python
           # https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#specifying-configuration-details-using-the-config-input
           config: |
             paths-ignore:


### PR DESCRIPTION
We don't have any runtime JS files that need CodeQL scanning and the complications in this workflow consistently result in warning output like:

> 1 configuration not found
>
> Warning: Code scanning cannot determine the alerts introduced by this
> pull request, because 1 configuration present on refs/heads/main was not found:
> Actions workflow (codeql.yml)
>
>    ❓  .github/workflows/codeql.yml:codeql/language:javascript

E.g. a recent run: https://github.com/cal-itp/benefits/pull/3997/checks?check_run_id=95882932873