### PR TITLE
chore: get codeql gh action versions back in sync

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,4 +35,4 @@ jobs:
               - tests
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9


### PR DESCRIPTION
i didn't notice yesterday that https://github.com/cal-itp/benefits/pull/4035 only bumped one of the two sibling actions we reference.

ref: https://github.com/cal-itp/benefits/actions/runs/34378331544

> 1 issue was detected with this workflow: Not all workflow steps that use `github/codeql-action` actions use the same version. Please ensure that all such steps use the same version to avoid compatibility issues.

the dummy commit 6529b5a is purely to demonstrate the fix. i intend to `-f` push it away prior to merge.

successful run: https://github.com/cal-itp/benefits/actions/runs/34379640822/job/102561022275