### PR TITLE
Research: MOBILEvario API

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,7 +21,7 @@
     "editor.codeActionsOnSave": { "source.organizeImports": "explicit" }
   },
   "python.languageServer": "Pylance",
-  "python.testing.pytestArgs": ["tests/pytest"],
+  "python.testing.pytestArgs": ["tests/pytest", "-s"],
   "python.testing.pytestEnabled": true,
   "python.testing.unittestEnabled": false,
   "[terraform]": {

--- a/mobilevario.http
+++ b/mobilevario.http
@@ -3,5 +3,28 @@
 
 ###
 
-GET {{baseUrl}}/api/farecategories HTTP/1.1
+GET {{baseUrl}}/api/FareCategories HTTP/1.1
 Authorization: {{authHeader}}
+
+###
+
+GET {{baseUrl}}/api/SalesChannels
+Authorization: {{authHeader}}
+
+###
+
+GET {{baseUrl}}/api/FareMedia?SaleschannelId=420
+Authorization: {{authHeader}}
+
+###
+
+POST {{baseUrl}}/api/TransitAccounts
+Authorization: {{authHeader}}
+Content-Type: application/json
+
+{
+  "FareMediaId": "133713370",
+  "PrintedNumber": "133713370",
+  "FareMediaTypeId": 1727934,
+  "SalesChannelId": 420,
+}

--- a/mobilevario.http
+++ b/mobilevario.http
@@ -28,3 +28,26 @@ Content-Type: application/json
   "FareMediaTypeId": 1727934,
   "SalesChannelId": 420,
 }
+
+###
+
+GET {{baseUrl}}/api/TransitAccounts?FareMediaId=133713370
+Authorization: {{authHeader}}
+
+###
+
+POST {{baseUrl}}/api/Cardholders
+Authorization: {{authHeader}}
+Content-Type: application/json
+
+{
+    "FareCategory": "7",
+    "TransitAccountId": "17718",
+    "FirstName": "Kim",
+    "LastName": "Possible"
+}
+
+###
+
+GET {{baseUrl}}/api/Cardholders/12002
+Authorization: {{authHeader}}

--- a/tests/playwright/pytest.ini
+++ b/tests/playwright/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --tracing on -v --template=html1/index.html --report=test-results/report.html --video on
+addopts = -s --tracing on -v --template=html1/index.html --report=test-results/report.html --video on --browser=firefox

--- a/tests/playwright/test_mobilevario.py
+++ b/tests/playwright/test_mobilevario.py
@@ -41,14 +41,20 @@ def generate_month_year_codes():
     return dates
 
 
-def generate_3digit_codes():
-    return [f"{i:03d}" for i in range(411, 501)]
+def generate_3digit_codes(start, end):
+    """
+    Generates an array of 3-digit codes.
+
+    :param start: starting 3-digit value, inclusive.
+    :param end: ending 3-digit value, exclusive.
+    """
+    return [f"{i:03d}" for i in range(start, end)]
 
 
-def my_params():
+def generate_test_cases():
     card_numbers = ["4111 1111 1111 1111", "4242 4242 4242 4242"]
     expiration_dates = generate_month_year_codes()
-    cvvs = generate_3digit_codes()
+    cvvs = generate_3digit_codes(400, 501)
 
     card_details = []
     for c in card_numbers:
@@ -58,10 +64,10 @@ def my_params():
     return card_details
 
 
