### PR TITLE
Fix: more graceful Switchio response parsing

### DIFF
--- a/benefits/enrollment_switchio/api.py
+++ b/benefits/enrollment_switchio/api.py
@@ -1,12 +1,46 @@
 import hashlib
 import hmac
 import json
+import logging
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
+from inspect import signature
 from tempfile import NamedTemporaryFile
 
 import requests
+
+logger = logging.getLogger(__name__)
+
+
+class BaseDataClass:
+
+    @classmethod
+    def from_kwargs(cls, **kwargs):
+        """
+        @classmethod for instantiating a dataclass that allows unexpected fields
+
+        See https://stackoverflow.com/a/55101438
+        """
+        # fetch the constructor's signature
+        class_fields = {field for field in signature(cls).parameters}
+
+        # split the kwargs into native ones and new ones
+        native_args, new_args = {}, {}
+        for name, val in kwargs.items():
+            if name in class_fields:
+                native_args[name] = val
+            else:
+                new_args[name] = val
+
+        # use the native ones to create the class ...
+        instance = cls(**native_args)
+
+        # ... and log any unexpected args
+        for new_name, new_val in new_args.items():
+            logger.info(f"Unexpected arg parsing response for {cls}: {new_name} = {new_val}")
+
+        return instance
 
 
 @dataclass

--- a/benefits/enrollment_switchio/api.py
+++ b/benefits/enrollment_switchio/api.py
@@ -44,7 +44,7 @@ class BaseDataClass:
 
 
 @dataclass
-class Registration:
+class Registration(BaseDataClass):
     regId: str
     gtwUrl: str
 
@@ -62,7 +62,7 @@ class EshopResponseMode(Enum):
 
 
 @dataclass
-class RegistrationStatus:
+class RegistrationStatus(BaseDataClass):
     regState: str
     created: datetime
     mode: str
@@ -181,7 +181,7 @@ class TokenizationClient(Client):
 
         response.raise_for_status()
 
-        return Registration(**response.json())
+        return Registration.from_kwargs(**response.json())
 
     def get_registration_status(self, registration_id, timeout=5) -> RegistrationStatus:
         request_path = f"/api/v1/registration/{registration_id}"
@@ -198,11 +198,11 @@ class TokenizationClient(Client):
 
         response.raise_for_status()
 
-        return RegistrationStatus(**response.json())
+        return RegistrationStatus.from_kwargs(**response.json())
 
 
 @dataclass
-class Group:
+class Group(BaseDataClass):
     id: int
     operatorId: int
     name: str
@@ -211,7 +211,7 @@ class Group:
 
 
 @dataclass
-class GroupExpiry:
+class GroupExpiry(BaseDataClass):
     group: str
     expiresAt: datetime | None = None
 
@@ -291,7 +291,7 @@ class EnrollmentClient(Client):
 
         response.raise_for_status()
 
-        return [Group(**discount_group) for discount_group in response.json()]
+        return [Group.from_kwargs(**discount_group) for discount_group in response.json()]
 
     def get_groups_for_token(self, pto_id, token, timeout=5):
         request_path = f"/api/external/discount/{pto_id}/token/{token}"
@@ -308,7 +308,7 @@ class EnrollmentClient(Client):
 
         response.raise_for_status()
 
-        return [GroupExpiry(**group_expiry) for group_expiry in response.json()]
+        return [GroupExpiry.from_kwargs(**group_expiry) for group_expiry in response.json()]
 
     def add_group_to_token(self, pto_id, group_id, token, expiry: datetime = None, timeout=5):
         request_path = f"/api/external/discount/{pto_id}/token/{token}/add"

--- a/tests/pytest/enrollment_switchio/test_api.py
+++ b/tests/pytest/enrollment_switchio/test_api.py
@@ -44,7 +44,7 @@ class TestRegistration:
         response_json = {"regId": "1234", "gtwUrl": "https://example.com", "unexpectedField": "value"}
 
         # this test will fail if any error occurs from instantiating the class
