### PR TITLE
Add MMW app-specific OAuth hooks and URL patterns

### DIFF
--- a/benefits/metro_mobility_wallet/oauth.py
+++ b/benefits/metro_mobility_wallet/oauth.py
@@ -10,7 +10,6 @@ from benefits.oauth import analytics
 # from django.utils.decorators import decorator_from_middleware, method_decorator
 
 
-
 class OAuthHooks(DefaultHooks):
     @classmethod
     def pre_login(cls, request):

--- a/benefits/metro_mobility_wallet/oauth.py
+++ b/benefits/metro_mobility_wallet/oauth.py
@@ -1,21 +1,21 @@
 import sentry_sdk
 from cdt_identity.hooks import DefaultHooks
 from django.shortcuts import redirect
-from django.utils.decorators import decorator_from_middleware, method_decorator
 
-from benefits.core import session
-from benefits.core.middleware import FlowSessionRequired
+# from benefits.core import session
+# from benefits.core.middleware import FlowSessionRequired
 from benefits.eligibility.views import analytics as eligibility_analytics
 from benefits.oauth import analytics
-from benefits.oauth.hooks import OAuthHooks as core_hooks
+
+# from django.utils.decorators import decorator_from_middleware, method_decorator
+
 
 
 class OAuthHooks(DefaultHooks):
-    # @classmethod
-    # def pre_login(cls, request):
-    #     super().pre_login(request)
-    #     analytics.started_sign_in(request)
-    pre_login = core_hooks.pre_login
+    @classmethod
+    def pre_login(cls, request):
+        super().pre_login(request)
+        analytics.started_sign_in(request)
 
     @classmethod
     def cancel_login(cls, request):
@@ -23,30 +23,28 @@ class OAuthHooks(DefaultHooks):
         analytics.canceled_sign_in(request)
         return redirect("metro_mobility_wallet:eligbility_unverified")
 
-    # @classmethod
-    # def pre_logout(cls, request):
-    #     super().pre_logout(request)
-    #     analytics.started_sign_out(request)
+    @classmethod
+    def pre_logout(cls, request):
+        super().pre_logout(request)
+        analytics.started_sign_out(request)
 
-    #     # the user is signed out of the app
-    #     session.logout(request)
-    pre_logout = core_hooks.pre_logout
-
-    # @classmethod
-    # def post_logout(cls, request):
-    #     super().post_logout(request)
-    #     analytics.finished_sign_out(request)
-
-    #     origin = session.origin(request)
-    #     return redirect(origin)
-    post_logout = core_hooks.post_logout
+        # the user is signed out of the app
+        session.logout(request)
 
     @classmethod
-    @method_decorator(
-        [
-            decorator_from_middleware(FlowSessionRequired),
-        ]
-    )
+    def post_logout(cls, request):
+        super().post_logout(request)
+        analytics.finished_sign_out(request)
+
+        origin = session.origin(request)
+        return redirect(origin)
+
+    @classmethod
+    # @method_decorator(
+    #     [
+    #         decorator_from_middleware(FlowSessionRequired),
+    #     ]
+    # )
     def failure_to_proof(cls, request):
         super().failure_to_proof(request)
         session.update(request, logged_in=True)  # QUESTION: Are they still considered "logged in" if they failed to prove?
@@ -60,12 +58,12 @@ class OAuthHooks(DefaultHooks):
         return redirect("metro_mobility_wallet:failure_to_proof")
 
     @classmethod
-    @method_decorator(
-        [
-            # decorator_from_middleware(AgencySessionRequired),
-            decorator_from_middleware(FlowSessionRequired),
-        ]
-    )
+    # @method_decorator(
+    #     [
+    #         # decorator_from_middleware(AgencySessionRequired),
+    #         decorator_from_middleware(FlowSessionRequired),
+    #     ]
+    # )
     def claims_verified_eligible(cls, request, claims_request, claims_result):
         super().claims_verified_eligible(request, claims_request, claims_result)
         session.update(request, logged_in=True)
@@ -80,12 +78,12 @@ class OAuthHooks(DefaultHooks):
         return redirect("metro_mobility_wallet:enrollment_index")
 
     @classmethod
-    @method_decorator(
-        [
-            # decorator_from_middleware(AgencySessionRequired),
-            decorator_from_middleware(FlowSessionRequired),
-        ]
-    )
+    # @method_decorator(
+    #     [
+    #         # decorator_from_middleware(AgencySessionRequired),
+    #         decorator_from_middleware(FlowSessionRequired),
+    #     ]
+    # )
     def claims_verified_not_eligible(cls, request, claims_request, claims_result):
         super().claims_verified_not_eligible(request, claims_request, claims_result)
         session.update(request, logged_in=True)