-TEST_CASES = my_params()
+TEST_CASES = generate_test_cases()
 
 
-@pytest.mark.parametrize("card_details", TEST_CASES, ids=lambda tc: tc)
+@pytest.mark.parametrize("card_details", TEST_CASES)
 def test_get_TransitAccount(page: Page, card_details: CardDetails):
     page.context.set_extra_http_headers(
         {

--- a/tests/playwright/test_mobilevario.py
+++ b/tests/playwright/test_mobilevario.py
@@ -1,0 +1,98 @@
+"""
+Tests that use requests to call the MOBILEvario API.
+"""
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from enum import Enum
+
+import pytest
+from playwright.sync_api import Dialog, Page, expect
+
+logger = logging.getLogger(__name__)
+
+PSTA_INIT_ENROLLMENT_API_BASE_URL = os.environ.get("psta_init_enrollment_api_base_url")
+PSTA_INIT_ENROLLMENT_API_AUTHORIZATION_HEADER = os.environ.get("psta_init_enrollment_api_authorization_header")
+
+
+def endpoint_url(endpoint):
+    return f"{PSTA_INIT_ENROLLMENT_API_BASE_URL}/api/{endpoint}"
+
+
+class Endpoints(Enum):
+    TransitAccounts = endpoint_url("TransitAccounts")
+
+
+@dataclass
+class CardDetails:
+    card_number: str
+    expiration_date: str
+    cvv: str
+
+
+def generate_month_year_codes():
+    dates = []
+    for year in range(2026, 2027):
+        for month in range(1, 13):
+            if not (year == 2026 and month < 8):
+                dates.append(f"{month:02d} / {str(year)[-2:]}")
+    return dates
+
+
+def generate_3digit_codes():
+    return [f"{i:03d}" for i in range(411, 501)]
+
+
+def my_params():
+    card_numbers = ["4111 1111 1111 1111", "4242 4242 4242 4242"]
+    expiration_dates = generate_month_year_codes()
+    cvvs = generate_3digit_codes()
+
+    card_details = []
+    for c in card_numbers:
+        for e in expiration_dates:
+            for cv in cvvs:
+                card_details.append(CardDetails(c, e, cv))
+    return card_details
+
+
+TEST_CASES = my_params()
+
+
+@pytest.mark.parametrize("card_details", TEST_CASES, ids=lambda tc: tc)
+def test_get_TransitAccount(page: Page, card_details: CardDetails):
+    page.context.set_extra_http_headers(
+        {
+            "Authorization": PSTA_INIT_ENROLLMENT_API_AUTHORIZATION_HEADER,
+        }
+    )
+
+    page.goto("https://benefits-4000--cal-itp-previews.netlify.app/init-research/collectjs-demo.html")
+
+    def handle_card_token(dialog: Dialog):
+        message_json = json.loads(dialog.message)
+        token = message_json["token"]
+        dialog.accept()
+
+        page.goto(Endpoints.TransitAccounts.value + f"?BankingServiceToken={token}")
+
+    page.on("dialog", lambda dialog: handle_card_token(dialog))
+
+    # page.wait_for_timeout(1500)  # need to wait for the iframes to load
+    card_number_input = page.locator("#CollectJSInlineccnumber").content_frame.get_by_role("textbox", name="Card Number")
+    card_number_input.type(card_details.card_number)
+
+    expiration_date_input = page.locator("#CollectJSInlineccexp").content_frame.get_by_role("textbox", name="Card Expiration")
+    expiration_date_input.type(card_details.expiration_date)
+
+    security_code_input = page.locator("#CollectJSInlinecvv").content_frame.get_by_role("textbox", name="CVV Code")
+    security_code_input.type(card_details.cvv)
+
+    pay_button = page.get_by_role("button", name="Pay")
+    pay_button.click()
+
+    page.wait_for_timeout(3000)
+
+    expect(page.get_by_text('{"TotalCount":0,"Result":[]}')).not_to_be_visible()

--- a/tests/pytest/test_mobilevario.py
+++ b/tests/pytest/test_mobilevario.py
@@ -1,0 +1,50 @@
+"""
+Tests that use requests to call the MOBILEvario API.
+"""
+
+import os
+from enum import StrEnum
+
+import pytest
+import requests
+
+PSTA_INIT_ENROLLMENT_API_BASE_URL = os.environ.get("psta_init_enrollment_api_base_url")
+PSTA_INIT_ENROLLMENT_API_AUTHORIZATION_HEADER = os.environ.get("psta_init_enrollment_api_authorization_header")
+
+
+def endpoint_url(endpoint):
+    return f"{PSTA_INIT_ENROLLMENT_API_BASE_URL}/api/{endpoint}"
+
+
+class Endpoints(StrEnum):
+    TransitAccounts = endpoint_url("TransitAccounts")
+
+
+@pytest.mark.enable_socket
+def test_get_TransitAccount():
+    # paste a list of card tokens for which to get TransitAccounts here
+    card_tokens = []
+
+    for token in card_tokens:
+        response = requests.get(
+            Endpoints.TransitAccounts,
+            params={
+                "IsBlocked": "false",
+                "BankingServiceToken": token,
+            },
+            headers={"Authorization": PSTA_INIT_ENROLLMENT_API_AUTHORIZATION_HEADER},
+            timeout=0,
+        )
+
+        response.raise_for_status()
+
+        results = response.json()["Result"]
+
+        print(f"## Trying token {token}")
+
+        if len(results) > 0:
+            print("We found a TransitAccount! (see below)")
+            print("")
+            print(results)
+        else:
+            print(f"Token {token} does not have a TransitAccount associated with it.")


### PR DESCRIPTION
Builds off the [`research/init-apis` branch](init-apis) from #4000.

Closes #4011 (we're not actually going to merge this though)

---

## Notes

To try out this branch, use the API credentials stored in LastPass in the secure note named `MOBILEvario (staging) API credentials`.

This PR contains the research / exploration I did of the MOBILEvario API and endpoints that we are meant to use to

> - Locate the rider’s transit account using the banking token.
> - Add the reduced-fare cardholder designation to the account.

which we understand, as mentioned in #4011, translates to:

> 1. `GET api/TransitAccounts?BankingServiceToken=<Collect.js token>` to get back the transit account associated with a given banking service token .
> 2. `POST api/Cardholders` using the transit account ID, and fare category to create a new cardholder and enable it for discounts with the appropriate fare category.

### Approaches taken for retrieving a `TransitAccount`

- (Approach 1) Try out a bunch of card tokens to see if we can get back a `TransitAccount`
  - Simple `pytest` test using the `requests` library
  - Playwright test that calls to our Collect.js POC site (which uses the doc example API key) and to the staging MOBILEvario API
- (Approach 2) Try creating a `TransitAccount`
  - REST requests defined in `mobilevario.http` and sent using the `REST Client` VS Code extension

### Findings

- **Tokenization is not a simple hash**: As separately and independently found by @jgravois  in https://github.com/cal-itp/benefits/issues/4010#issuecomment-5444492825, we were suprised to learn that Collect.js's tokenization of the same set of `(card number, expiration number, security code)` values results in a _different_ token each time. :thinking: I don't think this actually matters to us, but it was something we had never thought much about before, so it was surprising.
- **Trying to find an existing TransitAccount (`GET api/TransitAccounts?BankingServiceToken=<Collect.js token>`)**: I was unsuccessful in trying to find an existing `TransitAccount` using card tokens generated from test card numbers `4111 1111 1111 1111` and `4242 4242 4242 4242`.
- **Creating `TransitAccount`s (`POST api/TransitAccounts`)**: It was much easier for me to simply create a `TransitAccount`. It turns out the only _required_ parameters from the API's perspective are:
  - `FareMediaId`
  - `PrintedNumber`
  - `FareMediaTypeId`
  - `SalesChannelId`
  
  I was able to call `GET api/SalesChannels` and `GET api/FareMedia` with a `?SalesChannelId` URI parameter to find reasonable values to use for `SalesChannelId` and `FareMediaTypeId`. I made up values for `FareMediaId` and `PrintedNumber` and kept track of what I used so as to avoid needing to create more test accounts, i.e. minimize how much we add to their staging environment. I do not know how to get a `BankingServiceToken` value that will return the `TransitAccount` that I created.
- **Creating a Cardholder and associating it to a TransitAccount (`POST api/Cardholders`)**: this was straightforward once I had a `TransitAccount` to work with. I called `GET api/FareCategories` to see the available values. In `mobilevario.http`, I decided to also pass `FirstName` and `LastName`, but those are not required.
