### PR TITLE
Feat: Metro Mobility Wallet - Session class

### DIFF
--- a/benefits/metro_mobility_wallet/session.py
+++ b/benefits/metro_mobility_wallet/session.py
@@ -2,6 +2,8 @@ import logging
 
 from django.http import HttpRequest
 
+from benefits.core.models.enrollment import EnrollmentFlow, SystemName
+
 logger = logging.getLogger(__name__)
 
 
@@ -11,3 +13,11 @@ class Session:
 
         self.request = request
         self.session = request.session
+        self._flow = None
+
+    @property
+    def flow(self) -> EnrollmentFlow:
+        if self._flow is None:
+            self._flow = EnrollmentFlow.objects.filter(system_name=SystemName.METRO_MOBILITY_WALLET).first()
+
+        return self._flow

--- a/benefits/metro_mobility_wallet/session.py
+++ b/benefits/metro_mobility_wallet/session.py
@@ -1,8 +1,13 @@
 import logging
 
+from django.http import HttpRequest
+
 logger = logging.getLogger(__name__)
 
 
 class Session:
-    def __init__(self):
-        pass
+    def __init__(self, request: HttpRequest):
+        """Initialize a new Metro Mobility Wallet session wrapper for this request"""
+
+        self.request = request
+        self.session = request.session

--- a/benefits/metro_mobility_wallet/session.py
+++ b/benefits/metro_mobility_wallet/session.py
@@ -13,11 +13,7 @@ class Session:
 
         self.request = request
         self.session = request.session
-        self._flow = None
 
     @property
     def flow(self) -> EnrollmentFlow:
-        if self._flow is None:
-            self._flow = EnrollmentFlow.objects.filter(system_name=SystemName.METRO_MOBILITY_WALLET).first()
-
-        return self._flow
+        return EnrollmentFlow.objects.filter(system_name=SystemName.METRO_MOBILITY_WALLET).first()

--- a/benefits/metro_mobility_wallet/session.py
+++ b/benefits/metro_mobility_wallet/session.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class Session:
+    def __init__(self):
+        pass

--- a/tests/pytest/metro_mobility_wallet/test_session.py
+++ b/tests/pytest/metro_mobility_wallet/test_session.py
@@ -13,6 +13,13 @@ class TestSession:
         request.session = {"session_id": 123}
         return request
 
+    @pytest.fixture
+    def model_metro_EnrollmentFlow(self):
+        flow = EnrollmentFlow.objects.create(system_name=SystemName.METRO_MOBILITY_WALLET)
+        flow.save()
+
+        return flow
+
     def test_init(self, mock_request):
         session = Session(mock_request)
         assert session.request == mock_request
@@ -26,17 +33,9 @@ class TestSession:
 
         assert flow is None
 
+    @pytest.mark.usefixtures("model_metro_EnrollmentFlow")
     def test_flow_metro_flow_exists(self, mock_request):
-        # setup
-        flow = EnrollmentFlow.objects.create(system_name=SystemName.METRO_MOBILITY_WALLET)
-        flow.save()
-
-        # the actual test
         session = Session(mock_request)
         flow = session.flow
 
         assert flow is not None
-
-        # teardown
-        flow.delete()
-        flow.save()

--- a/tests/pytest/metro_mobility_wallet/test_session.py
+++ b/tests/pytest/metro_mobility_wallet/test_session.py
@@ -30,9 +30,8 @@ class TestSession:
 
         assert flow is None
 
-    @pytest.mark.usefixtures("model_metro_EnrollmentFlow")
-    def test_flow_metro_flow_exists(self, mock_request):
+    def test_flow_metro_flow_exists(self, mock_request, model_metro_EnrollmentFlow):
         session = Session(mock_request)
         flow = session.flow
 
-        assert flow is not None
+        assert flow == model_metro_EnrollmentFlow

--- a/tests/pytest/metro_mobility_wallet/test_session.py
+++ b/tests/pytest/metro_mobility_wallet/test_session.py
@@ -1,0 +1,7 @@
+from benefits.metro_mobility_wallet.session import Session
+
+
+class TestSession:
+    def test_init(self):
+        session = Session()
+        assert session

--- a/tests/pytest/metro_mobility_wallet/test_session.py
+++ b/tests/pytest/metro_mobility_wallet/test_session.py
@@ -15,10 +15,7 @@ class TestSession:
 
     @pytest.fixture
     def model_metro_EnrollmentFlow(self):
-        flow = EnrollmentFlow.objects.create(system_name=SystemName.METRO_MOBILITY_WALLET)
-        flow.save()
-
-        return flow
+        return EnrollmentFlow.objects.create(system_name=SystemName.METRO_MOBILITY_WALLET)
 
     def test_init(self, mock_request):
         session = Session(mock_request)

--- a/tests/pytest/metro_mobility_wallet/test_session.py
+++ b/tests/pytest/metro_mobility_wallet/test_session.py
@@ -1,7 +1,17 @@
+import pytest
+from django.http import HttpRequest
+
 from benefits.metro_mobility_wallet.session import Session
 
 
 class TestSession:
-    def test_init(self):
-        session = Session()
-        assert session
+    @pytest.fixture
+    def mock_request(self, mocker):
+        request = mocker.MagicMock(spec=HttpRequest)
+        request.session = {"session_id": 123}
+        return request
+
+    def test_init(self, mock_request):
+        session = Session(mock_request)
+        assert session.request == mock_request
+        assert session.session == mock_request.session

--- a/tests/pytest/metro_mobility_wallet/test_session.py
+++ b/tests/pytest/metro_mobility_wallet/test_session.py
@@ -1,9 +1,11 @@
 import pytest
 from django.http import HttpRequest
 
+from benefits.core.models.enrollment import EnrollmentFlow, SystemName
 from benefits.metro_mobility_wallet.session import Session
 
 
+@pytest.mark.django_db
 class TestSession:
     @pytest.fixture
     def mock_request(self, mocker):
@@ -15,3 +17,26 @@ class TestSession:
         session = Session(mock_request)
         assert session.request == mock_request
         assert session.session == mock_request.session
+
+    def test_flow_no_metro_flow(self, mock_request):
+        assert EnrollmentFlow.objects.filter(system_name=SystemName.METRO_MOBILITY_WALLET).count() == 0
+
+        session = Session(mock_request)
+        flow = session.flow
+
+        assert flow is None
+
+    def test_flow_metro_flow_exists(self, mock_request):
+        # setup
+        flow = EnrollmentFlow.objects.create(system_name=SystemName.METRO_MOBILITY_WALLET)
+        flow.save()
+
+        # the actual test
+        session = Session(mock_request)
+        flow = session.flow
+
+        assert flow is not None
+
+        # teardown
+        flow.delete()
+        flow.save()


### PR DESCRIPTION
Closes #3946 

## Acceptance criteria from #3946
- [x] Inside the folder from #3945, a `session.py` file exists with an appropriately named class (like `Session`)
- [x] The session class has at least one helper/attribute to return the (hard-coded) `EnrollmentFlow` instance for Metro Mobility Wallet
- [x] At least one test exists for the above