--- a/benefits/metro_mobility_wallet/oauth.py
+++ b/benefits/metro_mobility_wallet/oauth.py
@@ -1,0 +1,104 @@
+import sentry_sdk
+from cdt_identity.hooks import DefaultHooks
+from django.shortcuts import redirect
+from django.utils.decorators import decorator_from_middleware, method_decorator
+
+from benefits.core import session
+from benefits.core.middleware import FlowSessionRequired
+from benefits.eligibility.views import analytics as eligibility_analytics
+from benefits.oauth import analytics
+from benefits.oauth.hooks import OAuthHooks as core_hooks
+
+
+class OAuthHooks(DefaultHooks):
+    # @classmethod
+    # def pre_login(cls, request):
+    #     super().pre_login(request)
+    #     analytics.started_sign_in(request)
+    pre_login = core_hooks.pre_login
+
+    @classmethod
+    def cancel_login(cls, request):
+        super().cancel_login(request)
+        analytics.canceled_sign_in(request)
+        return redirect("metro_mobility_wallet:eligbility_unverified")
+
+    # @classmethod
+    # def pre_logout(cls, request):
+    #     super().pre_logout(request)
+    #     analytics.started_sign_out(request)
+
+    #     # the user is signed out of the app
+    #     session.logout(request)
+    pre_logout = core_hooks.pre_logout
+
+    # @classmethod
+    # def post_logout(cls, request):
+    #     super().post_logout(request)
+    #     analytics.finished_sign_out(request)
+
+    #     origin = session.origin(request)
+    #     return redirect(origin)
+    post_logout = core_hooks.post_logout
+
+    @classmethod
+    @method_decorator(
+        [
+            decorator_from_middleware(FlowSessionRequired),
+        ]
+    )
+    def failure_to_proof(cls, request):
+        super().failure_to_proof(request)
+        session.update(request, logged_in=True)  # QUESTION: Are they still considered "logged in" if they failed to prove?
+        analytics.failure_to_proof(request)
+
+        # TODO: Confirm whether this event is desired.
+        # Did they in fact "start eligibility", or does that only refer to the post-authentication piece?
+        flow = session.flow(request)
+        eligibility_analytics.started_eligibility(request, flow)
+
+        return redirect("metro_mobility_wallet:failure_to_proof")
+
+    @classmethod
+    @method_decorator(
+        [
+            # decorator_from_middleware(AgencySessionRequired),
+            decorator_from_middleware(FlowSessionRequired),
+        ]
+    )
+    def claims_verified_eligible(cls, request, claims_request, claims_result):
+        super().claims_verified_eligible(request, claims_request, claims_result)
+        session.update(request, logged_in=True)
+        analytics.finished_sign_in(request)
+
+        flow = session.flow(request)
+        eligibility_analytics.started_eligibility(request, flow)
+
+        session.update(request, eligible=True)
+        eligibility_analytics.returned_success(request, flow)
+
+        return redirect("metro_mobility_wallet:enrollment_index")
+
+    @classmethod
+    @method_decorator(
+        [
+            # decorator_from_middleware(AgencySessionRequired),
+            decorator_from_middleware(FlowSessionRequired),
+        ]
+    )
+    def claims_verified_not_eligible(cls, request, claims_request, claims_result):
+        super().claims_verified_not_eligible(request, claims_request, claims_result)
+        session.update(request, logged_in=True)
+        analytics.finished_sign_in(request, error=claims_result.errors)
+
+        flow = session.flow(request)
+        eligibility_analytics.started_eligibility(request, flow)
+
+        return redirect("metro_mobility_wallet:eligbility_unverified")
+
+    @classmethod
+    def system_error(cls, request, exception, operation):
+        super().system_error(request, exception, operation)
+        analytics.error(request, message=str(exception), operation=str(operation))
+        sentry_sdk.capture_exception(exception)
+        return redirect("metro_mobility_wallet:system_error")

