### PR TITLE
Docs: reorder production validation steps

### DIFF
--- a/docs/guides/transit-provider-onboarding/configure-production-validation.md
+++ b/docs/guides/transit-provider-onboarding/configure-production-validation.md
@@ -28,10 +28,6 @@ _Typically performed by a Cal-ITP developer._
         ```
 
     1.  Cal-ITP [creates a `TransitAgency`](./add-transit-provider.md#add-the-transit-provider-to-the-application) in the test environment
-    1. Cal-ITP creates a new `LittlepayGroup` in the Benefits test environment:
-      - Associate the new `LittlepayGroup` with the correct transit provider and enrollment flow using the dropdowns.
-      - Set the 'Group id' to the corresponding **production** group ID (from production Littlepay) for production validation.
-        - This will be set back to the QA group value after final production configuration is complete.
     1. Cal-ITP creates a new `LittlepayConfig` in the Benefits test environment:
       - Set Environment to **Production** for production validation.
         - This will be set back to **Testing** after final production configuration is complete.
@@ -39,6 +35,10 @@ _Typically performed by a Cal-ITP developer._
       - Retrieve Audience and Client ID values for the **production** config from shared LastPass note.
       - Client Secret Name: `${agency_slug}-payment-processor-client-secret`
       - [Create the corresponding secret in the Azure Key Vault](../../../tutorials/secrets/) for the environment
+    1. Cal-ITP creates a new `LittlepayGroup` in the Benefits test environment:
+      - Associate the new `LittlepayGroup` with the correct transit provider and enrollment flow using the dropdowns.
+      - Set the 'Group id' to the corresponding **production** group ID (from production Littlepay) for production validation.
+        - This will be set back to the QA group value after final production configuration is complete.
     1. Cal-ITP returns to the `TransitAgency` instance and selects the `LittlepayConfig` above as the agency's transit processor config and checks the **Active** box.
 
 === "Switchio"

--- a/docs/guides/transit-provider-onboarding/configure-production-validation.md
+++ b/docs/guides/transit-provider-onboarding/configure-production-validation.md
@@ -31,7 +31,6 @@ _Typically performed by a Cal-ITP developer._
     1. Cal-ITP creates a new `LittlepayConfig` in the Benefits test environment:
       - Set Environment to **Production** for production validation.
         - This will be set back to **Testing** after final production configuration is complete.
-      - Return to the `TransitAgency` and associate the new `LittlepayConfig` as its 'Transit processor config'.
       - Retrieve Audience and Client ID values for the **production** config from shared LastPass note.
       - Client Secret Name: `${agency_slug}-payment-processor-client-secret`
       - [Create the corresponding secret in the Azure Key Vault](../../../tutorials/secrets/) for the environment


### PR DESCRIPTION
Closes #3922, closes #3925 

Originally, it looked like we needed to reorder the [production validation steps in the issue scaffold](https://github.com/cal-itp/benefits/blob/main/.github/workflows/agency-onboarding/production-validation.md) to match the Littlepay section of the docs. It turns out that the issue scaffold matched the Switchio production validations steps in the docs, so the Littlepay section in the docs was actually out of order. This PR reorders the production validation configuration steps for Littlepay in the docs. The order now is: first setup the transit processor _Config_ and then the _Group_. I feel this makes more sense conceptually too.

As I was working on this, and since I ended up editing the docs in this PR, I went ahead and removed the redundant step in 0630f2b7cd5c49143ba37cfe707f34909a21617a to close #3925.