-        Registration(**response_json)
+        Registration.from_kwargs(**response_json)
 
 
 class TestRegistrationStatus:
@@ -62,7 +62,7 @@ class TestRegistrationStatus:
         }
 
         # this test will fail if any error occurs from instantiating the class
-        RegistrationStatus(**response_json)
+        RegistrationStatus.from_kwargs(**response_json)
 
 
 @pytest.mark.django_db
@@ -203,7 +203,7 @@ class TestGroup:
         }
 
         # this test will fail if any error occurs from instantiating the class
-        Group(**response_json)
+        Group.from_kwargs(**response_json)
 
 
 class TestGroupExpiry:
@@ -221,7 +221,7 @@ class TestGroupExpiry:
         response_json = {"group": "group", "expiresAt": "2025-09-12T00:00:00Z", "unexpectedField": "value"}
 
         # this test will fail if any error occurs from instantiating the class
-        GroupExpiry(**response_json)
+        GroupExpiry.from_kwargs(**response_json)
 
 
 class TestEnrollmentClient:

--- a/tests/pytest/enrollment_switchio/test_api.py
+++ b/tests/pytest/enrollment_switchio/test_api.py
@@ -18,144 +18,130 @@ from benefits.enrollment_switchio.api import (
 )
 
 
-@pytest.fixture
-def tokenization_client():
-    return TokenizationClient(
-        api_url="https://example.com",
-        api_key="api key",
-        api_secret="api secret",
-        private_key="private key contents",
-        client_certificate="client cert contents",
-        ca_certificate="ca cert contents",
-    )
-
-
-@pytest.fixture
-def enrollment_client():
-    return EnrollmentClient(
-        api_url="https://example.com",
-        authorization_header_value="Basic abc123",
-        private_key="private key contents",
-        client_certificate="client cert contents",
-        ca_certificate="ca cert contents",
-    )
-
-
 @pytest.mark.django_db
-def test_client_cert_request(mocker):
-    temp_file = mocker.patch("benefits.enrollment_switchio.api.NamedTemporaryFile")
-    request_func = mocker.Mock()
+class TestClient:
+    def test_cert_request(self, mocker):
+        temp_file = mocker.patch("benefits.enrollment_switchio.api.NamedTemporaryFile")
+        request_func = mocker.Mock()
 
-    client = Client(
-        private_key="private key contents",
-        client_certificate="client cert contents",
-        ca_certificate="ca cert contents",
-    )
-    client._cert_request(request_func)
+        client = Client(
+            private_key="private key contents",
+            client_certificate="client cert contents",
+            ca_certificate="ca cert contents",
+        )
+        client._cert_request(request_func)
 
-    temp_file.assert_called()
-    request_func.assert_called_once()
-    assert "verify" in request_func.call_args.kwargs
-    assert "cert" in request_func.call_args.kwargs
-
-
-@pytest.mark.parametrize("method", ["GET", "POST"])
-@pytest.mark.parametrize("body", ['{"exampleProperty": "blah"}', None, ""])
-def test_tokenization_client_signature_input_string(tokenization_client, method, body):
-    timestamp = str(int(datetime.now().timestamp()))
-    request_path = "/api/example"
-
-    input_string = tokenization_client._signature_input_string(
-        timestamp=timestamp, method=method, request_path=request_path, body=body
-    )
-
-    if body is None:
-        expected = f"{timestamp}{method}{request_path}"
-    else:
-        expected = f"{timestamp}{method}{request_path}{body}"
-
-    assert input_string == expected
+        temp_file.assert_called()
+        request_func.assert_called_once()
+        assert "verify" in request_func.call_args.kwargs
+        assert "cert" in request_func.call_args.kwargs
 
 
-def test_tokenization_client_stp_signature(tokenization_client):
-    timestamp = "1748637999"
-    method = "GET"
-    request_path = "/api/example"
-    body = '{"exampleProperty": "blah"}'
+class TestTokenizationClient:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.tokenization_client = TokenizationClient(
+            api_url="https://example.com",
+            api_key="api key",
+            api_secret="api secret",
+            private_key="private key contents",
+            client_certificate="client cert contents",
+            ca_certificate="ca cert contents",
+        )
 
