### PR TITLE
feat(analytics): Implement OAuth failure to proof event

### DIFF
--- a/benefits/oauth/analytics.py
+++ b/benefits/oauth/analytics.py
@@ -61,6 +61,13 @@ class FinishedSignOutEvent(OAuthEvent):
         self.update_event_properties(origin=session.origin(request))
 
 
+class FailureToProofEvent(OAuthEvent):
+    """Analytics event representing a failure to proof during identitity verification."""
+
+    def __init__(self, request):
+        super().__init__(request, "failure to proof")
+
+
 def error(request, message, operation):
     """Send the "oauth error" analytics event, specifying the message and operation"""
     core.send_event(OAuthErrorEvent(request, message, operation))
@@ -89,3 +96,8 @@ def started_sign_out(request):
 def finished_sign_out(request):
     """Send the "finished sign out" analytics event."""
     core.send_event(FinishedSignOutEvent(request))
+
+
+def failure_to_proof(request):
+    """Send the "failure to proof" analytics event."""
+    core.send_event(FailureToProofEvent(request))

--- a/tests/pytest/oauth/test_analytics.py
+++ b/tests/pytest/oauth/test_analytics.py
@@ -1,6 +1,12 @@
 import pytest
 
-from benefits.oauth.analytics import FinishedSignInEvent, OAuthErrorEvent, OAuthEvent
+import benefits.core.analytics
+from benefits.oauth.analytics import FailureToProofEvent, FinishedSignInEvent, OAuthErrorEvent, OAuthEvent, failure_to_proof
+
+
+@pytest.fixture
+def spy_send_event(mocker):
+    return mocker.spy(benefits.core.analytics, "send_event")
 
 
 @pytest.mark.django_db
@@ -42,3 +48,15 @@ def test_FinishedSignInEvent_with_error(app_request):
 def test_FinishedSignInEvent_without_error(app_request):
     event = FinishedSignInEvent(app_request)
     assert "error_code" not in event.event_properties
+
+
+@pytest.mark.django_db
+def test_failure_to_proof(app_request, spy_send_event):
+    failure_to_proof(app_request)
+
+    # event should have been sent
+    spy_send_event.assert_called_once()
+    # the first arg of the first (and only) call
+    call_arg = spy_send_event.call_args[0][0]
+    assert isinstance(call_arg, FailureToProofEvent)
+    assert call_arg.event_type == "failure to proof"

--- a/tests/pytest/oauth/test_analytics.py
+++ b/tests/pytest/oauth/test_analytics.py
@@ -1,7 +1,23 @@
 import pytest
 
 import benefits.core.analytics
-from benefits.oauth.analytics import FailureToProofEvent, FinishedSignInEvent, OAuthErrorEvent, OAuthEvent, failure_to_proof
+from benefits.oauth.analytics import (
+    CanceledSignInEvent,
+    FailureToProofEvent,
+    FinishedSignInEvent,
+    FinishedSignOutEvent,
+    OAuthErrorEvent,
+    OAuthEvent,
+    StartedSignInEvent,
+    StartedSignOutEvent,
+    canceled_sign_in,
+    error,
+    failure_to_proof,
+    finished_sign_in,
+    finished_sign_out,
+    started_sign_in,
+    started_sign_out,
+)
 
 
 @pytest.fixture
@@ -48,6 +64,80 @@ def test_FinishedSignInEvent_with_error(app_request):
 def test_FinishedSignInEvent_without_error(app_request):
     event = FinishedSignInEvent(app_request)
     assert "error_code" not in event.event_properties
+
+
+@pytest.mark.django_db
+def test_error(app_request, spy_send_event):
+    error(app_request, "the message", "the operation")
+
+    # event should have been sent
+    spy_send_event.assert_called_once()
+    # the first arg of the first (and only) call
+    call_arg = spy_send_event.call_args[0][0]
+    assert isinstance(call_arg, OAuthErrorEvent)
+    assert call_arg.event_type == "oauth error"
+    assert call_arg.event_properties["message"] == "the message"
+    assert call_arg.event_properties["operation"] == "the operation"
+
+
+@pytest.mark.django_db
+def test_started_sign_in(app_request, spy_send_event):
+    started_sign_in(app_request)
+
+    # event should have been sent
+    spy_send_event.assert_called_once()
+    # the first arg of the first (and only) call
+    call_arg = spy_send_event.call_args[0][0]
+    assert isinstance(call_arg, StartedSignInEvent)
+    assert call_arg.event_type == "started sign in"
+
+
+@pytest.mark.django_db
+def test_canceled_sign_in(app_request, spy_send_event):
+    canceled_sign_in(app_request)
+
+    # event should have been sent
+    spy_send_event.assert_called_once()
+    # the first arg of the first (and only) call
+    call_arg = spy_send_event.call_args[0][0]
+    assert isinstance(call_arg, CanceledSignInEvent)
+    assert call_arg.event_type == "canceled sign in"
+
+
+@pytest.mark.django_db
+def test_finished_sign_in(app_request, spy_send_event):
+    finished_sign_in(app_request)
+
+    # event should have been sent
+    spy_send_event.assert_called_once()
+    # the first arg of the first (and only) call
+    call_arg = spy_send_event.call_args[0][0]
+    assert isinstance(call_arg, FinishedSignInEvent)
+    assert call_arg.event_type == "finished sign in"
+
+
+@pytest.mark.django_db
+def test_started_sign_out(app_request, spy_send_event):
+    started_sign_out(app_request)
+
+    # event should have been sent
+    spy_send_event.assert_called_once()
+    # the first arg of the first (and only) call
+    call_arg = spy_send_event.call_args[0][0]
+    assert isinstance(call_arg, StartedSignOutEvent)
+    assert call_arg.event_type == "started sign out"
+
+
+@pytest.mark.django_db
+def test_finished_sign_out(app_request, spy_send_event):
+    finished_sign_out(app_request)
+
+    # event should have been sent
+    spy_send_event.assert_called_once()
+    # the first arg of the first (and only) call
+    call_arg = spy_send_event.call_args[0][0]
+    assert isinstance(call_arg, FinishedSignOutEvent)
+    assert call_arg.event_type == "finished sign out"
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Closes #3768 

---

@thekaveman I see that coverage in `oauth.analytics` is pretty sparse. Would you like me to beef it up in this PR using the approach I took here for failure to proof?