### PR TITLE
Tell robots not to index the app if it's not the production hostname

### DIFF
--- a/appcontainer/nginx.conf
+++ b/appcontainer/nginx.conf
@@ -96,4 +96,13 @@ http {
       include /calitp/run/proxy.conf;
     }
   }
+
+  map $http_host $allow_indexing {
+    hostnames;
+    default             none;
+
+    benefits.calitp.org all;
+  }
+
+  add_header X-Robots-Tag $allow_indexing;
 }


### PR DESCRIPTION
Part of cal-itp/calitp.org#577

---

Adds an NGINX directive that sets the `X-Robots-Tag` header on all requests. If the hostname is `benefits.calitp.org`, the header value is `allow`, otherwise it defaults to `none` (equivalent to `noindex, nofollow`). The NGINX `map` directive is used to set a variable dynamically based on the hostname, which is then injected into the `add_header` directive.

References:

- [`X-Robots-Tag` at MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Robots-Tag)
- [NGINX `map` module docs](https://nginx.org/en/docs/http/ngx_http_map_module.html)
- [NGINX `add_header` module docs](https://nginx.org/en/docs/http/ngx_http_headers_module.html)

### Testing instructions

1. Rebuild your app container with `bin/build.sh`.
2. Rebuild the dev container without cache.
3. Instead of launching the Django `runserver` process via the VS Code Run and Debug feature, open a shell on the dev container and run `bin/start.sh` to start up nginx.
4. Access the site with the usual `localhost:port` and check the response headers for the page request.