-    stp_signature = tokenization_client._stp_signature(
-        timestamp=timestamp, method=method, request_path=request_path, body=body
-    )
+    @pytest.mark.parametrize("method", ["GET", "POST"])
+    @pytest.mark.parametrize("body", ['{"exampleProperty": "blah"}', None, ""])
+    def test_signature_input_string(self, method, body):
+        timestamp = str(int(datetime.now().timestamp()))
+        request_path = "/api/example"
 
-    # the expected STP-SIGNATURE value based on those inputs
-    expected = "7da3dd8dad6af77d4f0d5b96ff250399f2ffe1dac2fdfbdbfae0c22a86366426"
+        input_string = self.tokenization_client._signature_input_string(
+            timestamp=timestamp, method=method, request_path=request_path, body=body
+        )
 
-    assert stp_signature == expected
+        if body is None:
+            expected = f"{timestamp}{method}{request_path}"
+        else:
+            expected = f"{timestamp}{method}{request_path}{body}"
 
+        assert input_string == expected
 
-@pytest.mark.parametrize("method", ["GET", "POST"])
-@pytest.mark.parametrize("body", [{"exampleProperty": "blah"}, None])
-def test_tokenization_client_get_headers(mocker, tokenization_client, method, body):
-    timestamp = 1516867520
+    def test_stp_signature(self):
+        timestamp = "1748637999"
+        method = "GET"
+        request_path = "/api/example"
+        body = '{"exampleProperty": "blah"}'
 
-    # mock datetime.now()
-    datetime_mock = mocker.Mock()
-    datetime_mock.now.return_value = datetime.fromtimestamp(timestamp)
-    mocker.patch.object(benefits.enrollment_switchio.api, "datetime", datetime_mock)
+        stp_signature = self.tokenization_client._stp_signature(
+            timestamp=timestamp, method=method, request_path=request_path, body=body
+        )
 
-    request_path = "/api/example"
+        # the expected STP-SIGNATURE value based on those inputs
+        expected = "7da3dd8dad6af77d4f0d5b96ff250399f2ffe1dac2fdfbdbfae0c22a86366426"
 
-    headers = tokenization_client._get_headers(method=method, request_path=request_path, request_body=body)
+        assert stp_signature == expected
 
-    # calculate the expected value
-    timestamp = str(timestamp)
-    expected = {
-        "STP-APIKEY": tokenization_client.api_key,
-        "STP-TIMESTAMP": timestamp,
-        "STP-SIGNATURE": tokenization_client._stp_signature(
-            timestamp=timestamp,
-            method=method,
-            request_path=request_path,
-            body=json.dumps(body) if body else None,
-        ),
-    }
+    @pytest.mark.parametrize("method", ["GET", "POST"])
+    @pytest.mark.parametrize("body", [{"exampleProperty": "blah"}, None])
+    def test_get_headers(self, mocker, method, body):
+        timestamp = 1516867520
 
-    assert headers == expected
+        # mock datetime.now()
+        datetime_mock = mocker.Mock()
+        datetime_mock.now.return_value = datetime.fromtimestamp(timestamp)
+        mocker.patch.object(benefits.enrollment_switchio.api, "datetime", datetime_mock)
 
+        request_path = "/api/example"
 
-def test_tokenization_client_request_registration(mocker, tokenization_client):
-    mock_response = mocker.Mock()
-    mock_json = dict(regId="1234", gtwUrl="https://example.com/cst/?regId=1234")
-    mock_response.json.return_value = mock_json
-    mocker.patch("benefits.enrollment_switchio.api.TokenizationClient._cert_request", return_value=mock_response)
+        headers = self.tokenization_client._get_headers(method=method, request_path=request_path, request_body=body)
 