--- a/benefits/metro_mobility_wallet/urls.py
+++ b/benefits/metro_mobility_wallet/urls.py
@@ -2,12 +2,35 @@
 The metro_mobility_wallet application: URLConf for the metro_mobility_wallet app.
 """
 
+from cdt_identity import views as cdt_identity_views
+from cdt_identity.routes import Routes
 from django.urls import path
+from django.utils.decorators import decorator_from_middleware
 
-from . import views
+from benefits.oauth.middleware import FlowUsesClaimsVerificationSessionRequired
+from benefits.oauth.views import SystemErrorView
+from benefits.routes import routes
+
+from . import oauth, views
+
+decorator = decorator_from_middleware(FlowUsesClaimsVerificationSessionRequired)
+kwargs = {"hooks": oauth.OAuthHooks}
 
 app_name = "metro_mobility_wallet"
 urlpatterns = [
     # /metro-mobility-wallet/
     path("", views.IndexView.as_view(), name="index"),
+    # /metro-mobility-wallet/oauth/...
+    path(f"oauth/{Routes.login}", decorator(cdt_identity_views.login), kwargs, name=Routes.login),
+    path(f"oauth/{Routes.authorize}", decorator(cdt_identity_views.authorize), kwargs, name=Routes.authorize),
+    path(f"oauth/{Routes.cancel}", decorator(cdt_identity_views.cancel), kwargs, name=Routes.cancel),
+    path(
+        f"oauth/{Routes.failure_to_proof}",
+        decorator(cdt_identity_views.failure_to_proof),
+        kwargs,
+        name=Routes.failure_to_proof,
+    ),
+    path(f"oauth/{Routes.logout}", decorator(cdt_identity_views.logout), kwargs, name=Routes.logout),
+    path(f"oauth/{Routes.post_logout}", decorator(cdt_identity_views.post_logout), kwargs, name=Routes.post_logout),
+    path("oauth/error", SystemErrorView.as_view(), name=routes.name(routes.OAUTH_SYSTEM_ERROR)),
 ]

--- a/benefits/metro_mobility_wallet/urls.py
+++ b/benefits/metro_mobility_wallet/urls.py
@@ -8,7 +8,6 @@ from django.urls import path
 from django.utils.decorators import decorator_from_middleware
 
 from benefits.oauth.middleware import FlowUsesClaimsVerificationSessionRequired
-from benefits.oauth.views import SystemErrorView
 from benefits.routes import routes
 
 from . import oauth, views
@@ -32,5 +31,5 @@ urlpatterns = [
     ),
     path(f"oauth/{Routes.logout}", decorator(cdt_identity_views.logout), kwargs, name=Routes.logout),
     path(f"oauth/{Routes.post_logout}", decorator(cdt_identity_views.post_logout), kwargs, name=Routes.post_logout),
-    path("oauth/error", SystemErrorView.as_view(), name=routes.name(routes.OAUTH_SYSTEM_ERROR)),
+    path("oauth/error", views.SystemErrorView.as_view(), name=routes.name(routes.OAUTH_SYSTEM_ERROR)),
 ]

--- a/benefits/metro_mobility_wallet/views.py
+++ b/benefits/metro_mobility_wallet/views.py
@@ -5,3 +5,7 @@ class IndexView(TemplateView):
     """View for the Metro Mobility Wallet landing page."""
 
     template_name = "metro_mobility_wallet/index.html"
+
+
+class SystemErrorView(TemplateView):
+    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "Django==5.2.17",
     "django-admin-sortable2==2.3.1",
     "django-azure-communication-email==1.6.0",
-    "django-cdt-identity @ git+https://github.com/Office-of-Digital-Services/django-cdt-identity.git@c635773a75e7f184a9382748afcef6d5a705b2d6",
+    "django-cdt-identity @ git+https://github.com/Office-of-Digital-Services/django-cdt-identity.git@756eac783eeaa670f5211d5de161b8760ded35ca",
     "django-csp==4.0",
     "django-google-sso==10.0.0",
     "django-multiselectfield==1.0.1",


### PR DESCRIPTION
Closes #3974 (eventually)

---

~~This draft is a little premature (sorta blocked by https://github.com/cal-itp/benefits/issues/3949 which will implement new MMW-specific analytics events), but I wanted to keep going in the OAuth area and see how well I'm understanding it.~~

~~I'll reach out to the team for a pairing session to see if I'm on the right track.~~

---

- Adds `metro_mobility_wallet.oauth`, providing `OAuthHooks` with an initial set of the ones we are fairly sure we'll want
  - Includes our first use of the `failure_to_proof` hook
  - Has redirects to theoretical MMW views where expected
  - Analytics calls are currently commented out pending those prerequisites
- Adds OAuth URLs to `metro_mobility_wallet.urls`
- Upgrades `django-cdt-identity` to support the new above