### PR TITLE
fix(newsletters): Add insertion point to archive index

### DIFF
--- a/docs/reference/newsletter-archive/index.md
+++ b/docs/reference/newsletter-archive/index.md
@@ -10,7 +10,7 @@ Most months we send a newsletter to share product updates, adoption metrics, and
 
     <div class="grid cards" id="newsletter-cards-2026" markdown>
 
-    ## 2026 {.sr-only}
+    ## 2026 {.sr-only .insertion-point}
 
     -   ### :material-email-newsletter: July 2026
 


### PR DESCRIPTION
Follow-up to #4030

The automation for adding a new card to the index won't work correctly without this.