-    registration = tokenization_client.request_registration(
-        eshopRedirectUrl="https://localhost/enrollment",
-        mode=RegistrationMode.REGISTER,
-        eshopResponseMode=EshopResponseMode.FORM_POST,
-    )
+        # calculate the expected value
+        timestamp = str(timestamp)
+        expected = {
+            "STP-APIKEY": self.tokenization_client.api_key,
+            "STP-TIMESTAMP": timestamp,
+            "STP-SIGNATURE": self.tokenization_client._stp_signature(
+                timestamp=timestamp,
+                method=method,
+                request_path=request_path,
+                body=json.dumps(body) if body else None,
+            ),
+        }
 
-    assert registration == Registration(**mock_json)
+        assert headers == expected
 
+    def test_request_registration(self, mocker):
+        mock_response = mocker.Mock()
+        mock_json = dict(regId="1234", gtwUrl="https://example.com/cst/?regId=1234")
+        mock_response.json.return_value = mock_json
+        mocker.patch("benefits.enrollment_switchio.api.TokenizationClient._cert_request", return_value=mock_response)
 
-def test_tokenization_client_get_registration_status(mocker, tokenization_client):
-    mock_response = mocker.Mock()
-    mock_json = dict(
-        regState="created",
-        created="2025-05-28T18:26:03.353",
-        mode="register",
-        tokens=[],
-        eshopResponseMode="form_post",
-        identType="BPK",
-        maskCln="412501****1234",
-        cardExp="1119",
-    )
-    mock_response.json.return_value = mock_json
-    mocker.patch("benefits.enrollment_switchio.api.TokenizationClient._cert_request", return_value=mock_response)
+        registration = self.tokenization_client.request_registration(
+            eshopRedirectUrl="https://localhost/enrollment",
+            mode=RegistrationMode.REGISTER,
+            eshopResponseMode=EshopResponseMode.FORM_POST,
+        )
 
-    registration_status = tokenization_client.get_registration_status(registration_id="1234")
+        assert registration == Registration(**mock_json)
 
-    assert registration_status == RegistrationStatus(**mock_json)
+    def test_get_registration_status(self, mocker):
+        mock_response = mocker.Mock()
+        mock_json = dict(
+            regState="created",
+            created="2025-05-28T18:26:03.353",
+            mode="register",
+            tokens=[],
+            eshopResponseMode="form_post",
+            identType="BPK",
+            maskCln="412501****1234",
+            cardExp="1119",
+        )
+        mock_response.json.return_value = mock_json
+        mocker.patch("benefits.enrollment_switchio.api.TokenizationClient._cert_request", return_value=mock_response)
+
+        registration_status = self.tokenization_client.get_registration_status(registration_id="1234")
+
+        assert registration_status == RegistrationStatus(**mock_json)
 
 
 class TestGroupExpiry:
@@ -170,107 +156,112 @@ class TestGroupExpiry:
         assert group.expiresAt is None
 
 
-@pytest.mark.parametrize(
-    "expiry_datetime",
-    [
-        datetime(2025, 9, 12, 19, 15, 0, tzinfo=timezone.utc),
-        datetime(2025, 9, 12, 19, 15, 0, tzinfo=None),
-        datetime(2025, 9, 12, 12, 15, 0, tzinfo=tz.get_fixed_timezone(timedelta(hours=-7))),
-    ],
-)
-def test_enrollment_client_format_expiry(enrollment_client, expiry_datetime):
-    expected_format = "2025-09-12T19:15:00Z"
-    formatted = enrollment_client._format_expiry(expiry_datetime)
+class TestEnrollmentClient:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.enrollment_client = EnrollmentClient(
+            api_url="https://example.com",
+            authorization_header_value="Basic abc123",
+            private_key="private key contents",
+            client_certificate="client cert contents",
+            ca_certificate="ca cert contents",
+        )
 
