### PR TITLE
Fix validation of new `EnrollmentFlow` objects

### DIFF
--- a/benefits/core/admin/enrollment.py
+++ b/benefits/core/admin/enrollment.py
@@ -5,6 +5,7 @@ from django.core.exceptions import ValidationError
 
 from benefits.core import models
 from benefits.core.models.common import template_path
+from benefits.core.models.enrollment import EnrollmentFlow
 
 from .mixins import ProdReadOnlyPermissionMixin, StaffPermissionMixin, SuperuserPermissionMixin
 
@@ -64,10 +65,12 @@ class EnrollmentFlowForm(forms.ModelForm):
             message = "Must configure either claims verification or Eligibility API verification."
             non_field_errors.append(ValidationError(message))
 
-        if supports_self_service and not template_path(self.instance.selection_label_template):
+        system_name = self.get(cleaned_data, "system_name")
+        selection_label_template_path = EnrollmentFlow.get_selection_label_template(system_name)
+        if supports_self_service and not template_path(selection_label_template_path):
             # we can't add a field-level validation error
             # because the actual template for the self-service flow is derived from a pattern
-            non_field_errors.append(ValidationError(f"Template not found: {self.instance.selection_label_template}"))
+            non_field_errors.append(ValidationError(f"Template not found: {selection_label_template_path}"))
 
         supports_in_person = (
             supported_enrollment_methods and models.EnrollmentMethods.IN_PERSON in supported_enrollment_methods

--- a/benefits/core/models/enrollment.py
+++ b/benefits/core/models/enrollment.py
@@ -193,7 +193,7 @@ class EnrollmentFlow(models.Model):
 
     @property
     def selection_label_template(self):
-        return f"eligibility/includes/selection-label--{self.system_name}.html"
+        return self.get_selection_label_template(self.system_name)
 
     @property
     def uses_claims_verification(self):
@@ -236,6 +236,10 @@ class EnrollmentFlow(models.Model):
         """Get an EnrollmentFlow instance by its ID."""
         logger.debug(f"Get {EnrollmentFlow.__name__} by id: {id}")
         return EnrollmentFlow.objects.get(id=id)
+
+    @staticmethod
+    def get_selection_label_template(system_name):
+        return f"eligibility/includes/selection-label--{system_name}.html"
 
 
 class EnrollmentGroup(models.Model):

--- a/tests/pytest/core/admin/test_enrollment.py
+++ b/tests/pytest/core/admin/test_enrollment.py
@@ -95,6 +95,25 @@ class TestEnrollmentFlowAdmin:
         error_dict = form.errors
         assert "Must configure either claims verification or Eligibility API verification." in error_dict[NON_FIELD_ERRORS]
 
+    def test_selection_label_template_validation_passes(self, admin_user_request):
+        request = admin_user_request()
+
+        request.POST = dict(
+            # value that maps to an existing template at eligibility/includes/selection-label--<system_name>.html
+            system_name="senior",
+            supported_enrollment_methods=[models.EnrollmentMethods.SELF_SERVICE],
+        )
+
+        form_class = self.model_admin.get_form(request)
+        form = form_class(request.POST)
+
+        assert not form.is_valid()
+        error_dict = form.errors
+        assert not any(
+            error.startswith("Template not found: eligibility/includes/selection-label--")
+            for error in error_dict[NON_FIELD_ERRORS]
+        )
+
     def test_without_selection_label_template(self, admin_user_request):
         request = admin_user_request()
 

--- a/tests/pytest/core/models/test_enrollment.py
+++ b/tests/pytest/core/models/test_enrollment.py
@@ -112,6 +112,12 @@ def test_EnrollmentFlow_template_eligibility_api(model_EnrollmentFlow_with_eligi
     )
 
 
+def test_EnrollmentFlow_get_selection_label_template():
+    assert (
+        EnrollmentFlow.get_selection_label_template("system_name") == "eligibility/includes/selection-label--system_name.html"
+    )
+
+
 @pytest.mark.django_db
 def test_EnrollmentGroup_str(model_LittlepayGroup):
     assert str(model_LittlepayGroup) == f"{model_LittlepayGroup.enrollment_flow} ({model_LittlepayGroup.transit_agency.slug})"


### PR DESCRIPTION
Fixes #4006

---

In moving the validation to the form, if we are creating a new `EnrollmentFlow` we now don't have the instance created before the template path is checked, so `not template_path(self.instance.selection_label_template)` was always true, failing the validation.

This adds a static method to the class that we can use to get the expected template path and check it against the selected system name.