-    assert formatted == expected_format
-
-
-def test_enrollment_client_get_headers(enrollment_client):
-    headers = enrollment_client._get_headers()
-
-    assert headers == {"Authorization": "Basic abc123"}
-
-
-def test_enrollment_client_healthcheck(mocker, enrollment_client):
-    mock_response = mocker.Mock()
-    mock_response.text.return_value = "Egibility is alive!"
-    mocker.patch("benefits.enrollment_switchio.api.EnrollmentClient._cert_request", return_value=mock_response)
-
-    response = enrollment_client.healthcheck()
-
-    assert response == mock_response.text
-
-
-def test_enrollment_client_get_groups(mocker, enrollment_client):
-    mock_response = mocker.Mock()
-    mock_json = dict(
-        id=1,
-        operatorId=123,
-        name="Veteran Discount",
-        code="veteran-discount",
-        value=10,
+    @pytest.mark.parametrize(
+        "expiry_datetime",
+        [
+            datetime(2025, 9, 12, 19, 15, 0, tzinfo=timezone.utc),
+            datetime(2025, 9, 12, 19, 15, 0, tzinfo=None),
+            datetime(2025, 9, 12, 12, 15, 0, tzinfo=tz.get_fixed_timezone(timedelta(hours=-7))),
+        ],
     )
-    mock_response.json.return_value = [mock_json]
-    mocker.patch("benefits.enrollment_switchio.api.EnrollmentClient._cert_request", return_value=mock_response)
+    def test_format_expiry(self, expiry_datetime):
+        expected_format = "2025-09-12T19:15:00Z"
+        formatted = self.enrollment_client._format_expiry(expiry_datetime)
 
-    groups = enrollment_client.get_groups(pto_id="123")
+        assert formatted == expected_format
 
-    assert groups == [Group(**mock_json)]
+    def test_get_headers(self):
+        headers = self.enrollment_client._get_headers()
 
+        assert headers == {"Authorization": "Basic abc123"}
 
-def test_enrollment_client_get_groups_for_token(mocker, enrollment_client):
-    mock_response = mocker.Mock()
-    mock_json = dict(group="veteran-discount", expiresAt=None)
-    mock_response.json.return_value = [mock_json]
-    mocker.patch("benefits.enrollment_switchio.api.EnrollmentClient._cert_request", return_value=mock_response)
+    def test_healthcheck(self, mocker):
+        mock_response = mocker.Mock()
+        mock_response.text.return_value = "Egibility is alive!"
+        mocker.patch("benefits.enrollment_switchio.api.EnrollmentClient._cert_request", return_value=mock_response)
 
-    groups = enrollment_client.get_groups_for_token(pto_id="123", token="abcde12345")
+        response = self.enrollment_client.healthcheck()
 
-    assert groups == [GroupExpiry(**mock_json)]
+        assert response == mock_response.text
 
+    def test_get_groups(self, mocker):
+        mock_response = mocker.Mock()
+        mock_json = dict(
+            id=1,
+            operatorId=123,
+            name="Veteran Discount",
+            code="veteran-discount",
+            value=10,
+        )
+        mock_response.json.return_value = [mock_json]
+        mocker.patch("benefits.enrollment_switchio.api.EnrollmentClient._cert_request", return_value=mock_response)
 
-@pytest.mark.parametrize(
-    "expiry, expected_expires_at",
-    [
-        (None, None),
-        (datetime(2025, 9, 12, 19, 15, 0, tzinfo=timezone.utc), "2025-09-12T19:15:00Z"),
-    ],
-)
-def test_enrollment_client_add_group_to_token(mocker, enrollment_client, expiry, expected_expires_at):
-    mock_post = mocker.patch("benefits.enrollment_switchio.api.requests.post")
+        groups = self.enrollment_client.get_groups(pto_id="123")
 
-    def cert_request_spy(request_func):
-        # the original `_cert_request` adds `verify` and `cert` kwargs.
-        # pass dummy values here to satisfy the lambda's signature.
-        return request_func(verify="dummy_ca_path", cert=("dummy_cert_path", "dummy_key_path"))
+        assert groups == [Group(**mock_json)]
 
-    mocker.patch.object(enrollment_client, "_cert_request", side_effect=cert_request_spy)
+    def test_get_groups_for_token(self, mocker):
+        mock_response = mocker.Mock()
+        mock_json = dict(group="veteran-discount", expiresAt=None)
+        mock_response.json.return_value = [mock_json]
+        mocker.patch("benefits.enrollment_switchio.api.EnrollmentClient._cert_request", return_value=mock_response)
 
-    pto_id = "123"
-    group_id = "test-group"
-    token = "test-token"
+        groups = self.enrollment_client.get_groups_for_token(pto_id="123", token="abcde12345")
 
-    enrollment_client.add_group_to_token(pto_id, group_id, token, expiry=expiry)
+        assert groups == [GroupExpiry(**mock_json)]
 
-    expected_body = {"group": group_id}
-    if expected_expires_at:
-        expected_body["expiresAt"] = expected_expires_at
+    @pytest.mark.parametrize(
+        "expiry, expected_expires_at",
+        [
+            (None, None),
+            (datetime(2025, 9, 12, 19, 15, 0, tzinfo=timezone.utc), "2025-09-12T19:15:00Z"),
+        ],
+    )
+    def test_add_group_to_token(self, mocker, expiry, expected_expires_at):
+        mock_post = mocker.patch("benefits.enrollment_switchio.api.requests.post")
 
-    # Assert that `requests.post` was called with the correct URL and body.
-    expected_url = f"{enrollment_client.api_url}/api/external/discount/{pto_id}/token/{token}/add"
-    mock_post.assert_called_once()
-    assert mock_post.call_args.args == (expected_url,)
-    assert mock_post.call_args.kwargs["json"] == expected_body
+        def cert_request_spy(request_func):
+            # the original `_cert_request` adds `verify` and `cert` kwargs.
+            # pass dummy values here to satisfy the lambda's signature.
+            return request_func(verify="dummy_ca_path", cert=("dummy_cert_path", "dummy_key_path"))
 
+        mocker.patch.object(self.enrollment_client, "_cert_request", side_effect=cert_request_spy)
 
-def test_enrollment_client_remove_group_from_token(mocker, enrollment_client):
-    group_code = "veteran-discount"
-    token = "abcde12345"
+        pto_id = "123"
+        group_id = "test-group"
+        token = "test-token"
 
-    mock_response = mocker.Mock()
-    mock_response.text.return_value = f"Discount {group_code} removed successfully for token {token}"
-    mocker.patch("benefits.enrollment_switchio.api.EnrollmentClient._cert_request", return_value=mock_response)
+        self.enrollment_client.add_group_to_token(pto_id, group_id, token, expiry=expiry)
 
-    response = enrollment_client.remove_group_from_token("123", group_code, token)
+        expected_body = {"group": group_id}
+        if expected_expires_at:
+            expected_body["expiresAt"] = expected_expires_at
 
-    assert response == mock_response.text
+        # Assert that `requests.post` was called with the correct URL and body.
+        expected_url = f"{self.enrollment_client.api_url}/api/external/discount/{pto_id}/token/{token}/add"
+        mock_post.assert_called_once()
+        assert mock_post.call_args.args == (expected_url,)
+        assert mock_post.call_args.kwargs["json"] == expected_body
+
+    def test_remove_group_from_token(self, mocker):
+        group_code = "veteran-discount"
+        token = "abcde12345"
+
+        mock_response = mocker.Mock()
+        mock_response.text.return_value = f"Discount {group_code} removed successfully for token {token}"
+        mocker.patch("benefits.enrollment_switchio.api.EnrollmentClient._cert_request", return_value=mock_response)
+
+        response = self.enrollment_client.remove_group_from_token("123", group_code, token)
+
+        assert response == mock_response.text

--- a/tests/pytest/enrollment_switchio/test_api.py
+++ b/tests/pytest/enrollment_switchio/test_api.py
@@ -1,4 +1,6 @@
 import json
+import logging
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -6,6 +8,7 @@ from django.utils import timezone as tz
 
 import benefits.enrollment_switchio.api
 from benefits.enrollment_switchio.api import (
+    BaseDataClass,
     Client,
     EnrollmentClient,
     EshopResponseMode,
@@ -16,6 +19,24 @@ from benefits.enrollment_switchio.api import (
     RegistrationStatus,
     TokenizationClient,
 )
+
+
+class TestBaseDataClass:
+
+    @dataclass
+    class SampleDataClass(BaseDataClass):
+        fieldOne: int
+        fieldTwo: str
+
+    def test_from_kwargs(self, caplog):
+        response_json = {"fieldOne": 1, "fieldTwo": "two", "fieldThree": "three"}
+
+        with caplog.at_level(logging.DEBUG):
+            instance = self.SampleDataClass.from_kwargs(**response_json)
+
+        assert instance.fieldOne == 1
+        assert instance.fieldTwo == "two"
+        assert f"Unexpected arg parsing response for {self.SampleDataClass}: fieldThree = three" in caplog.text
 
 
 class TestRegistration:

--- a/tests/pytest/enrollment_switchio/test_api.py
+++ b/tests/pytest/enrollment_switchio/test_api.py
@@ -18,6 +18,32 @@ from benefits.enrollment_switchio.api import (
 )
 
 
+class TestRegistration:
+    def test_unexpected_fields(self):
+        response_json = {"regId": "1234", "gtwUrl": "https://example.com", "unexpectedField": "value"}
+
+        # this test will fail if any error occurs from instantiating the class
+        Registration(**response_json)
+
+
+class TestRegistrationStatus:
+    def test_unexpected_fields(self):
+        response_json = {
+            "regState": "state",
+            "created": datetime(2026, 8, 24, 11, 30, 0),
+            "mode": RegistrationMode.REGISTER,
+            "tokens": [{"token": "1234"}],
+            "eshopResponseMode": EshopResponseMode.FORM_POST,
+            "identType": "ident",
+            "maskCln": "cln",
+            "cardExp": "08/26",
+            "unexpectedField": "value",
+        }
+
+        # this test will fail if any error occurs from instantiating the class
+        RegistrationStatus(**response_json)
+
+
 @pytest.mark.django_db
 class TestClient:
     def test_cert_request(self, mocker):
@@ -144,6 +170,21 @@ class TestTokenizationClient:
         assert registration_status == RegistrationStatus(**mock_json)
 
 
+class TestGroup:
+    def test_unexpected_fields(self):
+        response_json = {
+            "id": 1,
+            "operatorId": 1,
+            "name": "Group 1",
+            "code": "group",
+            "value": 1,
+            "unexpectedField": "value",
+        }
+
+        # this test will fail if any error occurs from instantiating the class
+        Group(**response_json)
+
+
 class TestGroupExpiry:
     def test_expiresAt(self):
         group = GroupExpiry(group="group", expiresAt="2025-09-12T00:00:00Z")
@@ -154,6 +195,12 @@ class TestGroupExpiry:
         group = GroupExpiry(group="group", expiresAt=None)
 
         assert group.expiresAt is None
+
+    def test_unexpected_fields(self):
+        response_json = {"group": "group", "expiresAt": "2025-09-12T00:00:00Z", "unexpectedField": "value"}
+
+        # this test will fail if any error occurs from instantiating the class
+        GroupExpiry(**response_json)
 
 
 class TestEnrollmentClient:


### PR DESCRIPTION
Fixes #4012 

---

This PR adapts the changes that were made on the Littlepay side in https://github.com/cal-itp/littlepay/pull/69 over to the Switchio side.

We implement a `from_kwargs(**kwargs)` class method helper to parse all responses coming back from Switchio API calls in order to more gracefully handle the case where an unexpected field is included in a response.

This PR adds tests for unexpected fields in responses, while also refactoring all Switchio API tests into a class-based format.